### PR TITLE
[security][fix][telemetry] Remove token from telemetry script

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,13 @@ OPENAI_API_KEY=""
 WORKSPACE_DIR="agent_workspace"
 ANTHROPIC_API_KEY=""
 GROQ_API_KEY=""
+SWARMS_API_KEY=""
 ```
 
 - [Learn more about the environment configuration here](https://docs.swarms.world/en/latest/swarms/install/env/)
+
+The optional `SWARMS_API_KEY` is used for interacting with the Swarms API and will
+be included in telemetry requests if set.
 
 ---
 

--- a/swarms/telemetry/main.py
+++ b/swarms/telemetry/main.py
@@ -11,6 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from threading import Lock
 from typing import Dict
+import os
 
 import aiohttp
 import pkg_resources
@@ -289,13 +290,14 @@ def get_session() -> Session:
                 )
                 _session.mount("http://", adapter)
                 _session.mount("https://", adapter)
-                _session.headers.update(
-                    {
-                        "Content-Type": "application/json",
-                        "Authorization": "Bearer sk-33979fd9a4e8e6b670090e4900a33dbe7452a15ccc705745f4eca2a70c88ea24",
-                        "Connection": "keep-alive",  # Enable keep-alive
-                    }
-                )
+                headers = {
+                    "Content-Type": "application/json",
+                    "Connection": "keep-alive",  # Enable keep-alive
+                }
+                api_key = os.getenv("SWARMS_API_KEY")
+                if api_key:
+                    headers["Authorization"] = f"Bearer {api_key}"
+                _session.headers.update(headers)
     return _session
 
 
@@ -316,13 +318,14 @@ async def get_aiohttp_session():
             use_dns_cache=True,  # Enable DNS caching
             keepalive_timeout=60,  # Keep-alive timeout
         )
+        headers = {"Content-Type": "application/json"}
+        api_key = os.getenv("SWARMS_API_KEY")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         _aiohttp_session = aiohttp.ClientSession(
             timeout=timeout,
             connector=connector,
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": "Bearer sk-33979fd9a4e8e6b670090e4900a33dbe7452a15ccc705745f4eca2a70c88ea24",
-            },
+            headers=headers,
         )
     return _aiohttp_session
 


### PR DESCRIPTION

**Description:**  
This PR removes the hardcoded API token from the telemetry module and replaces it with dynamic token loading from environment variables. Instead of embedding a token directly in the code, the telemetry client now looks for a `SWARMS_API_KEY` environment variable and includes it in API requests only when available. This change aligns with security best practices by avoiding hardcoded credentials in source code.

**Key Changes:**
- Removed the hardcoded API token from main.py.
- Modified the session creation to include the API key from `os.getenv("SWARMS_API_KEY")` only if provided.
- Added documentation for the `SWARMS_API_KEY` environment variable in README.md.
- Added proper import for the `os` module.

**Issue:**  
N/A 

**Dependencies:**  
None

**Tag maintainer:**  
@kyegomez


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--920.org.readthedocs.build/en/920/

<!-- readthedocs-preview swarms end -->