### PR TITLE
[BUGF-ATTR][Fixed Autosave Attr-error]

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2406,12 +2406,14 @@ class Agent:
             Dict[str, Any]: A dictionary representation of the class attributes.
         """
 
-        # Remove the llm object from the dictionary
-        self.__dict__.pop("llm", None)
+        # Create a copy of the dict to avoid mutating the original object
+        # Remove the llm object from the copy since it's not serializable
+        dict_copy = self.__dict__.copy()
+        dict_copy.pop("llm", None)
 
         return {
             attr_name: self._serialize_attr(attr_name, attr_value)
-            for attr_name, attr_value in self.__dict__.items()
+            for attr_name, attr_value in dict_copy.items()
         }
 
     def to_json(self, indent: int = 4, *args, **kwargs):


### PR DESCRIPTION
Description: Fix AttributeError in Agent.to_dict() method when autosave=True

Issue: https://github.com/kyegomez/swarms/issues/1125

Root Cause:
The to_dict() method at line 2410 in swarms/structs/agent.py permanently removed the llm attribute from the agent instance:

```python
def to_dict(self) -> Dict[str, Any]:
    # BUG: This permanently removes llm from the instance
    self.__dict__.pop("llm", None)
    
    return {
        attr_name: self._serialize_attr(attr_name, attr_value)
        for attr_name, attr_value in self.__dict__.items()
    }
```

When autosave=True, the agent initialization calls log_agent_data(self.to_dict()) at line 673, which triggers to_dict() and removes the llm attribute. Later, when the code checks if self.llm is None at line 678, it fails because the attribute no longer exists.

Fix:
Modified to_dict() to create a copy of __dict__ instead of mutating the original:

```python
def to_dict(self) -> Dict[str, Any]:
    # Create a copy of the dict to avoid mutating the original object
    # Remove the llm object from the copy since it's not serializable
    dict_copy = self.__dict__.copy()
    dict_copy.pop("llm", None)

    return {
        attr_name: self._serialize_attr(attr_name, attr_value)
        for attr_name, attr_value in dict_copy.items()
    }
```

Reproduction:
```python
from swarms import Agent

agent = Agent(
    agent_name="test",
    autosave=True  # Causes AttributeError
)
```

Dependencies: None

Tag maintainer: @kyegomez 

x: https://[x.com/IlumTheProtogen](https://x.com/IlumTheProtogen)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1126.org.readthedocs.build/en/1126/

<!-- readthedocs-preview swarms end -->