### PR TITLE
feat: PlannerWorkerSwarm — parallel multi-agent task execution

### DIFF
--- a/examples/planner_worker_swarm_example.py
+++ b/examples/planner_worker_swarm_example.py
@@ -1,0 +1,138 @@
+"""
+PlannerWorkerSwarm Example
+==========================
+
+Demonstrates the planner-worker-judge architecture with parallel execution:
+
+1. A **Planner** agent decomposes the goal into independent tasks
+2. **Worker** agents claim tasks from a shared queue and execute them
+   concurrently in a ThreadPoolExecutor — no worker-to-worker coordination
+3. A **Judge** agent evaluates the combined results and decides:
+   complete / fill gaps / fresh start (to combat drift)
+
+Based on Cursor's "Scaling long-running autonomous coding" research.
+https://cursor.com/blog/scaling-agents
+"""
+
+import time
+
+from swarms import Agent
+from swarms.structs.planner_worker_swarm import PlannerWorkerSwarm
+
+
+def main():
+    # --- Define 5 worker agents with different expertise ---
+    # More workers = more parallelism. Each worker independently
+    # claims tasks from the queue — they never talk to each other.
+
+    workers = [
+        Agent(
+            agent_name="Research-Agent",
+            agent_description="Gathers factual information and data points",
+            system_prompt=(
+                "You are a research specialist. Provide thorough, factual "
+                "information with specific details. Be concise but comprehensive."
+            ),
+            model_name="gpt-4o-mini",
+            max_loops=1,
+        ),
+        Agent(
+            agent_name="Analysis-Agent",
+            agent_description="Analyzes data and identifies patterns",
+            system_prompt=(
+                "You are an analysis specialist. Analyze information critically, "
+                "identify patterns, and provide structured conclusions with bullet points."
+            ),
+            model_name="gpt-4o-mini",
+            max_loops=1,
+        ),
+        Agent(
+            agent_name="Writing-Agent",
+            agent_description="Creates clear, well-structured content",
+            system_prompt=(
+                "You are a writing specialist. Produce clear, well-organized "
+                "content with good readability and logical flow."
+            ),
+            model_name="gpt-4o-mini",
+            max_loops=1,
+        ),
+        Agent(
+            agent_name="Strategy-Agent",
+            agent_description="Evaluates strategic implications and recommendations",
+            system_prompt=(
+                "You are a strategy specialist. Evaluate information from a "
+                "strategic perspective and provide actionable recommendations."
+            ),
+            model_name="gpt-4o-mini",
+            max_loops=1,
+        ),
+        Agent(
+            agent_name="Data-Agent",
+            agent_description="Compiles statistics, comparisons, and quantitative data",
+            system_prompt=(
+                "You are a data specialist. Compile relevant statistics, "
+                "create comparisons, and present quantitative insights clearly."
+            ),
+            model_name="gpt-4o-mini",
+            max_loops=1,
+        ),
+    ]
+
+    # --- Create the swarm ---
+    swarm = PlannerWorkerSwarm(
+        name="Market-Research-Swarm",
+        description="Conducts market research through parallel agent collaboration",
+        agents=workers,
+        max_loops=1,
+        planner_model_name="gpt-4o-mini",
+        judge_model_name="gpt-4o-mini",
+        max_workers=5,  # All 5 workers can run concurrently
+        worker_timeout=120,
+        output_type="string",
+    )
+
+    # --- Run and time it ---
+    task = (
+        "Research the current state of the electric vehicle (EV) market. "
+        "Cover: top manufacturers by market share, key technology trends, "
+        "biggest challenges facing EV adoption, regional market differences, "
+        "and a 5-year outlook. Each topic should be a separate task."
+    )
+
+    print(f"Starting swarm with {len(workers)} parallel workers...")
+    print(f"Task: {task}\n")
+
+    start = time.time()
+    result = swarm.run(task=task)
+    elapsed = time.time() - start
+
+    # --- Display results ---
+    print("\n" + "=" * 70)
+    print("RESULT")
+    print("=" * 70)
+    print(result)
+
+    # --- Show concurrency proof via task queue status ---
+    print("\n" + "=" * 70)
+    print("TASK QUEUE STATUS")
+    print("=" * 70)
+    status = swarm.get_status()
+    for t in status["queue"]["tasks"]:
+        print(
+            f"  [{t['status']:>9}] {t['title'][:60]:<60} "
+            f"-> {t['assigned_worker'] or 'unassigned'}"
+        )
+
+    print(f"\nTotal tasks: {status['queue']['total']}")
+    print(f"Completed:   {status['queue']['progress']}")
+    print(f"Wall time:   {elapsed:.1f}s (parallel execution)")
+    print(
+        f"Workers:     {len(workers)} concurrent threads\n"
+        f"\nIf sequential, {status['queue']['total']} tasks at ~5-8s each "
+        f"would take ~{status['queue']['total'] * 6}s.\n"
+        f"Parallel wall time: {elapsed:.1f}s — that's the concurrency."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/swarms/prompts/planner_worker_prompts.py
+++ b/swarms/prompts/planner_worker_prompts.py
@@ -1,0 +1,69 @@
+PLANNER_SYSTEM_PROMPT = """
+You are a Planner Agent in a planner-worker swarm system. Your ONLY job is to plan -- you do NOT execute tasks.
+
+Given a goal or objective, you must:
+
+1. **Analyze** the goal to understand what needs to be accomplished
+2. **Decompose** the goal into concrete, actionable tasks that a worker agent can execute independently
+3. **Prioritize** tasks (0=LOW, 1=NORMAL, 2=HIGH, 3=CRITICAL)
+4. **Identify dependencies** between tasks (which tasks must complete before others can start)
+
+Guidelines for creating tasks:
+- Each task must be self-contained: a worker with no context beyond the task description should be able to execute it
+- Tasks should be at a granularity where one agent can complete them in a single execution
+- Be specific: "Analyze Q3 revenue data and identify top 3 growth drivers" not "Analyze data"
+- Specify expected output format when relevant
+- If a task depends on another, list the dependency by title
+
+You must output your plan using the provided structured format with a plan narrative and a list of tasks.
+
+CRITICAL: You are a planner. You produce tasks. You do NOT execute them.
+"""
+
+WORKER_SYSTEM_PROMPT = """
+You are a Worker Agent in a planner-worker swarm system. You receive specific tasks from a task queue and execute them thoroughly.
+
+Your responsibilities:
+1. Read the task description carefully
+2. Execute the task completely and accurately
+3. Produce a clear, actionable result
+4. If you encounter an issue, describe it clearly so the task can be retried or reassigned
+
+Guidelines:
+- Focus ONLY on the task you are given -- do not attempt to plan or coordinate with other workers
+- Produce concrete output, not plans or suggestions
+- If the task asks for analysis, provide the analysis
+- If the task asks for code, write the code
+- If the task asks for a decision, make the decision with reasoning
+- Be thorough but concise
+"""
+
+JUDGE_SYSTEM_PROMPT = """
+You are a Cycle Judge in a planner-worker swarm system. After workers execute all planned tasks, you evaluate whether the original goal has been achieved.
+
+You will receive:
+1. The original goal
+2. A report of all tasks and their results
+3. The full conversation history
+
+Your evaluation must determine:
+1. **is_complete** (bool): Has the goal been satisfactorily achieved? Be strict -- partial completion is NOT complete.
+2. **overall_quality** (0-10): Quality of the combined results
+3. **summary**: Brief assessment of what was accomplished
+4. **gaps**: Specific things that are missing or need improvement
+5. **follow_up_instructions**: If not complete, what should the planner focus on in the next cycle?
+6. **needs_fresh_start** (bool): Set to true ONLY when you observe systemic problems that cannot be fixed by adding more tasks. Signs that a fresh start is needed:
+   - Workers are producing low-quality, drifting, or contradictory results
+   - The plan decomposition was fundamentally flawed
+   - Multiple tasks failed and retrying won't help
+   - Results are going in circles without meaningful progress
+   When true, ALL prior work is discarded and planning restarts from scratch. When false, prior completed work is preserved and the planner only fills gaps.
+
+Evaluation standards:
+- A score of 10 means exceptional, comprehensive achievement of the goal
+- A score of 5 means functional but with significant gaps
+- A score of 0-2 means the output is inadequate
+- Only set is_complete=true if the goal is genuinely and fully achieved
+- Be specific in gaps: "Missing competitive analysis section" not "Needs more work"
+- Default needs_fresh_start to false; only use it for severe drift or systemic failure
+"""

--- a/swarms/schemas/__init__.py
+++ b/swarms/schemas/__init__.py
@@ -3,10 +3,24 @@ from swarms.schemas.mcp_schemas import (
     MCPConnection,
     MultipleMCPConnections,
 )
+from swarms.schemas.planner_worker_schemas import (
+    CycleVerdict,
+    PlannerTask,
+    PlannerTaskOutput,
+    PlannerTaskSpec,
+    PlannerTaskStatus,
+    TaskPriority,
+)
 
 __all__ = [
     "Step",
     "ManySteps",
     "MCPConnection",
     "MultipleMCPConnections",
+    "CycleVerdict",
+    "PlannerTask",
+    "PlannerTaskOutput",
+    "PlannerTaskSpec",
+    "PlannerTaskStatus",
+    "TaskPriority",
 ]

--- a/swarms/schemas/planner_worker_schemas.py
+++ b/swarms/schemas/planner_worker_schemas.py
@@ -1,0 +1,178 @@
+import time
+import uuid
+from enum import Enum, IntEnum
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class TaskPriority(IntEnum):
+    """Priority levels for tasks in the queue."""
+
+    LOW = 0
+    NORMAL = 1
+    HIGH = 2
+    CRITICAL = 3
+
+
+class PlannerTaskStatus(str, Enum):
+    """Status of a task in the planner-worker queue.
+
+    Transitions:
+        PENDING -> CLAIMED -> RUNNING -> COMPLETED
+        PENDING -> CLAIMED -> RUNNING -> FAILED -> PENDING (retry)
+        Any non-terminal -> CANCELLED
+    """
+
+    PENDING = "pending"
+    CLAIMED = "claimed"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class PlannerTask(BaseModel):
+    """A single task in the shared planner-worker task queue.
+
+    Created by planner agents, consumed by worker agents.
+    The `version` field enables optimistic concurrency control.
+    """
+
+    id: str = Field(
+        default_factory=lambda: f"ptask-{uuid.uuid4().hex[:10]}",
+        description="Unique task identifier",
+    )
+    title: str = Field(
+        ...,
+        description="Short, descriptive title of the task",
+    )
+    description: str = Field(
+        ...,
+        description="Detailed description of what needs to be done",
+    )
+    priority: TaskPriority = Field(
+        default=TaskPriority.NORMAL,
+        description="Task priority level",
+    )
+    depends_on: List[str] = Field(
+        default_factory=list,
+        description="List of task IDs that must complete before this task can start",
+    )
+    parent_task_id: Optional[str] = Field(
+        default=None,
+        description="ID of the parent task if decomposed from a larger task",
+    )
+    status: PlannerTaskStatus = Field(
+        default=PlannerTaskStatus.PENDING,
+        description="Current task status",
+    )
+    assigned_worker: Optional[str] = Field(
+        default=None,
+        description="Name of the worker agent that claimed this task",
+    )
+    result: Optional[str] = Field(
+        default=None,
+        description="Result of task execution",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Error message if task failed",
+    )
+    retries: int = Field(
+        default=0,
+        description="Number of retry attempts so far",
+    )
+    max_retries: int = Field(
+        default=2,
+        description="Maximum retry attempts before permanent failure",
+    )
+    version: int = Field(
+        default=0,
+        description="Optimistic concurrency version counter",
+    )
+    created_at: float = Field(
+        default_factory=time.time,
+        description="Unix timestamp of task creation",
+    )
+    completed_at: Optional[float] = Field(
+        default=None,
+        description="Unix timestamp of task completion",
+    )
+    metadata: Dict = Field(
+        default_factory=dict,
+        description="Arbitrary metadata",
+    )
+
+
+class PlannerTaskOutput(BaseModel):
+    """A single task definition as output from a planner agent."""
+
+    title: str = Field(
+        ...,
+        description="Short, descriptive title",
+    )
+    description: str = Field(
+        ...,
+        description="Detailed description of what a worker agent should do",
+    )
+    priority: int = Field(
+        default=1,
+        description="Priority: 0=LOW, 1=NORMAL, 2=HIGH, 3=CRITICAL",
+    )
+    depends_on_titles: List[str] = Field(
+        default_factory=list,
+        description="Titles of other tasks in this plan that must complete first",
+    )
+
+
+class PlannerTaskSpec(BaseModel):
+    """Structured output from a planner agent.
+
+    The planner produces a plan narrative and a list of concrete tasks.
+    """
+
+    plan: str = Field(
+        ...,
+        description="Narrative explanation of the plan: what needs to be done, in what order, and why.",
+    )
+    tasks: List[PlannerTaskOutput] = Field(
+        ...,
+        description="List of concrete tasks to add to the queue.",
+    )
+
+
+class CycleVerdict(BaseModel):
+    """Structured output from the judge agent after evaluating a cycle."""
+
+    is_complete: bool = Field(
+        ...,
+        description="True if the overall goal has been satisfactorily achieved",
+    )
+    overall_quality: int = Field(
+        ...,
+        ge=0,
+        le=10,
+        description="Quality score 0-10 of the combined results",
+    )
+    summary: str = Field(
+        ...,
+        description="Summary assessment of the cycle results",
+    )
+    gaps: List[str] = Field(
+        default_factory=list,
+        description="Specific gaps or issues that need addressing in a follow-up cycle",
+    )
+    follow_up_instructions: Optional[str] = Field(
+        default=None,
+        description="Instructions for the planner if another cycle is needed",
+    )
+    needs_fresh_start: bool = Field(
+        default=False,
+        description=(
+            "True if accumulated drift or systemic issues require a complete "
+            "restart rather than incremental gap-filling. When True, all prior "
+            "tasks are discarded and the planner begins from scratch with the "
+            "original goal plus judge feedback."
+        ),
+    )

--- a/swarms/structs/__init__.py
+++ b/swarms/structs/__init__.py
@@ -61,6 +61,11 @@ from swarms.structs.multi_agent_exec import (
     run_single_agent,
 )
 from swarms.structs.multi_agent_router import MultiAgentRouter
+from swarms.structs.planner_worker_swarm import (
+    PlannerWorkerSwarm,
+    TaskQueue,
+    WorkerPool,
+)
 from swarms.structs.round_robin import RoundRobinSwarm
 from swarms.structs.self_moa_seq import SelfMoASeq
 from swarms.structs.sequential_workflow import SequentialWorkflow
@@ -174,4 +179,7 @@ __all__ = [
     "SubagentRegistry",
     "SubagentTask",
     "TaskStatus",
+    "PlannerWorkerSwarm",
+    "TaskQueue",
+    "WorkerPool",
 ]

--- a/swarms/structs/planner_worker_swarm.py
+++ b/swarms/structs/planner_worker_swarm.py
@@ -1,0 +1,937 @@
+import concurrent.futures
+import json
+import os
+import threading
+import time
+import traceback
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from loguru import logger
+
+from swarms.prompts.planner_worker_prompts import (
+    JUDGE_SYSTEM_PROMPT,
+    PLANNER_SYSTEM_PROMPT,
+    WORKER_SYSTEM_PROMPT,
+)
+from swarms.schemas.planner_worker_schemas import (
+    CycleVerdict,
+    PlannerTask,
+    PlannerTaskSpec,
+    PlannerTaskStatus,
+    TaskPriority,
+)
+from swarms.structs.agent import Agent
+from swarms.structs.conversation import Conversation
+from swarms.tools.base_tool import BaseTool
+from swarms.utils.history_output_formatter import (
+    history_output_formatter,
+)
+from swarms.utils.output_types import OutputType
+
+
+class TaskQueue:
+    """Thread-safe in-memory task queue with optimistic concurrency.
+
+    Uses a dict of PlannerTask objects protected by a threading.Lock.
+    Workers claim tasks atomically via claim(). The version field on
+    each task enables optimistic concurrency for start/complete/fail.
+    """
+
+    def __init__(self):
+        self._tasks: Dict[str, PlannerTask] = {}
+        self._lock = threading.Lock()
+
+    def add_task(self, task: PlannerTask) -> str:
+        """Add a task to the queue. Returns the task ID."""
+        with self._lock:
+            self._tasks[task.id] = task
+            logger.info(
+                f"[TaskQueue] Added task {task.id}: {task.title}"
+            )
+            return task.id
+
+    def add_tasks(self, tasks: List[PlannerTask]) -> List[str]:
+        """Bulk add tasks. Returns list of task IDs."""
+        ids = []
+        with self._lock:
+            for task in tasks:
+                self._tasks[task.id] = task
+                ids.append(task.id)
+        logger.info(f"[TaskQueue] Added {len(ids)} tasks")
+        return ids
+
+    def claim(self, worker_name: str) -> Optional[PlannerTask]:
+        """Atomically claim the highest-priority available task.
+
+        A task is available if:
+        1. status == PENDING
+        2. All depends_on task IDs are in COMPLETED status
+
+        Returns None if no tasks are available.
+        """
+        with self._lock:
+            completed_ids = {
+                tid
+                for tid, t in self._tasks.items()
+                if t.status == PlannerTaskStatus.COMPLETED
+            }
+
+            available = []
+            for task in self._tasks.values():
+                if task.status != PlannerTaskStatus.PENDING:
+                    continue
+                if all(
+                    dep_id in completed_ids
+                    for dep_id in task.depends_on
+                ):
+                    available.append(task)
+
+            if not available:
+                return None
+
+            # Highest priority first, then oldest first
+            available.sort(
+                key=lambda t: (-t.priority.value, t.created_at)
+            )
+
+            chosen = available[0]
+            chosen.status = PlannerTaskStatus.CLAIMED
+            chosen.assigned_worker = worker_name
+            chosen.version += 1
+
+            return chosen.model_copy()
+
+    def start(self, task_id: str, expected_version: int) -> bool:
+        """Mark a claimed task as RUNNING. Returns False on version mismatch."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return False
+            if task.version != expected_version:
+                return False
+            if task.status != PlannerTaskStatus.CLAIMED:
+                return False
+            task.status = PlannerTaskStatus.RUNNING
+            task.version += 1
+            return True
+
+    def complete(
+        self, task_id: str, result: str, expected_version: int
+    ) -> bool:
+        """Mark a running task as COMPLETED with result."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return False
+            if task.version != expected_version:
+                return False
+            if task.status != PlannerTaskStatus.RUNNING:
+                return False
+            task.status = PlannerTaskStatus.COMPLETED
+            task.result = result
+            task.completed_at = time.time()
+            task.version += 1
+            return True
+
+    def fail(
+        self, task_id: str, error: str, expected_version: int
+    ) -> bool:
+        """Mark a running task as FAILED. Resets to PENDING if retries remain."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return False
+            if task.version != expected_version:
+                return False
+            if task.status != PlannerTaskStatus.RUNNING:
+                return False
+
+            task.retries += 1
+            task.error = error
+
+            if task.retries <= task.max_retries:
+                # Reset for retry
+                task.status = PlannerTaskStatus.PENDING
+                task.assigned_worker = None
+                logger.info(
+                    f"[TaskQueue] Task {task_id} failed, retrying ({task.retries}/{task.max_retries})"
+                )
+            else:
+                task.status = PlannerTaskStatus.FAILED
+                task.completed_at = time.time()
+                logger.warning(
+                    f"[TaskQueue] Task {task_id} permanently failed: {error}"
+                )
+
+            task.version += 1
+            return True
+
+    def cancel(self, task_id: str) -> bool:
+        """Cancel a task if not yet completed."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return False
+            if task.status in (
+                PlannerTaskStatus.COMPLETED,
+                PlannerTaskStatus.CANCELLED,
+            ):
+                return False
+            task.status = PlannerTaskStatus.CANCELLED
+            task.version += 1
+            return True
+
+    def clear(self) -> int:
+        """Remove all tasks from the queue. Returns the count of tasks removed.
+
+        Used for fresh starts when the judge determines that accumulated
+        drift requires a complete restart rather than incremental gap-filling.
+        """
+        with self._lock:
+            count = len(self._tasks)
+            self._tasks.clear()
+            if count:
+                logger.info(
+                    f"[TaskQueue] Cleared {count} tasks (fresh start)"
+                )
+            return count
+
+    def clear_non_terminal(self) -> int:
+        """Remove only pending/claimed/running tasks, preserving completed results.
+
+        Used between cycles when the judge determines that completed work
+        is still valuable but remaining work should be replanned.
+        """
+        with self._lock:
+            terminal = {
+                PlannerTaskStatus.COMPLETED,
+                PlannerTaskStatus.FAILED,
+                PlannerTaskStatus.CANCELLED,
+            }
+            to_remove = [
+                tid
+                for tid, t in self._tasks.items()
+                if t.status not in terminal
+            ]
+            for tid in to_remove:
+                del self._tasks[tid]
+            if to_remove:
+                logger.info(
+                    f"[TaskQueue] Cleared {len(to_remove)} non-terminal tasks"
+                )
+            return len(to_remove)
+
+    def get_task(self, task_id: str) -> Optional[PlannerTask]:
+        """Get a read-only copy of a task by ID."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            return task.model_copy() if task else None
+
+    def get_all_tasks(self) -> List[PlannerTask]:
+        """Get read-only copies of all tasks."""
+        with self._lock:
+            return [t.model_copy() for t in self._tasks.values()]
+
+    def get_pending_count(self) -> int:
+        """Count of tasks in PENDING status with satisfied dependencies."""
+        with self._lock:
+            completed_ids = {
+                tid
+                for tid, t in self._tasks.items()
+                if t.status == PlannerTaskStatus.COMPLETED
+            }
+            return sum(
+                1
+                for t in self._tasks.values()
+                if t.status == PlannerTaskStatus.PENDING
+                and all(
+                    dep in completed_ids for dep in t.depends_on
+                )
+            )
+
+    def get_completed_count(self) -> int:
+        with self._lock:
+            return sum(
+                1
+                for t in self._tasks.values()
+                if t.status == PlannerTaskStatus.COMPLETED
+            )
+
+    def get_failed_count(self) -> int:
+        with self._lock:
+            return sum(
+                1
+                for t in self._tasks.values()
+                if t.status == PlannerTaskStatus.FAILED
+            )
+
+    def is_all_done(self) -> bool:
+        """True if all tasks are in a terminal state."""
+        terminal = {
+            PlannerTaskStatus.COMPLETED,
+            PlannerTaskStatus.FAILED,
+            PlannerTaskStatus.CANCELLED,
+        }
+        with self._lock:
+            if not self._tasks:
+                return True
+            return all(
+                t.status in terminal for t in self._tasks.values()
+            )
+
+    def get_results_summary(self) -> Dict[str, str]:
+        """Return {task_id: result} for all completed tasks."""
+        with self._lock:
+            return {
+                tid: t.result
+                for tid, t in self._tasks.items()
+                if t.status == PlannerTaskStatus.COMPLETED
+                and t.result is not None
+            }
+
+    def get_dependency_results(self, task_id: str) -> str:
+        """Get formatted results from all completed tasks that this task depends on."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if not task or not task.depends_on:
+                return ""
+            parts = []
+            for dep_id in task.depends_on:
+                dep = self._tasks.get(dep_id)
+                if (
+                    dep
+                    and dep.status == PlannerTaskStatus.COMPLETED
+                    and dep.result
+                ):
+                    parts.append(
+                        f"[Result from: {dep.title}]\n{dep.result}"
+                    )
+            return "\n\n".join(parts)
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return a structured status report of the task queue."""
+        with self._lock:
+            status_counts: Dict[str, int] = {}
+            task_details = []
+            for t in self._tasks.values():
+                status_counts[t.status.value] = (
+                    status_counts.get(t.status.value, 0) + 1
+                )
+                task_details.append(
+                    {
+                        "id": t.id,
+                        "title": t.title,
+                        "status": t.status.value,
+                        "assigned_worker": t.assigned_worker,
+                        "priority": t.priority.name,
+                        "retries": t.retries,
+                    }
+                )
+            total = len(self._tasks)
+            completed = status_counts.get("completed", 0)
+            return {
+                "total": total,
+                "progress": f"{completed}/{total}",
+                "status_counts": status_counts,
+                "tasks": task_details,
+            }
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._tasks)
+
+
+class WorkerPool:
+    """Manages a pool of worker agents that claim and execute tasks from a TaskQueue.
+
+    Each worker runs in a ThreadPoolExecutor thread, independently claiming
+    and executing tasks until the queue is drained or timeout is reached.
+    Workers do not coordinate with each other — they only interact with
+    the shared TaskQueue through atomic claim/start/complete/fail operations.
+    """
+
+    def __init__(
+        self,
+        agents: List[Agent],
+        task_queue: TaskQueue,
+        conversation: Conversation,
+        max_workers: Optional[int] = None,
+        poll_interval: float = 0.1,
+        task_timeout: Optional[float] = None,
+    ):
+        self.agents = agents
+        self.task_queue = task_queue
+        self.conversation = conversation
+        self.max_workers = max_workers or min(
+            len(agents), os.cpu_count() or 4
+        )
+        self.poll_interval = poll_interval
+        self.task_timeout = task_timeout
+        self._stop_event = threading.Event()
+
+    def run(
+        self, timeout: Optional[float] = None
+    ) -> Dict[str, str]:
+        """Run all workers until queue is drained or timeout.
+
+        Returns dict of {task_id: result} for completed tasks.
+        """
+        self._stop_event.clear()
+        start_time = time.time()
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.max_workers
+        ) as executor:
+            futures = []
+            for agent in self.agents:
+                future = executor.submit(
+                    self._worker_loop, agent, timeout, start_time
+                )
+                futures.append(future)
+
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    logger.error(f"[WorkerPool] Worker failed: {e}")
+
+        return self.task_queue.get_results_summary()
+
+    def stop(self):
+        """Signal all workers to stop."""
+        self._stop_event.set()
+
+    def _worker_loop(
+        self,
+        agent: Agent,
+        timeout: Optional[float],
+        start_time: float,
+    ):
+        """Main loop for a single worker agent."""
+        worker_name = getattr(
+            agent, "agent_name", str(id(agent))
+        )
+
+        while not self._stop_event.is_set():
+            # Check timeout
+            if timeout and (time.time() - start_time) > timeout:
+                logger.info(
+                    f"[WorkerPool] Worker {worker_name} timed out"
+                )
+                break
+
+            # Check if all done
+            if self.task_queue.is_all_done():
+                break
+
+            # Try to claim a task
+            task = self.task_queue.claim(worker_name)
+            if task is None:
+                time.sleep(self.poll_interval)
+                continue
+
+            # Transition to RUNNING
+            if not self.task_queue.start(task.id, task.version):
+                continue
+
+            logger.info(
+                f"[WorkerPool] Worker {worker_name} executing: {task.title}"
+            )
+
+            try:
+                # Reset agent memory so prior tasks don't leak into this one
+                agent.short_memory = agent.short_memory_init()
+
+                # Build context: worker focus prompt + task description + dependency results
+                dep_context = self.task_queue.get_dependency_results(
+                    task.id
+                )
+                context_parts = [
+                    WORKER_SYSTEM_PROMPT.strip(),
+                    f"\nTask: {task.title}",
+                    f"Description: {task.description}",
+                ]
+                if dep_context:
+                    context_parts.append(
+                        f"\nContext from prerequisite tasks:\n{dep_context}"
+                    )
+                context = "\n".join(context_parts)
+
+                # Run with per-task timeout to detect stuck workers
+                if self.task_timeout:
+                    with concurrent.futures.ThreadPoolExecutor(
+                        max_workers=1
+                    ) as task_executor:
+                        future = task_executor.submit(
+                            agent.run, task=context
+                        )
+                        try:
+                            result = future.result(
+                                timeout=self.task_timeout
+                            )
+                        except concurrent.futures.TimeoutError:
+                            raise TimeoutError(
+                                f"Task execution exceeded {self.task_timeout}s timeout"
+                            )
+                else:
+                    result = agent.run(task=context)
+
+                current = self.task_queue.get_task(task.id)
+                if current and self.task_queue.complete(
+                    task.id, result, current.version
+                ):
+                    self.conversation.add(
+                        role=worker_name,
+                        content=f"[Task: {task.title}]\n{result}",
+                    )
+                    logger.info(
+                        f"[WorkerPool] Worker {worker_name} completed: {task.title}"
+                    )
+                else:
+                    logger.warning(
+                        f"[WorkerPool] Version conflict completing {task.id}"
+                    )
+
+            except Exception as e:
+                logger.error(
+                    f"[WorkerPool] Worker {worker_name} failed on {task.id}: {e}"
+                )
+                current = self.task_queue.get_task(task.id)
+                if current:
+                    self.task_queue.fail(
+                        task.id, str(e), current.version
+                    )
+
+
+class PlannerWorkerSwarm:
+    """A swarm that separates planning from execution.
+
+    Implements the planner-worker architecture described in Cursor's
+    "Scaling long-running autonomous coding" research. Key principles:
+
+    - **Separation of concerns**: Planners only plan, workers only execute.
+    - **No worker coordination**: Workers interact only with the task queue.
+    - **Optimistic concurrency**: No locks — workers claim tasks atomically.
+    - **Judge-driven cycles**: A judge evaluates results and decides whether
+      to continue, fill gaps, or trigger a fresh start to combat drift.
+    - **Prompts matter**: Worker and planner behavior is controlled through
+      focused system prompts that reinforce role boundaries.
+
+    Architecture per cycle:
+        1. Planner agent(s) analyze the task and produce sub-tasks into a TaskQueue
+        2. Worker agents claim tasks from the queue and execute them concurrently
+        3. A judge agent evaluates the cycle results
+        4. If not complete, the planner gets feedback and produces new tasks
+        5. If drift is detected, the judge triggers a fresh start
+
+    Args:
+        name: Name of the swarm.
+        description: Description of purpose.
+        agents: Worker agents that execute tasks.
+        max_loops: Maximum planner-worker-judge cycles.
+        planner_model_name: Model for the planner agent.
+        judge_model_name: Model for the judge agent.
+        max_planner_depth: Max recursive sub-planner depth (1 = no sub-planners).
+        worker_timeout: Max seconds for worker pool per cycle.
+        task_timeout: Max seconds per individual task execution.
+        max_workers: Max concurrent worker threads.
+        output_type: Output format for the final result.
+        autosave: Whether to save conversation history.
+        verbose: Enable verbose logging.
+    """
+
+    def __init__(
+        self,
+        name: str = "PlannerWorkerSwarm",
+        description: str = "A planner-worker execution swarm",
+        agents: Optional[List[Union[Agent, Callable]]] = None,
+        max_loops: int = 1,
+        planner_model_name: str = "gpt-4o-mini",
+        judge_model_name: str = "gpt-4o-mini",
+        max_planner_depth: int = 1,
+        worker_timeout: Optional[float] = None,
+        task_timeout: Optional[float] = None,
+        max_workers: Optional[int] = None,
+        output_type: OutputType = "dict-all-except-first",
+        autosave: bool = False,
+        verbose: bool = False,
+        *args,
+        **kwargs,
+    ):
+        self.name = name
+        self.description = description
+        self.agents = agents or []
+        self.max_loops = max_loops
+        self.planner_model_name = planner_model_name
+        self.judge_model_name = judge_model_name
+        self.max_planner_depth = max_planner_depth
+        self.worker_timeout = worker_timeout
+        self.task_timeout = task_timeout
+        self.max_workers = max_workers
+        self.output_type = output_type
+        self.autosave = autosave
+        self.verbose = verbose
+
+        # Internal state
+        self.task_queue = TaskQueue()
+        self.conversation = Conversation(time_enabled=False)
+        self._original_task: Optional[str] = None
+
+        self._reliability_checks()
+
+    def _reliability_checks(self):
+        if not self.agents or len(self.agents) == 0:
+            raise ValueError(
+                "PlannerWorkerSwarm requires at least one worker agent."
+            )
+        if self.max_loops <= 0:
+            raise ValueError("max_loops must be > 0")
+
+    def _create_planner_agent(
+        self,
+        name: str = "Planner",
+    ) -> Agent:
+        """Create a planner agent configured for structured task output."""
+        schema = BaseTool().base_model_to_dict(PlannerTaskSpec)
+
+        return Agent(
+            agent_name=name,
+            agent_description="Creates plans and decomposes tasks into concrete work items",
+            system_prompt=PLANNER_SYSTEM_PROMPT,
+            model_name=self.planner_model_name,
+            max_loops=1,
+            base_model=PlannerTaskSpec,
+            tools_list_dictionary=[schema],
+            output_type="dict-all-except-first",
+        )
+
+    def _parse_structured_output(self, output: Any, model_class):
+        """Parse structured output from an agent, handling various output formats.
+
+        Follows the same pattern as HierarchicalSwarm.parse_orders().
+        """
+        try:
+            if isinstance(output, model_class):
+                return output
+
+            if isinstance(output, dict):
+                return model_class(**output)
+
+            if isinstance(output, list):
+                for item in output:
+                    if isinstance(item, dict):
+                        # Conversation format with role/content
+                        if "content" in item and isinstance(
+                            item["content"], list
+                        ):
+                            for content_item in item["content"]:
+                                if (
+                                    isinstance(content_item, dict)
+                                    and "function" in content_item
+                                ):
+                                    function_data = content_item[
+                                        "function"
+                                    ]
+                                    if (
+                                        "arguments"
+                                        in function_data
+                                    ):
+                                        try:
+                                            args = json.loads(
+                                                function_data[
+                                                    "arguments"
+                                                ]
+                                            )
+                                            return model_class(
+                                                **args
+                                            )
+                                        except (
+                                            json.JSONDecodeError,
+                                            TypeError,
+                                        ):
+                                            pass
+                        # Direct function call format
+                        elif "function" in item:
+                            function_data = item["function"]
+                            if "arguments" in function_data:
+                                try:
+                                    args = json.loads(
+                                        function_data["arguments"]
+                                    )
+                                    return model_class(**args)
+                                except (
+                                    json.JSONDecodeError,
+                                    TypeError,
+                                ):
+                                    pass
+                        # Try direct dict parse
+                        try:
+                            return model_class(**item)
+                        except (TypeError, ValueError):
+                            pass
+
+            # Try parsing as JSON string
+            if isinstance(output, str):
+                try:
+                    data = json.loads(output)
+                    return model_class(**data)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+            raise ValueError(
+                f"Unable to parse output as {model_class.__name__}: {type(output)}"
+            )
+
+        except Exception as e:
+            logger.error(
+                f"[PlannerWorkerSwarm] Failed to parse output: {e}\n"
+                f"[TRACE] {traceback.format_exc()}"
+            )
+            raise
+
+    def _run_planner(
+        self,
+        task: str,
+        depth: int = 0,
+        parent_task_id: Optional[str] = None,
+    ) -> List[PlannerTask]:
+        """Run a planner and add produced tasks to the queue.
+
+        Args:
+            task: The task description to plan for.
+            depth: Current recursion depth for sub-planners.
+            parent_task_id: ID of parent task if sub-planning.
+
+        Returns:
+            List of PlannerTask objects added to the queue.
+        """
+        planner_name = (
+            "Planner" if depth == 0 else f"SubPlanner-{depth}"
+        )
+        planner = self._create_planner_agent(name=planner_name)
+
+        logger.info(
+            f"[PlannerWorkerSwarm] Running {planner_name} (depth={depth})"
+        )
+
+        raw_output = planner.run(task=task)
+
+        spec = self._parse_structured_output(
+            raw_output, PlannerTaskSpec
+        )
+
+        self.conversation.add(
+            role=planner_name, content=spec.plan
+        )
+
+        # Convert PlannerTaskOutput items to PlannerTask objects
+        added_tasks = []
+        title_to_id: Dict[str, str] = {}
+
+        # First pass: create tasks and build title->id map
+        task_pairs: List[tuple[PlannerTask, List[str]]] = []
+        for task_output in spec.tasks:
+            priority = TaskPriority(
+                max(0, min(3, task_output.priority))
+            )
+            ptask = PlannerTask(
+                title=task_output.title,
+                description=task_output.description,
+                priority=priority,
+                parent_task_id=parent_task_id,
+            )
+            title_to_id[task_output.title] = ptask.id
+            task_pairs.append(
+                (ptask, task_output.depends_on_titles)
+            )
+
+        # Second pass: resolve dependency titles to IDs and add to queue
+        for ptask, dep_titles in task_pairs:
+            ptask.depends_on = [
+                title_to_id[t]
+                for t in dep_titles
+                if t in title_to_id
+            ]
+            self.task_queue.add_task(ptask)
+            added_tasks.append(ptask)
+
+        logger.info(
+            f"[PlannerWorkerSwarm] {planner_name} created {len(added_tasks)} tasks"
+        )
+
+        # Optionally decompose via sub-planners
+        if depth < self.max_planner_depth - 1:
+            for ptask in list(added_tasks):
+                if ptask.priority == TaskPriority.CRITICAL:
+                    self.task_queue.cancel(ptask.id)
+                    sub_tasks = self._run_planner(
+                        task=f"Decompose this task into smaller subtasks:\n\n{ptask.description}",
+                        depth=depth + 1,
+                        parent_task_id=ptask.id,
+                    )
+                    added_tasks.extend(sub_tasks)
+
+        return added_tasks
+
+    def _run_judge(self) -> CycleVerdict:
+        """Run the judge agent to evaluate cycle results."""
+        schema = BaseTool().base_model_to_dict(CycleVerdict)
+
+        judge = Agent(
+            agent_name="CycleJudge",
+            agent_description="Evaluates whether the planner-worker cycle achieved the goal",
+            system_prompt=JUDGE_SYSTEM_PROMPT,
+            model_name=self.judge_model_name,
+            max_loops=1,
+            base_model=CycleVerdict,
+            tools_list_dictionary=[schema],
+            output_type="dict-all-except-first",
+        )
+
+        all_tasks = self.task_queue.get_all_tasks()
+        task_report = "\n".join(
+            [
+                f"- [{t.status.value}] {t.title}: {t.result or t.error or 'No result'}"
+                for t in all_tasks
+            ]
+        )
+
+        eval_task = (
+            f"Original goal: {self._original_task}\n\n"
+            f"Task execution report:\n{task_report}\n\n"
+            f"Full conversation history:\n{self.conversation.get_str()}\n\n"
+            "Evaluate whether the goal has been achieved. "
+            "If not, identify specific gaps and provide instructions for the next planning cycle."
+        )
+
+        raw_output = judge.run(task=eval_task)
+
+        try:
+            verdict = self._parse_structured_output(
+                raw_output, CycleVerdict
+            )
+        except Exception:
+            logger.warning(
+                "[PlannerWorkerSwarm] Failed to parse judge output, defaulting to incomplete"
+            )
+            verdict = CycleVerdict(
+                is_complete=False,
+                overall_quality=0,
+                summary="Failed to parse judge evaluation",
+                gaps=["Judge output parsing failed"],
+                follow_up_instructions="Retry the evaluation",
+                needs_fresh_start=False,
+            )
+
+        self.conversation.add(
+            role="CycleJudge",
+            content=f"Quality: {verdict.overall_quality}/10 | Complete: {verdict.is_complete}\n{verdict.summary}",
+        )
+
+        return verdict
+
+    def _prepare_next_cycle(self, verdict: CycleVerdict) -> None:
+        """Prepare the task queue for the next planner-worker-judge cycle.
+
+        If the judge requested a fresh start, all tasks are discarded to
+        combat accumulated drift. Otherwise, only non-terminal tasks are
+        cleared so completed results remain available as context.
+        """
+        if verdict.needs_fresh_start:
+            logger.info(
+                "[PlannerWorkerSwarm] Judge requested fresh start — clearing all tasks"
+            )
+            self.task_queue.clear()
+        else:
+            self.task_queue.clear_non_terminal()
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return a structured status report of the swarm and its task queue."""
+        return {
+            "name": self.name,
+            "original_task": self._original_task,
+            "queue": self.task_queue.get_status(),
+        }
+
+    def run(
+        self,
+        task: Optional[str] = None,
+        img: Optional[str] = None,
+        *args,
+        **kwargs,
+    ) -> Any:
+        """Execute the planner-worker-judge cycle.
+
+        Args:
+            task: The goal to accomplish.
+            img: Optional image input.
+
+        Returns:
+            Formatted conversation history per output_type.
+        """
+        if not task:
+            raise ValueError("A task is required")
+
+        self._original_task = task
+        self.conversation.add(role="User", content=task)
+
+        verdict = None
+
+        for cycle in range(self.max_loops):
+            logger.info(
+                f"[PlannerWorkerSwarm] Cycle {cycle + 1}/{self.max_loops}"
+            )
+
+            # Between cycles: prepare queue based on judge feedback
+            if cycle > 0 and verdict is not None:
+                self._prepare_next_cycle(verdict)
+
+            # Phase 1: Planning
+            if cycle == 0:
+                planner_task = task
+            else:
+                planner_task = (
+                    f"Original goal: {task}\n\n"
+                    f"Previous cycle feedback: {verdict.follow_up_instructions}\n"
+                    f"Gaps identified: {verdict.gaps}\n\n"
+                    "Create new tasks to address these gaps."
+                )
+
+            self._run_planner(planner_task)
+
+            # Phase 2: Worker execution
+            worker_pool = WorkerPool(
+                agents=self.agents,
+                task_queue=self.task_queue,
+                conversation=self.conversation,
+                max_workers=self.max_workers,
+                task_timeout=self.task_timeout,
+            )
+            worker_pool.run(timeout=self.worker_timeout)
+
+            # Log progress
+            status = self.task_queue.get_status()
+            logger.info(
+                f"[PlannerWorkerSwarm] Worker phase done. "
+                f"Progress: {status['progress']}, "
+                f"Status: {status['status_counts']}"
+            )
+
+            # Phase 3: Judge evaluation
+            verdict = self._run_judge()
+
+            logger.info(
+                f"[PlannerWorkerSwarm] Cycle {cycle + 1} done. "
+                f"Quality: {verdict.overall_quality}/10, Complete: {verdict.is_complete}"
+            )
+
+            if verdict.is_complete:
+                logger.info(
+                    f"[PlannerWorkerSwarm] Goal achieved in cycle {cycle + 1}"
+                )
+                break
+
+        return history_output_formatter(
+            conversation=self.conversation,
+            type=self.output_type,
+        )

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -32,6 +32,7 @@ from swarms.structs.ma_utils import list_all_agents
 from swarms.structs.majority_voting import MajorityVoting
 from swarms.structs.mixture_of_agents import MixtureOfAgents
 from swarms.structs.multi_agent_router import MultiAgentRouter
+from swarms.structs.planner_worker_swarm import PlannerWorkerSwarm
 from swarms.structs.round_robin import RoundRobinSwarm
 from swarms.structs.sequential_workflow import SequentialWorkflow
 from swarms.utils.generate_keys import generate_api_key
@@ -61,6 +62,7 @@ SwarmType = Literal[
     "LLMCouncil",
     "DebateWithJudge",
     "RoundRobin",
+    "PlannerWorkerSwarm",
 ]
 
 
@@ -473,6 +475,7 @@ class SwarmRouter:
             "LLMCouncil": self._create_llm_council,
             "DebateWithJudge": self._create_debate_with_judge,
             "RoundRobin": self._create_round_robin_swarm,
+            "PlannerWorkerSwarm": self._create_planner_worker_swarm,
         }
 
     def _create_heavy_swarm(self, *args, **kwargs):
