### PR TITLE
[BUGF-DOCS][Fixed docs routing issue, Agent skills overview page not working]

### DIFF
--- a/docs/swarms/agents/agent_skills.md
+++ b/docs/swarms/agents/agent_skills.md
@@ -307,7 +307,7 @@ skills/
 
 ## Examples
 
-See the [Agent Skills Examples](/swarms/examples/agent_skills_overview/) section for:
+See the [Agent Skills Examples](/docs/swarms/examples/agent_skills_overview/) section for:
 - Basic usage tutorial
 - Creating custom skills
 - Using multiple skills


### PR DESCRIPTION
## Description:

`agent_skills_overview.md` from `swarms/agents/agent_skills.md` was routed incorrectly with a malformed path.

- issue: N/A;
- Deps: N/A;
- Files changed: `docs/swarms/agents/agent_skills.md`

### Changes made

specified path correctly:
Before:
``See the [Agent Skills Examples](/swarms/examples/agent_skills_overview/) section for:``

After:
```See the [Agent Skills Examples](/docs/swarms/examples/agent_skills_overview/) section for:```

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1329.org.readthedocs.build/en/1329/

<!-- readthedocs-preview swarms end -->