### PR TITLE
Fix RoundRobinSwarm initialization error in SwarmRouter      

### DIFF
--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -634,7 +634,6 @@ class SwarmRouter:
             agents=self.agents,
             max_loops=self.max_loops,
             verbose=self.verbose,
-            return_json_on=self.return_json,
             *args,
             **kwargs,
         )


### PR DESCRIPTION
  Remove return_json_on parameter from _create_round_robin_swarm factory method.           
  RoundRobinSwarm.__init__() does not accept this parameter, causing a 500 error whenever a
   RoundRobin swarm is created through the API.                                            
                                                                                           
  Error: RoundRobinSwarm.__init__() got an unexpected keyword argument 'return_json_on'    
                                                                                           
  Fix: One-line removal in swarms/structs/swarm_router.py — no other swarm types are       
  affected. Verified that return_json_on is not used in any other factory method or swarm
  class.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1363.org.readthedocs.build/en/1363/

<!-- readthedocs-preview swarms end -->