@@ -634,6 +637,19 @@ class SwarmRouter:
             description=self.description,
             agents=self.agents,
             max_loops=self.max_loops,
+            verbose=self.verbose,
+            *args,
+            **kwargs,
+        )
+
+    def _create_planner_worker_swarm(self, *args, **kwargs):
+        """Factory function for PlannerWorkerSwarm."""
+        return PlannerWorkerSwarm(
+            name=self.name,
+            description=self.description,
+            agents=self.agents,
+            max_loops=self.max_loops,
+            output_type=self.output_type,
             verbose=self.verbose,
             *args,
             **kwargs,

--- a/tests/structs/test_planner_worker_swarm.py
+++ b/tests/structs/test_planner_worker_swarm.py
@@ -1,0 +1,495 @@
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from swarms import Agent
+from swarms.prompts.planner_worker_prompts import WORKER_SYSTEM_PROMPT
+from swarms.schemas.planner_worker_schemas import (
+    CycleVerdict,
+    PlannerTask,
+    PlannerTaskSpec,
+    PlannerTaskOutput,
+    PlannerTaskStatus,
+    TaskPriority,
+)
+from swarms.structs.planner_worker_swarm import (
+    PlannerWorkerSwarm,
+    TaskQueue,
+    WorkerPool,
+)
+from swarms.structs.conversation import Conversation
+
+
+# -- helpers --
+
+def _agent(name="W"):
+    return Agent(
+        agent_name=name, agent_description=name,
+        model_name="gpt-4o-mini", max_loops=1,
+        verbose=False, print_on=False,
+    )
+
+def _mock_agent(name="W"):
+    a = MagicMock(spec=Agent)
+    a.agent_name = name
+    a.run = MagicMock(return_value=f"result-from-{name}")
+    a.short_memory_init = MagicMock(return_value="fresh")
+    return a
+
+def _swarm(max_loops=1, **kw):
+    return PlannerWorkerSwarm(agents=[_agent("W0"), _agent("W1")], max_loops=max_loops, **kw)
+
+def _drain(q, task_id):
+    """Claim→start→complete a single task through the queue."""
+    c = q.claim("w")
+    q.start(c.id, c.version)
+    cur = q.get_task(c.id)
+    q.complete(c.id, "done", cur.version)
+
+
+# ---------------------------------------------------------------------------
+# TaskQueue
+# ---------------------------------------------------------------------------
+class TestTaskQueue:
+    def test_add_and_len(self):
+        q = TaskQueue()
+        t = PlannerTask(title="T", description="D")
+        assert q.add_task(t) == t.id
+        assert len(q) == 1
+
+    def test_bulk_add(self):
+        q = TaskQueue()
+        ids = q.add_tasks([PlannerTask(title=f"T{i}", description="D") for i in range(5)])
+        assert len(ids) == 5
+
+    def test_claim_highest_priority(self):
+        q = TaskQueue()
+        q.add_tasks([
+            PlannerTask(title="Low", description="d", priority=TaskPriority.LOW),
+            PlannerTask(title="High", description="d", priority=TaskPriority.HIGH),
+            PlannerTask(title="Normal", description="d", priority=TaskPriority.NORMAL),
+        ])
+        assert q.claim("w").title == "High"
+
+    def test_claim_respects_deps(self):
+        q = TaskQueue()
+        a = PlannerTask(title="A", description="first")
+        b = PlannerTask(title="B", description="second", depends_on=[a.id])
+        q.add_tasks([a, b])
+        claimed = q.claim("w")
+        assert claimed.title == "A"  # B blocked
+        q.start(claimed.id, claimed.version)
+        cur = q.get_task(claimed.id)
+        q.complete(claimed.id, "done", cur.version)
+        assert q.claim("w").title == "B"
+
+    def test_claim_empty(self):
+        assert TaskQueue().claim("w") is None
+
+    def test_no_double_claims_50_threads(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title=f"T{i}", description="D") for i in range(20)])
+        claimed = []
+        lock = threading.Lock()
+        def claimer(name):
+            while (t := q.claim(name)):
+                q.start(t.id, t.version)
+                with lock: claimed.append(t.id)
+        threads = [threading.Thread(target=claimer, args=(f"w{i}",)) for i in range(50)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        assert len(claimed) == len(set(claimed)) == 20
+
+    def test_version_check(self):
+        q = TaskQueue()
+        q.add_task(PlannerTask(title="T", description="D"))
+        c = q.claim("w")
+        assert q.start(c.id, c.version + 999) is False
+        assert q.start(c.id, c.version) is True
+
+    def test_complete(self):
+        q = TaskQueue()
+        q.add_task(PlannerTask(title="T", description="D"))
+        c = q.claim("w"); q.start(c.id, c.version)
+        cur = q.get_task(c.id)
+        assert q.complete(c.id, "result!", cur.version)
+        f = q.get_task(c.id)
+        assert f.status == PlannerTaskStatus.COMPLETED and f.result == "result!"
+
+    def test_fail_retry(self):
+        q = TaskQueue()
+        q.add_task(PlannerTask(title="T", description="D", max_retries=2))
+        c = q.claim("w"); q.start(c.id, c.version)
+        cur = q.get_task(c.id)
+        q.fail(c.id, "oops", cur.version)
+        assert q.get_task(c.id).status == PlannerTaskStatus.PENDING
+
+    def test_fail_permanent(self):
+        q = TaskQueue()
+        q.add_task(PlannerTask(title="T", description="D", max_retries=0))
+        c = q.claim("w"); q.start(c.id, c.version)
+        cur = q.get_task(c.id)
+        q.fail(c.id, "fatal", cur.version)
+        assert q.get_task(c.id).status == PlannerTaskStatus.FAILED
+
+    def test_is_all_done(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title="T1", description="D"), PlannerTask(title="T2", description="D")])
+        assert not q.is_all_done()
+        for _ in range(2): _drain(q, None)
+        assert q.is_all_done()
+
+    def test_cancel(self):
+        q = TaskQueue()
+        t = PlannerTask(title="T", description="D")
+        q.add_task(t)
+        assert q.cancel(t.id)
+        assert q.get_task(t.id).status == PlannerTaskStatus.CANCELLED
+
+    def test_dependency_chain_abc(self):
+        q = TaskQueue()
+        a = PlannerTask(title="A", description="1")
+        b = PlannerTask(title="B", description="2", depends_on=[a.id])
+        c = PlannerTask(title="C", description="3", depends_on=[b.id])
+        q.add_tasks([a, b, c])
+        for expected in ["A", "B", "C"]:
+            cl = q.claim("w")
+            assert cl.title == expected
+            q.start(cl.id, cl.version)
+            cur = q.get_task(cl.id)
+            q.complete(cl.id, f"{expected}-done", cur.version)
+
+    def test_clear(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title=f"T{i}", description="D") for i in range(5)])
+        assert q.clear() == 5
+        assert len(q) == 0
+
+    def test_clear_non_terminal_preserves_completed(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title="A", description="D"), PlannerTask(title="B", description="D")])
+        _drain(q, None)  # completes A
+        assert q.clear_non_terminal() == 1
+        assert len(q) == 1
+        assert q.get_all_tasks()[0].status == PlannerTaskStatus.COMPLETED
+
+    def test_claim_returns_copy(self):
+        q = TaskQueue()
+        q.add_task(PlannerTask(title="T", description="D"))
+        c = q.claim("w")
+        c.title = "MODIFIED"
+        assert q.get_task(c.id).title == "T"
+
+    def test_dependency_results(self):
+        q = TaskQueue()
+        a = PlannerTask(title="Setup", description="d")
+        b = PlannerTask(title="Build", description="d", depends_on=[a.id])
+        q.add_tasks([a, b])
+        c = q.claim("w"); q.start(c.id, c.version)
+        cur = q.get_task(c.id); q.complete(c.id, "setup-ok", cur.version)
+        assert "setup-ok" in q.get_dependency_results(b.id)
+
+    def test_status_report(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title="A", description="d"), PlannerTask(title="B", description="d")])
+        _drain(q, None)
+        s = q.get_status()
+        assert s["total"] == 2 and s["progress"] == "1/2"
+
+    def test_200_tasks_100_threads(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title=f"T{i}", description="D") for i in range(200)])
+        claimed = []; lock = threading.Lock()
+        def claimer(name):
+            while (t := q.claim(name)):
+                q.start(t.id, t.version)
+                cur = q.get_task(t.id); q.complete(t.id, "r", cur.version)
+                with lock: claimed.append(t.id)
+        threads = [threading.Thread(target=claimer, args=(f"w{i}",)) for i in range(100)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        assert len(claimed) == len(set(claimed)) == 200
+
+    def test_diamond_dependency(self):
+        q = TaskQueue()
+        a = PlannerTask(title="A", description="root")
+        b = PlannerTask(title="B", description="l", depends_on=[a.id])
+        c = PlannerTask(title="C", description="r", depends_on=[a.id])
+        d = PlannerTask(title="D", description="join", depends_on=[b.id, c.id])
+        q.add_tasks([a, b, c, d])
+        _drain(q, None)  # A
+        names = {q.claim("w").title for _ in range(2)}  # B, C become available
+        assert names == {"B", "C"}
+
+    def test_retry_exhaustion(self):
+        q = TaskQueue()
+        q.add_task(PlannerTask(title="Flaky", description="d", max_retries=2))
+        for _ in range(3):
+            c = q.claim("w"); q.start(c.id, c.version)
+            cur = q.get_task(c.id); q.fail(c.id, "err", cur.version)
+        assert q.get_task(q.get_all_tasks()[0].id).status == PlannerTaskStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Structured output parsing
+# ---------------------------------------------------------------------------
+class TestParsing:
+    def test_dict(self):
+        r = _swarm()._parse_structured_output(
+            {"plan": "P", "tasks": [{"title": "T", "description": "D", "priority": 1, "depends_on_titles": []}]},
+            PlannerTaskSpec)
+        assert isinstance(r, PlannerTaskSpec)
+
+    def test_json_string(self):
+        import json
+        r = _swarm()._parse_structured_output(
+            json.dumps({"plan": "P", "tasks": [{"title": "T", "description": "D", "priority": 1, "depends_on_titles": []}]}),
+            PlannerTaskSpec)
+        assert isinstance(r, PlannerTaskSpec)
+
+    def test_function_call_format(self):
+        import json
+        r = _swarm()._parse_structured_output(
+            [{"function": {"name": "PlannerTaskSpec", "arguments": json.dumps(
+                {"plan": "P", "tasks": [{"title": "T", "description": "D", "priority": 0, "depends_on_titles": []}]})}}],
+            PlannerTaskSpec)
+        assert r.plan == "P"
+
+    def test_conversation_format(self):
+        import json
+        r = _swarm()._parse_structured_output(
+            [{"role": "assistant", "content": [{"function": {"name": "X", "arguments": json.dumps(
+                {"plan": "N", "tasks": [{"title": "T", "description": "D", "priority": 1, "depends_on_titles": []}]})}}]}],
+            PlannerTaskSpec)
+        assert r.plan == "N"
+
+    def test_model_instance_passthrough(self):
+        spec = PlannerTaskSpec(plan="P", tasks=[PlannerTaskOutput(title="T", description="D", priority=1)])
+        assert _swarm()._parse_structured_output(spec, PlannerTaskSpec) is spec
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError):
+            _swarm()._parse_structured_output(12345, PlannerTaskSpec)
+
+    def test_cycle_verdict(self):
+        r = _swarm()._parse_structured_output(
+            {"is_complete": True, "overall_quality": 8, "summary": "OK", "needs_fresh_start": False},
+            CycleVerdict)
+        assert r.is_complete and not r.needs_fresh_start
+
+
+# ---------------------------------------------------------------------------
+# WorkerPool (mocked — no API)
+# ---------------------------------------------------------------------------
+class TestWorkerPoolMocked:
+    def test_drains_queue(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title=f"T{i}", description=f"D{i}") for i in range(3)])
+        a = _mock_agent("W1")
+        WorkerPool(agents=[a], task_queue=q, conversation=Conversation(time_enabled=False), max_workers=1).run(timeout=10)
+        assert q.is_all_done() and a.run.call_count == 3
+
+    def test_worker_prompt_injected(self):
+        q = TaskQueue()
+        q.add_task(PlannerTask(title="MyTask", description="Do it"))
+        a = _mock_agent("W1")
+        WorkerPool(agents=[a], task_queue=q, conversation=Conversation(time_enabled=False), max_workers=1).run(timeout=10)
+        task_text = a.run.call_args[1]["task"]
+        assert "Worker Agent" in task_text and "MyTask" in task_text
+
+    def test_memory_reset_per_task(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title=f"T{i}", description="D") for i in range(3)])
+        a = _mock_agent("W1")
+        WorkerPool(agents=[a], task_queue=q, conversation=Conversation(time_enabled=False), max_workers=1).run(timeout=10)
+        assert a.short_memory_init.call_count == 3
+
+    def test_independent_workers(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title=f"T{i}", description="D") for i in range(6)])
+        agents = [_mock_agent(f"W{i}") for i in range(3)]
+        WorkerPool(agents=agents, task_queue=q, conversation=Conversation(time_enabled=False), max_workers=3).run(timeout=10)
+        assert q.is_all_done() and sum(a.run.call_count for a in agents) == 6
+
+    def test_dep_context_passed(self):
+        q = TaskQueue()
+        a = PlannerTask(title="Research", description="Do research")
+        b = PlannerTask(title="Summarize", description="Sum", depends_on=[a.id])
+        q.add_tasks([a, b])
+        agent = _mock_agent("W1")
+        agent.run = MagicMock(side_effect=["research-data", "summary"])
+        WorkerPool(agents=[agent], task_queue=q, conversation=Conversation(time_enabled=False), max_workers=1).run(timeout=10)
+        assert "research-data" in agent.run.call_args_list[1][1]["task"]
+
+    def test_retry_on_failure(self):
+        q = TaskQueue()
+        q.add_task(PlannerTask(title="Flaky", description="d", max_retries=1))
+        n = [0]
+        def fx(**kw):
+            n[0] += 1
+            if n[0] == 1: raise RuntimeError("fail")
+            return "ok"
+        a = _mock_agent("W1"); a.run = MagicMock(side_effect=fx)
+        WorkerPool(agents=[a], task_queue=q, conversation=Conversation(time_enabled=False), max_workers=1).run(timeout=10)
+        assert q.is_all_done() and list(q.get_results_summary().values()) == ["ok"]
+
+    def test_pool_timeout(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title=f"T{i}", description="D") for i in range(100)])
+        a = _mock_agent("W1"); a.run = MagicMock(side_effect=lambda **kw: time.sleep(0.5) or "done")
+        t0 = time.time()
+        WorkerPool(agents=[a], task_queue=q, conversation=Conversation(time_enabled=False), max_workers=1).run(timeout=1.5)
+        assert time.time() - t0 < 5 and not q.is_all_done()
+
+    def test_stop_signal(self):
+        q = TaskQueue()
+        q.add_tasks([PlannerTask(title=f"T{i}", description="D") for i in range(50)])
+        a = _mock_agent("W1"); a.run = MagicMock(side_effect=lambda **kw: time.sleep(0.2) or "done")
+        pool = WorkerPool(agents=[a], task_queue=q, conversation=Conversation(time_enabled=False), max_workers=1)
+        threading.Timer(0.5, pool.stop).start()
+        t0 = time.time(); pool.run()
+        assert time.time() - t0 < 5
+
+
+# ---------------------------------------------------------------------------
+# PlannerWorkerSwarm philosophy (mocked LLM)
+# ---------------------------------------------------------------------------
+class TestPhilosophy:
+    def test_planner_produces_tasks(self):
+        s = _swarm()
+        spec = PlannerTaskSpec(plan="My plan", tasks=[
+            PlannerTaskOutput(title="T1", description="D1", priority=1),
+            PlannerTaskOutput(title="T2", description="D2", priority=2, depends_on_titles=["T1"]),
+        ])
+        with patch.object(Agent, "run", return_value=spec):
+            tasks = s._run_planner("Build feature")
+        assert len(tasks) == 2 and len(s.task_queue) == 2
+        assert tasks[0].id in s.task_queue.get_task(tasks[1].id).depends_on
+
+    def test_fresh_start_clears_all(self):
+        s = _swarm()
+        s.task_queue.add_tasks([PlannerTask(title="A", description="d"), PlannerTask(title="B", description="d")])
+        _drain(s.task_queue, None)
+        s._prepare_next_cycle(CycleVerdict(
+            is_complete=False, overall_quality=1, summary="drift", needs_fresh_start=True))
+        assert len(s.task_queue) == 0
+
+    def test_gap_fill_preserves_completed(self):
+        s = _swarm()
+        s.task_queue.add_tasks([PlannerTask(title="A", description="d"), PlannerTask(title="B", description="d")])
+        _drain(s.task_queue, None)
+        s._prepare_next_cycle(CycleVerdict(
+            is_complete=False, overall_quality=5, summary="partial", needs_fresh_start=False))
+        assert len(s.task_queue) == 1
+        assert s.task_queue.get_all_tasks()[0].status == PlannerTaskStatus.COMPLETED
+
+    def test_full_cycle(self):
+        s = _swarm(); seq = [0]
+        spec = PlannerTaskSpec(plan="P", tasks=[
+            PlannerTaskOutput(title="T1", description="D", priority=1),
+            PlannerTaskOutput(title="T2", description="D", priority=1),
+        ])
+        verdict = CycleVerdict(is_complete=True, overall_quality=9, summary="done")
+        def fx(task=None, **kw):
+            seq[0] += 1
+            if seq[0] == 1: return spec
+            if seq[0] <= 3: return f"r{seq[0]}"
+            return verdict
+        with patch.object(Agent, "run", side_effect=fx):
+            assert s.run(task="Goal") is not None
+        assert s.task_queue.get_completed_count() == 2
+
+    def test_multi_cycle_feedback(self):
+        s = _swarm(max_loops=3); seq = [0]
+        s1 = PlannerTaskSpec(plan="P1", tasks=[PlannerTaskOutput(title="T1", description="D", priority=1)])
+        s2 = PlannerTaskSpec(plan="P2", tasks=[PlannerTaskOutput(title="T2", description="D", priority=2)])
+        v_no = CycleVerdict(is_complete=False, overall_quality=4, summary="gap",
+                            gaps=["missing"], follow_up_instructions="add more")
+        v_ok = CycleVerdict(is_complete=True, overall_quality=9, summary="done")
+        def fx(task=None, **kw):
+            seq[0] += 1
+            return [s1, "r1", v_no, s2, "r2", v_ok][seq[0]-1]
+        with patch.object(Agent, "run", side_effect=fx):
+            s.run(task="Goal")
+        assert seq[0] == 6
+
+    def test_fresh_start_cycle(self):
+        s = _swarm(max_loops=3); seq = [0]
+        s1 = PlannerTaskSpec(plan="bad", tasks=[PlannerTaskOutput(title="Drift", description="d", priority=1)])
+        s2 = PlannerTaskSpec(plan="fresh", tasks=[PlannerTaskOutput(title="Fresh", description="d", priority=1)])
+        v_fresh = CycleVerdict(is_complete=False, overall_quality=1, summary="drift", needs_fresh_start=True,
+                               follow_up_instructions="start over", gaps=["all"])
+        v_ok = CycleVerdict(is_complete=True, overall_quality=8, summary="ok")
+        def fx(task=None, **kw):
+            seq[0] += 1
+            return [s1, "dr", v_fresh, s2, "fr", v_ok][seq[0]-1]
+        with patch.object(Agent, "run", side_effect=fx):
+            s.run(task="Test")
+        titles = {t.title for t in s.task_queue.get_all_tasks()}
+        assert "Drift" not in titles and "Fresh" in titles
+
+    def test_sub_planner_decomposes_critical(self):
+        s = _swarm(max_planner_depth=2); seq = [0]
+        top = PlannerTaskSpec(plan="top", tasks=[
+            PlannerTaskOutput(title="Crit", description="big", priority=3),
+            PlannerTaskOutput(title="Normal", description="small", priority=1),
+        ])
+        sub = PlannerTaskSpec(plan="sub", tasks=[
+            PlannerTaskOutput(title="Sub1", description="p1", priority=2),
+            PlannerTaskOutput(title="Sub2", description="p2", priority=2),
+        ])
+        def fx(task=None, **kw):
+            seq[0] += 1
+            return top if seq[0] == 1 else sub
+        with patch.object(Agent, "run", side_effect=fx):
+            s._run_planner("test")
+        titles = {t.title for t in s.task_queue.get_all_tasks()}
+        assert {"Normal", "Sub1", "Sub2"} <= titles
+
+
+# ---------------------------------------------------------------------------
+# Validation & schemas
+# ---------------------------------------------------------------------------
+class TestValidation:
+    def test_no_agents(self):
+        with pytest.raises(ValueError): PlannerWorkerSwarm(agents=[])
+
+    def test_bad_max_loops(self):
+        with pytest.raises(ValueError): PlannerWorkerSwarm(agents=[_agent()], max_loops=0)
+
+    def test_run_no_task(self):
+        with pytest.raises(ValueError): _swarm().run(task=None)
+
+    def test_get_status(self):
+        s = _swarm()
+        assert s.get_status()["queue"]["total"] == 0
+
+class TestSchemas:
+    def test_verdict_fresh_start_default(self):
+        assert CycleVerdict(is_complete=True, overall_quality=10, summary="ok").needs_fresh_start is False
+
+    def test_task_defaults(self):
+        t = PlannerTask(title="T", description="D")
+        assert t.status == PlannerTaskStatus.PENDING and t.id.startswith("ptask-")
+
+    def test_priority_ordering(self):
+        assert TaskPriority.LOW < TaskPriority.NORMAL < TaskPriority.HIGH < TaskPriority.CRITICAL
+
+
+# ---------------------------------------------------------------------------
+# Live tests (require API key)
+# ---------------------------------------------------------------------------
+class TestLive:
+    @pytest.mark.live
+    def test_end_to_end(self):
+        s = PlannerWorkerSwarm(
+            agents=[_agent("Research"), _agent("Analysis")],
+            max_loops=1, worker_timeout=120,
+        )
+        assert s.run("What are the top 3 benefits of renewable energy?") is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements **[#1319](https://github.com/kyegomez/swarms/issues/1319)** (Hierarchical Planner System) and **[#1320](https://github.com/kyegomez/swarms/issues/1320)** (Worker Execution System) based on Cursor's ["Scaling long-running autonomous coding"](https://cursor.com/blog/scaling-agents) architecture.

The core idea: **planners only plan, workers only execute, and a judge decides when to stop or restart.** Workers run concurrently in a thread pool, independently claiming tasks from a shared queue with no worker-to-worker coordination — exactly like the Cursor research prescribes.

## Architecture

```
┌─────────────────────────────────────────────────────┐
│                 CYCLE (repeats max_loops)            │
│                                                     │
│  PLANNER ──→ TASK QUEUE ──→ WORKER POOL (parallel)  │
│  (decomposes    (priority,      (W1 claims T3,      │
│   goal into      deps,           W2 claims T1,      │
│   tasks)         optimistic      W3 claims T2...)   │
│                  concurrency)          │             │
│                                        ▼             │
│                                   JUDGE AGENT        │
│                                   ├─ Complete → done │
│                                   ├─ Gaps → replan   │
│                                   └─ Drift → fresh   │
│                                      start           │
└─────────────────────────────────────────────────────┘
```

## Key design decisions mapped to the Cursor blog

| Cursor Principle | Implementation |
|---|---|
| Planners plan, workers execute | `_run_planner()` produces `PlannerTaskSpec`, workers only get task descriptions + `WORKER_SYSTEM_PROMPT` reinforcing "only execute, never plan" |
| No worker-to-worker coordination | Workers interact only with `TaskQueue.claim()` — atomic, no shared state |
| No locks / optimistic concurrency | `TaskQueue` uses a version field per task; `claim()` is atomic under a single lock, but workers never block each other |
| Judge-driven cycles with fresh start | `CycleVerdict.needs_fresh_start` triggers `TaskQueue.clear()` to combat accumulated drift |
| Prompts matter more than infrastructure | `WORKER_SYSTEM_PROMPT` injected into every worker task context; `PLANNER_SYSTEM_PROMPT` and `JUDGE_SYSTEM_PROMPT` enforce strict role boundaries |
| Horizontal scaling | `ThreadPoolExecutor(max_workers=N)` — tested with 200 tasks across 100 threads, zero double-claims |
| Recursive sub-planners | `max_planner_depth > 1` decomposes CRITICAL tasks via sub-planner agents |
| Autonomous failure handling | Retry with configurable `max_retries`, automatic PENDING reset on failure |

## Files

| File | Lines | Purpose |
|---|---|---|
| `swarms/structs/planner_worker_swarm.py` | 937 | `TaskQueue`, `WorkerPool`, `PlannerWorkerSwarm` |
| `swarms/schemas/planner_worker_schemas.py` | 178 | `PlannerTask`, `PlannerTaskSpec`, `CycleVerdict`, enums |
| `swarms/prompts/planner_worker_prompts.py` | 69 | System prompts for planner, worker, judge |
| `tests/structs/test_planner_worker_swarm.py` | 495 | 50 unit tests (mocked) + 1 live integration test |
| `examples/planner_worker_swarm_example.py` | 138 | Runnable example with 5 parallel workers |
| `swarms/structs/swarm_router.py` | +16 | SwarmRouter factory for `"PlannerWorkerSwarm"` |
| `swarms/structs/__init__.py` | +8 | Export |
| `swarms/schemas/__init__.py` | +14 | Export |

## Test coverage

- **TaskQueue**: add, claim, start, complete, fail, cancel, clear, dependency chains (A→B→C, diamond), 200 tasks × 100 threads concurrency, retry exhaustion
- **WorkerPool** (mocked): queue draining, `WORKER_SYSTEM_PROMPT` injection, memory reset per task, independent workers, dependency context passing, retry on failure, timeout, stop signal
- **PlannerWorkerSwarm philosophy** (mocked): planner produces tasks not executes, judge fresh start clears all, gap-fill preserves completed, full cycle, multi-cycle feedback loop, fresh start cycle, sub-planner decomposition
- **Live**: end-to-end with real gpt-4o-mini API calls

## Usage

```python
from swarms import Agent
from swarms.structs.planner_worker_swarm import PlannerWorkerSwarm

swarm = PlannerWorkerSwarm(
    agents=[Agent(agent_name="W1", ...), Agent(agent_name="W2", ...)],
    max_loops=2,           # up to 2 planner-worker-judge cycles
    max_workers=5,         # 5 concurrent threads
    worker_timeout=120,    # 2 min max for worker phase
    task_timeout=30,       # 30s max per individual task
)
result = swarm.run("Your goal here")
```

Or via SwarmRouter:
```python
router = SwarmRouter(agents=[...], swarm_type="PlannerWorkerSwarm")
result = router.run("Your goal here")
```

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1443.org.readthedocs.build/en/1443/

<!-- readthedocs-preview swarms end -->