### PR TITLE
Add Apache Pulsar conversation example

### DIFF
--- a/examples/communication_examples/pulsar_conversation.py
+++ b/examples/communication_examples/pulsar_conversation.py
@@ -15,7 +15,7 @@ agent = Agent(
     model_name="gpt-4o-mini",
     long_term_memory=conversation_store,
     max_loops=1,
-    autosave=True,
+    autosave=False,
 )
 
 response = agent.run("What time is check-out?")


### PR DESCRIPTION
**Description:**  
This PR adds an example under pulsar_conversation.py demonstrating how to use the `PulsarConversation` class to store and retrieve chat history in Apache Pulsar.  
The example shows how to configure a Pulsar-backed conversation store, create an agent that uses this persistent memory, run a sample query, and print both the agent’s response and the stored messages.

**Issue:**  
N/A


**Dependencies:**  
- Requires a running Apache Pulsar broker (default: `pulsar://localhost:6650`)
- Requires the `pulsar-client` Python package (`pip install pulsar-client`)

**Tag maintainer:**  
@kyegomez


---

**Steps to test:**

1. **Start an Apache Pulsar broker** (if not already running):
   ```bash
   docker run -it -p 6650:6650 -p 8080:8080 apachepulsar/pulsar:latest bin/pulsar standalone
   ```

2. **Install the Pulsar Python client:**
   ```bash
   pip install pulsar-client
   ```

3. **Run the example:**
   ```bash
   python examples/communication_examples/pulsar_conversation.py
   ```

4. **Expected output:**
   - The agent’s response to "What time is check-out?"
   - The conversation history as stored in Pulsar


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--869.org.readthedocs.build/en/869/

<!-- readthedocs-preview swarms end -->