### PR TITLE
fixed reasoning agent to not use sonnet

### DIFF
--- a/swarms/agents/reasoning_agents.py
+++ b/swarms/agents/reasoning_agents.py
@@ -90,7 +90,7 @@ class ReasoningAgentRouter:
         majority_voting_prompt: Optional[str] = None,
         reasoning_model_name: Optional[
             str
-        ] = "claude-3-5-sonnet-20240620",
+        ] = "gpt-4o",
     ):
         """
         Initialize the ReasoningAgentRouter with the specified configuration.

--- a/swarms/agents/reasoning_duo.py
+++ b/swarms/agents/reasoning_duo.py
@@ -37,7 +37,7 @@ class ReasoningDuo:
         output_type: OutputType = "dict-all-except-first",
         reasoning_model_name: Optional[
             str
-        ] = "claude-3-5-sonnet-20240620",
+        ] = "gpt-4o",
         max_loops: int = 1,
         *args,
         **kwargs,

--- a/tests/structs/test_reasoning_agent_router.py
+++ b/tests/structs/test_reasoning_agent_router.py
@@ -6,6 +6,9 @@ from swarms.agents.reasoning_agents import (
     ReasoningAgentInitializationError,
     ReasoningAgentRouter,
 )
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def test_router_initialization():
@@ -55,7 +58,7 @@ def test_router_initialization():
             eval=True,
             random_models_on=True,
             majority_voting_prompt="Custom voting prompt",
-            reasoning_model_name="claude-3-5-sonnet-20240620",
+            reasoning_model_name="gpt-4o",
         )
         assert (
             custom_router is not None


### PR DESCRIPTION
Error:
litellm.exceptions.NotFoundError: AnthropicException - {
"type": "error",
"error": {
"type": "not_found_error",
"message": "model: claude-3-5-sonnet-20240620"
}
}

Root Cause: The default reasoning_model_name parameter used
claude-3-5-sonnet-20240620, which is not available or has been deprecated by
Anthropic.

Solution: Changed default reasoning model to gpt-4o, which is stable and
widely available.

Files Modified:

swarms/agents/reasoning_agents.py:93
swarms/agents/reasoning_duo.py:40
test_reasoning_agent_router.py:58, 253


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1220.org.readthedocs.build/en/1220/

<!-- readthedocs-preview swarms end -->