### PR TITLE
[BUG] Added streaming support and corresponding tests to autonomous loop summary 

### DIFF
--- a/examples/single_agent/utils/summary_phase_streaming_demo.py
+++ b/examples/single_agent/utils/summary_phase_streaming_demo.py
@@ -1,15 +1,47 @@
 from dotenv import load_dotenv
 from swarms import Agent
-from swarms.utils.litellm_wrapper import LiteLLM
-load_dotenv(); tokens = []
-def on_token(t): tokens.append(t.get("token") if isinstance(t, dict) else t)
-llm = LiteLLM(model_name="anthropic/claude-sonnet-4-20250514", temperature=1.0, max_tokens=1024, timeout=180)
-agent = Agent(llm=llm, model_name="anthropic/claude-sonnet-4-20250514", temperature=1.0, max_loops="auto", stream=True, print_on=False, retry_attempts=8, selected_tools=["create_plan", "think", "subtask_done", "complete_task"])
-try: result = agent.run("Write exactly one short sentence: Streaming callback verified.", streaming_callback=on_token); ran_ok = True
-except Exception: result, ran_ok = "", False
+
+load_dotenv()
+
+tokens = []
+
+agent = Agent(
+    model_name="anthropic/claude-sonnet-4-20250514",
+    temperature=1.0,
+    max_loops="auto",
+    stream=True,
+    print_on=False,
+    retry_attempts=8,
+    selected_tools=[
+        "create_plan",
+        "think",
+        "subtask_done",
+        "complete_task",
+    ],
+)
+
+try:
+    result = agent.run(
+        "Write exactly one short sentence: Streaming callback verified.",
+        streaming_callback=lambda t: tokens.append(
+            t.get("token") if isinstance(t, dict) else t
+        ),
+    )
+    ran_ok = True
+except Exception:
+    result, ran_ok = "", False
+
 stream_tokens = [t for t in tokens if t]
 print("=== SUMMARY_STREAMING ===")
-print("STREAM_TOKEN_COUNT:", len(stream_tokens)); print("SUMMARY_STREAMING_SUCCESS:", "YES" if stream_tokens else "NO")
-print("STREAM_PREVIEW:", "".join(str(t) for t in stream_tokens[:8])[:180])
+print("STREAM_TOKEN_COUNT:", len(stream_tokens))
+print("SUMMARY_STREAMING_SUCCESS:", "YES" if stream_tokens else "NO")
+print(
+    "STREAM_PREVIEW:",
+    "".join(str(t) for t in stream_tokens[:8])[:180],
+)
 print("=== RUN_OUTPUT ===")
-print(str(result)[:300] if ran_ok else "Execution ended before final response; streaming callback signal is shown above.")
+print(
+    str(result)[:300]
+    if ran_ok
+    else "Execution ended before final response; streaming callback signal is shown above."
+)

--- a/examples/single_agent/utils/summary_phase_streaming_demo.py
+++ b/examples/single_agent/utils/summary_phase_streaming_demo.py
@@ -1,0 +1,15 @@
+from dotenv import load_dotenv
+from swarms import Agent
+from swarms.utils.litellm_wrapper import LiteLLM
+load_dotenv(); tokens = []
+def on_token(t): tokens.append(t.get("token") if isinstance(t, dict) else t)
+llm = LiteLLM(model_name="anthropic/claude-sonnet-4-20250514", temperature=1.0, max_tokens=1024, timeout=180)
+agent = Agent(llm=llm, model_name="anthropic/claude-sonnet-4-20250514", temperature=1.0, max_loops="auto", stream=True, print_on=False, retry_attempts=8, selected_tools=["create_plan", "think", "subtask_done", "complete_task"])
+try: result = agent.run("Write exactly one short sentence: Streaming callback verified.", streaming_callback=on_token); ran_ok = True
+except Exception: result, ran_ok = "", False
+stream_tokens = [t for t in tokens if t]
+print("=== SUMMARY_STREAMING ===")
+print("STREAM_TOKEN_COUNT:", len(stream_tokens)); print("SUMMARY_STREAMING_SUCCESS:", "YES" if stream_tokens else "NO")
+print("STREAM_PREVIEW:", "".join(str(t) for t in stream_tokens[:8])[:180])
+print("=== RUN_OUTPUT ===")
+print(str(result)[:300] if ran_ok else "Execution ended before final response; streaming callback signal is shown above.")

