### PR TITLE
Docs+Tutorial: Add coverage for dynamic_skills_loader (#1372)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -317,6 +317,7 @@ nav:
           - GraphWorkflow: "swarms/structs/graph_workflow.md"
           - BatchedGridWorkflow: "swarms/structs/batched_grid_workflow.md"
 
+        - DynamicSkillsLoader: "swarms/structs/dynamic_skills_loader.md"
         - Communication Structure: "swarms/structs/conversation.md"
         - Dynamic Skills Loader: "swarms/structs/dynamic_skills_loader.md"
 
@@ -455,6 +456,7 @@ nav:
 
       - Utilities:
         - Unique Swarms: "swarms/examples/unique_swarms.md"
+        - DynamicSkillsLoader: "swarms/examples/dynamic_skills_loader_example.md"
         - Dynamic Skills Loader: "swarms/examples/dynamic_skills_loader_example.md"
         - Agents as Tools: "swarms/examples/agents_as_tools.md"
         - Aggregate Responses: "swarms/examples/aggregate.md"

--- a/docs/swarms/examples/dynamic_skills_loader_example.md
+++ b/docs/swarms/examples/dynamic_skills_loader_example.md
@@ -1,12 +1,11 @@
 # Dynamic Skills Loader Tutorial
 
-    End-to-end usage for `dynamic_skills_loader`.
+    End-to-end tutorial for `swarms.structs.dynamic_skills_loader`.
 
     ## Prerequisites
 
     - Python 3.10+
     - `pip install -U swarms`
-    - Provider credentials configured when using hosted LLMs
 
     ## Example
 
@@ -14,17 +13,14 @@
     from swarms.structs.dynamic_skills_loader import DynamicSkillsLoader
 
 loader = DynamicSkillsLoader(skills_dir="./skills", similarity_threshold=0.25)
-
-task = "Build a sales forecasting dashboard from quarterly data"
-print(loader.get_skill_names(task))
-print(loader.get_similarity_scores(task)[:3])
+print(loader.get_skill_names("Analyze quarterly revenue trends"))
     ```
 
     ## What this demonstrates
 
-    - Basic construction/import pattern for `dynamic_skills_loader`
-    - Minimal execution path you can adapt in production
-    - Safe starting defaults for iteration
+    - Correct import and initialization flow for `dynamic_skills_loader`
+    - Minimal execution path suitable for first integration tests
+    - A baseline pattern to adapt for production use
 
     ## Related
 

--- a/docs/swarms/structs/dynamic_skills_loader.md
+++ b/docs/swarms/structs/dynamic_skills_loader.md
@@ -1,30 +1,35 @@
 # Dynamic Skills Loader
 
-    `dynamic_skills_loader` reference documentation.
-
-    **Module Path**: `swarms.structs.dynamic_skills_loader`
+    Reference documentation for `swarms.structs.dynamic_skills_loader`.
 
     ## Overview
 
-    Task-similarity-driven skill loader that scores and selects relevant skills from `SKILL.md` metadata.
+    This module provides production utilities for `dynamic skills loader` in Swarms.
+
+    ## Module Path
+
+    ```python
+    from swarms.structs.dynamic_skills_loader import ...
+    ```
 
     ## Public API
 
-    - **`DynamicSkillsLoader`**: `load_relevant_skills()`, `get_skill_names()`, `load_full_skill_content()`, `get_similarity_scores()`
-- **`create_dynamic_skills_loader()`**
+    - `DynamicSkillsLoader`: `load_relevant_skills`, `get_skill_names`, `get_similarity_scores`
 
-    ## Quickstart
+    ## Quick Start
 
     ```python
-    from swarms.structs.dynamic_skills_loader import DynamicSkillsLoader, create_dynamic_skills_loader
+    from swarms.structs.dynamic_skills_loader import DynamicSkillsLoader
+
+loader = DynamicSkillsLoader(skills_dir="./skills", similarity_threshold=0.25)
+print(loader.get_skill_names("Analyze quarterly revenue trends"))
     ```
 
     ## Tutorial
 
-    A runnable tutorial is available at [`swarms/examples/dynamic_skills_loader_example.md`](../examples/dynamic_skills_loader_example.md).
+    See the runnable tutorial: [`swarms/examples/dynamic_skills_loader_example.md`](../examples/dynamic_skills_loader_example.md)
 
-    ## Notes
+    ## Operational Notes
 
-    - Keep task payloads small for first runs.
-    - Prefer deterministic prompts when comparing outputs across agents.
-    - Validate provider credentials (for LLM-backed examples) before production use.
+    - Validate credentials and model access before running LLM-backed examples.
+    - Start with small inputs/tasks, then scale once behavior is verified.


### PR DESCRIPTION
## Summary
Adds documentation and a runnable tutorial for `dynamic_skills_loader`.

Closes #1372

## Scope Checklist
- [ ] Add/verify struct docs page (`docs/swarms/structs/dynamic_skills_loader.md` or canonical equivalent)
- [ ] Add runnable tutorial page (`docs/swarms/examples/dynamic_skills_loader_example.md`)
- [ ] Add nav entries in `docs/mkdocs.yml`
- [ ] Add cross-links between struct docs and tutorial
- [ ] Validate docs build and links

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1385.org.readthedocs.build/en/1385/

<!-- readthedocs-preview swarms end -->