### PR TITLE
Update docker_setup.md remove netcat

### DIFF
--- a/docs/swarms/install/docker_setup.md
+++ b/docs/swarms/install/docker_setup.md
@@ -122,7 +122,7 @@ WORKDIR /usr/src/swarm_cloud
 
 # Install system dependencies
 RUN apt-get update \
-    && apt-get -y install netcat gcc \
+    && apt-get -y install gcc \
     && apt-get clean
 
 # Install Python dependencies


### PR DESCRIPTION
The sample docker file installed netcat which is not available as a package under that name. It's not a needed dependency, so I removed it.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--535.org.readthedocs.build/en/535/

<!-- readthedocs-preview swarms end -->