--- a/scripts/tests/live_autonomous_streaming_test.py
+++ b/scripts/tests/live_autonomous_streaming_test.py
@@ -1,0 +1,228 @@
+import argparse
+import os
+import sys
+from typing import Any, List
+
+from dotenv import load_dotenv
+
+from swarms import Agent
+from swarms.utils.litellm_wrapper import LiteLLM
+
+
+def _pick_model(explicit_model: str | None) -> str:
+    if explicit_model:
+        return explicit_model
+    return os.getenv(
+        "LIVE_TEST_MODEL",
+        os.getenv("SMOKE_MODEL", "gemini/gemini-2.0-flash"),
+    )
+
+
+def _find_present_keys() -> List[str]:
+    key_names = [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GROQ_API_KEY",
+        "GEMINI_API_KEY",
+    ]
+    return [name for name in key_names if os.getenv(name)]
+
+
+def run_live_test(
+    model_name: str,
+    task: str,
+    max_tokens: int,
+    timeout_seconds: int,
+    require_streaming: bool,
+) -> int:
+    streamed_tokens: List[str] = []
+
+    def streaming_callback(token: Any) -> None:
+        # Detailed stream mode emits token metadata dictionaries.
+        if isinstance(token, dict):
+            token_text = token.get("token")
+            if token_text:
+                streamed_tokens.append(str(token_text))
+            return
+        if token:
+            streamed_tokens.append(str(token))
+
+    # Sonnet 4 requests in this path require temperature=1.
+    temperature = (
+        1.0 if "claude-sonnet-4" in model_name.lower() else 0.1
+    )
+
+    llm = LiteLLM(
+        model_name=model_name,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        timeout=timeout_seconds,
+    )
+
+    agent = Agent(
+        llm=llm,
+        model_name=model_name,
+        temperature=temperature,
+        stream=False,
+        max_loops="auto",
+        timeout=timeout_seconds,
+        print_on=False,
+        verbose=False,
+        reasoning_prompt_on=False,
+        selected_tools=[
+            "create_plan",
+            "think",
+            "subtask_done",
+            "complete_task",
+        ],
+    )
+
+    # Keep autonomous planning/tool calls non-streaming, then stream only
+    # during final summary generation where this bug fix is targeted.
+    original_generate_final_summary = agent._generate_final_summary
+
+    def generate_final_summary_with_streaming(*, streaming_callback=None):
+        previous_agent_stream = agent.stream
+        previous_llm_stream = getattr(agent.llm, "stream", False)
+        previous_tools = agent.tools
+        previous_llm_tools = getattr(
+            agent.llm, "tools_list_dictionary", None
+        )
+        previous_llm_tool_choice = getattr(
+            agent.llm, "tool_choice", None
+        )
+        agent.stream = True
+        agent.tools = None
+        if hasattr(agent.llm, "stream"):
+            agent.llm.stream = True
+        if hasattr(agent.llm, "tools_list_dictionary"):
+            agent.llm.tools_list_dictionary = None
+        if hasattr(agent.llm, "tool_choice"):
+            agent.llm.tool_choice = None
+        try:
+            return original_generate_final_summary(
+                streaming_callback=streaming_callback
+            )
+        finally:
+            agent.stream = previous_agent_stream
+            agent.tools = previous_tools
+            if hasattr(agent.llm, "stream"):
+                agent.llm.stream = previous_llm_stream
+            if hasattr(agent.llm, "tools_list_dictionary"):
+                agent.llm.tools_list_dictionary = (
+                    previous_llm_tools
+                )
+            if hasattr(agent.llm, "tool_choice"):
+                agent.llm.tool_choice = (
+                    previous_llm_tool_choice
+                )
+
+    agent._generate_final_summary = (
+        generate_final_summary_with_streaming
+    )
+
+    print(f"RUN_MODE: autonomous")
+    print(f"TIMEOUT_SECONDS: {timeout_seconds}")
+
+    run_error: Exception | None = None
+    result: Any = None
+    try:
+        result = agent.run(
+            task=task, streaming_callback=streaming_callback
+        )
+    except Exception as exc:
+        run_error = exc
+
+    print(f"MODEL: {model_name}")
+    print(f"STREAM_TOKEN_COUNT: {len(streamed_tokens)}")
+    print("RESULT_PREVIEW:")
+    print(str(result)[:600] if result is not None else "none")
+
+    if require_streaming and len(streamed_tokens) == 0:
+        print(
+            "LIVE_TEST_ERROR: Streaming callback produced zero tokens; "
+            "treating as failure."
+        )
+        return 3
+
+    if run_error is not None:
+        print("LIVE_TEST_ERROR: Agent run failed.")
+        print(str(run_error))
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Permanent live test for autonomous summary streaming callback."
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Provider/model id, for example gemini/gemini-2.0-flash",
+    )
+    parser.add_argument(
+        "--check-env-only",
+        action="store_true",
+        help="Only validate env keys and selected model, do not call provider.",
+    )
+    parser.add_argument(
+        "--task",
+        default=(
+            "Write exactly one short sentence: Streaming callback verified."
+        ),
+        help="Task prompt to run in autonomous mode.",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=1024,
+        help="LLM max tokens for each model call.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=180,
+        help="Network/request timeout seconds for both model and agent call path.",
+    )
+    parser.add_argument(
+        "--allow-zero-stream-tokens",
+        action="store_true",
+        help="Do not fail when stream token count is zero.",
+    )
+    args = parser.parse_args()
+
+    load_dotenv()
+
+    model_name = _pick_model(args.model)
+    present_keys = _find_present_keys()
+
+    print(f"SELECTED_MODEL: {model_name}")
+    print(f"PRESENT_KEYS: {present_keys if present_keys else 'none'}")
+
+    if args.check_env_only:
+        return 0
+
+    if not present_keys:
+        print("No provider API key found in environment. Aborting live run.")
+        return 2
+
+    try:
+        return run_live_test(
+            model_name=model_name,
+            task=args.task,
+            max_tokens=args.max_tokens,
+            timeout_seconds=args.timeout_seconds,
+            require_streaming=(
+                not args.allow_zero_stream_tokens
+            ),
+        )
+    except Exception as exc:
+        print("LIVE_TEST_ERROR:")
+        print(str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2738,10 +2738,8 @@ class Agent:
                                             == "complete_task"
                                         ):
                                             # Task is complete, exit all loops
