### PR TITLE
[docs] Add async subagent reference + rewrite tutorial

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -232,6 +232,7 @@ nav:
       - Quickstart: "swarms/agents/index.md"
       - Reference: "swarms/structs/agent.md"
       - Fully Autonomous Agent Tutorial: "swarms/examples/autonomous_agent_tutorial.md"
+      - Sub-Agent Delegation: "swarms/examples/sub_agent_tutorial.md"
       - Agent Handoffs Tutorial: "swarms/examples/agent_handoff_tutorial.md"
       - Autosave Tutorial: "swarms/examples/autosave_tutorial.md"
       - Tools and MCP: "swarms/tools/tools_examples.md"
@@ -315,6 +316,7 @@ nav:
       - CLI Reference: "swarms/cli/cli_reference.md"
       - Agent Loader: "swarms/utils/agent_loader.md"
       - AgentRegistry: "swarms/structs/agent_registry.md"
+      - SubagentRegistry: "swarms/structs/async_subagent.md"
 
     - Tools:
       - Overview: "swarms_tools/overview.md"

--- a/docs/swarms/examples/sub_agent_tutorial.md
+++ b/docs/swarms/examples/sub_agent_tutorial.md
@@ -1,19 +1,106 @@
-# Sub-Agent Delegation Tutorial
+# Sub-Agent Delegation
 
-This tutorial explains how to use sub-agent delegation with the autonomous agent. When `max_loops="auto"`, the main agent can create specialized sub-agents, assign tasks to them, and aggregate results. Sub-agents run concurrently via `asyncio` and are cached on the main agent for reuse.
+Sub-agent delegation enables an autonomous agent to dynamically create specialized child agents, dispatch tasks to them concurrently, and aggregate results — all at runtime. When an agent runs with `max_loops="auto"`, it gains access to a suite of sub-agent tools that let the LLM orchestrate parallel workstreams without any manual wiring.
 
-## What are Sub-Agents?
+| Feature | Description |
+|---------|-------------|
+| **Parallel Execution** | Sub-agents run concurrently in background threads via a `ThreadPoolExecutor` |
+| **Dynamic Specialization** | Each sub-agent gets its own name, description, and optional system prompt |
+| **Async Task Registry** | A per-agent `SubagentRegistry` tracks every spawned task with status, retries, and timing |
+| **Fire-and-Forget Mode** | Dispatch tasks without blocking, then poll status or cancel later |
+| **Retry Policies** | Configurable retry count and exception-type filtering per task |
+| **Depth-Limited Recursion** | Prevents infinite nesting with a configurable `max_subagent_depth` (default 3) |
+| **Agent Reuse** | Sub-agents are cached by ID and can be assigned multiple tasks across the session |
 
-Sub-agents are agent instances created at runtime by the coordinator via the `create_sub_agent` tool. They are stored in the main agent's `sub_agents` dictionary and can be used repeatedly via `assign_task`. They provide:
+## Architecture
 
-- **Parallel execution**: Multiple sub-agents run at once using `asyncio.to_thread` and `asyncio.gather`
+```mermaid
+graph TD
+    A[Coordinator Agent<br/>max_loops=auto] --> B[create_sub_agent]
+    B --> C1[Sub-Agent A]
+    B --> C2[Sub-Agent B]
+    B --> C3[Sub-Agent N]
 
-- **Specialization**: Each sub-agent has its own `agent_name`, `agent_description`, and optional `system_prompt`
+    A --> D[assign_task]
+    D --> E[SubagentRegistry]
 
-- **Caching**: Sub-agents are keyed by ID (e.g. `sub-agent-{uuid}`) and reused across 
-assignments
+    E -->|spawn| F1[Thread: A.run]
+    E -->|spawn| F2[Thread: B.run]
+    E -->|spawn| F3[Thread: N.run]
 
-- **Same LLM**: Sub-agents use the parent's `model_name` and run with `max_loops=1`, `print_on=False`
+    F1 --> G[gather / get_results]
+    F2 --> G
+    F3 --> G
+
+    G --> H[Results returned to Coordinator]
+    H --> I[Coordinator synthesizes final output]
+
+    A -.-> J[check_sub_agent_status]
+    J -.-> E
+    A -.-> K[cancel_sub_agent_tasks]
+    K -.-> E
+```
+
+## How It Works
+
+Sub-agent delegation runs in three phases inside the autonomous loop:
+
+```mermaid
+sequenceDiagram
+    participant C as Coordinator
+    participant T as Tool Dispatch
+    participant R as SubagentRegistry
+    participant S1 as Sub-Agent 1
+    participant S2 as Sub-Agent 2
+
+    C->>T: create_sub_agent(agents=[...])
+    T-->>C: Created sub-agent-a1b2, sub-agent-c3d4
+
+    C->>T: assign_task(assignments=[...])
+    T->>R: registry.spawn(S1, task_1)
+    T->>R: registry.spawn(S2, task_2)
+    R->>S1: ThreadPool: S1.run(task_1)
+    R->>S2: ThreadPool: S2.run(task_2)
+
+    alt wait_for_completion = true
+        R-->>T: registry.gather(wait_all)
+        T-->>C: Formatted results from all sub-agents
+    else wait_for_completion = false
+        T-->>C: Spawned task IDs (fire-and-forget)
+        C->>T: check_sub_agent_status(agent_name)
+        T->>R: Inspect task statuses
+        R-->>T: Status report
+        T-->>C: Status details
+    end
+
+    C->>C: Synthesize final output
+```
+
+### Phase 1: Create Sub-Agents
+
+The coordinator calls the `create_sub_agent` tool to spawn specialized agents. Each sub-agent:
+
+- Inherits the parent's `model_name`
+- Runs with `max_loops=1` (single-pass execution)
+- Gets a unique ID in the format `sub-agent-{uuid_hex[:8]}`
+- Is cached in `agent.sub_agents` for reuse across multiple task assignments
+
+### Phase 2: Assign Tasks
+
+The coordinator calls the `assign_task` tool to dispatch work. Behind the scenes:
+
+1. `_find_registry(agent)` lazily creates a `SubagentRegistry` (stored as `agent._subagent_registry`)
+2. For each assignment, `registry.spawn()` submits the sub-agent's `.run()` call to a `ThreadPoolExecutor`
+3. A `SubagentTask` dataclass tracks each task's status, result, errors, retries, and timing
+
+Two execution modes are available:
+
+- **Wait mode** (`wait_for_completion=true`, default): Calls `registry.gather(strategy="wait_all")`, blocks until all tasks finish, and returns formatted results
+- **Fire-and-forget** (`wait_for_completion=false`): Returns immediately with spawned task IDs for later polling
+
+### Phase 3: Aggregate Results
+
+All results are added to the coordinator's `short_memory`, giving the LLM full context to synthesize a final output.
 
 ## Prerequisites
 
