### PR TITLE
[fix][compatibility][deps][bugfix][bounty-eligible] Fix field_validator syntax for Pydantic v2

### DIFF
--- a/swarms/structs/agent_rag_handler.py
+++ b/swarms/structs/agent_rag_handler.py
@@ -49,7 +49,7 @@ class RAGConfig(BaseModel):
         default=None, description="Keywords to check for relevance"
     )
 
-    @field_validator("relevance_keywords", pre=True)
+    @field_validator("relevance_keywords", mode="before")
     def set_default_keywords(cls, v):
         if v is None:
             return [
@@ -227,9 +227,12 @@ class AgentRAGHandler:
         formatted_sections = [header]
 
         for i, result in enumerate(results, 1):
-            content, score, source, metadata = (
-                self._extract_result_fields(result)
-            )
+            (
+                content,
+                score,
+                source,
+                metadata,
+            ) = self._extract_result_fields(result)
 
             section = f"""
 [Memory {i}] Relevance: {score} | Source: {source}


### PR DESCRIPTION
**Description:**  
This PR updates the `field_validator` usage in agent_rag_handler.py to be compatible with Pydantic v2.11.4, which is the version pinned in our requirements.txt. The fix ensures that our RAG functionality works correctly with the current dependencies.

**Technical Details:**
- Changed `@field_validator("relevance_keywords", pre=True)` to `@field_validator("relevance_keywords", mode="before")`
- The `pre=True` parameter was valid in Pydantic v1.x but was replaced with `mode="before"` in Pydantic v2.x
- This fixes the `TypeError: field_validator() got an unexpected keyword argument 'pre'` error that was occurring during test execution

**Impact:**
This change ensures that all code dependent on the `RAGConfig` class in agent_rag_handler.py works correctly, including tests and any agent functionality that utilizes RAG capabilities.

**Issue:**  
N/A

**Dependencies:**  
Compatible with Pydantic v2.11.4 as specified in requirements.txt

**Tag maintainer:**  
@kyegomez


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--878.org.readthedocs.build/en/878/

<!-- readthedocs-preview swarms end -->