### PR TITLE
Fix: LLMCouncil incompatible with SwarmRouter and API server

### DIFF
--- a/swarms/structs/llm_council.py
+++ b/swarms/structs/llm_council.py
@@ -381,17 +381,21 @@ class LLMCouncil:
 
         return members
 
-    def run(self, query: str):
+    def run(self, task: str = None, query: str = None):
         """
         Execute the full LLM Council workflow.
 
         Args:
-            query: The user's query to process
+            task: The user's task/query to process (preferred parameter name)
+            query: Alias for task (kept for backwards compatibility)
 
         Returns:
             Formatted output based on output_type, containing conversation history
             with all council member responses, evaluations, and final synthesis.
         """
+        query = task or query
+        if query is None:
+            raise ValueError("Either 'task' or 'query' must be provided")
         if self.verbose:
             print(f"\n{'='*80}")
             print("🏛️  LLM COUNCIL SESSION")

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -495,6 +495,7 @@ class SwarmRouter:
         return LLMCouncil(
             name=self.name,
             description=self.description,
+            council_members=self.agents if self.agents else None,
             output_type=self.output_type,
             verbose=self.verbose,
             chairman_model=self.chairman_model,


### PR DESCRIPTION
  Problem                                                                         
  
  LLMCouncil is broken when used via SwarmRouter or the Swarms API                
  (/v1/swarm/completions). Two issues:                      

  1. LLMCouncil.run() accepts query but SwarmRouter passes task — causes
  LLMCouncil.run() got an unexpected keyword argument 'task'
  2. _create_llm_council ignores user-defined agents — council_members is never
  passed from SwarmRouter, so user-configured agents are silently dropped and
  defaults are used instead

  Changes

  swarms/structs/llm_council.py
  - run() now accepts both task and query parameters, with task as the preferred
  name (consistent with every other swarm) and query kept for backwards
  compatibility

  swarms/structs/swarm_router.py
  - _create_llm_council now passes council_members=self.agents so user-defined
  agents are actually used

  Reproduction

  from swarms.structs.swarm_router import SwarmRouter

  router = SwarmRouter(
      name="Test",
      swarm_type="LLMCouncil",
      agents=[...],
  )
  router.run(task="What is 2+2?")  # TypeError before fix

  Impact

  - Unblocks LLMCouncil for all SwarmRouter and API server usage
  - Fully backwards compatible — existing code using run(query=...) still works

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1405.org.readthedocs.build/en/1405/

<!-- readthedocs-preview swarms end -->