@@ -21,127 +108,103 @@ assignments
 pip install -U swarms
 ```
 
+Set your API key for the model provider you intend to use:
+
 ```python
 import os
 os.environ["OPENAI_API_KEY"] = "your-api-key"
 ```
 
-## Basic Concepts
-
-### The Coordinator Agent
-
-The coordinator (main agent) is responsible for:
-1. Analyzing the main task
-2. Creating specialized sub-agents
-3. Delegating work to sub-agents
-4. Aggregating results
-
-### Sub-Agents
-
-Each sub-agent is created with:
-
-| Parameter          | Required? | Description                                                                                   |
-|--------------------|-----------|-----------------------------------------------------------------------------------------------|
-| `agent_name`       | Yes       | Descriptive identifier for the sub-agent                                                      |
-| `agent_description`| Yes       | Role and capabilities of the sub-agent                                                        |
-| `system_prompt`    | No        | Custom instructions for the sub-agent (if omitted, defaults to the agent description prompt)  |
-
-## Quick Start Example
-
-Here's a simple example that creates sub-agents for parallel research:
+## Quick Start
 
 ```python
 from swarms.structs.agent import Agent
 
-# Create the coordinator agent
 coordinator = Agent(
     agent_name="Research-Coordinator",
-    model_name="gpt-4o",
-    max_loops="auto",  # Enable autonomous mode
+    agent_description="Coordinates parallel research across multiple domains",
+    model_name="gpt-4.1",
+    max_loops="auto",
     interactive=False,
-    selected_tools="all",  # Enable all tools including sub-agent tools
 )
 
-# Define a task requiring parallel work
 task = """
 Research three topics in parallel:
 1. Latest trends in artificial intelligence
-2. Recent quantum computing breakthroughs  
+2. Recent quantum computing breakthroughs
 3. Advances in renewable energy
 
 Create a sub-agent for each topic, assign research tasks to them,
 and compile a comprehensive summary of all findings.
 """
 
-# Run the coordinator - it will automatically create and manage sub-agents
 result = coordinator.run(task)
 print(result)
 ```
 
-## How It Works
+When this runs, the coordinator autonomously:
 
-When you run the coordinator agent with a task requiring delegation:
+1. Plans the overall task
+2. Calls `create_sub_agent` to create three specialized agents
+3. Calls `assign_task` to dispatch research tasks concurrently
+4. Receives aggregated results
+5. Synthesizes a final comprehensive report
 
-### Step 1: Agent Creates Sub-Agents
+## Tool Reference
 
-The coordinator automatically calls the `create_sub_agent` tool:
+All four sub-agent tools are available when `max_loops="auto"`. You can control tool availability with the `selected_tools` parameter — set it to `"all"` (default) or pass a list of specific tool names.
 
-```python
-# This happens automatically inside the agent
-create_sub_agent({
-    "agents": [
-        {
-            "agent_name": "AI-Research-Agent",
-            "agent_description": "Expert in artificial intelligence research and trends",
-            "system_prompt": "You are an AI research specialist..." # Optional
-        },
-        {
-            "agent_name": "Quantum-Research-Agent",
-            "agent_description": "Expert in quantum computing and related technologies"
-        },
-        {
-            "agent_name": "Energy-Research-Agent",
-            "agent_description": "Expert in renewable energy and sustainability"
-        }
-    ]
-})
-```
+### create_sub_agent
 
-**Result:** Each sub-agent is created, cached in `agent.sub_agents`, and assigned a unique ID of the form `sub-agent-{uuid.uuid4().hex[:8]}` (e.g. `sub-agent-a1b2c3d4`). The handler returns a success message listing created agents and their IDs.
+Creates one or more sub-agents and caches them on the coordinator.
 
-### Step 2: Agent Assigns Tasks
+**Parameters:**
 
-The coordinator then assigns work using the `assign_task` tool:
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agents` | array | Yes | List of sub-agent specifications (see fields below) |
 
-```python
-# This happens automatically inside the agent
-assign_task({
-    "assignments": [
-        {
-            "agent_id": "sub-agent-a1b2c3d4",
-            "task": "Research the latest trends in artificial intelligence",
-            "task_id": "ai-research"
-        },
-        {
-            "agent_id": "sub-agent-e5f6g7h8",
-            "task": "Research recent quantum computing breakthroughs",
-            "task_id": "quantum-research"
-        },
-        {
-            "agent_id": "sub-agent-i9j0k1l2",
-            "task": "Research advances in renewable energy",
-            "task_id": "energy-research"
-        }
-    ],
-    "wait_for_completion": true
-})
-```
+**Fields for each item in `agents`:**
 
