### PR TITLE
Add MiniMax as first-class LLM provider

### DIFF
--- a/docs/swarms/examples/minimax.md
+++ b/docs/swarms/examples/minimax.md
@@ -1,0 +1,103 @@
+# Agent with MiniMax
+
+[MiniMax](https://www.minimax.io/) provides powerful language models with 204K context window and strong multilingual capabilities through an OpenAI-compatible API.
+
+## Setup
+
+1. Get your API key from the [MiniMax platform](https://platform.minimax.chat/)
+2. Add `MINIMAX_API_KEY` to your `.env` file
+
+```bash
+MINIMAX_API_KEY=your_minimax_api_key
+```
+
+## Available Models
+
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.7` | Latest flagship model with 204K context, strong reasoning and multilingual support |
+| `MiniMax-M2.5` | Balanced performance model with 204K context |
+| `MiniMax-M2.5-highspeed` | High-speed variant optimized for fast inference with 204K context |
+
+## Basic Usage
+
+Use the `minimax/` prefix with the model name to automatically route to the MiniMax API:
+
+```python
+from swarms import Agent
+from dotenv import load_dotenv
+
+load_dotenv()
+
+agent = Agent(
+    agent_name="MiniMax-Agent",
+    model_name="minimax/MiniMax-M2.7",
+    system_prompt="You are a helpful assistant.",
+    agent_description="Agent powered by MiniMax M2.7.",
+    max_loops=1,
+)
+
+response = agent.run("Explain the key differences between supervised and unsupervised learning.")
+print(response)
+```
+
+## High-Speed Model
+
+For latency-sensitive applications, use the high-speed variant:
+
+```python
+from swarms import Agent
+from dotenv import load_dotenv
+
+load_dotenv()
+
+agent = Agent(
+    agent_name="Fast-MiniMax-Agent",
+    model_name="minimax/MiniMax-M2.5-highspeed",
+    system_prompt="You are a fast and concise assistant.",
+    agent_description="Agent using MiniMax high-speed model.",
+    max_loops=1,
+    temperature=0.3,
+)
+
+response = agent.run("Summarize the benefits of microservices architecture.")
+print(response)
+```
+
+## Multi-Agent Workflow
+
+Combine MiniMax with other providers in a multi-agent setup:
+
+```python
+from swarms import Agent, ConcurrentWorkflow
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# MiniMax agent for long-context analysis
+analysis_agent = Agent(
+    agent_name="Analysis-Agent",
+    model_name="minimax/MiniMax-M2.7",
+    system_prompt="You are an expert analyst.",
+    max_loops=1,
+)
+
+# Another agent for summarization
+summary_agent = Agent(
+    agent_name="Summary-Agent",
+    model_name="minimax/MiniMax-M2.5-highspeed",
+    system_prompt="You are an expert summarizer.",
+    max_loops=1,
+)
+
+workflow = ConcurrentWorkflow(
+    name="Analysis-Summary-Workflow",
+    agents=[analysis_agent, summary_agent],
+)
+```
+
+## Notes
+
+- **Temperature**: MiniMax supports temperature values in the range `[0, 1.0]`. Values above 1.0 are automatically clamped.
+- **Context Window**: All MiniMax models support up to 204K tokens of context.
+- **API Compatibility**: MiniMax uses an OpenAI-compatible API, so all standard features (streaming, function calling, etc.) are supported.

--- a/docs/swarms/examples/model_providers.md
+++ b/docs/swarms/examples/model_providers.md
@@ -16,6 +16,7 @@ Swarms supports a vast array of model providers, giving you the flexibility to c
 | **XAI** | xAI's Grok models offering unique capabilities for research, analysis, and creative tasks with advanced reasoning abilities. | [XAI Integration](xai.md) |
 | **Llama4** | Meta's latest open-source language models including Llama-4-Maverick and Llama-4-Scout variants with expert routing capabilities. | [Llama4 Integration](llama4.md) |
 | **Azure OpenAI** | Enterprise-grade OpenAI models through Microsoft's cloud infrastructure with enhanced security, compliance, and enterprise features. | [Azure Integration](azure.md) |
+| **MiniMax** | Powerful language models with 204K context window and strong multilingual capabilities. Models include MiniMax-M2.7 and MiniMax-M2.5-highspeed. | [MiniMax Integration](minimax.md) |
 
 ## Quick Start
 
@@ -58,10 +59,17 @@ response = agent.run("Your query here")
 
 - **OpenRouter**: Access to cost-effective models
 
+### For Long Context Tasks
+
+- **MiniMax M2.7**: 204K context with strong multilingual capabilities
+
+- **MiniMax M2.5-highspeed**: Fast inference with 204K context
+
 ### For Real-Time Applications
 
 - **Groq**: Ultra-fast inference
 
+- **MiniMax M2.5-highspeed**: Fast inference with large context window
 
 ### For Specialized Tasks
 
@@ -101,6 +109,9 @@ XAI_API_KEY=your_xai_key
 AZURE_API_KEY=your_azure_openai_api_key
 AZURE_API_BASE=https://your-resource-name.openai.azure.com/
 AZURE_API_VERSION=2024-02-15-preview
+
+# MiniMax
+MINIMAX_API_KEY=your_minimax_api_key
 ```
 
 !!! note "No API Key Required"

--- a/swarms/cli/utils.py
+++ b/swarms/cli/utils.py
@@ -63,6 +63,8 @@ def _detect_active_provider() -> str:
         detected.append("Mistral")
     if os.getenv("TOGETHER_API_KEY"):
         detected.append("Together AI")
+    if os.getenv("MINIMAX_API_KEY"):
+        detected.append("MiniMax")
 
     if not detected:
         return (
@@ -341,6 +343,7 @@ def check_api_keys() -> Tuple[bool, str, str]:
         "ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY"),
         "GOOGLE_API_KEY": os.getenv("GOOGLE_API_KEY"),
         "COHERE_API_KEY": os.getenv("COHERE_API_KEY"),
+        "MINIMAX_API_KEY": os.getenv("MINIMAX_API_KEY"),
     }
 
     # At least one key must be present and non-empty

--- a/swarms/structs/model_router.py
+++ b/swarms/structs/model_router.py
@@ -93,6 +93,26 @@ model_recommendations = {
         ],
         "provider": "mistral",
     },
