### PR TITLE
Docs+Tutorial: Add coverage for base_structure (#1367)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -317,6 +317,7 @@ nav:
           - GraphWorkflow: "swarms/structs/graph_workflow.md"
           - BatchedGridWorkflow: "swarms/structs/batched_grid_workflow.md"
 
+        - BaseStructure: "swarms/structs/base_structure.md"
         - Communication Structure: "swarms/structs/conversation.md"
         - Base Structure: "swarms/structs/base_structure.md"
 
@@ -455,6 +456,7 @@ nav:
 
       - Utilities:
         - Unique Swarms: "swarms/examples/unique_swarms.md"
+        - BaseStructure: "swarms/examples/base_structure_example.md"
         - Base Structure: "swarms/examples/base_structure_example.md"
         - Agents as Tools: "swarms/examples/agents_as_tools.md"
         - Aggregate Responses: "swarms/examples/aggregate.md"

--- a/docs/swarms/examples/base_structure_example.md
+++ b/docs/swarms/examples/base_structure_example.md
@@ -1,32 +1,27 @@
-# Base Structure Tutorial
+# BaseStructure Tutorial
 
-    End-to-end usage for `base_structure`.
+    End-to-end tutorial for `swarms.structs.base_structure`.
 
     ## Prerequisites
 
     - Python 3.10+
     - `pip install -U swarms`
-    - Provider credentials configured when using hosted LLMs
 
     ## Example
 
     ```python
     from swarms.structs.base_structure import BaseStructure
 
-base = BaseStructure(name="demo-structure")
-base.save_to_file({"status": "ok"}, "./artifacts/demo.json")
-loaded = base.load_from_file("./artifacts/demo.json")
-print(loaded)
-
-base.log_event("Saved demo artifact")
-base.log_error("Example error message")
+base = BaseStructure(name="demo", save_metadata_on=False)
+base.save_to_file({"status": "ok"}, "./demo.json")
+print(base.load_from_file("./demo.json"))
     ```
 
     ## What this demonstrates
 
-    - Basic construction/import pattern for `base_structure`
-    - Minimal execution path you can adapt in production
-    - Safe starting defaults for iteration
+    - Correct import and initialization flow for `base_structure`
+    - Minimal execution path suitable for first integration tests
+    - A baseline pattern to adapt for production use
 
     ## Related
 

--- a/docs/swarms/structs/base_structure.md
+++ b/docs/swarms/structs/base_structure.md
@@ -1,29 +1,36 @@
-# Base Structure
+# BaseStructure
 
-`base_structure` reference documentation.
+    Reference documentation for `swarms.structs.base_structure`.
 
-**Module Path**: `swarms.structs.base_structure`
+    ## Overview
 
-## Overview
+    This module provides production utilities for `base structure` in Swarms.
 
-Base utility class that standardizes metadata, artifacts, errors, async helpers, and batching helpers for swarm structures.
+    ## Module Path
 
-## Public API
+    ```python
+    from swarms.structs.base_structure import ...
+    ```
 
-- **`BaseStructure`**: `run()`, `save_to_file()`, `load_from_file()`, `save_metadata()`, `load_metadata()`, `log_error()`, `save_artifact()`, `load_artifact()`
+    ## Public API
 
-## Quickstart
+    - `BaseStructure`: `save_to_file`, `load_from_file`, `save_metadata`, `log_event`, async/thread helpers
 
-```python
-from swarms.structs.base_structure import BaseStructure
-```
+    ## Quick Start
 
-## Tutorial
+    ```python
+    from swarms.structs.base_structure import BaseStructure
 
-A runnable tutorial is available at [`swarms/examples/base_structure_example.md`](../examples/base_structure_example.md).
+base = BaseStructure(name="demo", save_metadata_on=False)
+base.save_to_file({"status": "ok"}, "./demo.json")
+print(base.load_from_file("./demo.json"))
+    ```
 
-## Notes
+    ## Tutorial
 
-- Keep task payloads small for first runs.
-- Prefer deterministic prompts when comparing outputs across agents.
-- Validate provider credentials (for LLM-backed examples) before production use.
+    See the runnable tutorial: [`swarms/examples/base_structure_example.md`](../examples/base_structure_example.md)
+
+    ## Operational Notes
+
+    - Validate credentials and model access before running LLM-backed examples.
+    - Start with small inputs/tasks, then scale once behavior is verified.


### PR DESCRIPTION
## Summary
Adds documentation and a runnable tutorial for `base_structure`.

Closes #1367

## Scope Checklist
- [ ] Add/verify struct docs page (`docs/swarms/structs/base_structure.md` or canonical equivalent)
- [ ] Add runnable tutorial page (`docs/swarms/examples/base_structure_example.md`)
- [ ] Add nav entries in `docs/mkdocs.yml`
- [ ] Add cross-links between struct docs and tutorial
- [ ] Validate docs build and links

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1380.org.readthedocs.build/en/1380/

<!-- readthedocs-preview swarms end -->