-**Result:** All sub-agents run concurrently via `asyncio.to_thread(sub_agent.run, task)` and `asyncio.gather`. When `wait_for_completion` is true (default), the tool returns formatted results; when false, it dispatches tasks and returns immediately (fire-and-forget).
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_name` | string | Yes | Descriptive name for the sub-agent |
+| `agent_description` | string | Yes | Role and capabilities of the sub-agent |
+| `system_prompt` | string | No | Custom system prompt. If omitted, a default based on the description is used |
 
-### Step 3: Results Aggregation
+**What happens internally:**
 
-The coordinator receives results from all sub-agents:
+For each spec, a new `Agent` is created with `id=sub-agent-{uuid.hex[:8]}`, the parent's `model_name`, `max_loops=1`, and `print_on=True`. It is stored in `agent.sub_agents[agent_id]` with keys: `agent`, `name`, `description`, `system_prompt`, `created_at`.
+
+**Returns:** A success message listing created agents and their IDs.
+
+### assign_task
+
+Dispatches tasks to sub-agents for concurrent execution via the `SubagentRegistry`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `assignments` | array | Yes | — | List of task assignments (see fields below) |
+| `wait_for_completion` | boolean | No | `true` | Wait for all tasks or return immediately |
+
+**Fields for each item in `assignments`:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `agent_id` | string | Yes | — | ID of the sub-agent (from `create_sub_agent` output) |
+| `task` | string | Yes | — | Task description for the sub-agent |
+| `task_id` | string | No | `task-{idx+1}` | User-friendly identifier for this assignment |
+
+**What happens internally:**
+
+1. Validates all `agent_id` values exist in `agent.sub_agents`
+2. Calls `registry.spawn()` for each assignment, submitting `sub_agent.run(task)` to the thread pool
+3. If `wait_for_completion=true`: calls `registry.gather(strategy="wait_all")`, then formats and returns all results
+4. If `wait_for_completion=false`: returns spawned task IDs immediately
+
+**Returns (wait mode):**
 
 ```
 Completed 3 task assignment(s):
@@ -156,183 +219,295 @@ Result: Major quantum computing breakthroughs...
 Result: Renewable energy advances...
 ```
 
-## Tool Parameters Reference
+**Returns (fire-and-forget mode):**
 
-The tools are defined in `swarms.structs.autonomous_loop_utils` and wired in the agent's autonomous planning tool handlers.
+```
+Dispatched 3 task(s) to sub-agents (registry async mode).
+Spawned task IDs:
+- [AI-Research-Agent] task-1 -> task-a1b2c3d4
+- [Quantum-Research-Agent] task-2 -> task-e5f6g7h8
+- [Energy-Research-Agent] task-3 -> task-i9j0k1l2
+```
 
-### create_sub_agent
+### check_sub_agent_status
 
-Creates one or more sub-agents and caches them on the main agent's `sub_agents` dictionary.
+Inspects the async task status for a sub-agent by name.
 
-**Top-level parameters:**
+**Parameters:**
 
-| Parameter | Type   | Required | Description |
-|-----------|--------|----------|-------------|
-| agents    | array  | Yes      | List of sub-agent specifications. Each item is an object with the fields below. |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent_name` | string | Yes | Name of the sub-agent to inspect |
 
-**Fields for each item in `agents`:**
+**Returns:** A status report for all tasks associated with that sub-agent:
 
-| Field               | Type   | Required | Description |
-|---------------------|--------|----------|-------------|
-| agent_name          | string | Yes      | Name of the sub-agent. |
-| agent_description   | string | Yes      | Role and capabilities of the sub-agent. |
-| system_prompt       | string | No       | Custom system prompt. If omitted, a default based on the agent description is used. |
+```
+Async status for sub-agent 'AI-Research-Agent':
 
-**Handler behavior (`create_sub_agent_tool`):** For each spec, a new `Agent` is created with `id=sub-agent-{uuid.uuid4().hex[:8]}`, `agent_name`, `agent_description`, `system_prompt`, the parent's `model_name`, `max_loops=1`, and `print_on=False`. The sub-agent is stored in `agent.sub_agents[agent_id]` with keys `agent`, `name`, `description`, `system_prompt`, `created_at`. Returns a success message listing created agents and their IDs.
+Sub-agent: AI-Research-Agent
+- Task ID: task-a1b2c3d4 | status=completed | depth=0 | retries=0/0 | duration=12.34s
+```
 
-### assign_task
+Each task entry includes: task ID, current status (`pending`, `running`, `completed`, `failed`, `cancelled`), recursion depth, retry count, and duration.
 
-Assigns tasks to one or more sub-agents. Tasks are run asynchronously via `asyncio.to_thread(sub_agent.run, task)` and gathered with `asyncio.gather`.
+### cancel_sub_agent_tasks
 
-**Top-level parameters:**
+Cancels any pending or running tasks for a sub-agent by name.
 
-| Parameter           | Type    | Required | Description |
-|---------------------|---------|----------|-------------|
-| assignments         | array   | Yes      | List of task assignments. Each item is an object with the fields below. |
-| wait_for_completion | boolean | No       | If true (default), wait for all tasks and return formatted results. If false, dispatch tasks and return immediately. |
+**Parameters:**
 
