### PR TITLE
Fix progressive/tiered skill loading

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -269,10 +269,10 @@ class Agent:
             as the system prompt. This enables one-line prompt loading from the Swarms marketplace.
             Requires the SWARMS_API_KEY environment variable to be set.
         skills_dir (str): Path to directory containing Agent Skills in SKILL.md format.
-            Implements Anthropic's Agent Skills framework for modular, composable capabilities.
+            Implements progressive skill loading: Tier 1 loads skill name and description
+            into the system prompt; Tier 2 loads full content on demand via the load_full_skill tool.
             Each subdirectory should contain a SKILL.md file with YAML frontmatter (name, description)
-            and markdown instructions. Skills are auto-loaded into system prompt for context-aware activation.
-            Example: skills_dir="./skills" loads from ./skills/*/SKILL.md
+            and markdown instructions. Example: skills_dir="./skills" loads from ./skills/*/SKILL.md
         selected_tools (Union[str, List[str]]): Tools to enable for the autonomous looper when max_loops="auto".
             Available tools: "create_plan", "think", "subtask_done", "complete_task", "respond_to_user",
             "create_file", "update_file", "read_file", "list_directory", "delete_file", "run_bash",
@@ -708,30 +708,52 @@ class Agent:
                   based on similarity to the task. If not provided, loads all skills statically.
         """
         if task is not None:
-            # Dynamic skills loading based on task
             self._load_dynamic_skills_for_task(task)
         else:
-            # Static skills loading (original behavior)
             self._load_static_skills()
 
-    def _load_static_skills(self):
-        """Load all skills statically (original behavior)."""
-        skills_prompt = (
-            "\n\n# Available Skills\n\n"
-            "You have access to the following specialized skills. "
-            "Follow their instructions when relevant:\n\n"
+    def _register_skills_tool(self, skills: List[Dict[str, str]]):
+        """Register load_full_skill as a callable tool for the LLM."""
+        if not skills:
+            return
+
+        # Add skills prompt (Tier 1: name + description only)
+        self.system_prompt += self._build_skills_prompt(skills)
+
+        # Register load_full_skill as a tool
+        tool_schema = convert_multiple_functions_to_openai_function_schema(
+            [self.load_full_skill]
+        )
+        if self.tools_list_dictionary is None:
+            self.tools_list_dictionary = []
+
+        existing_names = {
+            t.get("function", {}).get("name", "")
+            for t in self.tools_list_dictionary
+            if isinstance(t, dict)
+        }
+        for tool in tool_schema:
+            if tool.get("function", {}).get("name", "") not in existing_names:
+                self.tools_list_dictionary.append(tool)
+
+        # Register in tool_struct so it can be executed
+        if self.tools is None:
+            self.tools = []
+        if self.load_full_skill not in self.tools:
+            self.tools.append(self.load_full_skill)
+            self.tool_struct = self.setup_tools()
+
+        logger.info(
+            f"Registered load_full_skill tool for {len(skills)} skills"
         )
 
-        self.system_prompt += skills_prompt
-
+    def _load_static_skills(self):
+        """Load all skills statically."""
         self.skills_metadata = self.load_skills_metadata(
             self.skills_dir
         )
-
         if self.skills_metadata:
-            self.system_prompt += self._build_skills_prompt(
-                self.skills_metadata
-            )
+            self._register_skills_tool(self.skills_metadata)
             logger.info(
                 f"Loaded {len(self.skills_metadata)} skills from {self.skills_dir}"
             )
@@ -743,7 +765,6 @@ class Agent:
         Args:
             task: The task description to match skills against
         """
-        # Initialize the dynamic skills loader if not already done
         if (
             not hasattr(self, "dynamic_skills_loader")
             or self.dynamic_skills_loader is None
@@ -761,15 +782,7 @@ class Agent:
         )
 
         if relevant_skills:
