### PR TITLE
[BUGF-ASB][Fixed AttrError in ASB]

### DIFF
--- a/swarms/structs/auto_swarm_builder.py
+++ b/swarms/structs/auto_swarm_builder.py
@@ -407,6 +407,10 @@ class AutoSwarmBuilder:
             model = self.build_llm_agent(config=Agents)
 
             agents_dictionary = model.run(task)
+            
+            # Parse JSON string if needed
+            if isinstance(agents_dictionary, str):
+                agents_dictionary = json.loads(agents_dictionary)
 
             return agents_dictionary
 
@@ -437,6 +441,10 @@ class AutoSwarmBuilder:
             swarm_spec = model.run(
                 f"Create the swarm spec for the following task: {task}"
             )
+            
+            # Parse JSON string if needed
+            if isinstance(swarm_spec, str):
+                swarm_spec = json.loads(swarm_spec)
 
             print(swarm_spec)
 
@@ -503,8 +511,16 @@ class AutoSwarmBuilder:
             # Convert dict to AgentSpec if needed
             if isinstance(agent_config, dict):
                 agent_config = AgentSpec(**agent_config)
+            
+            # Convert AgentSpec to dict for Agent constructor
+            if hasattr(agent_config, 'dict'):
+                agent_dict = agent_config.dict()
+            elif hasattr(agent_config, 'model_dump'):
+                agent_dict = agent_config.model_dump()
+            else:
+                agent_dict = agent_config
 
-            agent = Agent(**agent_config)
+            agent = Agent(**agent_dict)
             agents.append(agent)
 
         return agents
@@ -535,6 +551,8 @@ class AutoSwarmBuilder:
 
             if self.execution_type == "return-agents":
                 return self.create_agents(task)
+            elif self.execution_type == "execute-swarm-router":
+                return self._execute_task(task)
             elif self.execution_type == "return-swarm-router-config":
                 return self.create_router_config(task)
             elif self.execution_type == "return-agents-objects":

--- a/swarms/structs/ma_utils.py
+++ b/swarms/structs/ma_utils.py
@@ -131,9 +131,11 @@ def set_random_models_for_agents(
         return random.choice(model_names)
 
     if isinstance(agents, list):
-        for agent in agents:
+        return [
             setattr(agent, "model_name", random.choice(model_names))
-        return agents
+            or agent
+            for agent in agents
+        ]
     else:
         setattr(agents, "model_name", random.choice(model_names))
         return agents

--- a/swarms/structs/ma_utils.py
+++ b/swarms/structs/ma_utils.py
@@ -131,11 +131,9 @@ def set_random_models_for_agents(
         return random.choice(model_names)
 
     if isinstance(agents, list):
-        return [
+        for agent in agents:
             setattr(agent, "model_name", random.choice(model_names))
-            or agent
-            for agent in agents
-        ]
+        return agents
     else:
         setattr(agents, "model_name", random.choice(model_names))
         return agents


### PR DESCRIPTION
## Description
Fixed multiple issues in AutoSwarmBuilder that were preventing the execute-swarm-router execution type from working correctly.

## Issue
https://github.com/kyegomez/swarms/issues/1115

## Dependencies
No new dependencies required.

## Tag maintainer
@kyegomez 

## Twitter handle
https://x.com/IlumTheProtogen

## Code Changes

### Problem: Missing execute-swarm-router execution type in run method
```python
# OLD CODE (broken):
def run(self, task: str, *args, **kwargs):
    try:
        if self.execution_type == "return-agents":
            return self.create_agents(task)
        elif self.execution_type == "return-swarm-router-config":
            return self.create_router_config(task)
        elif self.execution_type == "return-agents-objects":
            agents = self.create_agents(task)
            return self.create_agents_from_specs(agents)
        else:
            raise ValueError(f"Invalid execution type: {self.execution_type}")
```
The execute-swarm-router execution type was missing, preventing _execute_task from being called.

### Solution: Added execute-swarm-router execution type
```python
# NEW CODE (working):
def run(self, task: str, *args, **kwargs):
    try:
        if self.execution_type == "return-agents":
            return self.create_agents(task)
        elif self.execution_type == "execute-swarm-router":
            return self._execute_task(task)
        elif self.execution_type == "return-swarm-router-config":
            return self.create_router_config(task)
        elif self.execution_type == "return-agents-objects":
            agents = self.create_agents(task)
            return self.create_agents_from_specs(agents)
        else:
            raise ValueError(f"Invalid execution type: {self.execution_type}")
```

### Problem: Missing JSON parsing in create_agents method
```python
# OLD CODE (broken):
def create_agents(self, task: str):
    try:
        logger.info("Creating agents from specifications")
        model = self.build_llm_agent(config=Agents)
        agents_dictionary = model.run(task)
        return agents_dictionary
```
The LLM returns a JSON string, but the code expected a dictionary.

### Solution: Added JSON parsing
```python
# NEW CODE (working):
def create_agents(self, task: str):
    try:
        logger.info("Creating agents from specifications")
        model = self.build_llm_agent(config=Agents)
        agents_dictionary = model.run(task)
        
        # Parse JSON string if needed
        if isinstance(agents_dictionary, str):
            agents_dictionary = json.loads(agents_dictionary)
        
        return agents_dictionary
```

### Problem: AgentSpec to Agent conversion issue
```python
# OLD CODE (broken):
for agent_config in agents_list:
    if isinstance(agent_config, dict):
        agent_config = AgentSpec(**agent_config)
    agent = Agent(**agent_config)  # TypeError: Agent() argument after ** must be a mapping, not AgentSpec
```

### Solution: Convert AgentSpec to dictionary
```python
# NEW CODE (working):
for agent_config in agents_list:
    if isinstance(agent_config, dict):
        agent_config = AgentSpec(**agent_config)
    
    # Convert AgentSpec to dict for Agent constructor
    if hasattr(agent_config, 'dict'):
        agent_dict = agent_config.dict()
    elif hasattr(agent_config, 'model_dump'):
        agent_dict = agent_config.model_dump()
    else:
        agent_dict = agent_config

    agent = Agent(**agent_dict)
    agents.append(agent)
```

The fix ensures AutoSwarmBuilder can successfully create agents and execute swarm workflows with the execute-swarm-router execution type.
