### PR TITLE
Update .env.example quotes around True

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,6 @@ LOG_LEVEL="INFO"
 BOT_NAME="Orca"
 HF_API_KEY="your_huggingface_api_key_here"
 
-USE_TELEMETRY=True
+USE_TELEMETRY="True"
 AGENTOPS_API_KEY=""
 FIREWORKS_API_KEY=""


### PR DESCRIPTION
Environment variables cannot be booleans they must be strings or empty.


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--531.org.readthedocs.build/en/531/

<!-- readthedocs-preview swarms end -->