### PR TITLE
Update transformers requirement from >=4.39.0,<5.0.0 to >=4.39.0,<4.49.0; LogitsWarper deprecated in transformers version 4.49.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 torch>=2.1.1,<3.0
-transformers>=4.39.0,<5.0.0
+transformers>=4.39.0,<4.49.0
 asyncio>=3.4.3,<4.0
 toml
 pypdf==5.1.0


### PR DESCRIPTION
Update requirements.txt: transformers version <4.49.0, 
LogitsWarper deprecated in  transformers 4.49.0

used in tools/logits_processor.py: 
"""
class OutputNumbersTokens(transformers.LogitsWarper):
"""

This PR addresses an issue caused by the recent release of the transformers library version 4.49.0, where the LogitsWarper class has been deprecated. The tools/logits_processor.py file in the swarms codebase currently references this deprecated class, which may lead to runtime errors.




<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--781.org.readthedocs.build/en/781/

<!-- readthedocs-preview swarms end -->