### PR TITLE
fix random_speaker issues 

### DIFF
--- a/swarms/structs/interactive_groupchat.py
+++ b/swarms/structs/interactive_groupchat.py
@@ -947,6 +947,30 @@ Remember: You are part of a team. Your response should reflect that you've read,
         for agent_name in speaking_order:
             self._get_agent_response(agent_name, img, imgs)
 
+    def _process_random_speaker(
+        self,
+        mentioned_agents: List[str],
+        img: Optional[str],
+        imgs: Optional[List[str]],
+    ) -> None:
+        """
+        Process responses using the random speaker function.
+        This function randomly selects a single agent from the mentioned agents
+        to respond to the user query.
+        """
+        # Filter out invalid agents
+        valid_agents = [name for name in mentioned_agents if name in self.agent_map]
+        
+        if not valid_agents:
+            raise AgentNotFoundError("No valid agents found in the conversation")
+        
+        # Randomly select exactly one agent to respond
+        random_agent = random.choice(valid_agents)
+        logger.info(f"Random speaker selected: {random_agent}")
+        
+        # Get response from the randomly selected agent
+        self._get_agent_response(random_agent, img, imgs)
+
     def run(
         self,
         task: str,
@@ -972,6 +996,11 @@ Remember: You are part of a team. Your response should reflect that you've read,
                 self._process_dynamic_speakers(
                     mentioned_agents, img, imgs
                 )
+            elif self.speaker_function == random_speaker:
+                # Use the specialized function for random_speaker
+                self._process_random_speaker(
+                    mentioned_agents, img, imgs
+                )    
             else:
                 self._process_static_speakers(
                     mentioned_agents, img, imgs


### PR DESCRIPTION
After fix, run the example video:https://www.loom.com/share/7dd7772c9b8847e69c02c1a1b1597a8c?sid=67b8a668-6211-4893-8c25-f7bf92f71540

Problem
In the current implementation, when users select random_speaker, the system doesn't select a single agent to respond as expected. Instead, it returns responses from all agents, with their order randomly shuffled. This behavior contradicts the intended functionality of random_speaker, which should randomly select exactly one agent to respond to the user's question.

Solution
This PR implements proper random speaker functionality by:

Add a dedicated _process_random_speaker method to handle the case where the user selects random_speaker

Modifying the run method to detect when random_speaker is selected and route execution to our new specialized handler
Ensuring proper logging and error handling consistent with the existing codebase
close #907 
close #945  

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--973.org.readthedocs.build/en/973/

<!-- readthedocs-preview swarms end -->