### PR TITLE
remove duplicate OPENAI_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,6 @@ BOT_NAME="Orca"
 HF_API_KEY="your_huggingface_api_key_here"
 AGENTOPS_API_KEY=""
 FIREWORKS_API_KEY=""
-OPENAI_API_KEY=your_openai_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 AZURE_OPENAI_ENDPOINT=your_azure_openai_endpoint
 AZURE_OPENAI_DEPLOYMENT=your_azure_openai_deployment


### PR DESCRIPTION
Issue:
      - The issue I am encountering arises from having multiple entries for OPENAI_API_KEY in your .env.example file. When the environment variables are loaded, the latter entry overwrites the former, leading to potential confusion or misconfiguration.

Solution:
	- Remove Duplicate Entries: Ensure that each environment variable is defined only once in your .env.example file. This practice prevents unintended overwrites and maintains clarity.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--712.org.readthedocs.build/en/712/

<!-- readthedocs-preview swarms end -->