### PR TITLE
Docs+Tutorial: Add coverage for safe_loading (#1376)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -317,6 +317,7 @@ nav:
           - GraphWorkflow: "swarms/structs/graph_workflow.md"
           - BatchedGridWorkflow: "swarms/structs/batched_grid_workflow.md"
 
+        - SafeStateManager: "swarms/structs/safe_loading.md"
         - Communication Structure: "swarms/structs/conversation.md"
         - Safe Loading: "swarms/structs/safe_loading.md"
 
@@ -455,6 +456,7 @@ nav:
 
       - Utilities:
         - Unique Swarms: "swarms/examples/unique_swarms.md"
+        - SafeStateManager: "swarms/examples/safe_loading_example.md"
         - Safe Loading: "swarms/examples/safe_loading_example.md"
         - Agents as Tools: "swarms/examples/agents_as_tools.md"
         - Aggregate Responses: "swarms/examples/aggregate.md"

--- a/docs/swarms/examples/safe_loading_example.md
+++ b/docs/swarms/examples/safe_loading_example.md
@@ -1,37 +1,34 @@
 # Safe Loading Tutorial
 
-    End-to-end usage for `safe_loading`.
+    End-to-end tutorial for `swarms.structs.safe_loading`.
 
     ## Prerequisites
 
     - Python 3.10+
     - `pip install -U swarms`
-    - Provider credentials configured when using hosted LLMs
 
     ## Example
 
     ```python
     from swarms.structs.safe_loading import SafeStateManager
 
-class WorkflowState:
+class Config:
     def __init__(self):
-        self.name = "pipeline-a"
-        self.retries = 2
-        self.tags = ["etl", "daily"]
+        self.name = "demo"
+        self.version = 1
 
-state = WorkflowState()
-SafeStateManager.save_state(state, "./state/workflow_state.json")
-
-state.retries = 0
-SafeStateManager.load_state(state, "./state/workflow_state.json")
-print(state.retries)  # 2
+cfg = Config()
+SafeStateManager.save_state(cfg, "./state/config.json")
+cfg.version = 2
+SafeStateManager.load_state(cfg, "./state/config.json")
+print(cfg.version)
     ```
 
     ## What this demonstrates
 
-    - Basic construction/import pattern for `safe_loading`
-    - Minimal execution path you can adapt in production
-    - Safe starting defaults for iteration
+    - Correct import and initialization flow for `safe_loading`
+    - Minimal execution path suitable for first integration tests
+    - A baseline pattern to adapt for production use
 
     ## Related
 

--- a/docs/swarms/structs/safe_loading.md
+++ b/docs/swarms/structs/safe_loading.md
@@ -1,30 +1,43 @@
 # Safe Loading
 
-    `safe_loading` reference documentation.
-
-    **Module Path**: `swarms.structs.safe_loading`
+    Reference documentation for `swarms.structs.safe_loading`.
 
     ## Overview
 
-    Safe state serialization/loading utilities that preserve object instances and only persist safe values.
+    This module provides production utilities for `safe loading` in Swarms.
+
+    ## Module Path
+
+    ```python
+    from swarms.structs.safe_loading import ...
+    ```
 
     ## Public API
 
-    - **`SafeLoaderUtils`**: `is_class_instance()`, `is_safe_type()`, `get_class_attributes()`, `create_state_dict()`, `preserve_instances()`
-- **`SafeStateManager`**: `save_state()`, `load_state()`
+    - `SafeLoaderUtils` and `SafeStateManager.save_state/load_state`
 
-    ## Quickstart
+    ## Quick Start
 
     ```python
-    from swarms.structs.safe_loading import SafeLoaderUtils, SafeStateManager
+    from swarms.structs.safe_loading import SafeStateManager
+
+class Config:
+    def __init__(self):
+        self.name = "demo"
+        self.version = 1
+
+cfg = Config()
+SafeStateManager.save_state(cfg, "./state/config.json")
+cfg.version = 2
+SafeStateManager.load_state(cfg, "./state/config.json")
+print(cfg.version)
     ```
 
     ## Tutorial
 
-    A runnable tutorial is available at [`swarms/examples/safe_loading_example.md`](../examples/safe_loading_example.md).
+    See the runnable tutorial: [`swarms/examples/safe_loading_example.md`](../examples/safe_loading_example.md)
 
-    ## Notes
+    ## Operational Notes
 
-    - Keep task payloads small for first runs.
-    - Prefer deterministic prompts when comparing outputs across agents.
-    - Validate provider credentials (for LLM-backed examples) before production use.
+    - Validate credentials and model access before running LLM-backed examples.
+    - Start with small inputs/tasks, then scale once behavior is verified.


### PR DESCRIPTION
## Summary
Adds documentation and a runnable tutorial for `safe_loading`.

Closes #1376

## Scope Checklist
- [ ] Add/verify struct docs page (`docs/swarms/structs/safe_loading.md` or canonical equivalent)
- [ ] Add runnable tutorial page (`docs/swarms/examples/safe_loading_example.md`)
- [ ] Add nav entries in `docs/mkdocs.yml`
- [ ] Add cross-links between struct docs and tutorial
- [ ] Validate docs build and links

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1389.org.readthedocs.build/en/1389/

<!-- readthedocs-preview swarms end -->