### PR TITLE
Fixed mcp_ds.md routing for documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -346,6 +346,7 @@ nav:
       - Overview: "deployment_solutions/overview.md"
       - FastAPI + Uvicorn: "deployment_solutions/fastapi_agent_api.md"
       - CronJob: "swarms/structs/cron_job.md"
+      - Agent on MCP: "examples/mcp_ds.md"
       - Providers:
         - Deploy on Google Cloud Run: "swarms_cloud/cloud_run.md"
         - Deploy on Phala: "swarms_cloud/phala_deploy.md"


### PR DESCRIPTION
- Description: changed the connection method for "Agent on MCP" on full documentation (as has been routed the wrong way within the files)


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1069.org.readthedocs.build/en/1069/

<!-- readthedocs-preview swarms end -->