### PR TITLE
[fix][dependency][maintenance][bounty-eligible] Replace PyPDF2 with pypdf in long_agent.py

### DIFF
--- a/swarms/structs/long_agent.py
+++ b/swarms/structs/long_agent.py
@@ -1,7 +1,7 @@
 import concurrent.futures
 import os
 from typing import Union, List
-import PyPDF2
+import pypdf
 import markdown
 from pathlib import Path
 from swarms.utils.litellm_tokenizer import count_tokens
@@ -57,7 +57,7 @@ class LongAgent:
 
         text = ""
         with open(file_path, "rb") as file:
-            pdf_reader = PyPDF2.PdfReader(file)
+            pdf_reader = pypdf.PdfReader(file)
             for page in pdf_reader.pages:
                 text += page.extract_text()
 


### PR DESCRIPTION
**Description:**  
This PR updates long_agent.py to remove the deprecated `PyPDF2` dependency and replace it with the modern, actively maintained `pypdf` package. All PDF reading functionality has been migrated to use `pypdf`, ensuring continued compatibility and maintainability. If present, related documentation and requirements should also be updated to reflect this change.

**Key Changes:**
- Replaced all imports and usage of `PyPDF2` with `pypdf` in `long_agent.py`.
- Ensured that PDF extraction logic remains functionally equivalent.
- (If applicable) Update requirements.txt or pyproject.toml to require `pypdf` instead of `PyPDF2`.

**Issue:**  
N/A

**Dependencies:**  
Requires `pypdf` to be installed in the environment.

**Tag maintainer:**  
@kyegomez


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--900.org.readthedocs.build/en/900/

<!-- readthedocs-preview swarms end -->