### PR TITLE
Update agent.py initialize out

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -957,6 +957,7 @@ class Agent(BaseStructure):
         Returns:
             str: The agent history prompt
         """
+        out = ""
         try:
             logger.info(f"Querying long term memory database for {query}")
             ltr = self.long_term_memory.query(query, *args, **kwargs)


### PR DESCRIPTION
To fix the local variable 'out' reference before assigment in running the Agent + LongTerm Memory error:
```
2024-07-11T02:00:55.457112+0000 Couting tokens of retrieved document
2024-07-11T02:00:55.459163+0000 Retrieved document token count 1
2024-07-11T02:00:55.460820+0000 Error querying long term memory: local variable 'out' referenced before assignment
2024-07-11T02:00:55.461227+0000 Attempt 1: Error generating response: local variable 'out' referenced before assignment
```

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--532.org.readthedocs.build/en/532/

<!-- readthedocs-preview swarms end -->