-**Fields for each item in `assignments`:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent_name` | string | Yes | Name of the sub-agent whose tasks to cancel |
 
-| Field     | Type   | Required | Description |
-|-----------|--------|----------|-------------|
-| agent_id  | string | Yes      | ID of the sub-agent (from `create_sub_agent` output). |
-| task      | string | Yes      | Task description for the sub-agent. |
-| task_id   | string | No       | Identifier for this assignment; defaults to `task-{idx + 1}`. |
+**Returns:** A summary of how many tasks were cancelled and how many were already finished.
 
-**Handler behavior (`assign_task_tool`):** Validates that `agent.sub_agents` exists and that each `agent_id` is in it. Runs each assignment concurrently. On success, each result has `status: "success"` and `result`; on error, `status: "error"` and `error`. When `wait_for_completion` is true, returns a formatted string of all results; otherwise returns a dispatch confirmation.
+```
+Cancelled 1 async task(s) and skipped 2 already finished or non-cancellable task(s) for sub-agent 'AI-Research-Agent'.
+```
 
-## Advanced Example
+!!! note
+    Only tasks with status `pending` or `running` can be cancelled. Tasks that are already `completed`, `failed`, or `cancelled` are skipped.
 
-Here's a more complex example with custom system prompts:
+## SubagentRegistry Reference
+
+The `SubagentRegistry` is the execution engine behind sub-agent task management. It is lazily created per coordinator agent and stored as `agent._subagent_registry`.
+
+```python
+from swarms.structs.async_subagent import SubagentRegistry, SubagentTask, TaskStatus
+```
+
+### TaskStatus
+
+| Value | Description |
+|-------|-------------|
+| `PENDING` | Task created but not yet submitted |
+| `RUNNING` | Task currently executing in the thread pool |
+| `COMPLETED` | Task finished successfully |
+| `FAILED` | Task raised an exception after all retries exhausted |
+| `CANCELLED` | Task was cancelled before completion |
+
+### SubagentTask
+
+Dataclass tracking a single async task:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `str` | Unique task identifier (`task-{uuid_hex[:8]}`) |
+| `agent` | `Any` | The `Agent` instance executing this task |
+| `task_str` | `str` | The task description |
+| `status` | `TaskStatus` | Current lifecycle status |
+| `result` | `Any` | Return value from `agent.run()` on success |
+| `error` | `Optional[Exception]` | Exception instance on failure |
+| `future` | `Optional[Future]` | The `concurrent.futures.Future` handle |
+| `parent_id` | `Optional[str]` | ID of the parent task (for nested sub-agents) |
+| `depth` | `int` | Recursion depth (0 = top-level) |
+| `retries` | `int` | Number of retries attempted so far |
+| `max_retries` | `int` | Maximum retries allowed |
+| `retry_on` | `Optional[List[Type[Exception]]]` | Exception types that trigger a retry |
+| `created_at` | `float` | Timestamp when the task was created |
+| `completed_at` | `Optional[float]` | Timestamp when the task finished |
+
+### SubagentRegistry Methods
+
+| Method | Parameters | Returns | Description |
+|--------|------------|---------|-------------|
+| `spawn()` | `agent`, `task`, `parent_id=None`, `depth=0`, `max_retries=0`, `retry_on=None`, `fail_fast=True` | `str` (task ID) | Submit a task to the thread pool |
+| `get_task()` | `task_id` | `SubagentTask` | Retrieve a task by ID |
+| `get_results()` | — | `Dict[str, Any]` | Collect results from all completed/failed tasks |
+| `gather()` | `strategy="wait_all"`, `timeout=None` | `List[Any]` | Block until tasks complete. Strategy: `"wait_all"` or `"wait_first"` |
+| `cancel()` | `task_id` | `bool` | Cancel a pending/running task |
+| `shutdown()` | — | `None` | Shut down the thread pool executor |
+
+### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `max_depth` | `int` | `3` | Maximum recursion depth for nested sub-agents |
+| `max_workers` | `Optional[int]` | `None` | Thread pool size (defaults to Python's `ThreadPoolExecutor` default) |
+
+## Examples
+
+### Parallel Research with Wait Mode
+
+The most common pattern — create sub-agents, assign tasks, and wait for all results:
 
 ```python
 from swarms.structs.agent import Agent
 
-# Create a sophisticated coordinator
 coordinator = Agent(
-    agent_name="Advanced-Research-Coordinator",
-    agent_description="Manages complex multi-domain research projects",
-    model_name="gpt-4o",
+    agent_name="Market-Research-Lead",
+    agent_description="Coordinates parallel market research across sectors",
+    model_name="gpt-4.1",
     max_loops="auto",
     interactive=False,
-    verbose=True,  # See detailed execution
 )
 
-# Complex multi-stage task
 task = """
-Conduct a comprehensive analysis of the technology landscape:
+Analyze three market sectors in parallel:
 
-Phase 1: Create specialized sub-agents
-- Create an AI/ML expert agent with deep knowledge of machine learning
-- Create a cybersecurity expert agent
-- Create a cloud computing expert agent
+1. Create a sub-agent named "Tech-Analyst" specializing in technology sector analysis
+2. Create a sub-agent named "Healthcare-Analyst" specializing in healthcare sector analysis
+3. Create a sub-agent named "Energy-Analyst" specializing in energy sector analysis
 
-Phase 2: Parallel research
-- Assign each agent to research their domain's latest trends
-- Request detailed analysis including challenges and opportunities
+Assign each analyst a task to research:
+- Current market trends and key players
+- Growth projections for the next 5 years
+- Major risks and opportunities
 
-Phase 3: Integration
-- Compile findings into a unified technology landscape report
-- Identify cross-domain synergies and opportunities
+Wait for all results and compile a unified market overview report.
 """
 
-# Execute the multi-phase task
 result = coordinator.run(task)
 print(result)
 ```
 
-## Use Cases
+### Fire-and-Forget with Status Polling
 
-### 1. Research & Analysis
-
-Break down research topics into parallel investigations:
+For long-running tasks, dispatch without blocking and check status later:
 
 ```python
-task = """
-Research the impact of climate change on three sectors:
-1. Agriculture
-2. Healthcare  
-3. Technology infrastructure
+from swarms.structs.agent import Agent
 
-Create expert sub-agents for each sector and compile findings.
+coordinator = Agent(
+    agent_name="Data-Pipeline-Manager",
+    agent_description="Manages long-running data processing pipelines",
+    model_name="gpt-4.1",
+    max_loops="auto",
+    interactive=False,
+)
+
+task = """
+Process three large datasets concurrently using fire-and-forget mode:
+
+1. Create sub-agents: "ETL-Agent-Sales", "ETL-Agent-Marketing", "ETL-Agent-Support"
+2. Assign each agent a data processing task with wait_for_completion=false
+3. Check the status of each sub-agent using check_sub_agent_status
+4. If any agent is taking too long, cancel its tasks using cancel_sub_agent_tasks
+5. Report final status of all tasks
 """
+
+result = coordinator.run(task)
+print(result)
 ```
 
-### 2. Content Creation
+### Custom System Prompts
 
-Distribute content creation across specialized writers:
+Give sub-agents specialized instructions:
 
 ```python
-task = """
-Create a comprehensive guide on Python web development:
-1. Backend development (Django/Flask expert)
-2. Frontend integration (React expert)
-3. DevOps and deployment (Infrastructure expert)
+from swarms.structs.agent import Agent
 
