### PR TITLE
[QUICKFIX][Quickfix added to /requirements.txt to mimic pyproject.toml config surrounding winloop]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,5 @@ mcp
 numpy
 orjson
 schedule
-uvloop
-winloop
+uvloop; sys_platform == 'linux' or sys_platform == 'darwin' # linux or macos only
+winloop; sys_platform == 'win32' # windows only


### PR DESCRIPTION
# In `requirements.txt` 

Before:
``uvloop``
``winloop``
After:
``uvloop; sys_platform == 'linux' or sys_platform == 'darwin' # linux or macos only``
``winloop; sys_platform == 'win32' # windows only``

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1121.org.readthedocs.build/en/1121/

<!-- readthedocs-preview swarms end -->