### PR TITLE
[FEAT][Implement token by token streaming in Agent.py] #921

### DIFF
--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -449,7 +449,12 @@ class LiteLLM:
             # Make the completion call
             response = completion(**completion_params)
 
-            # Handle tool-based response
+            # If streaming is enabled, return the response generator directly.
+            # The Agent class will handle iterating through it.
+            if self.stream:
+                return response
+
+            # If not streaming, process the complete response object as before.
             if self.tools_list_dictionary is not None:
                 return self.output_for_tools(response)
             elif self.return_all is True:


### PR DESCRIPTION
This PR adds token streaming to the Agent class.

When streaming_on=True, the agent's responses will now print to the console token-by-token for a more interactive feel. This is handled by updating the LiteLLM wrapper to return the raw stream and having the Agent class iterate through it.

Also includes a fix for an AuthenticationError by ensuring the llm_api_key is correctly passed through all relevant methods.

Note: This requires the litellm package to be installed (pip install litellm)
![2025-06-26_12-33](https://github.com/user-attachments/assets/0815fd85-958d-435f-bad4-22405015446e)


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--926.org.readthedocs.build/en/926/

<!-- readthedocs-preview swarms end -->