### PR TITLE
fix: groupchat needs more than 2 agents

### DIFF
--- a/swarms/structs/groupchat.py
+++ b/swarms/structs/groupchat.py
@@ -248,8 +248,8 @@ class GroupChat:
         Raises:
             ValueError: If any required components are missing or invalid
         """
-        if not self.agents:
-            raise ValueError("No agents provided")
+        if len(self.agents)<2:
+            raise ValueError("At least two agents are required for a group chat")
         if self.speaker_fn is None:
             raise ValueError("No speaker function provided")
         if self.max_loops <= 0:


### PR DESCRIPTION

  - Description: 
This pull request includes an important change to the `reliability_check` method in the `swarms/structs/groupchat.py` file. The change ensures that at least two agents are required for a group chat, improving the reliability check process.

* [`swarms/structs/groupchat.py`](diffhunk://#diff-2f2fa7afc32857b502279c00b02f31a06ea184ed4c2637151f242dcb93767298L251-R252): Modified the `reliability_check` method to raise a `ValueError` if fewer than two agents are provided, ensuring that group chats have a minimum of two agents.


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--776.org.readthedocs.build/en/776/

<!-- readthedocs-preview swarms end -->