-            skills_prompt = (
-                "\n\n# Available Skills\n\n"
-                "You have access to the following specialized skills. "
-                "Follow their instructions when relevant:\n\n"
-            )
-            self.system_prompt += skills_prompt
-            self.system_prompt += self._build_skills_prompt(
-                relevant_skills
-            )
+            self._register_skills_tool(relevant_skills)
             logger.info(
                 f"Dynamically loaded {len(relevant_skills)} relevant skills for task: {task[:100]}..."
             )
@@ -4423,21 +4436,17 @@ Subtask Breakdown:
         self, skills_dir: str
     ) -> List[Dict[str, str]]:
         """
-        Load skill metadata from SKILL.md files in the skills directory.
+        Load skill metadata from SKILL.md files in the skills directory (Tier 1).
 
-        Implements Tier 1 loading from Anthropic's Agent Skills framework:
-        loads skill name and description into memory for context-aware activation.
+        Only loads name and description. Full content is loaded on demand
+        via load_full_skill (Tier 2).
 
         Args:
             skills_dir: Path to directory containing skill folders.
                 Each folder should contain a SKILL.md file with YAML frontmatter.
 
         Returns:
-            List of skill metadata dicts with 'name', 'description', 'path', 'content'
-
-        Example:
-            >>> agent = Agent(skills_dir="./skills")
-            >>> # Loads all skills from ./skills/*/SKILL.md
+            List of skill metadata dicts with 'name', 'description', 'path'
         """
         skills = []
 
@@ -4476,11 +4485,6 @@ Subtask Breakdown:
                                     "description", ""
                                 ),
                                 "path": skill_file,
-                                "content": (
-                                    parts[2].strip()
-                                    if len(parts) > 2
-                                    else ""
-                                ),
                             }
                         )
                         logger.info(
@@ -4498,36 +4502,31 @@ Subtask Breakdown:
         self, skills: List[Dict[str, str]]
     ) -> str:
         """
-        Build the skills section to append to system prompt.
+        Build the skills summary to append to system prompt (Tier 1).
 
-        Loads full skill content (YAML frontmatter + markdown instructions)
-        into the system prompt for immediate availability.
+        Only includes skill name and description. The agent can call
+        the load_full_skill tool to get full content on demand (Tier 2).
 
         Args:
             skills: List of skill metadata dicts from load_skills_metadata()
 
         Returns:
             Formatted skills prompt section to append to system_prompt
-
-        Example:
-            >>> skills = [{"name": "financial-analysis", "description": "DCF modeling", "content": "..."}]
-            >>> prompt = agent._build_skills_prompt(skills)
-            >>> # Returns formatted skills section with full instructions
         """
         if not skills:
             return ""
 
         prompt = "\n\n# Available Skills\n\n"
         prompt += (
-            "You have access to the following specialized skills. "
+            "You have access to the following skills. "
+            "To use a skill, call the `load_full_skill` tool with the skill name "
+            "to load its full instructions.\n\n"
         )
-        prompt += "Follow their instructions when relevant:\n\n"
 
         for skill in skills:
-            prompt += f"## {skill['name']}\n\n"
-            prompt += f"**Description**: {skill['description']}\n\n"
-            prompt += skill["content"]
-            prompt += "\n\n---\n\n"
+            prompt += f"- **{skill['name']}**: {skill['description']}\n"
+
+        prompt += "\n"
 
         return prompt
 

--- a/swarms/structs/dynamic_skills_loader.py
+++ b/swarms/structs/dynamic_skills_loader.py
@@ -73,11 +73,6 @@ class DynamicSkillsLoader:
                                     "description", ""
                                 ),
                                 "path": skill_file,
-                                "content": (
-                                    parts[2].strip()
-                                    if len(parts) > 2
-                                    else ""
-                                ),
                             }
                         )
             except Exception as e:
@@ -223,7 +218,7 @@ class DynamicSkillsLoader:
         self, skill_name: str
     ) -> Optional[str]:
         """
-        Load the full content of a specific skill.
+        Load the full content of a specific skill from disk.
 
         Args:
             skill_name: Name of the skill to load
@@ -233,7 +228,20 @@ class DynamicSkillsLoader:
         """
         for skill in self.skills_metadata:
             if skill["name"] == skill_name:
