### PR TITLE
Docs+Tutorial: Add coverage for image_batch_processor (#1373)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -317,6 +317,7 @@ nav:
           - GraphWorkflow: "swarms/structs/graph_workflow.md"
           - BatchedGridWorkflow: "swarms/structs/batched_grid_workflow.md"
 
+        - ImageAgentBatchProcessor: "swarms/structs/image_batch_processor.md"
         - Communication Structure: "swarms/structs/conversation.md"
         - Image Batch Processor: "swarms/structs/image_batch_processor.md"
 
@@ -455,6 +456,7 @@ nav:
 
       - Utilities:
         - Unique Swarms: "swarms/examples/unique_swarms.md"
+        - ImageAgentBatchProcessor: "swarms/examples/image_batch_processor_example.md"
         - Image Batch Processor: "swarms/examples/image_batch_processor_example.md"
         - Agents as Tools: "swarms/examples/agents_as_tools.md"
         - Aggregate Responses: "swarms/examples/aggregate.md"

--- a/docs/swarms/examples/image_batch_processor_example.md
+++ b/docs/swarms/examples/image_batch_processor_example.md
@@ -1,12 +1,11 @@
 # Image Batch Processor Tutorial
 
-    End-to-end usage for `image_batch_processor`.
+    End-to-end tutorial for `swarms.structs.image_batch_processor`.
 
     ## Prerequisites
 
     - Python 3.10+
     - `pip install -U swarms`
-    - Provider credentials configured when using hosted LLMs
 
     ## Example
 
@@ -14,26 +13,16 @@
     from swarms import Agent
 from swarms.structs.image_batch_processor import ImageAgentBatchProcessor
 
-vision_agent = Agent(
-    agent_name="Vision-Analyst",
-    system_prompt="Describe and analyze images.",
-    model_name="gpt-4.1",
-    max_loops=1,
-)
-
-processor = ImageAgentBatchProcessor(agents=vision_agent)
-results = processor.run(
-    image_paths=["./examples/sample1.png", "./examples/sample2.png"],
-    tasks=["Describe key objects", "Identify risks"],
-)
-print(results)
+vision_agent = Agent(agent_name="Vision", model_name="gpt-4.1")
+processor = ImageAgentBatchProcessor(agents=[vision_agent], max_workers=2)
+print(processor.run(image_paths=["./sample.jpg"], tasks=["Describe the image"]))
     ```
 
     ## What this demonstrates
 
-    - Basic construction/import pattern for `image_batch_processor`
-    - Minimal execution path you can adapt in production
-    - Safe starting defaults for iteration
+    - Correct import and initialization flow for `image_batch_processor`
+    - Minimal execution path suitable for first integration tests
+    - A baseline pattern to adapt for production use
 
     ## Related
 

--- a/docs/swarms/structs/image_batch_processor.md
+++ b/docs/swarms/structs/image_batch_processor.md
@@ -1,31 +1,38 @@
 # Image Batch Processor
 
-    `image_batch_processor` reference documentation.
-
-    **Module Path**: `swarms.structs.image_batch_processor`
+    Reference documentation for `swarms.structs.image_batch_processor`.
 
     ## Overview
 
-    Parallel image-processing orchestrator for running one or many agents across image files and tasks.
+    This module provides production utilities for `image batch processor` in Swarms.
+
+    ## Module Path
+
+    ```python
+    from swarms.structs.image_batch_processor import ...
+    ```
 
     ## Public API
 
-    - **`ImageProcessingError`**: No public methods documented in this module.
-- **`InvalidAgentError`**: No public methods documented in this module.
-- **`ImageAgentBatchProcessor`**: `run()`
+    - `ImageAgentBatchProcessor.run(image_paths, tasks)` and callable shortcut via `__call__`
 
-    ## Quickstart
+    ## Quick Start
 
     ```python
-    from swarms.structs.image_batch_processor import ImageProcessingError, InvalidAgentError, ImageAgentBatchProcessor
+    from swarms import Agent
+from swarms.structs.image_batch_processor import ImageAgentBatchProcessor
+
+vision_agent = Agent(agent_name="Vision", model_name="gpt-4.1")
+processor = ImageAgentBatchProcessor(agents=[vision_agent], max_workers=2)
+print(processor.run(image_paths=["./sample.jpg"], tasks=["Describe the image"]))
     ```
 
     ## Tutorial
 
-    A runnable tutorial is available at [`swarms/examples/image_batch_processor_example.md`](../examples/image_batch_processor_example.md).
+    See the runnable tutorial: [`swarms/examples/image_batch_processor_example.md`](../examples/image_batch_processor_example.md)
 
-    ## Notes
+    ## Operational Notes
 
-    - Keep task payloads small for first runs.
-    - Prefer deterministic prompts when comparing outputs across agents.
-    - Validate provider credentials (for LLM-backed examples) before production use.
+    - Validate credentials and model access before running LLM-backed examples.
+    - Start with small inputs/tasks, then scale once behavior is verified.
+- All image paths must exist and use supported suffixes (`.jpg`, `.jpeg`, `.png`) unless overridden.


### PR DESCRIPTION
## Summary
Adds documentation and a runnable tutorial for `image_batch_processor`.

Closes #1373

## Scope Checklist
- [ ] Add/verify struct docs page (`docs/swarms/structs/image_batch_processor.md` or canonical equivalent)
- [ ] Add runnable tutorial page (`docs/swarms/examples/image_batch_processor_example.md`)
- [ ] Add nav entries in `docs/mkdocs.yml`
- [ ] Add cross-links between struct docs and tutorial
- [ ] Validate docs build and links

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1386.org.readthedocs.build/en/1386/

<!-- readthedocs-preview swarms end -->