### PR TITLE
quantized models don't have .to

### DIFF
--- a/swarms/models/huggingface.py
+++ b/swarms/models/huggingface.py
@@ -181,7 +181,7 @@ class HuggingfaceLLM(AbstractLLM):
                 quantization_config=bnb_config,
                 *args,
                 **kwargs,
-            ).to(self.device)
+            )
         else:
             self.model = AutoModelForCausalLM.from_pretrained(
                 self.model_id, *args, **kwargs


### PR DESCRIPTION
Description:
Remove breaking .to(device) 

Issue:
```python
ValueError: `.to` is not supported for `4-bit` or `8-bit` bitsandbytes models. Please use the model as it is, since the model has already been set to the correct devices and casted to the correct `dtype`.
```


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--450.org.readthedocs.build/en/450/

<!-- readthedocs-preview swarms end -->