### PR TITLE
fix: resolve ModuleNotFoundError by adding mcp and fastmcp to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ numpy = "*"
 litellm = "*"
 torch = "*"
 httpx = "*"
+mcp = "*"
+fastmcp = "*"
 
 [tool.poetry.scripts]
 swarms = "swarms.cli.main:main"


### PR DESCRIPTION
- **Description:**  
  This PR resolves runtime import errors by adding `mcp` and `fastmcp` as dependencies in `pyproject.toml`. These packages are essential for enabling MCP-based integrations inside `swarms/tools/mcp_integration.py` and `swarms/tools/mcp_client.py`.

- **Issue Fixed:**  
  Fixes `ModuleNotFoundError: No module named 'mcp'` and `fastmcp` when running `example.py`.  
  Even though `example.py` does not explicitly import these modules, they are required internally via the `Agent` class and related toolchains.

- **Dependencies Added:**  
  - `mcp = "*"`  
  - `fastmcp = "*"`

- **Maintainer Tag:** @kyegomez  
- **Twitter handle (optional):** [@the_complex_one](https://x.com/the_complex_one)

These additions ensure editable installs with `pip install -e .` include all necessary MCP-related modules.