+    "minimax/MiniMax-M2.7": {
+        "description": "MiniMax's latest model with 204K context window and strong multilingual capabilities",
+        "best_for": [
+            "Long context understanding",
+            "Multilingual tasks",
+            "Complex reasoning",
+            "Code generation",
+        ],
+        "provider": "minimax",
+    },
+    "minimax/MiniMax-M2.5-highspeed": {
+        "description": "MiniMax's high-speed model optimized for fast inference with 204K context",
+        "best_for": [
+            "Real-time applications",
+            "High throughput",
+            "Cost-effective processing",
+            "Chat applications",
+        ],
+        "provider": "minimax",
+    },
 }
 
 providers = {
@@ -103,6 +123,7 @@ providers = {
     "azure": "Cloud platform for various model deployments",
     "deepseek": "Provider of specialized reasoning models",
     "mistral": "Provider of open source and commercial language models",
+    "minimax": "Provider of MiniMax models with 204K context and multilingual support",
 }
 
 
@@ -138,6 +159,8 @@ Available Models and Their Strengths:
 - Claude-3-Sonnet: Well-balanced for creative writing and nuanced responses
 - Gemini Pro: Strong at multimodal tasks and code generation
 - Mistral Large: Versatile open source model good for general tasks
+- MiniMax M2.7: Strong multilingual model with 204K context window
+- MiniMax M2.5-highspeed: Fast inference with 204K context for real-time applications
 
 Provider Considerations:
 - OpenAI: Industry standard with consistent performance
@@ -145,6 +168,7 @@ Provider Considerations:
 - Google: Strong technical capabilities and multimodal support
 - Groq: Optimized for high-speed inference
 - Mistral: Balance of open source and commercial offerings
+- MiniMax: Long context window (204K) with strong multilingual and reasoning capabilities
 
 Data:
 {data}

--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -19,6 +19,7 @@ for various input modalities and output formats.
 
 import asyncio
 import base64
+import os
 import socket
 import traceback
 from pathlib import Path
@@ -316,6 +317,21 @@ class LiteLLM:
         )
 
         litellm.drop_params = drop_params
+
+        # Auto-configure MiniMax provider: when model_name starts with
+        # "minimax/", route through the MiniMax OpenAI-compatible API.
+        # LiteLLM requires the "openai/" prefix for custom base_url
+        # endpoints, so we replace "minimax/" with "openai/".
+        if self.model_name.lower().startswith("minimax/"):
+            actual_model = self.model_name.split("/", 1)[1]
+            self.model_name = f"openai/{actual_model}"
+            if self.base_url is None:
+                self.base_url = "https://api.minimax.io/v1"
+            if self.api_key is None:
+                self.api_key = os.getenv("MINIMAX_API_KEY")
+            # MiniMax temperature range is [0, 1.0]
+            if self.temperature is not None and self.temperature > 1.0:
+                self.temperature = 1.0
 
         # Add system prompt if present (Anthropic rejects empty system blocks)
         if isinstance(self.system_prompt, str):
