### PR TITLE
[BUGF] [SwarmNet] [test_swarmnetwork]

### DIFF
--- a/tests/structs/test_swarmnetwork.py
+++ b/tests/structs/test_swarmnetwork.py
@@ -1,8 +1,8 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
-from swarms.structs.swarm_net import SwarmNet
+
 from swarms.structs.agent import Agent
 from swarms.structs.swarm_net import SwarmNetwork
 
@@ -52,41 +52,3 @@ def test_swarm_network_remove_agent(swarm_network):
     assert len(swarm_network.agents) == 4
     assert agent_to_remove not in swarm_network.agents
 
-
-@pytest.fixture
-def swarmnet():
-    swarmnet = SwarmNet()
-    agent_mock = MagicMock()
-    agent_mock.id = "1"
-    swarmnet.agents = [agent_mock]
-    return swarmnet
-
-
-def test_run_agent(swarmnet):
-    swarmnet.run_agent("1", "task")
-    swarmnet.agents[0].run.assert_called_once_with("task")
-
-
-def test_run_agent_no_agent(swarmnet):
-    with pytest.raises(ValueError, match="No agent found with ID"):
-        swarmnet.run_agent("2", "task")
-
-
-def test_run_many_agents(swarmnet):
-    swarmnet.run_many_agents("task")
-    swarmnet.agents[0].run.assert_called_once_with("task")
-
-
-def test_list_agents(swarmnet):
-    swarmnet.list_agents()
-    assert swarmnet.agents[0].id == "1"
-
-
-def test_get_agent(swarmnet):
-    agent = swarmnet.get_agent("1")
-    assert agent.id == "1"
-
-
-def test_get_agent_no_agent(swarmnet):
-    with pytest.raises(ValueError, match="No agent found with ID"):
-        swarmnet.get_agent("2")


### PR DESCRIPTION


_____________________________ ERROR collecting tests/structs/test_swarmnetwork.py _____________________________
ImportError while importing test module '/home/v/vswarms/tests/structs/test_swarmnetwork.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/structs/test_swarmnetwork.py:5: in <module>
    from swarms.structs.swarm_net import SwarmNet
E   ImportError: cannot import name 'SwarmNet' from 'swarms.structs.swarm_net' (/home/v/.local/lib/python3.10/site-packages/swarms/structs/swarm_net.py)