### PR TITLE
fix Issues#897

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -1051,7 +1051,19 @@ class Agent:
 
                         # # Convert to a str if the response is not a str
                         # if self.mcp_url is None or self.tools is None:
-                        response = self.parse_llm_output(response)
+                        # response = self.parse_llm_output(response)
+                        # Check if response is empty
+                        if (response is None or
+                            (isinstance(response, dict) and not response) or
+                            (isinstance(response, str) and not response.strip()) or
+                            (isinstance(response, list) and not response) or
+                            (hasattr(response, "__len__") and len(response) == 0)):
+                            
+                            # response is empty, assign prompt information
+                            response = {"message": "The LLM return value is empty"}
+                        else:
+                            # response is not empty, perform normal parsing
+                            response = self.parse_llm_output(response)
 
                         self.short_memory.add(
                             role=self.agent_name,


### PR DESCRIPTION
![微信图片_20250620145403](https://github.com/user-attachments/assets/6845dc38-669b-4085-a647-3ec0db33b154)
If we just want to fix the current bug, we don’t need to change a lot of code. We just need to replace “response = self.parse_llm_output(response)” with the part in the red box in the screenshot.
fix #897  

I've reproduced and analyzed this bug. The issue occurs in the _run method of agent.py when dealing with multi-modal requests without images.

Root Cause Analysis:
The main problem is that in your example code, you commented out the image upload line:

python


img=factory_image
This causes the LLM call to receive no image input while in multi-modal mode.

In agent.py, when self.call_llm(...) is executed without proper image data, it returns an empty response.

This empty response is then passed to self.parse_llm_output(response), which tries to standardize the LLM output but fails because there's nothing to parse.

The error becomes visible when executing:

python


self.short_memory.add(
    role=self.agent_name,
    content=format_dict_to_string(response),
)
The format_dict_to_string() method (defined in swarms\utils\index.py) fails because it's trying to format an empty dictionary into a string.

Additional Finding:
I also noticed a potential circular dependency issue in the agent.py file with this function calling pattern:


call_llm → run → _run → call_llm
While this isn't causing the current error (as the dependency between _run → call_llm isn't fully formed), it creates a risky architecture that could lead to infinite recursion and stack overflow errors in future development.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--906.org.readthedocs.build/en/906/

<!-- readthedocs-preview swarms end -->