@@ -1262,6 +1278,9 @@ class LiteLLM:
 
             if self.base_url is not None:
                 completion_params["base_url"] = self.base_url
+
+            if self.api_key is not None:
+                completion_params["api_key"] = self.api_key
 
             if self.response_format is not None:
                 completion_params["response_format"] = (

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,236 @@
+"""
+Tests for MiniMax provider integration in Swarms.
+
+Unit tests verify provider configuration and auto-routing without
+making actual API calls. Integration tests validate real API
+connectivity (skipped unless MINIMAX_API_KEY is set).
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from swarms.utils.litellm_wrapper import LiteLLM
+from swarms.structs.model_router import (
+    model_recommendations,
+    providers,
+)
+from swarms.cli.utils import _detect_active_provider, check_api_keys
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – model_router.py
+# ---------------------------------------------------------------------------
+
+
+class TestModelRouterMiniMax:
+    """Verify MiniMax is registered in model_router metadata."""
+
+    def test_minimax_m27_in_recommendations(self):
+        assert "minimax/MiniMax-M2.7" in model_recommendations
+
+    def test_minimax_m25_highspeed_in_recommendations(self):
+        assert "minimax/MiniMax-M2.5-highspeed" in model_recommendations
+
+    def test_minimax_m27_provider_field(self):
+        entry = model_recommendations["minimax/MiniMax-M2.7"]
+        assert entry["provider"] == "minimax"
+
+    def test_minimax_m25_highspeed_provider_field(self):
+        entry = model_recommendations["minimax/MiniMax-M2.5-highspeed"]
+        assert entry["provider"] == "minimax"
+
+    def test_minimax_m27_has_best_for(self):
+        entry = model_recommendations["minimax/MiniMax-M2.7"]
+        assert isinstance(entry["best_for"], list)
+        assert len(entry["best_for"]) > 0
+
+    def test_minimax_in_providers_dict(self):
+        assert "minimax" in str(providers).lower()
+
+    def test_minimax_m27_description_nonempty(self):
+        entry = model_recommendations["minimax/MiniMax-M2.7"]
+        assert len(entry["description"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – cli/utils.py provider detection
+# ---------------------------------------------------------------------------
+
+
+class TestCLIProviderDetection:
+    """Verify MiniMax API key detection in CLI utilities."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False)
+    def test_detect_active_provider_includes_minimax(self):
+        result = _detect_active_provider()
+        assert "MiniMax" in result
+
+    @patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "",
+            "ANTHROPIC_API_KEY": "",
+            "GROQ_API_KEY": "",
+            "GOOGLE_API_KEY": "",
+            "COHERE_API_KEY": "",
+            "MISTRAL_API_KEY": "",
+            "TOGETHER_API_KEY": "",
+            "MINIMAX_API_KEY": "test-key",
+        },
+    )
+    def test_minimax_only_provider(self):
+        result = _detect_active_provider()
+        assert "MiniMax" in result
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False)
+    def test_check_api_keys_includes_minimax(self):
+        success, icon, msg = check_api_keys()
+        assert success is True
+        assert "MINIMAX_API_KEY" in msg
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – LiteLLM wrapper MiniMax auto-routing
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMWrapperMiniMax:
+    """Verify MiniMax auto-routing in the LiteLLM wrapper."""
+
+    def test_minimax_prefix_sets_base_url(self):
+        llm = LiteLLM(model_name="minimax/MiniMax-M2.7")
+        assert llm.base_url == "https://api.minimax.io/v1"
+
+    def test_minimax_prefix_routes_via_openai(self):
+        """Model name should be rewritten to openai/<model> for litellm."""
+        llm = LiteLLM(model_name="minimax/MiniMax-M2.7")
+        assert llm.model_name == "openai/MiniMax-M2.7"
+
+    def test_minimax_prefix_case_insensitive(self):
+        llm = LiteLLM(model_name="MiniMax/MiniMax-M2.5")
+        assert llm.base_url == "https://api.minimax.io/v1"
+        assert llm.model_name == "openai/MiniMax-M2.5"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "env-test-key"}, clear=False)
+    def test_minimax_prefix_reads_env_api_key(self):
+        llm = LiteLLM(model_name="minimax/MiniMax-M2.7")
+        assert llm.api_key == "env-test-key"
+
+    def test_minimax_prefix_explicit_api_key_takes_precedence(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            api_key="explicit-key",
+        )
+        assert llm.api_key == "explicit-key"
+
+    def test_minimax_prefix_explicit_base_url_takes_precedence(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            base_url="https://custom.api.com/v1",
+        )
+        assert llm.base_url == "https://custom.api.com/v1"
+
+    def test_minimax_temperature_clamping_above_1(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            temperature=1.5,
+        )
+        assert llm.temperature == 1.0
+
+    def test_minimax_temperature_no_clamp_within_range(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            temperature=0.7,
+        )
+        assert llm.temperature == 0.7
+
+    def test_minimax_temperature_zero_allowed(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            temperature=0.0,
+        )
+        assert llm.temperature == 0.0
+
+    def test_minimax_highspeed_model_routing(self):
+        llm = LiteLLM(model_name="minimax/MiniMax-M2.5-highspeed")
+        assert llm.model_name == "openai/MiniMax-M2.5-highspeed"
+        assert llm.base_url == "https://api.minimax.io/v1"
+
+    def test_non_minimax_model_no_routing(self):
+        llm = LiteLLM(model_name="gpt-4.1")
+        assert llm.base_url is None
+        assert llm.model_name == "gpt-4.1"
+
+    def test_minimax_system_prompt_preserved(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            system_prompt="You are a helpful assistant.",
+        )
+        assert any(
+            m.get("content") == "You are a helpful assistant."
+            for m in llm.messages
+        )
+
+    def test_minimax_max_tokens_preserved(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            max_tokens=8192,
+        )
+        assert llm.max_tokens == 8192
+
+    def test_minimax_stream_option_preserved(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            stream=True,
+        )
+        assert llm.stream is True
+
+    def test_minimax_default_temperature(self):
+        llm = LiteLLM(model_name="minimax/MiniMax-M2.7")
+        assert llm.temperature == 0.5  # default
+
+
+# ---------------------------------------------------------------------------
+# Integration tests – require MINIMAX_API_KEY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.getenv("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set",
+)
+class TestMiniMaxIntegration:
+    """Integration tests that call the real MiniMax API."""
+
+    def test_minimax_m27_simple_completion(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            max_tokens=64,
+            temperature=0.1,
+        )
+        response = llm.run("Say hello in exactly three words.")
+        assert isinstance(response, str)
+        assert len(response) > 0
+
+    def test_minimax_m25_highspeed_completion(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.5-highspeed",
+            max_tokens=64,
+            temperature=0.1,
+        )
+        response = llm.run("What is 2 + 2?")
+        assert isinstance(response, str)
+        assert "4" in response
+
+    def test_minimax_with_system_prompt(self):
+        llm = LiteLLM(
+            model_name="minimax/MiniMax-M2.7",
+            system_prompt="Always respond in JSON format with a 'result' key.",
+            max_tokens=128,
+            temperature=0.1,
+        )
+        response = llm.run("What is the capital of France?")
+        assert isinstance(response, str)
+        assert len(response) > 0


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io/) as a first-class LLM provider in Swarms, enabling users to use MiniMax models (M2.7, M2.5, M2.5-highspeed) with a simple `minimax/` prefix just like other providers.

