### PR TITLE
feat: Add tests for any_to_str and str_to_dict utilities

### DIFF
--- a/tests/utils/test_any_to_str.py
+++ b/tests/utils/test_any_to_str.py
@@ -1,11 +1,7 @@
 import pytest
-import logging
 
+from loguru import logger
 from swarms.utils.any_to_str import any_to_str
-
-# Configure logging for tests
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
 
 
 class TestAnyToStr:

--- a/tests/utils/test_str_to_dict.py
+++ b/tests/utils/test_str_to_dict.py
@@ -1,12 +1,8 @@
 import pytest
 import json
-import logging
 
+from loguru import logger
 from swarms.utils.str_to_dict import str_to_dict
-
-# Configure logging for tests
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
 
 
 class TestStrToDict:


### PR DESCRIPTION
- Adds  test coverage for two previously untested utilities:
      - `any_to_str`: Converts Python objects (dicts, lists, tuples, etc.) to formatted strings
      - `str_to_dict`: Converts JSON strings to Python dictionaries
- No new dependencies required. Uses existing test infrastructure

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1165.org.readthedocs.build/en/1165/

<!-- readthedocs-preview swarms end -->