### PR TITLE
feat(HierarchicalSwarm): O(1) agent lookup + parallel execution default

### DIFF
--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -696,7 +696,7 @@ class HierarchicalSwarm:
         planning_enabled: bool = True,
         autosave: bool = True,
         verbose: bool = False,
-        parallel_execution: bool = False,
+        parallel_execution: bool = True,
         agent_as_judge: bool = False,
         judge_agent_model_name: str = "gpt-4o-mini",
         *args,
@@ -721,6 +721,9 @@ class HierarchicalSwarm:
             director_feedback_on (bool): Whether director feedback is enabled.
             autosave (bool): Whether to enable autosaving of conversation history.
             verbose (bool): Whether to enable verbose logging.
+            parallel_execution (bool): Whether to execute agent orders in parallel.
+                Defaults to True since director orders target independent agents
+                with I/O-bound LLM calls, yielding significant latency reduction.
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
@@ -762,6 +765,13 @@ class HierarchicalSwarm:
         self.initialize_swarm()
 
     def initialize_swarm(self):
+        # Build O(1) agent lookup map (consistent with AgentRearrange)
+        self.agent_map = {
+            agent.agent_name: agent
+            for agent in self.agents
+            if hasattr(agent, "agent_name")
+        }
+
         if self.interactive:
             self.agents_no_print()
 
@@ -1487,24 +1497,12 @@ class HierarchicalSwarm:
             Exception: If agent execution fails.
         """
         try:
-            # Find agent by name
-            agent = None
-            for a in self.agents:
-                if (
-                    hasattr(a, "agent_name")
-                    and a.agent_name == agent_name
-                ):
-                    agent = a
-                    break
+            # O(1) agent lookup via pre-built dict (consistent with AgentRearrange)
+            agent = self.agent_map.get(agent_name)
 
             if agent is None:
-                available_agents = [
-                    a.agent_name
-                    for a in self.agents
-                    if hasattr(a, "agent_name")
-                ]
                 raise ValueError(
-                    f"Agent '{agent_name}' not found in swarm. Available agents: {available_agents}"
+                    f"Agent '{agent_name}' not found in swarm. Available agents: {list(self.agent_map.keys())}"
                 )
 
             # Update dashboard for agent execution


### PR DESCRIPTION
## Summary

Closes #1458

Two performance improvements for `HierarchicalSwarm`:

### 1. O(1) agent lookup via dict

`call_single_agent` previously did an O(n) linear scan through the agents list to find an agent by name. This PR adds a `self.agent_map` dict (keyed by `agent_name`) built at init time, consistent with how `AgentRearrange` already stores agents.

**Before:**
```python
# O(n) per lookup
for a in self.agents:
    if hasattr(a, "agent_name") and a.agent_name == agent_name:
        agent = a
        break
```

**After:**
```python
# O(1) per lookup
agent = self.agent_map.get(agent_name)
```

### 2. Parallel execution as default

Changed `parallel_execution` default from `False` to `True`. The director's orders target independent agents with I/O-bound LLM API calls — parallel execution yields significant latency reduction with no ordering constraints.

### Changes

- Add `self.agent_map` dict at init for O(1) agent lookup
- Use `agent_map.get()` in `call_single_agent` instead of O(n) scan
- Change `parallel_execution` default to `True`
- Update docstrings to reflect the new default

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1472.org.readthedocs.build/en/1472/

<!-- readthedocs-preview swarms end -->