### PR TITLE
 Fix DebateWithJudge initialization error in SwarmRouter

### DIFF
--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -506,7 +506,7 @@ class SwarmRouter:
             pro_agent=self.agents[0],
             con_agent=self.agents[1],
             judge_agent=self.agents[2],
-            max_rounds=self.max_loops,
+            max_loops=self.max_loops,
             output_type=self.output_type,
             verbose=self.verbose,
         )


### PR DESCRIPTION
  The _create_debate_with_judge factory method passes max_rounds but                       
  DebateWithJudge.__init__() expects max_loops, causing a 500 error whenever a             
  DebateWithJudge swarm is created through the API.                                        
                                                                                           
  Error: DebateWithJudge.__init__() got an unexpected keyword argument 'max_rounds'        
                                                                                           
  Fix: Renamed max_rounds to max_loops in swarm_router.py line 509. max_rounds only exists 
  in the unrelated ExpertPanelDiscussion class — no other swarm types are affected.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1364.org.readthedocs.build/en/1364/

<!-- readthedocs-preview swarms end -->