### Changes

- **LiteLLM Wrapper** (`swarms/utils/litellm_wrapper.py`): Auto-route `minimax/` model prefix through MiniMax's OpenAI-compatible API with automatic base_url, api_key detection, and temperature clamping to [0, 1.0]
- **Model Router** (`swarms/structs/model_router.py`): Register MiniMax-M2.7 and MiniMax-M2.5-highspeed in model recommendations and providers
- **CLI Utils** (`swarms/cli/utils.py`): Detect `MINIMAX_API_KEY` in setup-check and active provider display
- **Documentation**: New `minimax.md` provider guide + update `model_providers.md` with MiniMax entry
- **Tests**: 14 unit tests (auto-routing, temp clamping, config preservation) + 3 integration tests

### Usage

```python
from swarms import Agent
from dotenv import load_dotenv

load_dotenv()

agent = Agent(
    agent_name="MiniMax-Agent",
    model_name="minimax/MiniMax-M2.7",
    system_prompt="You are a helpful assistant.",
    max_loops=1,
)

response = agent.run("Explain quantum computing.")
```

### MiniMax Model Highlights

- **MiniMax-M2.7**: Latest flagship model, 204K context window, strong multilingual and reasoning
- **MiniMax-M2.5-highspeed**: Optimized for fast inference, 204K context
- OpenAI-compatible API (base URL: `https://api.minimax.io/v1`)

## Test plan

- [x] 14 unit tests pass (auto-routing, temperature clamping, API key detection, config preservation)
- [x] 3 integration tests pass with real MiniMax API
- [ ] Verify `swarms setup-check` shows MiniMax when `MINIMAX_API_KEY` is set
- [ ] Test Agent with `model_name="minimax/MiniMax-M2.7"` end-to-end


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1486.org.readthedocs.build/en/1486/

<!-- readthedocs-preview swarms end -->