### PR TITLE
remove 3.9 from python packaging action

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,8 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
+# [ ] TODO [pep 458](https://blog.pypi.org/posts/2024-11-14-pypi-now-supports-digital-attestations/)
+
 name: Python package
 
 on:
@@ -16,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Thank you for contributing to Swarms!

Replace this comment with:
  - Description: remove 3.9 from python packaging action
  - Issue: the minimum python version supported is now, 3.10, this removes testing on the older python
  - Dependencies: none
  - Tag maintainer: 


Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.
    **I will need to clean up quite a bit before I get a clean lint, and test.**

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/kyegomez/swarms/blob/master/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.


Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: kye@apac.ai
  - DataLoaders / VectorStores / Retrievers: kye@apac.ai
  - swarms.models: kye@apac.ai
  - swarms.memory: kye@apac.ai
  - swarms.structures: kye@apac.ai

If no one reviews your PR within a few days, feel free to email Kye at kye@apac.ai

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/kyegomez/swarms

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--644.org.readthedocs.build/en/644/

<!-- readthedocs-preview swarms end -->