### PR TITLE
[BUG-FIX] Reflexion Agent task attribute error

### DIFF
--- a/swarms/agents/reasoning_agents.py
+++ b/swarms/agents/reasoning_agents.py
@@ -284,8 +284,12 @@ class ReasoningAgentRouter:
             The result of the reasoning process (format depends on agent and output_type).
         """
         try:
-            swarm = self.select_swarm()
-            return swarm.run(task=task, *args, **kwargs)
+            if self.swarm_type == "ReflexionAgent":
+                swarm = self.select_swarm()
+                return swarm.run(tasks=[task], *args, **kwargs)
+            else:
+                swarm = self.select_swarm()
+                return swarm.run(task=task, *args, **kwargs)
         except Exception as e:
             raise ReasoningAgentExecutorError(
                 f"ReasoningAgentRouter Error: {e} Traceback: {traceback.format_exc()} If the error persists, please check the agent's configuration and try again. If you would like support book a call with our team at https://cal.com/swarms"


### PR DESCRIPTION
- Description: attribute task was not taking in tasks with reasoning router. So, added term to make sure task is executed for Reflexion agent specifically.
- Video: https://www.loom.com/share/a0fc89fa632345048fb08d09d1549d30

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1205.org.readthedocs.build/en/1205/

<!-- readthedocs-preview swarms end -->