### PR TITLE
[fix][best-practice][structs][bounty-eligible] Change mutable default parameters to None

### DIFF
--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -63,7 +63,7 @@ class ConcurrentWorkflow(BaseSwarm):
         self,
         name: str = "ConcurrentWorkflow",
         description: str = "Execution of multiple agents concurrently",
-        agents: List[Union[Agent, Callable]] = [],
+        agents: List[Union[Agent, Callable]] = None,
         metadata_output_path: str = "agent_metadata.json",
         auto_save: bool = True,
         output_type: str = "dict-all-except-first",
@@ -77,6 +77,7 @@ class ConcurrentWorkflow(BaseSwarm):
         *args,
         **kwargs,
     ):
+        agents = agents or []
         super().__init__(
             name=name,
             description=description,

--- a/swarms/structs/dynamic_conversational_swarm.py
+++ b/swarms/structs/dynamic_conversational_swarm.py
@@ -52,12 +52,13 @@ class DynamicConversationalSwarm:
         self,
         name: str = "Dynamic Conversational Swarm",
         description: str = "A swarm that uses a dynamic conversational model to solve complex tasks.",
-        agents: List[Agent] = [],
+        agents: List[Agent] = None,
         max_loops: int = 1,
         output_type: str = "list",
         *args,
         **kwargs,
     ):
+        agents = agents or []
         self.name = name
         self.description = description
         self.agents = agents

--- a/swarms/structs/groupchat.py
+++ b/swarms/structs/groupchat.py
@@ -222,12 +222,13 @@ class GroupChat:
         self,
         name: str = "GroupChat",
         description: str = "A group chat for multiple agents",
-        agents: List[Agent] = [],
+        agents: List[Agent] = None,
         speaker_fn: SpeakerFunction = round_robin,
         max_loops: int = 1,
         rules: str = "",
         output_type: str = "string",
     ):
+        agents = agents or []
         self.name = name
         self.description = description
         self.agents = agents

--- a/swarms/structs/interactive_groupchat.py
+++ b/swarms/structs/interactive_groupchat.py
@@ -67,11 +67,12 @@ class InteractiveGroupChat:
         id: str = generate_api_key(prefix="swarms-"),
         name: str = "InteractiveGroupChat",
         description: str = "An interactive group chat for multiple agents",
-        agents: List[Union[Agent, Callable]] = [],
+        agents: List[Union[Agent, Callable]] = None,
         max_loops: int = 1,
         output_type: str = "string",
         interactive: bool = False,
     ):
+        agents = agents or []
         self.id = id
         self.name = name
         self.description = description

--- a/swarms/structs/majority_voting.py
+++ b/swarms/structs/majority_voting.py
@@ -142,7 +142,7 @@ class MajorityVoting:
         self,
         name: str = "MajorityVoting",
         description: str = "A majority voting system for agents",
-        agents: List[Agent] = [],
+        agents: List[Agent] = None,
         output_parser: Optional[Callable] = majority_voting,
         consensus_agent: Optional[Agent] = None,
         autosave: bool = False,
@@ -152,6 +152,7 @@ class MajorityVoting:
         *args,
         **kwargs,
     ):
+        agents = agents or []
         self.name = name
         self.description = description
         self.agents = agents

--- a/swarms/structs/malt.py
+++ b/swarms/structs/malt.py
@@ -167,12 +167,13 @@ class MALT:
         max_loops: int = 1,
         return_list: bool = False,
         return_dict: bool = False,
-        agents: list[Agent] = [],
+        agents: list[Agent] = None,
         preset_agents: bool = True,
     ):
         logger.info(
             "Initializing MALT with provided agents and parameters."
         )
+        agents = agents or []
         self.main_agent = main_agent
         self.refiner_agent = refiner_agent
         self.verifier_agent = verifier_agent

--- a/swarms/structs/mixture_of_agents.py
+++ b/swarms/structs/mixture_of_agents.py
@@ -25,7 +25,7 @@ class MixtureOfAgents:
         self,
         name: str = "MixtureOfAgents",
         description: str = "A class to run a mixture of agents and aggregate their responses.",
-        agents: List[Agent] = [],
+        agents: List[Agent] = None,
         aggregator_agent: Agent = None,
         aggregator_system_prompt: str = aggregator_system_prompt_main,
         layers: int = 3,
