### PR TITLE
perf: guard any_to_str() with isinstance check in AgentRearrange

### DIFF
--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -574,7 +574,8 @@ class AgentRearrange:
             *args,
             **kwargs,
         )
-        current_task = any_to_str(current_task)
+        if not isinstance(current_task, str):
+            current_task = any_to_str(current_task)
 
         self.conversation.add(agent.agent_name, current_task)
 


### PR DESCRIPTION
## Summary

Skip redundant `any_to_str()` call in `_run_sequential_workflow` when `agent.run()` already returns a string (the common path).

## Changes

- Added `isinstance(current_task, str)` guard before `any_to_str()` call at line 577
- Near-zero cost check that avoids function call overhead on every agent step

## Before
```python
current_task = agent.run(task=self.conversation.get_str(), img=img)
current_task = any_to_str(current_task)  # Always called, even when already str
```

## After
```python
current_task = agent.run(task=self.conversation.get_str(), img=img)
if not isinstance(current_task, str):
    current_task = any_to_str(current_task)  # Only when needed
```

## Test plan

- [x] Existing tests pass unchanged (behavior is identical)
- [x] `any_to_str()` still called for non-string returns (dicts, lists, objects)
- [x] String returns skip the redundant conversion

Fixes #1462

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1492.org.readthedocs.build/en/1492/

<!-- readthedocs-preview swarms end -->