### PR TITLE
replace-conditionals-with-factory-pattern

### DIFF
--- a/swarms/agents/reasoning_agents.py
+++ b/swarms/agents/reasoning_agents.py
@@ -1,4 +1,4 @@
-from typing import List, Literal
+from typing import List, Literal, Dict, Callable, Any
 
 from swarms.agents.consistency_agent import SelfConsistencyAgent
 from swarms.agents.flexion_agent import ReflexionAgent
@@ -7,7 +7,7 @@ from swarms.agents.i_agent import (
     IterativeReflectiveExpansion as IREAgent,
 )
 from swarms.agents.reasoning_duo import ReasoningDuo
-from swarms.utils.output_types import OutputType
+from swarms.structs.output_types import OutputType
 from swarms.agents.agent_judge import AgentJudge
 
 agent_types = Literal[
@@ -21,7 +21,6 @@ agent_types = Literal[
     "GKPAgent",
     "AgentJudge",
 ]
-
 
 class ReasoningAgentRouter:
     """
@@ -61,13 +60,103 @@ class ReasoningAgentRouter:
         self.output_type = output_type
         self.num_knowledge_items = num_knowledge_items
         self.memory_capacity = memory_capacity
+        
+        # Added: Initialize the factory mapping dictionary
+        self._initialize_agent_factories()
+
+    # Added: Factory method initialization function
+    def _initialize_agent_factories(self) -> None:
+        """
+        Initialize the agent factory mapping dictionary, mapping various agent types to their respective creation functions.
+        This method replaces the original if-elif chain, making the code easier to maintain and extend.
+        """
+        self.agent_factories: Dict[str, Callable[[], Any]] = {
+            # ReasoningDuo factory methods
+            "reasoning-duo": self._create_reasoning_duo,
+            "reasoning-agent": self._create_reasoning_duo,
+            
+            # SelfConsistencyAgent factory methods
+            "self-consistency": self._create_consistency_agent,
+            "consistency-agent": self._create_consistency_agent,
+            
+            # IREAgent factory methods
+            "ire": self._create_ire_agent,
+            "ire-agent": self._create_ire_agent,
+            
+            # Other agent type factory methods
+            "AgentJudge": self._create_agent_judge,
+            "ReflexionAgent": self._create_reflexion_agent,
+            "GKPAgent": self._create_gkp_agent
+        }
+
+    # Added: Concrete factory methods for various agent types
+    def _create_reasoning_duo(self):
+        """Creates an agent instance for ReasoningDuo type"""
+        return ReasoningDuo(
+            agent_name=self.agent_name,
+            agent_description=self.description,
+            model_name=[self.model_name, self.model_name],
+            system_prompt=self.system_prompt,
+            output_type=self.output_type,
+        )
+    
+    def _create_consistency_agent(self):
+        """Creates an agent instance for SelfConsistencyAgent type"""
+        return SelfConsistencyAgent(
+            agent_name=self.agent_name,
+            description=self.description,
+            model_name=self.model_name,
+            system_prompt=self.system_prompt,
+            max_loops=self.max_loops,
+            num_samples=self.num_samples,
+            output_type=self.output_type,
+        )
+    
+    def _create_ire_agent(self):
+        """Creates an agent instance for IREAgent type"""
+        return IREAgent(
+            agent_name=self.agent_name,
+            description=self.description,
+            model_name=self.model_name,
+            system_prompt=self.system_prompt,
+            max_loops=self.max_loops,
+            max_iterations=self.num_samples,
+            output_type=self.output_type,
+        )
+    
+    def _create_agent_judge(self):
+        """Creates an agent instance for AgentJudge type"""
+        return AgentJudge(
+            agent_name=self.agent_name,
+            model_name=self.model_name,
+            system_prompt=self.system_prompt,
+            max_loops=self.max_loops,
+        )
+    
+    def _create_reflexion_agent(self):
+        """Creates an agent instance for ReflexionAgent type"""
+        return ReflexionAgent(
+            agent_name=self.agent_name,
+            system_prompt=self.system_prompt,
+            model_name=self.model_name,
+            max_loops=self.max_loops,
+        )
+    
+    def _create_gkp_agent(self):
+        """Creates an agent instance for GKPAgent type"""
+        return GKPAgent(
+            agent_name=self.agent_name,
+            model_name=self.model_name,
+            num_knowledge_items=self.num_knowledge_items,
+        )
 
     def select_swarm(self):
         """
         Selects and initializes the appropriate reasoning swarm based on the specified swarm type.
-
         Returns:
             An instance of the selected reasoning swarm.
+        """
+        # Commented out original if-elif chain implementation
         """
         if (
             self.swarm_type == "reasoning-duo"
@@ -131,6 +220,15 @@ class ReasoningAgentRouter:
                 num_knowledge_items=self.num_knowledge_items,
             )
         else:
+            raise ValueError(f"Invalid swarm type: {self.swarm_type}")
+        """
+        
+        # Added: Implementation using factory pattern and dictionary mapping
+        try:
+            # Get the corresponding creation function from the factory dictionary and call it
+            return self.agent_factories[self.swarm_type]()
+        except KeyError:
+            # Maintain the same error handling as the original code
             raise ValueError(f"Invalid swarm type: {self.swarm_type}")
 
     def run(self, task: str, *args, **kwargs):

--- a/swarms/agents/reasoning_agents.py
+++ b/swarms/agents/reasoning_agents.py
@@ -7,7 +7,7 @@ from swarms.agents.i_agent import (
     IterativeReflectiveExpansion as IREAgent,
 )
 from swarms.agents.reasoning_duo import ReasoningDuo
-from swarms.structs.output_types import OutputType
+from swarms.utils.output_types import OutputType
 from swarms.agents.agent_judge import AgentJudge
 
 agent_types = Literal[


### PR DESCRIPTION
Thank you for contributing to Swarms!

Replace this comment with:
  - Description: 
  Refactored the agent selection mechanism in the ReasoningAgentRouter class by implementing a factory pattern with dictionary mapping to replace the lengthy if-elif chain structure.
 The original code used a long chain of if-elif statements for agent type selection, which becomes increasingly difficult to maintain as the number of supported agent types grows. This refactoring aims to improve:
Efficiency - Dictionary lookups have O(1) time complexity, making them more efficient than long if-elif chains
Maintainability - Each agent type's creation logic is now encapsulated in dedicated methods
Extensibility - Adding new agent types only requires adding a new mapping to the dictionary, without modifying the select_swarm method
Readability - The code structure is cleaner and easier to understand

what i did:
Added an _initialize_agent_factories method to create a mapping dictionary from agent types to factory functions
Created dedicated factory methods for each agent type (e.g., _create_reasoning_duo, etc.)
Refactored the select_swarm method to use dictionary lookup instead of if-elif chain
Maintained the same error handling logic as the original code to ensure backward compatibility


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--898.org.readthedocs.build/en/898/

<!-- readthedocs-preview swarms end -->