@@ -44,6 +44,7 @@ class MixtureOfAgents:
             aggregator_system_prompt (str, optional): The system prompt for the aggregator agent. Defaults to "".
             layers (int, optional): The number of layers to process in the mixture. Defaults to 3.
         """
+        agents = agents or []
         self.name = name
         self.description = description
         self.agents = agents

--- a/swarms/structs/multi_agent_router.py
+++ b/swarms/structs/multi_agent_router.py
@@ -59,7 +59,7 @@ class MultiAgentRouter:
         self,
         name: str = "swarm-router",
         description: str = "Routes tasks to specialized agents based on their capabilities",
-        agents: List[Agent] = [],
+        agents: List[Agent] = None,
         model: str = "gpt-4o-mini",
         temperature: float = 0.1,
         shared_memory_system: callable = None,
@@ -78,6 +78,7 @@ class MultiAgentRouter:
             output_type (Literal["json", "string"], optional): The type of output expected from the agents. Defaults to "json".
             execute_task (bool, optional): A flag indicating whether the task should be executed by the selected agent. Defaults to True.
         """
+        agents = agents or []
         self.name = name
         self.description = description
         self.shared_memory_system = shared_memory_system

--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -31,13 +31,14 @@ class SequentialWorkflow:
         self,
         name: str = "SequentialWorkflow",
         description: str = "Sequential Workflow, where agents are executed in a sequence.",
-        agents: List[Union[Agent, Callable]] = [],
+        agents: List[Union[Agent, Callable]] = None,
         max_loops: int = 1,
         output_type: OutputType = "dict",
         shared_memory_system: callable = None,
         *args,
         **kwargs,
     ):
+        agents = agents or []
         self.name = name
         self.description = description
         self.agents = agents

--- a/swarms/structs/spreadsheet_swarm.py
+++ b/swarms/structs/spreadsheet_swarm.py
@@ -81,7 +81,7 @@ class SpreadSheetSwarm(BaseSwarm):
         self,
         name: str = "Spreadsheet-Swarm",
         description: str = "A swarm that that processes tasks concurrently using multiple agents and saves the metadata to a CSV file.",
-        agents: Union[Agent, List[Agent]] = [],
+        agents: Union[Agent, List[Agent]] = None,
         autosave_on: bool = True,
         save_file_path: str = None,
         max_loops: int = 1,
@@ -90,6 +90,7 @@ class SpreadSheetSwarm(BaseSwarm):
         *args,
         **kwargs,
     ):
+        agents = agents or []
         super().__init__(
             name=name,
             description=description,

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -178,7 +178,7 @@ class SwarmRouter:
         name: str = "swarm-router",
         description: str = "Routes your task to the desired swarm",
         max_loops: int = 1,
-        agents: List[Union[Agent, Callable]] = [],
+        agents: List[Union[Agent, Callable]] = None,
         swarm_type: SwarmType = "SequentialWorkflow",  # "SpreadSheetSwarm" # "auto"
         autosave: bool = False,
         rearrange_flow: str = None,
@@ -197,6 +197,7 @@ class SwarmRouter:
         *args,
         **kwargs,
     ):
+        agents = agents or []
         self.name = name
         self.description = description
         self.max_loops = max_loops


### PR DESCRIPTION

**Description:**  
This PR fixes a common Python anti-pattern by replacing mutable default parameters (empty lists) with `None` across multiple swarm structure classes. This prevents the well-known issue where mutable defaults are instantiated once at definition time rather than per function call, which can lead to unexpected behavior and hard-to-debug issues.

**Technical Details:**
- Changed default parameters from `[]` to `None` in 11 structure classes
- Added the pattern `self.agents = agents or []` inside each constructor
- Classes updated include: `ConcurrentWorkflow`, `DynamicConversationalSwarm`, `GroupChat`, `InteractiveGroupChat`, `MajorityVoting`, `MALT`, `MixtureOfAgents`, `MultiAgentRouter`, `SequentialWorkflow`, `SpreadsheetSwarm`, and `SwarmRouter`
- This follows the Python best practice for handling mutable default arguments

**Impact:**
- Prevents potential bugs where agent lists could be unexpectedly shared between instances
- Makes the code more robust and follows Python best practices
- Maintains backward compatibility with all existing code

**Issue:**  
N/A 

**Dependencies:**  
None

**Tag maintainer:**  
@kyegomez


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--884.org.readthedocs.build/en/884/

<!-- readthedocs-preview swarms end -->