### PR TITLE
Docs+Tutorial: Add coverage for multi_model_gpu_manager (#1374)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -317,6 +317,7 @@ nav:
           - GraphWorkflow: "swarms/structs/graph_workflow.md"
           - BatchedGridWorkflow: "swarms/structs/batched_grid_workflow.md"
 
+        - ModelGrid: "swarms/structs/multi_model_gpu_manager.md"
         - Communication Structure: "swarms/structs/conversation.md"
         - Multi Model Gpu Manager: "swarms/structs/multi_model_gpu_manager.md"
 
@@ -455,6 +456,7 @@ nav:
 
       - Utilities:
         - Unique Swarms: "swarms/examples/unique_swarms.md"
+        - ModelGrid: "swarms/examples/multi_model_gpu_manager_example.md"
         - Multi Model Gpu Manager: "swarms/examples/multi_model_gpu_manager_example.md"
         - Agents as Tools: "swarms/examples/agents_as_tools.md"
         - Aggregate Responses: "swarms/examples/aggregate.md"

--- a/docs/swarms/examples/multi_model_gpu_manager_example.md
+++ b/docs/swarms/examples/multi_model_gpu_manager_example.md
@@ -1,39 +1,26 @@
-# Multi Model Gpu Manager Tutorial
+# Multi Model GPU Manager Tutorial
 
-    End-to-end usage for `multi_model_gpu_manager`.
+    End-to-end tutorial for `swarms.structs.multi_model_gpu_manager`.
 
     ## Prerequisites
 
     - Python 3.10+
     - `pip install -U swarms`
-    - Provider credentials configured when using hosted LLMs
 
     ## Example
 
     ```python
-    import torch
-from swarms.structs.multi_model_gpu_manager import ModelGrid, GPUAllocationStrategy
+    from swarms.structs.multi_model_gpu_manager import ModelGrid, GPUAllocationStrategy
 
-# Minimal local model (example)
-model = torch.nn.Linear(128, 16)
-
-grid = ModelGrid(allocation_strategy=GPUAllocationStrategy.MEMORY_OPTIMIZED)
-grid.add_model(model_name="linear-demo", model=model)
-
-grid.allocate_all_models()
-grid.load_all_models()
-
-result = grid.run(model_name="linear-demo", task="forward", input_data=torch.randn(1, 128))
-print(result)
-
-grid.unload_all_models()
+grid = ModelGrid(allocation_strategy=GPUAllocationStrategy.MEMORY_OPTIMIZED, use_multiprocessing=False)
+print(grid.get_gpu_status())
     ```
 
     ## What this demonstrates
 
-    - Basic construction/import pattern for `multi_model_gpu_manager`
-    - Minimal execution path you can adapt in production
-    - Safe starting defaults for iteration
+    - Correct import and initialization flow for `multi_model_gpu_manager`
+    - Minimal execution path suitable for first integration tests
+    - A baseline pattern to adapt for production use
 
     ## Related
 

--- a/docs/swarms/structs/multi_model_gpu_manager.md
+++ b/docs/swarms/structs/multi_model_gpu_manager.md
@@ -1,38 +1,36 @@
-# Multi Model Gpu Manager
+# Multi Model GPU Manager
 
-    `multi_model_gpu_manager` reference documentation.
-
-    **Module Path**: `swarms.structs.multi_model_gpu_manager`
+    Reference documentation for `swarms.structs.multi_model_gpu_manager`.
 
     ## Overview
 
-    Production utility for allocating and running many ML models across available GPUs with memory-aware placement.
+    This module provides production utilities for `multi model gpu manager` in Swarms.
+
+    ## Module Path
+
+    ```python
+    from swarms.structs.multi_model_gpu_manager import ...
+    ```
 
     ## Public API
 
-    - **`ModelType`**: No public methods documented in this module.
-- **`GPUAllocationStrategy`**: No public methods documented in this module.
-- **`ModelMetadata`**: No public methods documented in this module.
-- **`GPUMetadata`**: No public methods documented in this module.
-- **`ModelMemoryCalculator`**: `get_pytorch_model_size()`, `get_huggingface_model_size()`
-- **`GPUManager`**: `update_gpu_memory_info()`
-- **`ModelGrid`**: `add_model()`, `remove_model()`, `allocate_all_models()`, `load_model()`, `unload_model()`, `load_all_models()`, `unload_all_models()`, `run()`
-- **`ModelWithCustomRunMethod`**: `run()`
-- **`PyTorchModelWrapper`**: `run()`
-- **`HuggingFaceModelWrapper`**: `run()`
+    - `ModelGrid`: `add_model`, `allocate_all_models`, `load_all_models`, `run`, `get_gpu_status`
 
-    ## Quickstart
+    ## Quick Start
 
     ```python
-    from swarms.structs.multi_model_gpu_manager import ModelType, GPUAllocationStrategy, ModelMetadata
+    from swarms.structs.multi_model_gpu_manager import ModelGrid, GPUAllocationStrategy
+
+grid = ModelGrid(allocation_strategy=GPUAllocationStrategy.MEMORY_OPTIMIZED, use_multiprocessing=False)
+print(grid.get_gpu_status())
     ```
 
     ## Tutorial
 
-    A runnable tutorial is available at [`swarms/examples/multi_model_gpu_manager_example.md`](../examples/multi_model_gpu_manager_example.md).
+    See the runnable tutorial: [`swarms/examples/multi_model_gpu_manager_example.md`](../examples/multi_model_gpu_manager_example.md)
 
-    ## Notes
+    ## Operational Notes
 
-    - Keep task payloads small for first runs.
-    - Prefer deterministic prompts when comparing outputs across agents.
-    - Validate provider credentials (for LLM-backed examples) before production use.
+    - Validate credentials and model access before running LLM-backed examples.
+    - Start with small inputs/tasks, then scale once behavior is verified.
+- This module expects CUDA/PyTorch runtime for full GPU orchestration. Start with status calls before loading models.


### PR DESCRIPTION
## Summary
Adds documentation and a runnable tutorial for `multi_model_gpu_manager`.

Closes #1374

## Scope Checklist
- [ ] Add/verify struct docs page (`docs/swarms/structs/multi_model_gpu_manager.md` or canonical equivalent)
- [ ] Add runnable tutorial page (`docs/swarms/examples/multi_model_gpu_manager_example.md`)
- [ ] Add nav entries in `docs/mkdocs.yml`
- [ ] Add cross-links between struct docs and tutorial
- [ ] Validate docs build and links

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1387.org.readthedocs.build/en/1387/

<!-- readthedocs-preview swarms end -->