-Create sub-agents for each area and combine into a cohesive guide.
+coordinator = Agent(
+    agent_name="Content-Director",
+    agent_description="Directs content creation across formats and audiences",
+    model_name="gpt-4.1",
+    max_loops="auto",
+    interactive=False,
+)
+
+task = """
+Create a content suite for a product launch:
+
+1. Create a sub-agent named "Blog-Writer" with system_prompt:
+   "You are a technical blog writer. Write in a clear, informative style
+   with code examples where relevant. Target audience: developers."
+
+2. Create a sub-agent named "Social-Media-Writer" with system_prompt:
+   "You write punchy, engaging social media posts. Keep posts under
+   280 characters for Twitter. Use hashtags strategically."
+
+3. Create a sub-agent named "Email-Writer" with system_prompt:
+   "You write professional marketing emails. Use a conversational
+   but polished tone. Include a clear call-to-action."
+
+Assign each agent to create content about our new AI-powered code review tool.
+Compile all content into a launch package.
 """
+
+result = coordinator.run(task)
+print(result)
 ```
 
-### 3. Data Processing
+### Selective Tool Access
 
-Parallel processing of different data sources:
+Restrict the coordinator to only sub-agent tools:
 
 ```python
-task = """
-Analyze market data from three sources:
-1. Social media sentiment (Twitter, Reddit)
-2. News articles (Financial news)
-3. Technical indicators (Stock charts)
+from swarms.structs.agent import Agent
 
-Create specialized sub-agents for each data source.
-"""
+coordinator = Agent(
+    agent_name="Delegation-Only-Coordinator",
+    agent_description="Coordinates work purely through sub-agent delegation",
+    model_name="gpt-4.1",
+    max_loops="auto",
+    interactive=False,
+    selected_tools=[
+        "create_plan",
+        "think",
+        "subtask_done",
+        "complete_task",
+        "respond_to_user",
+        "create_sub_agent",
+        "assign_task",
+        "check_sub_agent_status",
+        "cancel_sub_agent_tasks",
+    ],
+)
+
+result = coordinator.run("Research AI safety approaches using sub-agents.")
+print(result)
 ```
 
-### 4. Software Development Tasks
+## Agent Configuration
 
-Distribute development work:
+These `Agent` constructor parameters control sub-agent behavior:
 
-```python
-task = """
-Plan and design a new feature:
-1. Frontend design and UX (Design expert)
-2. Backend API architecture (API expert)
-3. Database schema (Database expert)
-4. Testing strategy (QA expert)
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `max_loops` | `Union[int, str]` | `1` | Set to `"auto"` to enable autonomous mode with sub-agent tools |
+| `max_subagent_depth` | `int` | `3` | Maximum recursion depth for nested sub-agent hierarchies |
+| `selected_tools` | `Union[str, List[str]]` | `"all"` | Controls which autonomous loop tools are available. Set to `"all"` or a list of tool names |
+| `interactive` | `bool` | `False` | Set to `False` for fully autonomous execution |
+| `verbose` | `bool` | `False` | Enable detailed logging of sub-agent creation and execution |
 
-Create sub-agents for each role and compile a comprehensive plan.
-"""
-```
+## Best Practices
+
+| Practice | Recommendation |
+|----------|----------------|
+| **Sub-agent count** | 3-5 agents is ideal for most tasks. Beyond 10, coordination overhead increases |
+| **Task granularity** | Give each sub-agent a focused, self-contained task. Avoid inter-agent dependencies |
+| **Naming** | Use descriptive agent names (e.g., `"Financial-Analyst"`, not `"Agent-1"`) so the coordinator can reason about delegation |
+| **System prompts** | Provide custom system prompts when sub-agents need specific expertise, tone, or output format |
+| **Wait vs fire-and-forget** | Use wait mode for tasks that must complete before synthesis. Use fire-and-forget for long-running tasks where you want to check progress incrementally |
+| **Error handling** | The registry catches exceptions per-task. Failed tasks are reported alongside successful ones rather than crashing the coordinator |
 
 ## Troubleshooting
 
-### Sub-agents not created
+### Sub-agents not being created
 
-Ensure `selected_tools="all"` or include `"create_sub_agent"` and `"assign_task"` in the selected tools list. If the agent returns "Error: Each agent must have agent_name and agent_description", every entry in the `agents` array must have both `agent_name` and `agent_description`.
+Ensure the coordinator is running with `max_loops="auto"`. The sub-agent tools are only available in autonomous mode. Also verify that `selected_tools` includes `"create_sub_agent"` (or is set to `"all"`).
 
-### No sub-agents have been created
+### "No sub-agents have been created" error
 
-If `assign_task` returns "Error: No sub-agents have been created. Use create_sub_agent first.", call `create_sub_agent` before `assign_task`. The main agent must create and cache sub-agents before assigning work.
+The `assign_task` tool requires sub-agents to exist first. The coordinator must call `create_sub_agent` before `assign_task`. If the LLM skips creation, make the task prompt explicit about creating sub-agents first.
 
-### Sub-agent not found
+### "Sub-agent with ID '...' not found" error
 
-If you see "Error: Sub-agent with ID '...' not found. Available agents: [...]", the `agent_id` in the assignment does not match any key in `agent.sub_agents`. Use the exact IDs returned from `create_sub_agent` (e.g. `sub-agent-a1b2c3d4`).
+The `agent_id` in the assignment doesn't match any cached sub-agent. Sub-agent IDs are returned by `create_sub_agent` in the format `sub-agent-{hex}` (e.g., `sub-agent-a1b2c3d4`). The coordinator LLM must use the exact IDs from the creation response.
 
-### Tasks not waiting for completion
+### "Subagent depth exceeds max_depth" error
 
-When `wait_for_completion` is true (default), the tool waits for all sub-agent runs and returns formatted results. When false, it dispatches tasks and returns "Dispatched N task(s) to sub-agents (async mode)" without waiting.
+A sub-agent attempted to spawn its own sub-agents beyond the allowed recursion depth. Increase `max_subagent_depth` on the coordinator agent, or restructure the task to avoid deep nesting.
 
-## Performance Considerations
+### Fire-and-forget tasks never checked
 
-### Optimal Number of Sub-Agents
+When using `wait_for_completion=false`, the coordinator must explicitly call `check_sub_agent_status` to retrieve results. Make the task prompt explicit about polling for status after dispatching.
 
-| Number of Sub-Agents | Recommended Use                                |
-|----------------------|------------------------------------------------|
-| 3-5                  | Ideal for most tasks                           |
-| 5-10                 | Good for complex multi-domain projects         |
-| 10+                  | May increase coordination overhead             |
+## Next Steps
 
-
-## Summary
-
-Sub-agent delegation allows an autonomous agent to divide complex tasks among specialized sub-agents, improving efficiency and scalability. When enabled, the main agent can dynamically create sub-agents with defined roles and assign them tasks to work on in parallel. Sub-agents are managed and reused by the coordinator, and their results are gathered and synthesized for the overall task outcome. This approach is ideal for scenarios requiring concurrent execution, expertise in multiple domains, or efficient handling of multi-step problems.
+| Resource | Description |
+|----------|-------------|
+| [Autonomous Agent Tutorial](autonomous_agent_tutorial.md) | Full guide to autonomous mode and the planning/execution loop |
+| [Agent Reference](../structs/agent.md) | Complete `Agent` class API documentation |
+| [Agent Handoff Tutorial](agent_handoff_tutorial.md) | Transfer tasks between agents based on specialization |

--- a/docs/swarms/structs/async_subagent.md
+++ b/docs/swarms/structs/async_subagent.md
@@ -1,0 +1,507 @@
+# `SubagentRegistry`
+
+The `SubagentRegistry` is a thread-safe task execution engine that manages background sub-agent tasks with status tracking, result aggregation, retry policies, and depth-limited recursion. It is the core runtime behind the [sub-agent delegation](../examples/sub_agent_tutorial.md) feature.
+
+```mermaid
+graph TD
+    A[Coordinator Agent] -->|spawn| B[SubagentRegistry]
+    B --> C[ThreadPoolExecutor]
+    C --> D1[SubagentTask 1<br/>status: running]
+    C --> D2[SubagentTask 2<br/>status: running]
+    C --> D3[SubagentTask N<br/>status: running]
+
+    D1 -->|success| E1[status: completed<br/>result stored]
+    D1 -->|exception| F1{retry_on match?}
+    F1 -->|yes, retries left| D1
+    F1 -->|no| G1[status: failed<br/>error stored]
+
+    D2 -->|success| E2[status: completed]
+    D3 -->|success| E3[status: completed]
+
+    E1 --> H[gather / get_results]
+    E2 --> H
+    E3 --> H
+    G1 --> H
+
+    H --> I[Results returned to caller]
+
+    A -.->|cancel| B
+    B -.->|cancel future| D2
+```
+
+Each spawned task is tracked as a `SubagentTask` dataclass through a five-state lifecycle (`pending` → `running` → `completed` / `failed` / `cancelled`). The registry uses Python's `concurrent.futures.ThreadPoolExecutor` for background execution, making it compatible with any Python environment without requiring an async event loop.
+
+## Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **Background Execution** | Tasks run in a `ThreadPoolExecutor`, freeing the coordinator to continue planning |
+| **Status Tracking** | Every task is tracked with status, timestamps, retry count, and depth |
+| **Result Aggregation** | `get_results()` and `gather()` collect outcomes from all tasks in one call |
+| **Retry Policies** | Per-task `max_retries` and `retry_on` exception-type filtering |
+| **Depth-Limited Recursion** | `max_depth` prevents infinite nesting of sub-agent hierarchies |
+| **Cancellation** | Cancel pending or running tasks via their `Future` handle |
+| **Gather Strategies** | `wait_all` blocks until every task completes; `wait_first` returns as soon as any task finishes |
+| **Thread Safety** | Task registration is protected by a `threading.Lock` |
+
+## Installation
+
+```bash
+pip install -U swarms
+```
+
+## Import
+
+```python
+from swarms.structs.async_subagent import (
+    SubagentRegistry,
+    SubagentTask,
+    TaskStatus,
+)
+```
+
+## `TaskStatus`
+
+Enum representing the lifecycle states of a sub-agent task.
+
+| Value | Description |
+|-------|-------------|
+| `PENDING` | Task created but not yet submitted to the executor |
+| `RUNNING` | Task currently executing in the thread pool |
+| `COMPLETED` | Task finished successfully; result is available |
+| `FAILED` | Task raised an exception after all retries were exhausted |
+| `CANCELLED` | Task was cancelled before completion |
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING
+    PENDING --> RUNNING : submitted to executor
+    RUNNING --> COMPLETED : agent.run() returns
+    RUNNING --> FAILED : exception after max retries
+    RUNNING --> CANCELLED : cancel() called
+    PENDING --> CANCELLED : cancel() called
+```
+
+## `SubagentTask`
+
+Dataclass that tracks a single async sub-agent task.
+
+### Attributes
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `id` | `str` | — | Unique task identifier (`task-{uuid_hex[:8]}`) |
+| `agent` | `Any` | — | The `Agent` instance assigned to this task |
+| `task_str` | `str` | — | The task description passed to `agent.run()` |
+| `status` | `TaskStatus` | `PENDING` | Current lifecycle status |
+| `result` | `Any` | `None` | Return value from `agent.run()` on success |
+| `error` | `Optional[Exception]` | `None` | Exception instance on failure |
+| `future` | `Optional[Future]` | `None` | The `concurrent.futures.Future` handle for this task |
+| `parent_id` | `Optional[str]` | `None` | ID of the parent task, for nested sub-agent hierarchies |
+| `depth` | `int` | `0` | Recursion depth (0 = top-level task) |
+| `retries` | `int` | `0` | Number of retries attempted so far |
+| `max_retries` | `int` | `0` | Maximum retries allowed for this task |
+| `retry_on` | `Optional[List[Type[Exception]]]` | `None` | Exception types that should trigger a retry |
+| `created_at` | `float` | `time.time()` | Timestamp when the task was created |
+| `completed_at` | `Optional[float]` | `None` | Timestamp when the task finished (success, failure, or cancellation) |
+
+## `SubagentRegistry`
+
+### Constructor
+
+```python
+SubagentRegistry(
+    max_depth: int = 3,
+    max_workers: Optional[int] = None,
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Description |
+|-----------|------|---------|----------|-------------|
+| `max_depth` | `int` | `3` | No | Maximum recursion depth for nested sub-agent spawning. A `ValueError` is raised if `spawn()` is called with `depth > max_depth` |
+| `max_workers` | `Optional[int]` | `None` | No | Maximum number of threads in the `ThreadPoolExecutor`. When `None`, uses Python's default (typically `min(32, os.cpu_count() + 4)`) |
+
+#### Internal State
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `_tasks` | `Dict[str, SubagentTask]` | Map of task IDs to task objects |
+| `_executor` | `ThreadPoolExecutor` | The thread pool used for background execution |
+| `_lock` | `threading.Lock` | Guards concurrent access to `_tasks` |
+
+---
+
+### Methods
+
+### `spawn()`
+
+Submit an agent task for background execution in the thread pool.
+
+```python
+def spawn(
+    self,
+    agent: Any,
+    task: str,
+    parent_id: Optional[str] = None,
+    depth: int = 0,
+    max_retries: int = 0,
+    retry_on: Optional[List[Type[Exception]]] = None,
+    fail_fast: bool = True,
+) -> str
+```
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Description |
+|-----------|------|---------|----------|-------------|
+| `agent` | `Any` | — | **Yes** | An `Agent` instance (must have a `.run(task_str)` method) |
+| `task` | `str` | — | **Yes** | Task description to pass to `agent.run()` |
+| `parent_id` | `Optional[str]` | `None` | No | ID of a parent task, for tracking nested hierarchies |
+| `depth` | `int` | `0` | No | Recursion depth of this task. Must be `<= max_depth` |
+| `max_retries` | `int` | `0` | No | Number of times to retry the task on failure |
+| `retry_on` | `Optional[List[Type[Exception]]]` | `None` | No | Only retry when the exception is an instance of one of these types. If empty or `None`, retries on any exception |
+| `fail_fast` | `bool` | `True` | No | If `True`, re-raises the exception after all retries are exhausted. If `False`, stores the error and returns `None` |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `str` | The unique task ID (format: `task-{uuid_hex[:8]}`) |
+
+#### Raises
+
+| Exception | Condition |
+|-----------|-----------|
+| `ValueError` | If `depth > max_depth` |
+
+#### Example
+
+```python
+from swarms.structs.agent import Agent
+from swarms.structs.async_subagent import SubagentRegistry
+
+registry = SubagentRegistry(max_depth=3)
+
+agent = Agent(
+    agent_name="Researcher",
+    model_name="gpt-4.1",
+    max_loops=1,
+)
+
+task_id = registry.spawn(
+    agent=agent,
+    task="Research the latest advances in quantum computing",
+    max_retries=2,
+    retry_on=[TimeoutError],
+    fail_fast=False,
+)
+print(f"Spawned task: {task_id}")
+```
+
+---
+
+### `get_task()`
+
+Retrieve a task by its ID.
+
+```python
+def get_task(self, task_id: str) -> SubagentTask
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `task_id` | `str` | **Yes** | The task ID returned by `spawn()` |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `SubagentTask` | The task object with current status, result, and metadata |
+
+#### Raises
+
+| Exception | Condition |
+|-----------|-----------|
+| `KeyError` | If no task exists with the given ID |
+
+---
+
+### `get_results()`
+
+Collect results from all completed and failed tasks.
+
+```python
+def get_results(self) -> Dict[str, Any]
+```
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Dict[str, Any]` | Map of task ID → result (for completed tasks) or exception (for failed tasks). Tasks still running or pending are excluded |
+
+#### Example
+
+```python
+results = registry.get_results()
+for task_id, value in results.items():
+    if isinstance(value, Exception):
+        print(f"{task_id} failed: {value}")
+    else:
+        print(f"{task_id} result: {value[:100]}...")
+```
+
+---
+
+### `gather()`
+
+Block until tasks complete and return their results.
+
+```python
+def gather(
+    self,
+    strategy: str = "wait_all",
+    timeout: Optional[float] = None,
+) -> List[Any]
+```
+
+#### Parameters
+
+| Parameter | Type | Default | Required | Description |
+|-----------|------|---------|----------|-------------|
+| `strategy` | `str` | `"wait_all"` | No | `"wait_all"` waits for every task to finish. `"wait_first"` returns as soon as any task completes |
+| `timeout` | `Optional[float]` | `None` | No | Maximum seconds to wait. `None` means wait indefinitely |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `List[Any]` | List of results. Completed tasks contribute their return value; failed tasks contribute their exception |
+
+#### Example
+
+```python
+# Spawn multiple tasks
+ids = []
+for agent, task in work_items:
+    ids.append(registry.spawn(agent=agent, task=task))
+
+# Wait for all tasks to complete
+results = registry.gather(strategy="wait_all", timeout=120.0)
+
+for i, result in enumerate(results):
+    print(f"Task {i}: {result}")
+```
+
+---
+
+### `cancel()`
+
+Cancel a pending or running task.
+
+```python
+def cancel(self, task_id: str) -> bool
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `task_id` | `str` | **Yes** | The task ID to cancel |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `bool` | `True` if the task was successfully cancelled, `False` if it was already completed/failed or could not be cancelled |
+
+!!! note
+    Cancellation calls `Future.cancel()` from `concurrent.futures`. A task that has already started executing may not be cancellable depending on timing — the executor does not forcibly kill running threads.
+
+---
+
+### `shutdown()`
+
+Shut down the thread pool executor. Running tasks are not waited on.
+
+```python
+def shutdown(self) -> None
+```
+
+---
+
+### `tasks` (property)
+
+Read-only snapshot of all tracked tasks.
+
+```python
+@property
+def tasks(self) -> Dict[str, SubagentTask]
+```
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Dict[str, SubagentTask]` | A shallow copy of the internal tasks dictionary |
+
+---
+
+## Integration with the Agent Class
+
+The `SubagentRegistry` is not used directly in most workflows. Instead, it is created and managed automatically by the autonomous loop when an `Agent` runs with `max_loops="auto"`.
+
+### How It Is Wired
+
+1. The `Agent` class has two related attributes:
+   - `max_subagent_depth` (constructor parameter, default `3`) — passed to `SubagentRegistry(max_depth=...)`
+   - `_subagent_registry` (internal, default `None`) — holds the lazily-created registry instance
+
+2. When the autonomous loop's `assign_task` tool is called, the helper function `_find_registry(agent)` checks for an existing registry on `agent._subagent_registry`. If none exists, it creates one and stores it:
+
+```python
+def _find_registry(agent):
+    existing = getattr(agent, "_subagent_registry", None)
+    if isinstance(existing, SubagentRegistry):
+        return existing
+    max_depth = getattr(agent, "max_subagent_depth", 3)
+    registry = SubagentRegistry(max_depth=max_depth)
+    setattr(agent, "_subagent_registry", registry)
+    return registry
+```
+
+3. The four autonomous loop tools that interact with the registry:
+
+| Tool | Registry Method Used |
+|------|---------------------|
+| `assign_task` | `spawn()`, `gather()`, `get_results()` |
+| `check_sub_agent_status` | `tasks` property (reads task status) |
+| `cancel_sub_agent_tasks` | `cancel()` |
+| `create_sub_agent` | Does not use registry (stores agents in `agent.sub_agents`) |
+
+### Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant A as Agent (max_loops=auto)
+    participant T as assign_task tool
+    participant R as SubagentRegistry
+
+    Note over A: First assign_task call
+    A->>T: assign_task(assignments=[...])
+    T->>T: _find_registry(agent)
+    Note over T: No registry exists yet
+    T->>R: SubagentRegistry(max_depth=3)
+    T->>A: Store as agent._subagent_registry
+
+    T->>R: spawn(sub_agent_1, task_1)
+    T->>R: spawn(sub_agent_2, task_2)
+    R-->>R: ThreadPoolExecutor runs tasks
+
+    T->>R: gather(strategy=wait_all)
+    R-->>T: [result_1, result_2]
+    T-->>A: Formatted results
+
+    Note over A: Subsequent calls reuse same registry
+    A->>T: assign_task(assignments=[...])
+    T->>T: _find_registry(agent)
+    Note over T: Registry already exists
+    T->>R: spawn(sub_agent_3, task_3)
+```
+
+## Direct Usage
+
+While the registry is typically used indirectly through autonomous loop tools, it can be used directly for programmatic sub-agent orchestration:
+
+```python
+from swarms.structs.agent import Agent
+from swarms.structs.async_subagent import SubagentRegistry
+
+# Create agents
+analyst = Agent(agent_name="Analyst", model_name="gpt-4.1", max_loops=1)
+writer = Agent(agent_name="Writer", model_name="gpt-4.1", max_loops=1)
+
+# Create registry
+registry = SubagentRegistry(max_depth=3, max_workers=4)
+
+# Spawn tasks concurrently
+task_1 = registry.spawn(
+    agent=analyst,
+    task="Analyze Q4 revenue trends",
+    fail_fast=False,
+)
+task_2 = registry.spawn(
+    agent=writer,
+    task="Draft an executive summary of Q4 performance",
+    fail_fast=False,
+)
+
+# Wait for all tasks
+results = registry.gather(strategy="wait_all")
+print(f"Analyst result: {results[0]}")
+print(f"Writer result: {results[1]}")
+
+# Or inspect individual tasks
+task = registry.get_task(task_1)
+print(f"Status: {task.status}, Duration: {task.completed_at - task.created_at:.2f}s")
+
+# Clean up
+registry.shutdown()
+```
+
+### With Retry Policies
+
+```python
+registry = SubagentRegistry(max_depth=3)
+
+task_id = registry.spawn(
+    agent=analyst,
+    task="Fetch and analyze live market data",
+    max_retries=3,
+    retry_on=[ConnectionError, TimeoutError],
+    fail_fast=False,
+)
+
+results = registry.gather()
+
+task = registry.get_task(task_id)
+if task.status == TaskStatus.FAILED:
+    print(f"Failed after {task.retries} retries: {task.error}")
+elif task.status == TaskStatus.COMPLETED:
+    print(f"Completed in {task.retries} retries: {task.result[:100]}...")
+```
+
+### With Cancellation
+
+```python
+import time
+
+registry = SubagentRegistry()
+
+task_id = registry.spawn(
+    agent=analyst,
+    task="Run a very long analysis",
+    fail_fast=False,
+)
+
+# Cancel after some condition
+time.sleep(2)
+cancelled = registry.cancel(task_id)
+print(f"Cancelled: {cancelled}")
+
+task = registry.get_task(task_id)
+print(f"Status: {task.status}")  # CANCELLED if it hadn't finished yet
+```
+
+## Related Resources
+
+| Resource | Description |
+|----------|-------------|
+| [Sub-Agent Delegation Tutorial](../examples/sub_agent_tutorial.md) | End-to-end guide with examples for using sub-agents through the autonomous loop |
+| [Autonomous Agent Tutorial](../examples/autonomous_agent_tutorial.md) | Full guide to autonomous mode (`max_loops="auto"`) |
+| [Agent Reference](agent.md) | Complete `Agent` class API documentation |
+| [AgentRegistry](agent_registry.md) | Separate registry for managing collections of `Agent` instances (not related to async task execution) |


### PR DESCRIPTION
## Summary
- **Rewrote** `sub_agent_tutorial.md` to fix inaccuracies (was describing `asyncio.to_thread`/`asyncio.gather` — actual implementation uses `SubagentRegistry` with `ThreadPoolExecutor`), document all 4 autonomous loop tools (including previously undocumented `check_sub_agent_status` and `cancel_sub_agent_tasks`), add Mermaid architecture and sequence diagrams, and expand examples (fire-and-forget, custom system prompts, selective tool access)
- **Added** new `async_subagent.md` reference doc covering `SubagentRegistry`, `SubagentTask`, and `TaskStatus` with full API documentation, state diagrams, direct usage examples, retry/cancellation patterns, and Agent class integration details
- **Updated** `mkdocs.yml` with nav entries in the Agents section and Utilities section

## Test plan
- [ ] Verify `mkdocs serve` renders both docs without errors
- [ ] Verify Mermaid diagrams render correctly (architecture graph, sequence diagram, state diagram)
- [ ] Verify all cross-links between tutorial ↔ reference ↔ agent docs resolve
- [ ] Review parameter tables against source code in `async_subagent.py` and `autonomous_loop_utils.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1447.org.readthedocs.build/en/1447/

<!-- readthedocs-preview swarms end -->