### PR TITLE
precommit lint check and Developer doc

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+extend-ignore = E501, W292, W291

--- a/Developers.md
+++ b/Developers.md
@@ -1,0 +1,21 @@
+Developers
+
+Install pre-commit (https://pre-commit.com/)
+
+```bash
+pip install pre-commit
+```
+
+Check that it's installed
+
+```bash
+pre-commit --versioni
+```
+
+This repository already has a pre-commit configuration. To install the hooks, run:
+
+```bash
+pre-commit install
+```
+
+Now when you make a git commit, the black code formatter and ruff linter will run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,6 @@ ignore = "E501,W6"  # or ["E501", "W6"]
 in-place = true
 recursive = true
 aggressive = 3
+
+[tool.ruff]
+line-length = 200

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,3 +74,5 @@ rich
 mkdocs
 mkdocs-material
 mkdocs-glightbox
+
+pre-commit


### PR DESCRIPTION
I didn't have the pre-commit check for black and ruff installed. 

This adds developer docs, flake8 config and ruff config to ignore line too long.