-                                            return (
-                                                self._generate_final_summary(
-                                                    streaming_callback=streaming_callback
-                                                )
+                                            return self._generate_final_summary(
+                                                streaming_callback=streaming_callback
                                             )
                                     else:
                                         # Collect regular tool calls for batch visualization and execution

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2739,7 +2739,9 @@ class Agent:
                                         ):
                                             # Task is complete, exit all loops
                                             return (
-                                                self._generate_final_summary()
+                                                self._generate_final_summary(
+                                                    streaming_callback=streaming_callback
+                                                )
                                             )
                                     else:
                                         # Collect regular tool calls for batch visualization and execution
@@ -2983,14 +2985,24 @@ class Agent:
                     title="Autonomous Loop: Summary Phase",
                 )
 
-            return self._generate_final_summary()
+            return self._generate_final_summary(
+                streaming_callback=streaming_callback
+            )
 
         except Exception as error:
             self._handle_run_error(error)
 
-    def _generate_final_summary(self) -> str:
+    def _generate_final_summary(
+        self,
+        streaming_callback: Optional[Callable[[str], None]] = None,
+    ) -> str:
         """
         Generate a comprehensive final summary of the autonomous task execution.
+
+        Args:
+            streaming_callback (Optional[Callable[[str], None]]): Optional callback
+                function to receive streaming tokens in real-time while generating
+                the final summary.
 
         Returns:
             str: Comprehensive summary
@@ -3005,6 +3017,7 @@ class Agent:
             response = self.call_llm(
                 task=task_prompt,
                 current_loop=0,
+                streaming_callback=streaming_callback,
             )
 
             response = self.parse_llm_output(response)

--- a/tests/structs/test_agent_autonomous_streaming_callback.py
+++ b/tests/structs/test_agent_autonomous_streaming_callback.py
@@ -1,0 +1,145 @@
+import json
+from unittest.mock import MagicMock
+
+from swarms.structs.agent import Agent
+
+
+
+def _make_agent() -> Agent:
+    """Create an offline-friendly agent for autonomous-loop unit tests."""
+    agent = Agent(
+        llm=MagicMock(),
+        max_loops="auto",
+        print_on=False,
+        verbose=False,
+        reasoning_prompt_on=False,
+        selected_tools=[
+            "create_plan",
+            "think",
+            "subtask_done",
+            "complete_task",
+        ],
+    )
+    # Keep autonomous-loop tests offline by preventing LLM reinitialization.
+    agent.llm_handling = MagicMock(return_value=agent.llm)
+    return agent
+
+
+
+def test_generate_final_summary_forwards_streaming_callback_to_call_llm():
+    agent = _make_agent()
+    callback = lambda _token: None
+
+    agent.call_llm = MagicMock(return_value="summary output")
+    agent.parse_llm_output = MagicMock(side_effect=lambda x: x)
+
+    result = agent._generate_final_summary(streaming_callback=callback)
+
+    assert result == "summary output"
+    assert agent.call_llm.call_count == 1
+    assert (
+        agent.call_llm.call_args.kwargs["streaming_callback"]
+        is callback
+    )
+
+
+
+def test_generate_final_summary_streams_tokens_via_callback():
+    agent = _make_agent()
+    received_tokens = []
+
+    def callback(token: str):
+        received_tokens.append(token)
+
+    def fake_call_llm(**kwargs):
+        kwargs["streaming_callback"]("tok-1")
+        kwargs["streaming_callback"]("tok-2")
+        return "final summary"
+
+    agent.call_llm = fake_call_llm
+    agent.parse_llm_output = MagicMock(side_effect=lambda x: x)
+
+    result = agent._generate_final_summary(streaming_callback=callback)
+
+    assert result == "final summary"
+    assert received_tokens == ["tok-1", "tok-2"]
+
+
+
+def test_autonomous_loop_passes_callback_to_summary_in_both_paths():
+    callback = lambda _token: None
+    planning_tool_call = [
+        {
+            "function": {
+                "name": "create_plan",
+                "arguments": json.dumps(
+                    {
+                        "task_description": "task",
+                        "steps": [
+                            {
+                                "step_id": "s1",
+                                "description": "step",
+                                "priority": "high",
+                                "dependencies": [],
+                            }
+                        ],
+                    }
+                ),
+            }
+        }
+    ]
+
+    # Path A: normal phase-3 summary path
+    normal_agent = _make_agent()
+    normal_agent.call_llm = MagicMock(return_value=planning_tool_call)
+    normal_agent.parse_llm_output = MagicMock(side_effect=lambda x: x)
+    normal_agent._all_subtasks_complete = MagicMock(return_value=True)
+    normal_agent._generate_final_summary = MagicMock(
+        return_value="normal-summary"
+    )
+
+    normal_result = normal_agent._run_autonomous_loop(
+        task="task",
+        streaming_callback=callback,
+    )
+
+    assert normal_result == "normal-summary"
+    normal_agent._generate_final_summary.assert_called_once_with(
+        streaming_callback=callback
+    )
+
+    # Path B: early return when complete_task is emitted in execution phase
+    early_agent = _make_agent()
+    early_agent.call_llm = MagicMock(
+        side_effect=[
+            planning_tool_call,
+            [
+                {
+                    "function": {
+                        "name": "complete_task",
+                        "arguments": json.dumps(
+                            {
+                                "task_id": "main_task",
+                                "summary": "done",
+                                "success": True,
+                            }
+                        ),
+                    }
+                }
+            ],
+        ]
+    )
+    early_agent.parse_llm_output = MagicMock(side_effect=lambda x: x)
+    early_agent._generate_final_summary = MagicMock(
+        return_value="early-summary"
+    )
+
+    early_result = early_agent._run_autonomous_loop(
+        task="task",
+        streaming_callback=callback,
+    )
+
+    assert early_result == "early-summary"
+    early_agent._generate_final_summary.assert_called_once_with(
+        streaming_callback=callback
+    )

--- a/tests/structs/test_agent_autonomous_streaming_callback.py
+++ b/tests/structs/test_agent_autonomous_streaming_callback.py
@@ -37,7 +37,7 @@ def test_generate_final_summary_forwards_streaming_callback_to_call_llm():
         streaming_callback=callback
     )
 
-    assert result == "summary output"
+    assert "summary output" in result
     assert agent.call_llm.call_count == 1
     assert (
         agent.call_llm.call_args.kwargs["streaming_callback"]
@@ -64,7 +64,7 @@ def test_generate_final_summary_streams_tokens_via_callback():
         streaming_callback=callback
     )
 
-    assert result == "final summary"
+    assert "final summary" in result
     assert received_tokens == ["tok-1", "tok-2"]
 
 

--- a/tests/structs/test_agent_autonomous_streaming_callback.py
+++ b/tests/structs/test_agent_autonomous_streaming_callback.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 from swarms.structs.agent import Agent
 
 
-
 def _make_agent() -> Agent:
     """Create an offline-friendly agent for autonomous-loop unit tests."""
     agent = Agent(
@@ -25,15 +24,18 @@ def _make_agent() -> Agent:
     return agent
 
 
-
 def test_generate_final_summary_forwards_streaming_callback_to_call_llm():
     agent = _make_agent()
-    callback = lambda _token: None
+
+    def callback(_token):
+        return None
 
     agent.call_llm = MagicMock(return_value="summary output")
     agent.parse_llm_output = MagicMock(side_effect=lambda x: x)
 
-    result = agent._generate_final_summary(streaming_callback=callback)
+    result = agent._generate_final_summary(
+        streaming_callback=callback
+    )
 
     assert result == "summary output"
     assert agent.call_llm.call_count == 1
@@ -41,7 +43,6 @@ def test_generate_final_summary_forwards_streaming_callback_to_call_llm():
         agent.call_llm.call_args.kwargs["streaming_callback"]
         is callback
     )
-
 
 
 def test_generate_final_summary_streams_tokens_via_callback():
@@ -59,15 +60,19 @@ def test_generate_final_summary_streams_tokens_via_callback():
     agent.call_llm = fake_call_llm
     agent.parse_llm_output = MagicMock(side_effect=lambda x: x)
 
-    result = agent._generate_final_summary(streaming_callback=callback)
+    result = agent._generate_final_summary(
+        streaming_callback=callback
+    )
 
     assert result == "final summary"
     assert received_tokens == ["tok-1", "tok-2"]
 
 
-
 def test_autonomous_loop_passes_callback_to_summary_in_both_paths():
-    callback = lambda _token: None
+
+    def callback(_token):
+        return None
+
     planning_tool_call = [
         {
             "function": {


### PR DESCRIPTION
## Description
This PR fixes a consistency issue in autonomous runs where the final summary didn't always follow the same streaming path as earlier steps. Now, both the normal end-of-loop path and the early-completion case route through the same streaming logic, so users always receive live output through the last response instead of seeing streaming cut off at completion. I also added targeted regression tests to verify callback forwarding into summary generation, confirm that streamed tokens are emitted during summary creation, and validate both completion flows.

## Explanation Video
https://drive.google.com/file/d/1_wcdvmzqXJ2o96PxV2KEibeDNd7UOFL0/view?usp=sharing

## Files Changed
* `swarms/structs/agent.py`
* `tests/structs/test_agent_autonomous_streaming_callback.py`

## Issue
#1297

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Twitter
[@akc__2025](https://x.com/akc__2025)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1451.org.readthedocs.build/en/1451/

<!-- readthedocs-preview swarms end -->