### PR TITLE
[BUG][DOCS] README.md - import error in ModelParallelizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ import os
 from dotenv import load_dotenv
 
 from swarms.models import Anthropic, Gemini, Mixtral, OpenAIChat
-from swarms.swarms import ModelParallelizer
+from swarms.structs import ModelParallelizer
 
 load_dotenv()
 


### PR DESCRIPTION
swarms.swarms should be swarms.structs

```
ModuleNotFoundError                       Traceback (most recent call last)

[<ipython-input-21-1275a159d137>](https://localhost:8080/#) in <cell line: 6>()
      4 
      5 from swarms.models import Anthropic, Gemini, Mixtral, OpenAIChat
----> 6 from swarms.swarms import ModelParallelizer
      7 
      8 load_dotenv()

ModuleNotFoundError: No module named 'swarms.swarms'
```
Gets farther after this fix.