### PR TITLE
[FEAT] Add CLI feature to fetch and install agents from Swarms market…

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -365,6 +365,7 @@ nav:
       - YAML Configuration: "swarms/cli/cli_yaml_guide.md"
       - LLM Council CLI: "swarms/cli/cli_llm_council_guide.md"
       - Heavy Swarm CLI: "swarms/cli/cli_heavy_swarm_guide.md"
+      - Marketplace CLI: "swarms/cli/cli_marketplace_guide.md"
       - CLI Multi-Agent Commands: "examples/cli_multi_agent_quickstart.md"
       - CLI Examples: "swarms/cli/cli_examples.md"
 

--- a/docs/swarms/cli/cli_marketplace_guide.md
+++ b/docs/swarms/cli/cli_marketplace_guide.md
@@ -1,0 +1,217 @@
+# Swarms CLI Marketplace Guide
+
+The Swarms CLI marketplace commands allow you to search, browse, and install agents from the [Swarms Marketplace](https://swarms.world).
+
+## Prerequisites
+
+1. **API Key**: Set your `SWARMS_API_KEY` environment variable:
+   ```bash
+   export SWARMS_API_KEY="your-api-key-here"
+   ```
+   Get your API key at: [https://swarms.world/platform/api-keys](https://swarms.world/platform/api-keys)
+
+2. **Install Swarms**:
+   ```bash
+   pip install swarms
+   ```
+
+## Commands Overview
+
+| Command | Description |
+|---------|-------------|
+| `swarms marketplace` | Show marketplace help |
+| `swarms marketplace list` | List available agents |
+| `swarms marketplace search` | Search for agents |
+| `swarms marketplace info <id>` | View agent details |
+| `swarms marketplace install <id>` | Install agent locally |
+
+## Command Reference
+
+### List Agents
+
+List all available agents in the marketplace:
+
+```bash
+swarms marketplace list
+```
+
+**Options:**
+- `--limit <n>`: Maximum results (default: 20, max: 100)
+- `--category <cat>`: Filter by category
+- `--free-only`: Show only free agents
+
+**Examples:**
+```bash
+# List first 10 agents
+swarms marketplace list --limit 10
+
+# List free agents only
+swarms marketplace list --free-only
+
+# List agents in finance category
+swarms marketplace list --category finance
+```
+
+### Search Agents
+
+Search for agents by keyword:
+
+```bash
+swarms marketplace search --query "keyword"
+```
+
+**Options:**
+- `--query <text>`: Search keyword (searches name, description, tags)
+- `--category <cat>`: Filter by category
+- `--free-only`: Show only free agents
+- `--limit <n>`: Maximum results
+
+**Examples:**
+```bash
+# Search for trading agents
+swarms marketplace search --query "trading"
+
+# Search in finance category
+swarms marketplace search --query "analysis" --category "finance"
+
+# Search free agents only
+swarms marketplace search --query "automation" --free-only
+```
+
+### View Agent Details
+
+Get detailed information about a specific agent:
+
+```bash
+swarms marketplace info <agent-id>
+```
+
+**Example:**
+```bash
+swarms marketplace info a2e3d0d3-9b6a-40a3-9904-000f2e1d03e3
+```
+
+This displays:
+- Agent name and description
+- Category and language
+- Price (free or paid)
+- Tags and requirements
+- Use cases
+
+### Install Agent
+
+Download and install an agent to your local directory:
+
+```bash
+swarms marketplace install <agent-id>
+```
+
+**Options:**
+- `--output-dir <path>`: Directory to save the agent (default: current directory)
+
+**Examples:**
+```bash
+# Install to current directory
+swarms marketplace install a2e3d0d3-9b6a-40a3-9904-000f2e1d03e3
+
+# Install to specific directory
+swarms marketplace install a2e3d0d3-9b6a-40a3-9904-000f2e1d03e3 --output-dir ./my_agents
+```
+
+The installed file includes:
+- Agent metadata as docstring
+- Requirements as comments
+- Agent code or template
+
+## Available Categories
+
+- `finance`
+- `research`
+- `coding`
+- `content`
+- `data-analysis`
+- `automation`
+- `customer-service`
+- `healthcare`
+- `legal`
+- `marketing`
+- `education`
+- `general`
+
+## Python API
+
+You can also use the marketplace programmatically:
+
+```python
+from swarms.utils.agent_marketplace import (
+    query_agents,
+    get_agent_by_id,
+    install_agent,
+    list_available_categories,
+)
+
+# List categories
+categories = list_available_categories()
+
+# Search agents
+result = query_agents(search="trading", category="finance", limit=10)
+agents = result["agents"]
+
+# Get agent details
+agent = get_agent_by_id("agent-uuid-here")
+
+# Install agent
+result = install_agent(agent_id="agent-uuid-here", output_dir="./agents")
+print(f"Installed to: {result['file_path']}")
+```
+
+## Typical Workflow
+
+1. **Search** for agents matching your needs:
+   ```bash
+   swarms marketplace search --query "customer service"
+   ```
+
+2. **Review** the list and note the agent ID
+
+3. **Get details** about a specific agent:
+   ```bash
+   swarms marketplace info <agent-id>
+   ```
+
+4. **Install** the agent:
+   ```bash
+   swarms marketplace install <agent-id> --output-dir ./agents
+   ```
+
+5. **Use** the agent in your code:
+   ```python
+   from agents.my_agent import agent
+   result = agent.run("Your task here")
+   ```
+
+## Troubleshooting
+
+### API Key Error
+```
+Swarms API key is not set
+```
+**Solution:** Set your `SWARMS_API_KEY` environment variable or add it to your `.env` file.
+
+### Agent Not Found
+```
+Agent with ID 'xxx' not found
+```
+**Solution:** Verify the agent ID is correct using `swarms marketplace list`.
+
+### Rate Limit Exceeded
+```
+HTTP 429: Too Many Requests
+```
+**Solution:** The API has a limit of 500 requests per day. Wait until midnight UTC for reset.
+
+## Support
+
+- Documentation: [https://docs.swarms.world](https://docs.swarms.world)
+- Marketplace: [https://swarms.world](https://swarms.world)
+- Issues: [https://github.com/kyegomez/swarms/issues](https://github.com/kyegomez/swarms/issues)

--- a/docs/swarms/cli/cli_reference.md
+++ b/docs/swarms/cli/cli_reference.md
@@ -16,6 +16,7 @@ The Swarms CLI is a comprehensive command-line interface for managing and execut
   - [setup-check Command](#setup-check-command)
   - [llm-council Command](#llm-council-command)
   - [heavy-swarm Command](#heavy-swarm-command)
+  - [marketplace Command](#marketplace-command)
   - [features Command](#features-command)
 - [Error Handling](#error-handling)
 - [Examples](#examples)
@@ -63,6 +64,7 @@ swarms <command> [options]
 | `setup-check` | Run comprehensive environment setup check | None |
 | `llm-council` | Run LLM Council with multiple agents collaborating on a task | `--task` |
 | `heavy-swarm` | Run HeavySwarm with specialized agents for complex task analysis | `--task` |
+| `marketplace` | Search, browse, and install agents from Swarms Marketplace | Subcommand |
 
 ## Global Arguments
 
@@ -340,6 +342,60 @@ HeavySwarm includes specialized agents for different aspects of analysis:
 - Technical analysis and evaluation
 - Comprehensive report generation
 - Multi-faceted problem solving
+
+### `marketplace` Command
+
+Search, browse, and install agents from the [Swarms Marketplace](https://swarms.world).
+
+```bash
+swarms marketplace <action> [options]
+```
+
+#### Actions
+
+| Action | Description |
+|--------|-------------|
+| `search` | Search for agents by keyword |
+| `list` | List available agents |
+| `info <id>` | View agent details |
+| `install <id>` | Install agent locally |
+
+#### Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `--query` | `str` | None | Search keyword for agent names/descriptions |
+| `--category` | `str` | None | Filter by category |
+| `--free-only` | `bool` | `False` | Show only free agents |
+| `--limit` | `int` | `20` | Maximum results (1-100) |
+| `--output-dir` | `str` | `.` | Directory for installed agents |
+
+**Examples:**
+```bash
+# Show marketplace help
+swarms marketplace
+
+# List available agents
+swarms marketplace list --limit 10
+
+# Search for agents
+swarms marketplace search --query "trading" --category "finance"
+
+# View agent details
+swarms marketplace info a2e3d0d3-9b6a-40a3-9904-000f2e1d03e3
+
+# Install agent to directory
+swarms marketplace install a2e3d0d3-9b6a-40a3-9904-000f2e1d03e3 --output-dir ./agents
+```
+
+**Available Categories:**
+`finance`, `research`, `coding`, `content`, `data-analysis`, `automation`, `customer-service`, `healthcare`, `legal`, `marketing`, `education`, `general`
+
+**Prerequisites:**
+- Set `SWARMS_API_KEY` environment variable
+- Get your API key at: [https://swarms.world/platform/api-keys](https://swarms.world/platform/api-keys)
+
+For detailed documentation, see [CLI Marketplace Guide](cli_marketplace_guide.md).
 
 ### `features` Command
 

--- a/examples/marketplace/marketplace_cli_example.py
+++ b/examples/marketplace/marketplace_cli_example.py
@@ -1,0 +1,196 @@
+"""
+Swarms Marketplace CLI Examples
+
+This file demonstrates how to use the Swarms marketplace CLI commands
+to search, browse, and install agents from the Swarms marketplace.
+
+Prerequisites:
+1. Set your SWARMS_API_KEY environment variable:
+   export SWARMS_API_KEY="your-api-key-here"
+
+   Get your API key at: https://swarms.world/platform/api-keys
+
+2. Install swarms:
+   pip install swarms
+
+Usage Examples (run these in your terminal):
+"""
+
+# =============================================================================
+# CLI COMMAND EXAMPLES
+# =============================================================================
+
+CLI_EXAMPLES = """
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. SEARCH FOR AGENTS
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Search by keyword
+swarms marketplace search --query "trading"
+
+# Search by category
+swarms marketplace search --category "finance"
+
+# Search with multiple filters
+swarms marketplace search --query "analysis" --category "data-analysis" --free-only
+
+# Limit results
+swarms marketplace search --query "automation" --limit 10
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. LIST ALL AGENTS
+# ─────────────────────────────────────────────────────────────────────────────
+
+# List all available agents
+swarms marketplace list
+
+# List only free agents
+swarms marketplace list --free-only
+
+# List agents in a specific category
+swarms marketplace list --category "coding"
+
+# List with custom limit
+swarms marketplace list --limit 50
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. VIEW AGENT DETAILS
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Get detailed information about an agent
+swarms marketplace info <agent-id>
+
+# Example with a real ID:
+# swarms marketplace info 550e8400-e29b-41d4-a716-446655440000
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. INSTALL AGENTS
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Install to current directory
+swarms marketplace install <agent-id>
+
+# Install to a specific directory
+swarms marketplace install <agent-id> --output-dir ./my_agents
+
+# Install to agents folder
+swarms marketplace install <agent-id> --output-dir ./agents
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. GET HELP
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Show marketplace help
+swarms marketplace
+
+# Show all available CLI commands
+swarms help
+"""
+
+# =============================================================================
+# PROGRAMMATIC USAGE (Python API)
+# =============================================================================
+
+def example_programmatic_usage():
+    """
+    Example of using the marketplace utilities programmatically in Python.
+    """
+    from swarms.utils.agent_marketplace import (
+        query_agents,
+        get_agent_by_id,
+        install_agent,
+        list_available_categories,
+    )
+
+    # List available categories
+    categories = list_available_categories()
+    print(f"Available categories: {categories}")
+
+    # Search for agents
+    results = query_agents(
+        search="trading",
+        category="finance",
+        price_filter="free",
+        limit=10,
+    )
+    print(f"Found agents: {results}")
+
+    # Get agent details
+    # agent = get_agent_by_id("your-agent-id-here")
+    # print(f"Agent details: {agent}")
+
+    # Install an agent
+    # result = install_agent(
+    #     agent_id="your-agent-id-here",
+    #     output_dir="./my_agents"
+    # )
+    # print(f"Installation result: {result}")
+
+
+# =============================================================================
+# WORKFLOW EXAMPLE
+# =============================================================================
+
+WORKFLOW_EXAMPLE = """
+TYPICAL WORKFLOW:
+
+1. First, search for agents that match your needs:
+   $ swarms marketplace search --query "customer service" --category "automation"
+
+2. Review the list and find an agent you like. Note its ID.
+
+3. Get more details about the agent:
+   $ swarms marketplace info abc123-def456
+
+4. Install the agent to your project:
+   $ swarms marketplace install abc123-def456 --output-dir ./agents
+
+5. The agent file will be created with all metadata and code.
+   You can then import and use it in your project:
+
+   from agents.customer_service_agent import agent
+   result = agent.run("Help me with a customer inquiry")
+"""
+
+# =============================================================================
+# AVAILABLE CATEGORIES
+# =============================================================================
+
+CATEGORIES = [
+    "finance",
+    "research",
+    "coding",
+    "content",
+    "data-analysis",
+    "automation",
+    "customer-service",
+    "healthcare",
+    "legal",
+    "marketing",
+    "education",
+    "general",
+]
+
+
+if __name__ == "__main__":
+    print("=" * 70)
+    print("SWARMS MARKETPLACE CLI EXAMPLES")
+    print("=" * 70)
+    print(CLI_EXAMPLES)
+    print("\n" + "=" * 70)
+    print("WORKFLOW EXAMPLE")
+    print("=" * 70)
+    print(WORKFLOW_EXAMPLE)
+    print("\n" + "=" * 70)
+    print("AVAILABLE CATEGORIES")
+    print("=" * 70)
+    for cat in CATEGORIES:
+        print(f"  - {cat}")
+    print("\n" + "=" * 70)
+    print("For more info: https://docs.swarms.world")
+    print("Get API key: https://swarms.world/platform/api-keys")
+    print("=" * 70)

--- a/swarms/utils/__init__.py
+++ b/swarms/utils/__init__.py
@@ -35,6 +35,12 @@ from swarms.utils.output_types import HistoryOutputType
 from swarms.utils.parse_code import extract_code_from_markdown
 from swarms.utils.pdf_to_text import pdf_to_text
 from swarms.utils.try_except_wrapper import try_except_wrapper
+from swarms.utils.agent_marketplace import (
+    query_agents,
+    get_agent_by_id,
+    install_agent,
+    list_available_categories,
+)
 
 __all__ = [
     "csv_to_text",
@@ -60,4 +66,8 @@ __all__ = [
     "LiteLLM",
     "NetworkConnectionError",
     "LiteLLMException",
+    "query_agents",
+    "get_agent_by_id",
+    "install_agent",
+    "list_available_categories",
 ]

--- a/swarms/utils/agent_marketplace.py
+++ b/swarms/utils/agent_marketplace.py
@@ -1,0 +1,323 @@
+"""
+Agent Marketplace Utilities
+
+This module provides utilities for interacting with the Swarms Agent Marketplace API.
+It supports searching, listing, fetching details, and installing agents from the marketplace.
+
+Environment Variables:
+    SWARMS_API_KEY: Required API key for authenticated requests.
+
+Example:
+    >>> from swarms.utils.agent_marketplace import query_agents, install_agent
+    >>> agents = query_agents(search="trading", category="finance")
+    >>> install_agent(agent_id="abc123", output_dir="./agents")
+"""
+
+import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+from loguru import logger
+
+from swarms.utils.swarms_marketplace_utils import check_swarms_api_key
+
+
+BASE_URL = "https://swarms.world"
+
+
+def query_agents(
+    search: Optional[str] = None,
+    category: Optional[str] = None,
+    free_only: bool = False,
+    limit: int = 20,
+    timeout: float = 30.0,
+) -> Dict[str, Any]:
+    """
+    Query agents from the Swarms marketplace.
+
+    Args:
+        search: Search keyword for matching agent names/descriptions.
+        category: Filter by category (case-insensitive).
+        free_only: Only return free agents.
+        limit: Maximum number of results (1-100, default 20).
+        timeout: Request timeout in seconds (default 30.0).
+
+    Returns:
+        Dictionary containing the query results with agent data.
+
+    Raises:
+        httpx.HTTPError: If the HTTP request fails.
+        ValueError: If SWARMS_API_KEY is not set.
+    """
+    try:
+        api_key = check_swarms_api_key()
+        url = f"{BASE_URL}/api/query-agents"
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        data = {
+            "limit": min(max(1, limit), 100),
+        }
+
+        if search:
+            data["search"] = search
+        if category:
+            data["category"] = category
+        if free_only:
+            data["priceFilter"] = "free"
+
+        logger.debug(f"Querying agents with params: {data}")
+
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(url, json=data, headers=headers)
+            response.raise_for_status()
+            result = response.json()
+
+        # Parse response - API returns {"data": [...], "total": N}
+        agents = result.get("data", [])
+        total = result.get("total", len(agents))
+
+        return {"agents": agents, "total": total}
+
+    except httpx.HTTPStatusError as e:
+        logger.error(f"HTTP error querying agents: {e}")
+        if hasattr(e, "response") and e.response is not None:
+            try:
+                error_body = e.response.json()
+                logger.error(f"Error response: {error_body}")
+            except Exception:
+                logger.error(f"Error response text: {e.response.text}")
+        raise
+    except Exception as e:
+        logger.error(
+            f"Error querying agents: {e} Traceback: {traceback.format_exc()}"
+        )
+        raise
+
+
+def get_agent_by_id(
+    agent_id: str,
+    timeout: float = 30.0,
+) -> Optional[Dict[str, Any]]:
+    """
+    Fetch a specific agent from the marketplace by its ID.
+
+    Args:
+        agent_id: The unique identifier of the agent.
+        timeout: Request timeout in seconds (default 30.0).
+
+    Returns:
+        Dictionary containing the agent data, or None if not found.
+
+    Raises:
+        httpx.HTTPError: If the HTTP request fails.
+        ValueError: If SWARMS_API_KEY is not set.
+    """
+    try:
+        # Query with a search that should match the ID
+        # Since there's no direct get-by-id endpoint, we query and filter
+        result = query_agents(search=agent_id, limit=100, timeout=timeout)
+
+        if isinstance(result, list):
+            agents = result
+        elif isinstance(result, dict):
+            agents = result.get("agents", result.get("data", []))
+            if not isinstance(agents, list):
+                agents = [result] if result.get("id") == agent_id else []
+        else:
+            agents = []
+
+        # Find exact match by ID
+        for agent in agents:
+            if agent.get("id") == agent_id:
+                return agent
+
+        # If no exact match found, return first result if search was specific
+        if agents and len(agent_id) > 10:  # Likely a UUID
+            return agents[0] if agents else None
+
+        return None
+
+    except Exception as e:
+        logger.error(f"Error fetching agent {agent_id}: {e}")
+        raise
+
+
+def install_agent(
+    agent_id: str,
+    output_dir: str = ".",
+    timeout: float = 30.0,
+) -> Dict[str, Any]:
+    """
+    Install an agent from the marketplace to a local directory.
+
+    Creates a Python file with the agent configuration and metadata.
+
+    Args:
+        agent_id: The unique identifier of the agent to install.
+        output_dir: Directory to save the agent file (default: current directory).
+        timeout: Request timeout in seconds (default 30.0).
+
+    Returns:
+        Dictionary with installation result including file path.
+
+    Raises:
+        httpx.HTTPError: If the HTTP request fails.
+        ValueError: If SWARMS_API_KEY is not set or agent not found.
+        OSError: If file creation fails.
+    """
+    try:
+        # Fetch agent details
+        agent = get_agent_by_id(agent_id, timeout=timeout)
+
+        if not agent:
+            raise ValueError(f"Agent with ID '{agent_id}' not found in marketplace")
+
+        # Extract agent information
+        agent_name = agent.get("name", "marketplace_agent")
+        agent_code = agent.get("agent", "")
+        description = agent.get("description", "")
+        language = agent.get("language", "python")
+        requirements = agent.get("requirements", [])
+        tags = agent.get("tags", "")
+        use_cases = agent.get("useCases", [])
+
+        # Sanitize filename
+        safe_name = "".join(
+            c if c.isalnum() or c in ("_", "-") else "_"
+            for c in agent_name.lower()
+        ).strip("_")
+
+        if not safe_name:
+            safe_name = "marketplace_agent"
+
+        # Determine file extension based on language
+        ext = ".py" if language.lower() == "python" else f".{language.lower()}"
+        filename = f"{safe_name}{ext}"
+
+        # Create output directory if it doesn't exist
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        file_path = output_path / filename
+
+        # Build file content with metadata header
+        content_lines = [
+            '"""',
+            f"Agent: {agent_name}",
+            f"Description: {description}",
+            f"",
+            f"Source: Swarms Marketplace",
+            f"Agent ID: {agent_id}",
+        ]
+
+        if tags:
+            content_lines.append(f"Tags: {tags}")
+
+        if requirements:
+            # Handle requirements as list of dicts or strings
+            req_strs = []
+            for req in requirements:
+                if isinstance(req, dict):
+                    req_strs.append(req.get("package", str(req)))
+                else:
+                    req_strs.append(str(req))
+            content_lines.append(f"Requirements: {', '.join(req_strs)}")
+
+        if use_cases:
+            content_lines.append("")
+            content_lines.append("Use Cases:")
+            for uc in use_cases:
+                title = uc.get("title", "")
+                desc = uc.get("description", "")
+                if title:
+                    content_lines.append(f"  - {title}: {desc}")
+
+        content_lines.append('"""')
+        content_lines.append("")
+
+        # Add requirements comment if present
+        if requirements:
+            content_lines.append("# Requirements:")
+            for req in requirements:
+                if isinstance(req, dict):
+                    install_cmd = req.get("installation", f"pip install {req.get('package', '')}")
+                    content_lines.append(f"# {install_cmd}")
+                else:
+                    content_lines.append(f"# pip install {req}")
+            content_lines.append("")
+
+        # Add the agent code
+        if agent_code:
+            content_lines.append(agent_code)
+        else:
+            # Provide a template if no code is available
+            # Escape description for use in triple-quoted string
+            safe_description = description.replace('"""', '\\"\\"\\"')
+            safe_name = agent_name.replace('"', '\\"')
+            content_lines.extend([
+                "from swarms import Agent",
+                "",
+                "agent = Agent(",
+                f'    agent_name="{safe_name}",',
+                f'    agent_description="""{safe_description}""",',
+                '    model_name="gpt-4o-mini",',
+                "    max_loops=1,",
+                ")",
+                "",
+                "# Run the agent",
+                '# result = agent.run("Your task here")',
+            ])
+
+        # Write the file
+        file_content = "\n".join(content_lines)
+        file_path.write_text(file_content, encoding="utf-8")
+
+        logger.info(f"Agent '{agent_name}' installed to {file_path}")
+
+        return {
+            "success": True,
+            "agent_name": agent_name,
+            "file_path": str(file_path),
+            "agent_id": agent_id,
+            "description": description,
+        }
+
+    except ValueError:
+        raise
+    except Exception as e:
+        logger.error(
+            f"Error installing agent: {e} Traceback: {traceback.format_exc()}"
+        )
+        raise
+
+
+def list_available_categories(timeout: float = 30.0) -> List[str]:
+    """
+    Get a list of available agent categories from the marketplace.
+
+    Args:
+        timeout: Request timeout in seconds (default 30.0).
+
+    Returns:
+        List of category names.
+    """
+    # Common categories based on marketplace structure
+    return [
+        "finance",
+        "research",
+        "coding",
+        "content",
+        "data-analysis",
+        "automation",
+        "customer-service",
+        "healthcare",
+        "legal",
+        "marketing",
+        "education",
+        "general",
+    ]


### PR DESCRIPTION
  - Add new `swarms marketplace` CLI command to search, browse, and install agents from the Swarms marketplace
  - Create marketplace API client utilities for programmatic access
  - Add comprehensive documentation and examples

  ## Changes

  ### New Files
  - `swarms/utils/agent_marketplace.py` - API client with `query_agents()`, `get_agent_by_id()`, `install_agent()` functions
  - `examples/marketplace/marketplace_cli_example.py` - Usage examples
  - `docs/swarms/cli/cli_marketplace_guide.md` - Full documentation

  ### Modified Files
  - `swarms/cli/main.py` - Added marketplace command and subcommands
  - `swarms/utils/__init__.py` - Exported new marketplace functions
  - `docs/swarms/cli/cli_reference.md` - Added marketplace command reference
  - `docs/mkdocs.yml` - Added marketplace guide to navigation

  ## CLI Commands
  ```bash
  swarms marketplace                              # Show help
  swarms marketplace list --limit 10              # List agents
  swarms marketplace search --query "trading"     # Search agents
  swarms marketplace info <agent-id>              # View details
  swarms marketplace install <agent-id>           # Install locally

  API Integration

  - Endpoint: POST https://swarms.world/api/query-agents
  - Auth: Authorization: Bearer <SWARMS_API_KEY>
  - Docs: https://docs.swarms.ai/docs/marketplace/agents-api

  Test plan

  - swarms marketplace shows help
  - swarms marketplace list returns agents
  - swarms marketplace search --query X filters results
  - swarms marketplace info <id> displays agent details
  - swarms marketplace install <id> creates valid Python file
  - Python imports work: from swarms.utils.agent_marketplace import query_agents

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1282.org.readthedocs.build/en/1282/

<!-- readthedocs-preview swarms end -->