-                return skill["content"]
+                try:
+                    with open(
+                        skill["path"], "r", encoding="utf-8"
+                    ) as f:
+                        content = f.read()
+                    if content.startswith("---"):
+                        parts = content.split("---", 2)
+                        if len(parts) >= 3:
+                            return parts[2].strip()
+                except Exception as e:
+                    print(
+                        f"Error loading skill {skill_name}: {e}"
+                    )
+                return None
         return None
 
     def get_similarity_scores(

--- a/tests/structs/test_progressive_skills_loading.py
+++ b/tests/structs/test_progressive_skills_loading.py
@@ -1,0 +1,323 @@
+"""
+Tests for progressive/tiered skill loading (Issue #1400).
+
+Verifies:
+1. Tier 1: Only skill name + description in system prompt (no full content)
+2. Tier 2: load_full_skill is registered as a tool and returns correct content
+3. DynamicSkillsLoader no longer stores full content in metadata
+4. End-to-end: handle_skills on a real Agent, tool_struct can execute load_full_skill
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from swarms.structs.dynamic_skills_loader import DynamicSkillsLoader
+
+
+SKILL_CONTENT = """\
+---
+name: test-skill
+description: A test skill for unit testing
+---
+# Full Instructions
+
+This is the full skill content that should NOT appear in the system prompt.
+It should only be loaded on demand via load_full_skill.
+"""
+
+SKILL2_CONTENT = """\
+---
+name: another-skill
+description: Another test skill for similarity matching
+---
+# Another Skill Instructions
+
+Detailed instructions for another skill.
+"""
+
+
+@pytest.fixture
+def skills_dir():
+    """Create a temporary skills directory with test skills."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test-skill
+        skill1_dir = os.path.join(tmpdir, "test-skill")
+        os.makedirs(skill1_dir)
+        with open(
+            os.path.join(skill1_dir, "SKILL.md"), "w"
+        ) as f:
+            f.write(SKILL_CONTENT)
+
+        # Create another-skill
+        skill2_dir = os.path.join(tmpdir, "another-skill")
+        os.makedirs(skill2_dir)
+        with open(
+            os.path.join(skill2_dir, "SKILL.md"), "w"
+        ) as f:
+            f.write(SKILL2_CONTENT)
+
+        yield tmpdir
+
+
+# ── DynamicSkillsLoader unit tests ──────────────────────────────────
+
+
+class TestDynamicSkillsLoaderTiered:
+    """Test that DynamicSkillsLoader implements tiered loading."""
+
+    def test_metadata_does_not_contain_content(self, skills_dir):
+        """Tier 1: metadata should only have name, description, path."""
+        loader = DynamicSkillsLoader(skills_dir)
+        for skill in loader.skills_metadata:
+            assert "name" in skill
+            assert "description" in skill
+            assert "path" in skill
+            assert "content" not in skill
+
+    def test_load_full_skill_content_from_disk(self, skills_dir):
+        """Tier 2: load_full_skill_content reads full content from disk."""
+        loader = DynamicSkillsLoader(skills_dir)
+        content = loader.load_full_skill_content("test-skill")
+        assert content is not None
+        assert "Full Instructions" in content
+        assert "should only be loaded on demand" in content
+
+    def test_load_full_skill_content_not_found(self, skills_dir):
+        """load_full_skill_content returns None for unknown skill."""
+        loader = DynamicSkillsLoader(skills_dir)
+        assert loader.load_full_skill_content("nonexistent") is None
+
+    def test_relevant_skills_no_content(self, skills_dir):
+        """Relevant skills returned by similarity should not have content."""
+        loader = DynamicSkillsLoader(
+            skills_dir, similarity_threshold=0.0
+        )
+        relevant = loader.load_relevant_skills("test skill")
+        assert len(relevant) > 0
+        for skill in relevant:
+            assert "content" not in skill
+
+
+# ── Agent unit tests ─────────────────────────────────────────────────
+
+
+class TestAgentSkillsPrompt:
+    """Test that Agent builds Tier 1 prompt without full content."""
+
+    def test_build_skills_prompt_no_content(self):
+        """_build_skills_prompt should only include name and description."""
+        from swarms.structs.agent import Agent
+
+        agent = Agent.__new__(Agent)
+        skills = [
+            {
+                "name": "test-skill",
+                "description": "A test skill",
+                "path": "/fake/path",
+            },
+        ]
+        prompt = agent._build_skills_prompt(skills)
+        assert "test-skill" in prompt
+        assert "A test skill" in prompt
+        assert "load_full_skill" in prompt
+        # Should NOT contain any full content markers
+        assert "Full Instructions" not in prompt
+
+    def test_build_skills_prompt_empty(self):
+        """_build_skills_prompt returns empty string for no skills."""
+        from swarms.structs.agent import Agent
+
+        agent = Agent.__new__(Agent)
+        assert agent._build_skills_prompt([]) == ""
+
+
+class TestAgentLoadFullSkill:
+    """Test that Agent.load_full_skill works as Tier 2 loader."""
+
+    def test_load_full_skill_returns_content(self, skills_dir):
+        """load_full_skill reads full content from disk on demand."""
+        from swarms.structs.agent import Agent
+
+        agent = Agent.__new__(Agent)
+        agent.skills_metadata = []
+
+        for skill_folder in os.listdir(skills_dir):
+            skill_path = os.path.join(skills_dir, skill_folder)
+            if os.path.isdir(skill_path):
+                skill_file = os.path.join(skill_path, "SKILL.md")
+                if os.path.exists(skill_file):
+                    agent.skills_metadata.append(
+                        {
+                            "name": skill_folder,
+                            "description": "test",
+                            "path": skill_file,
+                        }
+                    )
+
+        content = agent.load_full_skill("test-skill")
+        assert content is not None
+        assert "Full Instructions" in content
+        assert "should only be loaded on demand" in content
+
+    def test_load_full_skill_not_found(self):
+        """load_full_skill returns None for unknown skill."""
+        from swarms.structs.agent import Agent
+
+        agent = Agent.__new__(Agent)
+        agent.skills_metadata = []
+        assert agent.load_full_skill("nonexistent") is None
+
+
+# ── Integration tests ────────────────────────────────────────────────
+
+
+class TestHandleSkillsIntegration:
+    """Test the full handle_skills flow on a real Agent instance."""
+
+    def test_handle_skills_static_loading(self, skills_dir):
+        """handle_skills(task=None) loads all skills with Tier 1 only."""
+        from swarms.structs.agent import Agent
+
+        agent = Agent(
+            agent_name="Skills-Test-Agent",
+            skills_dir=skills_dir,
+            max_loops=1,
+            model_name="gpt-4o-mini",
+        )
+
+        # handle_skills is called during run(), but we can call it directly
+        initial_prompt = agent.system_prompt
+        agent.handle_skills(task=None)
+
+        # Tier 1: system prompt has skill names
+        assert "test-skill" in agent.system_prompt
+        assert "another-skill" in agent.system_prompt
+
+        # Tier 1: system prompt does NOT have full content
+        assert "Full Instructions" not in agent.system_prompt
+        assert "should only be loaded on demand" not in agent.system_prompt
+        assert "Another Skill Instructions" not in agent.system_prompt
+
+        # Tier 2: load_full_skill is registered as a tool
+        tool_names = [
+            t.get("function", {}).get("name", "")
+            for t in agent.tools_list_dictionary
+            if isinstance(t, dict)
+        ]
+        assert "load_full_skill" in tool_names
+
+    def test_handle_skills_dynamic_loading(self, skills_dir):
+        """handle_skills(task=...) loads relevant skills with Tier 1 only."""
+        from swarms.structs.agent import Agent
+
+        agent = Agent(
+            agent_name="Dynamic-Skills-Test-Agent",
+            skills_dir=skills_dir,
+            max_loops=1,
+            model_name="gpt-4o-mini",
+        )
+
+        # Use a task that should match skills (low threshold in DynamicSkillsLoader)
+        agent.handle_skills(task="test skill for unit testing")
+
+        # Should have loaded at least one skill
+        assert "load_full_skill" in [
+            t.get("function", {}).get("name", "")
+            for t in (agent.tools_list_dictionary or [])
+            if isinstance(t, dict)
+        ]
+
+        # System prompt should NOT have full content
+        assert "should only be loaded on demand" not in agent.system_prompt
+
+    def test_tool_struct_can_execute_load_full_skill(self, skills_dir):
+        """Simulate LLM calling load_full_skill — tool_struct executes it."""
+        from swarms.structs.agent import Agent
+
+        agent = Agent(
+            agent_name="Tool-Exec-Test-Agent",
+            skills_dir=skills_dir,
+            max_loops=1,
+            model_name="gpt-4o-mini",
+        )
+        agent.handle_skills(task=None)
+
+        # Simulate what the LLM would return as a tool call
+        simulated_llm_response = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "load_full_skill",
+                    "arguments": json.dumps(
+                        {"skill_name": "test-skill"}
+                    ),
+                },
+                "id": "call_test_123",
+            }
+        ]
+
+        # Execute through tool_struct — this is the real execution path
+        result = agent.tool_struct.execute_function_calls_from_api_response(
+            simulated_llm_response
+        )
+
+        # Result should contain the full skill content
+        result_str = str(result)
+        assert "Full Instructions" in result_str
+        assert "should only be loaded on demand" in result_str
+
+    def test_tool_struct_execute_nonexistent_skill(self, skills_dir):
+        """load_full_skill returns None for unknown skill via tool_struct."""
+        from swarms.structs.agent import Agent
+
+        agent = Agent(
+            agent_name="Tool-Exec-Test-Agent-2",
+            skills_dir=skills_dir,
+            max_loops=1,
+            model_name="gpt-4o-mini",
+        )
+        agent.handle_skills(task=None)
+
+        simulated_llm_response = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "load_full_skill",
+                    "arguments": json.dumps(
+                        {"skill_name": "nonexistent-skill"}
+                    ),
+                },
+                "id": "call_test_456",
+            }
+        ]
+
+        result = agent.tool_struct.execute_function_calls_from_api_response(
+            simulated_llm_response
+        )
+
+        # Should return None (no skill found)
+        result_str = str(result)
+        assert "None" in result_str
+
+    def test_no_duplicate_tool_registration(self, skills_dir):
+        """Calling handle_skills twice should not duplicate the tool."""
+        from swarms.structs.agent import Agent
+
+        agent = Agent(
+            agent_name="Dedup-Test-Agent",
+            skills_dir=skills_dir,
+            max_loops=1,
+            model_name="gpt-4o-mini",
+        )
+        agent.handle_skills(task=None)
+        agent.handle_skills(task=None)
+
+        tool_names = [
+            t.get("function", {}).get("name", "")
+            for t in agent.tools_list_dictionary
+            if isinstance(t, dict)
+        ]
+        assert tool_names.count("load_full_skill") == 1


### PR DESCRIPTION
## Summary

Fixes #1400

- **Tier 1**: `_build_skills_prompt` now only injects skill name + description into the system prompt (no full content)
- **Tier 2**: `load_full_skill` is registered as a callable tool so the LLM can load full skill content on demand mid-conversation
- Removed `content` from metadata in both `DynamicSkillsLoader._load_all_skills_metadata` and `Agent.load_skills_metadata`
- `DynamicSkillsLoader.load_full_skill_content` now reads from disk instead of returning cached content
- Added `_register_skills_tool` to handle tool registration and deduplication

## Test plan

- [x] 13 new tests in `tests/structs/test_progressive_skills_loading.py`
- [x] Metadata has no `content` key (Tier 1 verified)
- [x] `load_full_skill` reads full content from disk on demand (Tier 2 verified)
- [x] `handle_skills` on a real Agent registers `load_full_skill` as a tool
- [x] `tool_struct.execute_function_calls_from_api_response` can execute a simulated LLM `load_full_skill` call and returns correct content
- [x] No duplicate tool registration on repeated `handle_skills` calls
- [x] Existing agent tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1434.org.readthedocs.build/en/1434/

<!-- readthedocs-preview swarms end -->