### PR TITLE
fix: Add docs example: Integrate Hugging Face with a custom base LLM in

### DIFF
--- a/docs/examples/basic_examples_overview.md
+++ b/docs/examples/basic_examples_overview.md
@@ -69,6 +69,7 @@ Connect your agents to various language model providers:
 | **Llama4** | Meta's Llama 4 models | [View Example](../swarms/examples/llama4.md) |
 | **Custom Base URL** | Connect to any OpenAI-compatible API | [View Example](../swarms/examples/custom_base_url_example.md) |
 | **vLLM Custom Wrapper** | High-performance local inference with vLLM | [View Example](../swarms/examples/vllm_custom_wrapper.md) |
+| **Hugging Face Custom LLM** | Use any Hugging Face model as a custom base LLM | [View Example](./huggingface_custom_llm.md) |
 
 ---
 

--- a/docs/examples/huggingface_custom_llm.md
+++ b/docs/examples/huggingface_custom_llm.md
@@ -1,22 +1,15 @@
-# Integrate Hugging Face with a Custom Base LLM in Agent
+# Hugging Face Custom Base LLM in Agent
 
-This example shows how to wrap a Hugging Face model as a custom LLM and pass it to the `Agent` class.
-
-## Installation
+Wrap a Hugging Face model as a custom LLM and pass it to the `Agent` class.
 
 ```bash
 pip install swarms transformers torch
 ```
 
-## The `run` Method Contract
-
-The `Agent` class expects a custom LLM object with a `run(task: str) -> str` method (and optionally a `__call__` method). The method receives the task string and must return the model's response as a string.
-
-## Full Example
+The `Agent` class expects a custom LLM with a `run(task: str) -> str` method.
 
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer
-
 from swarms import Agent
 
 
@@ -29,15 +22,9 @@ class HuggingFaceLLM:
         self.max_tokens = max_tokens
 
     def run(self, task: str) -> str:
-        inputs = self.tokenizer(task, return_tensors="pt").to(
-            self.model.device
-        )
-        outputs = self.model.generate(
-            **inputs, max_new_tokens=self.max_tokens
-        )
-        return self.tokenizer.decode(
-            outputs[0], skip_special_tokens=True
-        )
+        inputs = self.tokenizer(task, return_tensors="pt").to(self.model.device)
+        outputs = self.model.generate(**inputs, max_new_tokens=self.max_tokens)
+        return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
 
     def __call__(self, task: str) -> str:
         return self.run(task)
@@ -49,16 +36,9 @@ agent = Agent(
     agent_name="HuggingFace-Agent",
     llm=llm,
     max_loops=1,
-    agent_description="An agent powered by a local Hugging Face model",
 )
 
 agent.run("Explain quantum computing in simple terms.")
 ```
-
-## How It Works
-
-1. `HuggingFaceLLM.__init__` loads the tokenizer and model from the Hugging Face Hub.
-2. `run(task)` tokenizes the input, generates output tokens, and decodes them back to a string.
-3. The `llm` instance is passed to `Agent(llm=...)`. The agent calls `llm.run(task)` (or `llm(task)`) when processing each step.
 
 Any Hugging Face causal language model can be used by changing `model_name`.

--- a/docs/examples/huggingface_custom_llm.md
+++ b/docs/examples/huggingface_custom_llm.md
@@ -1,0 +1,64 @@
+# Integrate Hugging Face with a Custom Base LLM in Agent
+
+This example shows how to wrap a Hugging Face model as a custom LLM and pass it to the `Agent` class.
+
+## Installation
+
+```bash
+pip install swarms transformers torch
+```
+
+## The `run` Method Contract
+
+The `Agent` class expects a custom LLM object with a `run(task: str) -> str` method (and optionally a `__call__` method). The method receives the task string and must return the model's response as a string.
+
+## Full Example
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from swarms import Agent
+
+
+class HuggingFaceLLM:
+    def __init__(self, model_name: str, max_tokens: int = 500):
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_name, torch_dtype="auto", device_map="auto"
+        )
+        self.max_tokens = max_tokens
+
+    def run(self, task: str) -> str:
+        inputs = self.tokenizer(task, return_tensors="pt").to(
+            self.model.device
+        )
+        outputs = self.model.generate(
+            **inputs, max_new_tokens=self.max_tokens
+        )
+        return self.tokenizer.decode(
+            outputs[0], skip_special_tokens=True
+        )
+
+    def __call__(self, task: str) -> str:
+        return self.run(task)
+
+
+llm = HuggingFaceLLM(model_name="meta-llama/Llama-2-7b-chat-hf")
+
+agent = Agent(
+    agent_name="HuggingFace-Agent",
+    llm=llm,
+    max_loops=1,
+    agent_description="An agent powered by a local Hugging Face model",
+)
+
+agent.run("Explain quantum computing in simple terms.")
+```
+
+## How It Works
+
+1. `HuggingFaceLLM.__init__` loads the tokenizer and model from the Hugging Face Hub.
+2. `run(task)` tokenizes the input, generates output tokens, and decodes them back to a string.
+3. The `llm` instance is passed to `Agent(llm=...)`. The agent calls `llm.run(task)` (or `llm(task)`) when processing each step.
+
+Any Hugging Face causal language model can be used by changing `model_name`.


### PR DESCRIPTION
Fixes #1456

Adds documentation showing how to integrate a Hugging Face model as a custom base LLM with the `Agent` class. The `Agent` class supports any custom LLM object implementing a `run(task: str) -> str` method, but no example existed for Hugging Face models. Creates `docs/examples/huggingface_custom_llm.md` with a minimal `HuggingFaceLLM` wrapper class using `AutoModelForCausalLM` and `AutoTokenizer`, and registers it in the LLM providers table in `docs/examples/basic_examples_overview.md`. Verified that the diff stays within the 50-line addition limit.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1459.org.readthedocs.build/en/1459/

<!-- readthedocs-preview swarms end -->