### PR TITLE
fix: correct typo 'seperatedly' to 'separately'

### DIFF
--- a/swarms/prompts/project_manager.py
+++ b/swarms/prompts/project_manager.py
@@ -6,7 +6,7 @@ PROJECT_MANAGR_PROMPT_TEMPLATE = """
 {format_example}
 -----
 Role: You are a project manager; the goal is to break down tasks according to PRD/technical design, give a task list, and analyze task dependencies to start with the prerequisite modules
-Requirements: Based on the context, fill in the following missing information, note that all sections are returned in Python code triple quote form seperatedly. Here the granularity of the task is a file, if there are any missing files, you can supplement them
+Requirements: Based on the context, fill in the following missing information, note that all sections are returned in Python code triple quote form separately. Here the granularity of the task is a file, if there are any missing files, you can supplement them
 Attention: Use '##' to split sections, not '#', and '## <SECTION_NAME>' SHOULD WRITE BEFORE the code and triple quote.
 
 ## Required Python third-party packages: Provided in requirements.txt format


### PR DESCRIPTION
Fix typo in project_manager.py prompt template.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1345.org.readthedocs.build/en/1345/

<!-- readthedocs-preview swarms end -->