### PR TITLE
chore: link open issues without linked PR

### DIFF
--- a/.github/unlinked-issues-pr-tracker.md
+++ b/.github/unlinked-issues-pr-tracker.md
@@ -1,0 +1,5 @@
+# Unlinked Issues PR Tracker
+
+This file exists to create a lightweight pull request that links all currently open issues without a linked PR.
+
+Date: 2026-02-26


### PR DESCRIPTION
This PR links currently open issues that do not yet have a linked PR.

Linked issues:
- Related to #1404
- Related to #1400
- Related to #1399
- Related to #1392
- Related to #1344
- Related to #1340
- Related to #1339
- Related to #1272
- Related to #1268
- Related to #1261
- Related to #1232
- Related to #1199
- Related to #1169
- Related to #1159
- Related to #957
- Related to #910
- Related to #909


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1406.org.readthedocs.build/en/1406/

<!-- readthedocs-preview swarms end -->