### PR TITLE
feat: implement PlannerGeneratorEvaluator multi-agent harness

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -282,6 +282,7 @@ nav:
           
 
 
+        - PlannerGeneratorEvaluator: "swarms/structs/planner_generator_evaluator.md"
         - DebateWithJudge: "swarms/structs/debate_with_judge.md"
         - MajorityVoting: "swarms/structs/majorityvoting.md"
         - MAKER: "swarms/structs/maker.md"

--- a/docs/swarms/structs/planner_generator_evaluator.md
+++ b/docs/swarms/structs/planner_generator_evaluator.md
@@ -1,0 +1,293 @@
+# `PlannerGeneratorEvaluator`
+
+The `PlannerGeneratorEvaluator` is a domain-agnostic three-agent orchestration harness inspired by the GAN-style architecture described in [Anthropic's harness design research](https://www.anthropic.com/engineering/harness-design-long-running-apps). It coordinates long-running autonomous tasks from a short natural-language prompt, using an iterative generate-evaluate feedback loop to converge on high-quality output across any domain.
+
+All three agents communicate through a single shared file on disk.
+
+```mermaid
+graph TD
+    A[User Prompt] --> B[Planner]
+    B --> C[Plan + Evaluation Criteria]
+    C --> D{For Each Step}
+    D --> E[Generator Proposes Contract]
+    E --> F[Evaluator Reviews Contract]
+    F --> G[Generator Executes Step]
+    G --> H[Generator Self-Assessment]
+    H --> I[Evaluator Scores Output]
+    I --> J{All Criteria Pass?}
+    J -->|Yes| D
+    J -->|No| K{Retries Left?}
+    K -->|Yes + Scores Improving| L[REFINE: Fix Issues]
+    K -->|Yes + Scores Declining| M[PIVOT: New Approach]
+    L --> G
+    M --> G
+    K -->|No| D
+    D -->|Done| N[Final Output + Shared State File]
+```
+
+The harness follows this workflow:
+
+1. **Planning**: Planner expands a short prompt into an ambitious plan with steps and evaluation criteria
+2. **Contract Negotiation**: Generator proposes what "done" looks like for each step; Evaluator reviews
+3. **Execution**: Generator produces concrete output and self-assesses before handoff
+4. **Evaluation**: Evaluator scores output per-criterion with hard thresholds — any criterion below its threshold fails the step
+5. **Feedback Loop**: On failure, Generator receives scores + trajectory signal (refine or pivot) and retries
+6. **All state on disk**: The shared state file is the single append-only record of the entire run
+
+
+## Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **GAN-Style Separation** | Distinct Generator and Evaluator agents prevent self-evaluation bias |
+| **Step Contracts** | Generator and Evaluator agree on success criteria before execution |
+| **Hard Threshold Enforcement** | Any single criterion below its threshold fails the step |
+| **Score Trajectory** | Tracks score trends across retries — signals Generator to refine or pivot |
+| **Self-Assessment** | Generator self-evaluates before Evaluator handoff |
+| **Shared State File** | Single append-only `.md` file for all inter-agent communication |
+| **Domain-Agnostic** | Planner defines evaluation criteria tailored to the task domain |
+| **Custom Agents** | Pass pre-configured agents with tools, MCP, or any Agent settings |
+| **Configurable Thresholds** | Default thresholds plus Planner-defined per-criterion thresholds |
+
+
+## Constructor
+
+### `PlannerGeneratorEvaluator.__init__()`
+
+| Parameter | Type | Default | Required | Description |
+|-----------|------|---------|----------|-------------|
+| `model_name` | `str` | `"gpt-4.1"` | No | Model identifier for all three agents |
+| `planner_model_name` | `str` | `None` | No | Override model for the Planner |
+| `generator_model_name` | `str` | `None` | No | Override model for the Generator |
+| `evaluator_model_name` | `str` | `None` | No | Override model for the Evaluator |
+| `max_steps` | `int` | `10` | No | Upper bound on plan steps to execute |
+| `max_retries_per_step` | `int` | `3` | No | Max evaluation failures before advancing |
+| `working_directory` | `str` | `os.getcwd()` | No | Directory where output is produced |
+| `shared_state_path` | `str` | `None` | No | Path for the shared state file (auto-generated if None) |
+| `default_thresholds` | `Dict[str, float]` | `{}` | No | Fallback score thresholds by criterion name |
+| `output_type` | `OutputType` | `"dict"` | No | Format for output (dict, str, list, final, json, yaml) |
+| `verbose` | `bool` | `False` | No | Enable verbose logging |
+| `planner_agent` | `Agent` | `None` | No | Pre-configured Agent for planning |
+| `generator_agent` | `Agent` | `None` | No | Pre-configured Agent for generation (e.g., with file/code tools) |
+| `evaluator_agent` | `Agent` | `None` | No | Pre-configured Agent for evaluation (e.g., with Playwright MCP) |
+
+#### Raises
+
+| Exception | Condition |
+|-----------|-----------|
+| `ValueError` | If `max_steps < 1`, `max_retries_per_step < 0`, or `model_name` is empty |
+
+---
+
+## Core Methods
+
+### `run()`
+
+Execute the full PGE harness pipeline from a short prompt to completed output.
+
+| Parameter | Type | Default | Required | Description |
+|-----------|------|---------|----------|-------------|
+| `task` | `str` | — | **Yes** | A short natural-language description of the desired task |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Any` | Formatted conversation history according to `output_type` |
+
+After `run()` completes, access `harness.last_result` for structured metadata:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `output_path` | `str` | Path to the shared state file |
+| `plan` | `str` | The generated plan text |
+| `step_logs` | `List[Dict]` | Per-step metadata (contract, scores, retries) |
+| `total_duration` | `float` | Wall-clock time in seconds |
+| `total_steps_completed` | `int` | Number of steps that passed evaluation |
+| `total_retries` | `int` | Total retry attempts across all steps |
+
+---
+
+### `batched_run()`
+
+Run the harness on multiple tasks sequentially.
+
+| Parameter | Type | Default | Required | Description |
+|-----------|------|---------|----------|-------------|
+| `tasks` | `List[str]` | — | **Yes** | List of task prompts to process |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `List[Any]` | List of results, one per task |
+
+---
+
+## Usage Examples
+
+### Basic Usage
+
+```python
+from swarms import PlannerGeneratorEvaluator
+
+harness = PlannerGeneratorEvaluator(
+    model_name="gpt-4.1",
+    max_steps=3,
+    max_retries_per_step=2,
+    output_type="final",
+    verbose=True,
+)
+
+result = harness.run(
+    "Write a comprehensive guide on the benefits and risks of intermittent fasting"
+)
+
+print(result)
+print(f"Steps completed: {harness.last_result.total_steps_completed}")
+print(f"Duration: {harness.last_result.total_duration:.1f}s")
+```
+
+### Custom Agents with Tools
+
+Pass pre-configured agents with tools so the Generator can write files and the Evaluator can verify them on disk:
+
+```python
+from swarms import Agent, PlannerGeneratorEvaluator
+
+
+def write_file(filename: str, content: str) -> str:
+    """Write content to a file."""
+    with open(filename, "w") as f:
+        f.write(content)
+    return f"Written: {filename}"
+
+
+def read_file(filename: str) -> str:
+    """Read content from a file."""
+    with open(filename, "r") as f:
+        return f.read()
+
+
+generator = Agent(
+    agent_name="PGE-Generator",
+    model_name="gpt-4.1",
+    max_loops=1,
+    tools=[write_file],
+)
+
+evaluator = Agent(
+    agent_name="PGE-Evaluator",
+    model_name="gpt-4.1",
+    max_loops=1,
+    tools=[read_file],
+)
+
+harness = PlannerGeneratorEvaluator(
+    model_name="gpt-4.1",
+    generator_agent=generator,
+    evaluator_agent=evaluator,
+    max_steps=3,
+)
+
+result = harness.run("Create a Python module for string manipulation utilities")
+```
+
+### Evaluator with Playwright MCP (Web App Testing)
+
+For web application development, give the Evaluator browser automation via Playwright MCP so it can test the running app like a real user:
+
+```python
+from swarms import Agent, PlannerGeneratorEvaluator
+
+evaluator = Agent(
+    agent_name="PGE-Evaluator",
+    model_name="gpt-4.1",
+    max_loops=1,
+    mcp_config={"url": "http://localhost:3000/playwright"},
+)
+
+harness = PlannerGeneratorEvaluator(
+    model_name="gpt-4.1",
+    evaluator_agent=evaluator,
+    max_steps=5,
+    max_retries_per_step=3,
+)
+
+result = harness.run("Build a todo app with React frontend and FastAPI backend")
+```
+
+### Custom Thresholds
+
+Provide default score thresholds that apply when the Planner doesn't define them:
+
+```python
+from swarms import PlannerGeneratorEvaluator
+
+harness = PlannerGeneratorEvaluator(
+    model_name="gpt-4.1",
+    default_thresholds={
+        "accuracy": 8.0,
+        "clarity": 7.0,
+        "completeness": 7.0,
+    },
+    max_retries_per_step=4,
+)
+
+result = harness.run("Write a technical specification for a rate-limiting middleware")
+```
+
+---
+
+## Architecture Details
+
+### Shared State File
+
+All inter-agent communication flows through a single append-only markdown file. Each section is timestamped and labeled:
+
+```
+# PGE Harness Shared State
+
+## User Prompt
+[original prompt]
+
+---
+### [PLANNER OUTPUT] (2026-03-25 10:30:00)
+[plan with steps and evaluation criteria]
+
+---
+### [STEP 1 CONTRACT PROPOSAL] (2026-03-25 10:30:15)
+[Generator's proposed contract]
+
+---
+### [STEP 1 CONTRACT REVIEW] (2026-03-25 10:30:25)
+[Evaluator's review — APPROVED or AMENDMENTS REQUIRED]
+
+---
+### [STEP 1 WORK LOG] (2026-03-25 10:30:45)
+[Generator's output + self-assessment]
+
+---
+### [STEP 1 EVALUATION] (2026-03-25 10:31:00)
+[Evaluator's per-criterion scores, findings, and feedback]
+```
+
+### Refine vs. Pivot
+
+When a step fails evaluation, the harness computes a score trajectory across retries:
+
+- **Scores improving** → REFINE: keep the current direction, fix specific issues
+- **Scores declining or stagnant** → PIVOT: take a fundamentally different approach
+
+This signal is passed to the Generator alongside the Evaluator's feedback.
+
+### Evaluation Criteria
+
+The Planner defines domain-appropriate criteria as part of the plan. Each criterion has:
+
+| Field | Description |
+|-------|-------------|
+| **Name** | Short label (e.g., "accuracy", "clarity") |
+| **Weight** | Relative importance (high, standard, low) |
+| **Description** | What it measures and what good/bad looks like |
+| **Threshold** | Minimum passing score (1-10). Any criterion below threshold = step fails |

--- a/examples/multi_agent/planner_generator_evaluator/pge_example.py
+++ b/examples/multi_agent/planner_generator_evaluator/pge_example.py
@@ -1,0 +1,32 @@
+"""
+Planner-Generator-Evaluator Harness — Basic Example
+
+Demonstrates the PGE harness with default agents. The Planner expands
+the prompt into a plan, the Generator executes each step, and the
+Evaluator scores output against criteria in an iterative feedback loop.
+
+To run:
+    python examples/multi_agent/planner_generator_evaluator/pge_example.py
+"""
+
+from swarms import PlannerGeneratorEvaluator
+
+if __name__ == "__main__":
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+        max_steps=3,
+        max_retries_per_step=2,
+        output_type="final",
+        verbose=True,
+    )
+
+    result = harness.run(
+        "Write a comprehensive guide on the benefits and risks of intermittent fasting"
+    )
+
+    print(result)
+
+    print(f"\nSteps completed: {harness.last_result.total_steps_completed}")
+    print(f"Total retries: {harness.last_result.total_retries}")
+    print(f"Duration: {harness.last_result.total_duration:.1f}s")
+    print(f"Shared state file: {harness.last_result.output_path}")

--- a/examples/multi_agent/planner_generator_evaluator/pge_with_tools_example.py
+++ b/examples/multi_agent/planner_generator_evaluator/pge_with_tools_example.py
@@ -1,0 +1,96 @@
+"""
+Planner-Generator-Evaluator Harness — Custom Agents with Tools
+
+Demonstrates passing pre-configured agents with tools to the PGE harness.
+The Generator gets a file-writing tool, and the Evaluator gets a
+file-reading tool to verify the Generator's output on disk.
+
+To run:
+    python examples/multi_agent/planner_generator_evaluator/pge_with_tools_example.py
+"""
+
+import os
+import tempfile
+
+from swarms import Agent, PlannerGeneratorEvaluator
+
+WORK_DIR = tempfile.mkdtemp(prefix="pge_tools_")
+
+
+def write_file(filename: str, content: str) -> str:
+    """Write content to a file in the working directory.
+
+    Args:
+        filename: Name of the file to create.
+        content: Text content to write.
+
+    Returns:
+        Confirmation message with the file path.
+    """
+    path = os.path.join(WORK_DIR, filename)
+    with open(path, "w") as f:
+        f.write(content)
+    return f"File written: {path} ({len(content)} chars)"
+
+
+def read_file(filename: str) -> str:
+    """Read content from a file in the working directory.
+
+    Args:
+        filename: Name of the file to read.
+
+    Returns:
+        The file contents, or an error message if not found.
+    """
+    path = os.path.join(WORK_DIR, filename)
+    if not os.path.exists(path):
+        return f"File not found: {path}"
+    with open(path, "r") as f:
+        return f.read()
+
+
+def list_files() -> str:
+    """List all files in the working directory.
+
+    Returns:
+        Newline-separated list of filenames.
+    """
+    files = os.listdir(WORK_DIR)
+    return "\n".join(files) if files else "No files found"
+
+
+if __name__ == "__main__":
+    generator = Agent(
+        agent_name="PGE-Generator",
+        agent_description="Generator that can write files to disk",
+        model_name="gpt-4.1",
+        max_loops=1,
+        tools=[write_file, list_files],
+    )
+
+    evaluator = Agent(
+        agent_name="PGE-Evaluator",
+        agent_description="Evaluator that can read and verify files on disk",
+        model_name="gpt-4.1",
+        max_loops=1,
+        tools=[read_file, list_files],
+    )
+
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+        generator_agent=generator,
+        evaluator_agent=evaluator,
+        max_steps=2,
+        max_retries_per_step=1,
+        output_type="final",
+        verbose=True,
+    )
+
+    result = harness.run(
+        "Create a Python utility module with helper functions for string manipulation"
+    )
+
+    print(result)
+    print(f"\nFiles created in {WORK_DIR}:")
+    for f in os.listdir(WORK_DIR):
+        print(f"  - {f}")

--- a/swarms/prompts/planner_generator_evaluator_prompts.py
+++ b/swarms/prompts/planner_generator_evaluator_prompts.py
@@ -1,0 +1,164 @@
+"""
+System prompts for the Planner-Generator-Evaluator (PGE) harness.
+
+These prompts define the behavior of the three cooperating agents in the
+GAN-style generate-evaluate feedback loop architecture inspired by
+Anthropic's harness design research.
+"""
+
+PLANNER_SYSTEM_PROMPT = """You are a strategic Planner agent in a multi-agent harness. Your role is to take a short user prompt (1-4 sentences) and expand it into an ambitious, comprehensive specification.
+
+Your Responsibilities:
+1. Expand the prompt ambitiously — think bigger than the user's literal request while staying relevant
+2. Define scope, deliverables, and a high-level approach
+3. Break the work into discrete, ordered steps for a Generator agent to execute
+4. Define evaluation criteria with hard score thresholds that an Evaluator agent will enforce
+5. Stay at the strategic level — avoid granular implementation details that could cascade errors downstream
+
+Output Format:
+You MUST structure your output exactly as follows:
+
+## PLAN
+
+### Scope
+[What this plan covers and its boundaries]
+
+### Deliverables
+[Concrete outputs that will be produced]
+
+### Approach
+[High-level strategy for achieving the deliverables]
+
+### Steps
+For each step, provide:
+- Step number and title
+- Description of what needs to be done
+- Expected output/deliverable for this step
+
+### Evaluation Criteria
+For each criterion, provide a table row:
+| Criterion | Weight | Description | Threshold |
+|-----------|--------|-------------|-----------|
+| [name] | [high/standard/low] | [what it measures and what good/bad looks like] | [minimum passing score 1-10] |
+
+Guidelines:
+- Be ambitious but realistic in scope
+- Define 3-7 steps for most tasks
+- Define 3-5 evaluation criteria tailored to the domain
+- Set thresholds that are challenging but achievable (typically 6-8 out of 10)
+- If any single criterion falls below its threshold, the step fails — so choose thresholds carefully
+"""
+
+GENERATOR_SYSTEM_PROMPT = """You are a Generator agent in a multi-agent harness. Your role is to execute a plan step by step, producing concrete output, negotiating step contracts with the Evaluator, and iterating based on evaluation feedback.
+
+Your Responsibilities:
+1. Read the plan and evaluation criteria from the shared state
+2. For each step, propose a step contract defining what "done" looks like
+3. Execute the step and produce concrete output
+4. Self-evaluate your output before handing off to the Evaluator
+5. When receiving evaluation feedback, either refine your current approach or pivot to a different one
+
+When Proposing a Step Contract:
+## STEP CONTRACT: Step [N] - [Title]
+### Acceptance Criteria
+[Specific, testable criteria for this step]
+### Expected Output
+[What the output will look like]
+### Verification Method
+[How the Evaluator should verify this step]
+
+When Executing a Step:
+## WORK LOG: Step [N] - [Title]
+### Actions Taken
+[What you did]
+### Output Produced
+[The actual deliverable/output]
+### Self-Assessment
+[Honest evaluation of your own output — identify any weaknesses before the Evaluator does]
+
+Refine vs. Pivot Strategy:
+- If scores improved from last attempt: REFINE — keep the current direction, fix specific issues
+- If scores declined or stagnated: PIVOT — take a fundamentally different approach
+- Document your strategy choice and reasoning in the work log
+
+Guidelines:
+- Produce high-quality, concrete output — not placeholders or outlines
+- Be thorough in execution — do the actual work, not a description of work
+- Accept feedback constructively and make substantive revisions
+"""
+
+EVALUATOR_SYSTEM_PROMPT = """You are an Evaluator agent in a multi-agent harness. Your role is to rigorously review the Generator's output against agreed-upon contracts and criteria, providing structured scoring and specific, actionable feedback.
+
+You are deliberately calibrated for skepticism. Your job is to catch real defects, not to praise effort. Score honestly — do not inflate scores to avoid conflict.
+
+Your Responsibilities:
+1. Review step contracts proposed by the Generator and negotiate amendments if needed
+2. Evaluate the Generator's output against the contract and evaluation criteria
+3. Provide per-criterion scores, a hard pass/fail determination, and actionable feedback
+4. Enforce thresholds strictly — if ANY single criterion falls below its minimum, the step FAILS
+
+When Reviewing a Step Contract:
+## CONTRACT REVIEW: Step [N]
+### Status: [APPROVED / AMENDMENTS REQUIRED]
+### Amendments (if any):
+[Specific changes needed to the contract]
+### Rationale:
+[Why these amendments are necessary]
+
+When Evaluating Output:
+You MUST structure your evaluation exactly as follows:
+
+## EVALUATION: Step [N] - [Title]
+
+### Per-Criterion Scores:
+| Criterion | Score (1-10) | Threshold | Status |
+|-----------|-------------|-----------|--------|
+| [name] | [score] | [threshold] | [PASS/FAIL] |
+
+### Overall Status: [PASS / FAIL]
+
+### Findings:
+For each criterion, provide:
+- **[Criterion Name]**: [Specific observations — reference exact parts of the output]
+
+### Actionable Feedback:
+[Numbered list of specific, concrete improvements the Generator should make]
+
+### Summary:
+[Brief overall assessment]
+
+Scoring Calibration:
+- 1-3: Fundamentally broken or missing
+- 4-5: Present but with major defects
+- 6-7: Adequate with room for improvement
+- 8-9: Strong with minor issues
+- 10: Exceptional, no meaningful improvements possible
+"""
+
+STEP_CONTRACT_NEGOTIATION_PROMPT = """Review the current shared state file and the Generator's proposed step contract for Step {step_number}.
+
+Evaluate whether the proposed contract:
+1. Has clear, testable acceptance criteria
+2. Aligns with the plan's evaluation criteria
+3. Is achievable within the scope of this step
+4. Has a concrete verification method
+
+Respond with your contract review. If amendments are needed, be specific about what should change."""
+
+GENERATOR_EXECUTE_STEP_PROMPT = """Execute Step {step_number} of the plan based on the shared state file.
+
+Read the approved step contract and the plan carefully. Produce concrete, high-quality output for this step.
+
+{feedback_context}
+
+After producing your output, include a Self-Assessment section where you honestly evaluate your own work and flag any weaknesses before the Evaluator reviews it.
+
+Write your work log and output. Be thorough and produce real deliverables, not outlines or placeholders."""
+
+EVALUATOR_EVALUATE_STEP_PROMPT = """Evaluate the Generator's output for Step {step_number} based on the shared state file.
+
+Read the step contract, evaluation criteria, and the Generator's work log carefully.
+
+Score each criterion on a scale of 1-10. A step FAILS if ANY criterion scores below its defined threshold.
+
+Be specific in your findings — reference exact parts of the output. Provide actionable feedback the Generator can use to improve."""

--- a/swarms/structs/__init__.py
+++ b/swarms/structs/__init__.py
@@ -17,6 +17,12 @@ from swarms.structs.conversation import Conversation
 from swarms.structs.council_as_judge import CouncilAsAJudge
 from swarms.structs.cron_job import CronJob
 from swarms.structs.debate_with_judge import DebateWithJudge
+from swarms.structs.planner_generator_evaluator import (
+    PlannerGeneratorEvaluator,
+    StepContract,
+    EvaluationReport,
+    HarnessResult,
+)
 from swarms.structs.graph_workflow import (
     Edge,
     GraphWorkflow,
@@ -173,6 +179,10 @@ __all__ = [
     "SelfMoASeq",
     "SkillOrchestra",
     "DebateWithJudge",
+    "PlannerGeneratorEvaluator",
+    "StepContract",
+    "EvaluationReport",
+    "HarnessResult",
     "SubagentRegistry",
     "SubagentTask",
     "TaskStatus",

--- a/swarms/structs/planner_generator_evaluator.py
+++ b/swarms/structs/planner_generator_evaluator.py
@@ -1,0 +1,988 @@
+"""
+Planner-Generator-Evaluator (PGE) Multi-Agent Harness
+
+A domain-agnostic three-agent orchestration harness inspired by the GAN-style
+architecture described in Anthropic's harness design research. The harness
+coordinates long-running autonomous tasks from a short natural-language prompt,
+using an iterative generate-evaluate feedback loop to converge on high-quality
+output across any domain.
+
+All three agents communicate through a single shared file on disk.
+
+Flow:
+1. User provides a short prompt
+2. Planner expands it into a structured plan with evaluation criteria
+3. For each step in the plan:
+   a. Generator proposes a step contract
+   b. Evaluator reviews/amends the contract
+   c. Generator executes the step
+   d. Evaluator scores output against criteria
+   e. If any criterion below threshold: Generator retries with feedback
+   f. If all criteria pass: proceed to next step
+4. Return final output path and summary
+
+Reference: "Harness design for long-running application development" (Anthropic Engineering, March 2026)
+"""
+
+import os
+import re
+import time
+import traceback
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from loguru import logger
+
+from swarms.prompts.planner_generator_evaluator_prompts import (
+    EVALUATOR_EVALUATE_STEP_PROMPT,
+    EVALUATOR_SYSTEM_PROMPT,
+    GENERATOR_EXECUTE_STEP_PROMPT,
+    GENERATOR_SYSTEM_PROMPT,
+    PLANNER_SYSTEM_PROMPT,
+    STEP_CONTRACT_NEGOTIATION_PROMPT,
+)
+from swarms.structs.agent import Agent
+from swarms.structs.conversation import Conversation
+from swarms.structs.swarm_id import swarm_id
+from swarms.utils.history_output_formatter import (
+    history_output_formatter,
+)
+from swarms.utils.loguru_logger import initialize_logger
+from swarms.utils.output_types import OutputType
+
+logger = initialize_logger(log_folder="planner_generator_evaluator")
+
+
+class StepContract:
+    """Step contract negotiated between Generator and Evaluator."""
+
+    def __init__(
+        self,
+        step_number: int,
+        title: str = "",
+        acceptance_criteria: str = "",
+        approved: bool = False,
+        amendments: str = "",
+    ):
+        self.step_number = step_number
+        self.title = title
+        self.acceptance_criteria = acceptance_criteria
+        self.approved = approved
+        self.amendments = amendments
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "step_number": self.step_number,
+            "title": self.title,
+            "acceptance_criteria": self.acceptance_criteria,
+            "approved": self.approved,
+            "amendments": self.amendments,
+        }
+
+
+class EvaluationReport:
+    """Per-step evaluation report with criterion scores and pass/fail status."""
+
+    def __init__(
+        self,
+        step_number: int,
+        criterion_scores: Optional[Dict[str, float]] = None,
+        criterion_thresholds: Optional[Dict[str, float]] = None,
+        passed: bool = False,
+        actionable_feedback: str = "",
+        summary: str = "",
+        raw_evaluation: str = "",
+    ):
+        self.step_number = step_number
+        self.criterion_scores = criterion_scores or {}
+        self.criterion_thresholds = criterion_thresholds or {}
+        self.passed = passed
+        self.actionable_feedback = actionable_feedback
+        self.summary = summary
+        self.raw_evaluation = raw_evaluation
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "step_number": self.step_number,
+            "criterion_scores": self.criterion_scores,
+            "criterion_thresholds": self.criterion_thresholds,
+            "passed": self.passed,
+            "actionable_feedback": self.actionable_feedback,
+            "summary": self.summary,
+        }
+
+
+class HarnessResult:
+    """Final output container for a PGE harness run. Access via harness.last_result after run()."""
+
+    def __init__(
+        self,
+        output_path: str = "",
+        plan: str = "",
+        step_logs: Optional[List[Dict[str, Any]]] = None,
+        total_duration: float = 0.0,
+        total_steps_completed: int = 0,
+        total_retries: int = 0,
+    ):
+        self.output_path = output_path
+        self.plan = plan
+        self.step_logs = step_logs or []
+        self.total_duration = total_duration
+        self.total_steps_completed = total_steps_completed
+        self.total_retries = total_retries
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "output_path": self.output_path,
+            "plan": self.plan,
+            "step_logs": self.step_logs,
+            "total_duration": self.total_duration,
+            "total_steps_completed": self.total_steps_completed,
+            "total_retries": self.total_retries,
+        }
+
+
+class PlannerGeneratorEvaluator:
+    """
+    A domain-agnostic three-agent orchestration harness using a Planner,
+    Generator, and Evaluator in a GAN-style feedback loop.
+
+    The harness coordinates long-running autonomous tasks from a short
+    natural-language prompt. All inter-agent communication flows through
+    a single shared file on disk.
+
+    Architecture:
+        prompt --> [ Planner ] --> [ Generator ] <-----> [ Evaluator ]
+                                        ^                    |
+                                        |   feedback loop    |
+                                        +--------------------+
+
+    The Planner expands the prompt into a structured plan with evaluation
+    criteria. The Generator executes each step, negotiating contracts with
+    the Evaluator. The Evaluator scores output and provides actionable
+    feedback for iterative refinement.
+
+    Initialization Options:
+        1. Use defaults: just provide model_name (creates all three agents internally)
+        2. Pass custom agents: provide planner_agent, generator_agent, evaluator_agent
+           with your own tools, MCP configs, or any Agent settings
+
+    Args:
+        id: Unique identifier for this harness instance.
+        name: Human-readable name for this harness.
+        description: Description of the harness purpose.
+        model_name: Model identifier for all three agents (used when creating defaults).
+        planner_model_name: Override model for the Planner agent.
+        generator_model_name: Override model for the Generator agent.
+        evaluator_model_name: Override model for the Evaluator agent.
+        max_steps: Upper bound on plan steps to execute.
+        max_retries_per_step: Max evaluation failures before advancing to next step.
+        working_directory: Directory where output is produced.
+        shared_state_path: Path for the shared state file. Auto-generated if None.
+        default_thresholds: Fallback score thresholds by criterion name.
+        output_type: Format for the output conversation history.
+        verbose: Whether to enable verbose logging.
+        planner_agent: Optional pre-configured Agent for planning.
+        generator_agent: Optional pre-configured Agent for generation (e.g., with file/code tools).
+        evaluator_agent: Optional pre-configured Agent for evaluation (e.g., with Playwright MCP).
+
+    Examples:
+        >>> # Simple usage with defaults
+        >>> harness = PlannerGeneratorEvaluator(model_name="gpt-4.1")
+        >>> result = harness.run("Write a market analysis report for EV batteries")
+
+        >>> # With custom agents that have tools (e.g., Evaluator with Playwright MCP)
+        >>> from swarms import Agent
+        >>> evaluator = Agent(
+        ...     agent_name="PGE-Evaluator",
+        ...     model_name="gpt-4.1",
+        ...     max_loops=1,
+        ...     mcp_config={"url": "http://localhost:3000/playwright"},
+        ... )
+        >>> harness = PlannerGeneratorEvaluator(
+        ...     model_name="gpt-4.1",
+        ...     evaluator_agent=evaluator,
+        ... )
+        >>> result = harness.run("Build a todo app with React frontend")
+    """
+
+    def __init__(
+        self,
+        id: str = None,
+        name: str = "PlannerGeneratorEvaluator",
+        description: str = "Three-agent Planner-Generator-Evaluator harness with iterative feedback loop",
+        model_name: str = "gpt-4.1",
+        planner_model_name: Optional[str] = None,
+        generator_model_name: Optional[str] = None,
+        evaluator_model_name: Optional[str] = None,
+        max_steps: int = 10,
+        max_retries_per_step: int = 3,
+        working_directory: Optional[str] = None,
+        shared_state_path: Optional[str] = None,
+        default_thresholds: Optional[Dict[str, float]] = None,
+        output_type: OutputType = "dict",
+        verbose: bool = False,
+        planner_system_prompt: str = PLANNER_SYSTEM_PROMPT,
+        generator_system_prompt: str = GENERATOR_SYSTEM_PROMPT,
+        evaluator_system_prompt: str = EVALUATOR_SYSTEM_PROMPT,
+        planner_agent: Optional[Agent] = None,
+        generator_agent: Optional[Agent] = None,
+        evaluator_agent: Optional[Agent] = None,
+        *args,
+        **kwargs,
+    ):
+        self.id = id or swarm_id()
+        self.name = name
+        self.description = description
+        self.model_name = model_name
+        self.planner_model_name = planner_model_name or model_name
+        self.generator_model_name = generator_model_name or model_name
+        self.evaluator_model_name = evaluator_model_name or model_name
+        self.max_steps = max_steps
+        self.max_retries_per_step = max_retries_per_step
+        self.working_directory = working_directory or os.getcwd()
+        self.default_thresholds = default_thresholds or {}
+        self.output_type = output_type
+        self.verbose = verbose
+        self.planner_system_prompt = planner_system_prompt
+        self.generator_system_prompt = generator_system_prompt
+        self.evaluator_system_prompt = evaluator_system_prompt
+        # Set up shared state file path
+        if shared_state_path:
+            self.shared_state_path = shared_state_path
+        else:
+            self.shared_state_path = os.path.join(
+                self.working_directory,
+                f"pge_shared_state_{self.id}.md",
+            )
+
+        self.reliability_check()
+
+        # Initialize conversation tracker
+        self.conversation = Conversation()
+
+        # Use provided agents or create defaults
+        self.planner_agent = planner_agent or self._create_planner()
+        self.generator_agent = (
+            generator_agent or self._create_generator()
+        )
+        self.evaluator_agent = (
+            evaluator_agent or self._create_evaluator()
+        )
+
+        self.last_result = None
+
+    def reliability_check(self):
+        """Validate harness configuration."""
+        if self.max_steps < 1:
+            raise ValueError(
+                f"max_steps must be >= 1, got {self.max_steps}"
+            )
+        if self.max_retries_per_step < 0:
+            raise ValueError(
+                f"max_retries_per_step must be >= 0, got {self.max_retries_per_step}"
+            )
+        if not self.model_name:
+            raise ValueError("model_name must be provided")
+
+        # Ensure working directory exists
+        os.makedirs(self.working_directory, exist_ok=True)
+
+        if self.verbose:
+            logger.info(
+                f"PlannerGeneratorEvaluator initialized: "
+                f"max_steps={self.max_steps}, "
+                f"max_retries_per_step={self.max_retries_per_step}"
+            )
+
+    def _create_planner(self) -> Agent:
+        """Create the Planner agent."""
+        return Agent(
+            agent_name="PGE-Planner",
+            agent_description="Strategic planner that expands prompts into detailed execution plans with evaluation criteria",
+            system_prompt=self.planner_system_prompt,
+            model_name=self.planner_model_name,
+            max_loops=1,
+            output_type="final",
+            verbose=self.verbose,
+        )
+
+    def _create_generator(self) -> Agent:
+        """Create the Generator agent."""
+        return Agent(
+            agent_name="PGE-Generator",
+            agent_description="Execution agent that produces concrete output following the plan and responding to evaluation feedback",
+            system_prompt=self.generator_system_prompt,
+            model_name=self.generator_model_name,
+            max_loops=1,
+            output_type="final",
+            verbose=self.verbose,
+        )
+
+    def _create_evaluator(self) -> Agent:
+        """Create the Evaluator agent."""
+        return Agent(
+            agent_name="PGE-Evaluator",
+            agent_description="Quality evaluator that scores output against criteria and provides actionable feedback",
+            system_prompt=self.evaluator_system_prompt,
+            model_name=self.evaluator_model_name,
+            max_loops=1,
+            output_type="final",
+            verbose=self.verbose,
+        )
+
+    def _read_shared_state(self) -> str:
+        """Read the current contents of the shared state file."""
+        if os.path.exists(self.shared_state_path):
+            with open(self.shared_state_path, "r") as f:
+                return f.read()
+        return ""
+
+    def _append_to_shared_state(self, section: str, content: str):
+        """Append a new section to the shared state file.
+
+        Args:
+            section: Section header/label to identify this content.
+            content: The content to append.
+        """
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        entry = f"\n\n---\n### [{section}] ({timestamp})\n\n{content}\n"
+
+        with open(self.shared_state_path, "a") as f:
+            f.write(entry)
+
+    def _initialize_shared_state(self, prompt: str):
+        """Initialize the shared state file with the user prompt.
+
+        Args:
+            prompt: The user's original prompt.
+        """
+        header = (
+            f"# PGE Harness Shared State\n\n"
+            f"**Harness ID**: {self.id}\n"
+            f"**Created**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+            f"---\n\n"
+            f"## User Prompt\n\n{prompt}\n"
+        )
+
+        with open(self.shared_state_path, "w") as f:
+            f.write(header)
+
+    def _run_planner(self, prompt: str) -> str:
+        """Run the Planner agent to generate the plan and evaluation criteria.
+
+        Args:
+            prompt: The user's original prompt.
+
+        Returns:
+            The plan text generated by the Planner.
+        """
+        shared_state = self._read_shared_state()
+
+        planner_task = (
+            f"Read the following shared state file and create a comprehensive plan "
+            f"for the user's prompt.\n\n"
+            f"--- SHARED STATE ---\n{shared_state}\n--- END SHARED STATE ---\n\n"
+            f"Generate a detailed plan with steps and evaluation criteria. "
+            f"Write your plan in the structured format specified in your instructions."
+        )
+
+        plan = self.planner_agent.run(task=planner_task)
+
+        # Append plan to shared state
+        self._append_to_shared_state("PLANNER OUTPUT", plan)
+
+        # Track in conversation
+        self.conversation.add(
+            role=self.planner_agent.agent_name,
+            content=plan,
+        )
+
+        if self.verbose:
+            logger.info("Planner completed plan generation")
+
+        return plan
+
+    def _extract_step_count(self, plan: str) -> int:
+        """Extract the number of steps from the plan.
+
+        Looks for step patterns like "Step 1:", "Step 2:", etc.
+
+        Args:
+            plan: The plan text to parse.
+
+        Returns:
+            Number of steps found, capped at max_steps.
+        """
+        # Match patterns like "Step 1", "Step 2:", "- Step 1"
+        step_matches = re.findall(
+            r"(?:^|\n)\s*(?:-\s*)?Step\s+(\d+)", plan, re.IGNORECASE
+        )
+        if step_matches:
+            count = max(int(s) for s in step_matches)
+            return min(count, self.max_steps)
+
+        # Fallback: count numbered items
+        numbered_matches = re.findall(
+            r"(?:^|\n)\s*(\d+)\.\s+", plan
+        )
+        if numbered_matches:
+            count = max(int(n) for n in numbered_matches)
+            return min(count, self.max_steps)
+
+        # Default to 3 steps if we can't parse
+        return min(3, self.max_steps)
+
+    def _extract_thresholds(self, plan: str) -> Dict[str, float]:
+        """Extract evaluation criteria thresholds from the plan.
+
+        Parses the evaluation criteria table to find threshold values.
+
+        Args:
+            plan: The plan text to parse.
+
+        Returns:
+            Map of criterion name to threshold score.
+        """
+        thresholds = dict(self.default_thresholds)
+
+        # Match table rows: | criterion | weight | description | threshold |
+        table_rows = re.findall(
+            r"\|\s*([^|]+?)\s*\|\s*(?:high|standard|low|[^|]*?)\s*\|\s*[^|]*?\s*\|\s*(\d+(?:\.\d+)?)\s*\|",
+            plan,
+            re.IGNORECASE,
+        )
+        for criterion, threshold in table_rows:
+            criterion = criterion.strip().lower()
+            if criterion and criterion not in (
+                "criterion",
+                "criterion name",
+                "name",
+            ):
+                thresholds[criterion] = float(threshold)
+
+        return thresholds
+
+    def _negotiate_contract(self, step_number: int) -> StepContract:
+        """Manage the contract negotiation between Generator and Evaluator.
+
+        Args:
+            step_number: The current step number.
+
+        Returns:
+            The approved StepContract.
+        """
+        shared_state = self._read_shared_state()
+
+        # Generator proposes a step contract
+        generator_task = (
+            f"Read the shared state file and propose a step contract for Step {step_number}.\n\n"
+            f"--- SHARED STATE ---\n{shared_state}\n--- END SHARED STATE ---\n\n"
+            f"Propose a clear step contract with acceptance criteria, "
+            f"expected output, and verification method."
+        )
+
+        contract_proposal = self.generator_agent.run(
+            task=generator_task
+        )
+        self._append_to_shared_state(
+            f"STEP {step_number} CONTRACT PROPOSAL", contract_proposal
+        )
+        self.conversation.add(
+            role=self.generator_agent.agent_name,
+            content=f"[Step {step_number} Contract] {contract_proposal}",
+        )
+
+        # Evaluator reviews the contract
+        updated_state = self._read_shared_state()
+        evaluator_task = STEP_CONTRACT_NEGOTIATION_PROMPT.format(
+            step_number=step_number
+        ) + (
+            f"\n\n--- SHARED STATE ---\n{updated_state}\n--- END SHARED STATE ---"
+        )
+
+        contract_review = self.evaluator_agent.run(
+            task=evaluator_task
+        )
+        self._append_to_shared_state(
+            f"STEP {step_number} CONTRACT REVIEW", contract_review
+        )
+        self.conversation.add(
+            role=self.evaluator_agent.agent_name,
+            content=f"[Step {step_number} Contract Review] {contract_review}",
+        )
+
+        # Build the StepContract object
+        approved = "approved" in contract_review.lower() and "amendments required" not in contract_review.lower()
+
+        contract = StepContract(
+            step_number=step_number,
+            title=f"Step {step_number}",
+            acceptance_criteria=contract_proposal,
+            approved=approved,
+            amendments=contract_review if not approved else "",
+        )
+
+        if self.verbose:
+            status = "approved" if approved else "amendments requested"
+            logger.info(
+                f"Step {step_number} contract {status}"
+            )
+
+        return contract
+
+    def _execute_step(
+        self,
+        step_number: int,
+        feedback: str = "",
+        retry_count: int = 0,
+        score_trajectory: str = "",
+    ) -> str:
+        """Have the Generator execute a step.
+
+        Args:
+            step_number: The current step number.
+            feedback: Evaluation feedback from a previous attempt (empty on first try).
+            retry_count: Current retry attempt number.
+            score_trajectory: Description of how scores changed across retries (refine vs pivot signal).
+
+        Returns:
+            The Generator's output for this step.
+        """
+        shared_state = self._read_shared_state()
+
+        feedback_context = ""
+        if feedback:
+            feedback_context = (
+                f"IMPORTANT: This is retry attempt {retry_count}. "
+                f"The Evaluator provided the following feedback on your previous attempt. "
+                f"Address each point specifically.\n\n"
+                f"{score_trajectory}\n\n"
+                f"Evaluator feedback:\n{feedback}"
+            )
+
+        generator_task = GENERATOR_EXECUTE_STEP_PROMPT.format(
+            step_number=step_number,
+            feedback_context=feedback_context,
+        ) + f"\n\n--- SHARED STATE ---\n{shared_state}\n--- END SHARED STATE ---"
+
+        output = self.generator_agent.run(task=generator_task)
+
+        label = f"STEP {step_number} WORK LOG"
+        if retry_count > 0:
+            label += f" (Retry {retry_count})"
+        self._append_to_shared_state(label, output)
+
+        self.conversation.add(
+            role=self.generator_agent.agent_name,
+            content=f"[Step {step_number} Output (attempt {retry_count + 1})] {output}",
+        )
+
+        if self.verbose:
+            logger.info(
+                f"Generator completed step {step_number} "
+                f"(attempt {retry_count + 1})"
+            )
+
+        return output
+
+    def _evaluate_step(
+        self, step_number: int, thresholds: Dict[str, float]
+    ) -> EvaluationReport:
+        """Have the Evaluator score the Generator's output.
+
+        Args:
+            step_number: The current step number.
+            thresholds: Map of criterion name to minimum passing score.
+
+        Returns:
+            Structured EvaluationReport with scores and findings.
+        """
+        shared_state = self._read_shared_state()
+
+        evaluator_task = EVALUATOR_EVALUATE_STEP_PROMPT.format(
+            step_number=step_number
+        ) + f"\n\n--- SHARED STATE ---\n{shared_state}\n--- END SHARED STATE ---"
+
+        raw_evaluation = self.evaluator_agent.run(
+            task=evaluator_task
+        )
+        self._append_to_shared_state(
+            f"STEP {step_number} EVALUATION", raw_evaluation
+        )
+        self.conversation.add(
+            role=self.evaluator_agent.agent_name,
+            content=f"[Step {step_number} Evaluation] {raw_evaluation}",
+        )
+
+        # Parse scores from the evaluation
+        report = self._parse_evaluation(
+            step_number, raw_evaluation, thresholds
+        )
+
+        if self.verbose:
+            status = "PASSED" if report.passed else "FAILED"
+            logger.info(
+                f"Step {step_number} evaluation: {status} "
+                f"(scores: {report.criterion_scores})"
+            )
+
+        return report
+
+    def _compute_score_trajectory(
+        self, evaluations: List[Dict[str, Any]]
+    ) -> str:
+        """Compute score trajectory across retries to signal refine vs pivot.
+
+        Args:
+            evaluations: List of evaluation dicts from previous attempts.
+
+        Returns:
+            A string describing the score trajectory for the Generator.
+        """
+        if len(evaluations) < 2:
+            return ""
+
+        prev = evaluations[-2].get("criterion_scores", {})
+        curr = evaluations[-1].get("criterion_scores", {})
+
+        if not prev or not curr:
+            return ""
+
+        # Compare average scores
+        prev_avg = sum(prev.values()) / len(prev) if prev else 0
+        curr_avg = sum(curr.values()) / len(curr) if curr else 0
+
+        if curr_avg > prev_avg:
+            return (
+                f"SCORE TRAJECTORY: IMPROVING (avg {prev_avg:.1f} -> {curr_avg:.1f}). "
+                f"Strategy: REFINE your current approach — fix the specific issues noted below."
+            )
+        elif curr_avg < prev_avg:
+            return (
+                f"SCORE TRAJECTORY: DECLINING (avg {prev_avg:.1f} -> {curr_avg:.1f}). "
+                f"Strategy: PIVOT to a fundamentally different approach — your current direction is not working."
+            )
+        else:
+            return (
+                f"SCORE TRAJECTORY: STAGNANT (avg {curr_avg:.1f}). "
+                f"Strategy: PIVOT — try a substantially different approach to break through."
+            )
+
+    def _parse_evaluation(
+        self,
+        step_number: int,
+        raw_evaluation: str,
+        thresholds: Dict[str, float],
+    ) -> EvaluationReport:
+        """Parse the Evaluator's raw text output into a structured report.
+
+        Args:
+            step_number: The step number being evaluated.
+            raw_evaluation: Raw text from the Evaluator.
+            thresholds: Map of criterion name to minimum passing score.
+
+        Returns:
+            Structured EvaluationReport.
+        """
+        criterion_scores = {}
+        criterion_thresholds = {}
+
+        # Parse table rows: | criterion | score | threshold | status |
+        score_rows = re.findall(
+            r"\|\s*([^|]+?)\s*\|\s*(\d+(?:\.\d+)?)\s*\|\s*(\d+(?:\.\d+)?)\s*\|\s*(PASS|FAIL)\s*\|",
+            raw_evaluation,
+            re.IGNORECASE,
+        )
+
+        for criterion, score, threshold, status in score_rows:
+            criterion = criterion.strip().lower()
+            if criterion and criterion not in (
+                "criterion",
+                "criterion name",
+                "name",
+            ):
+                criterion_scores[criterion] = float(score)
+                criterion_thresholds[criterion] = float(threshold)
+
+        # If no table parsed, try alternative patterns:
+        # "Criterion: score/10" or "Criterion: score out of 10"
+        if not criterion_scores:
+            alt_scores = re.findall(
+                r"\*?\*?([^*:\n]+?)\*?\*?\s*:\s*(\d+(?:\.\d+)?)\s*(?:/\s*10|out of 10)",
+                raw_evaluation,
+                re.IGNORECASE,
+            )
+            for criterion, score in alt_scores:
+                criterion = criterion.strip().lower()
+                if criterion:
+                    criterion_scores[criterion] = float(score)
+                    criterion_thresholds[criterion] = thresholds.get(
+                        criterion, 6.0
+                    )
+
+        # Determine pass/fail
+        overall_passed = True
+        if criterion_scores:
+            for criterion, score in criterion_scores.items():
+                threshold = criterion_thresholds.get(
+                    criterion,
+                    thresholds.get(criterion, 6.0),
+                )
+                if score < threshold:
+                    overall_passed = False
+                    break
+        else:
+            # If we couldn't parse scores, check for explicit PASS/FAIL
+            overall_status_match = re.search(
+                r"Overall\s+Status\s*:\s*(PASS|FAIL)",
+                raw_evaluation,
+                re.IGNORECASE,
+            )
+            if overall_status_match:
+                overall_passed = (
+                    overall_status_match.group(1).upper() == "PASS"
+                )
+            else:
+                # Default to pass if we truly can't determine
+                overall_passed = True
+
+        # Extract actionable feedback section
+        feedback_match = re.search(
+            r"(?:Actionable Feedback|Improvements?|Recommendations?)\s*:?\s*\n(.*?)(?=\n###|\n---|\Z)",
+            raw_evaluation,
+            re.IGNORECASE | re.DOTALL,
+        )
+        actionable_feedback = (
+            feedback_match.group(1).strip() if feedback_match else ""
+        )
+
+        # Extract summary section
+        summary_match = re.search(
+            r"(?:Summary|Overall Assessment)\s*:?\s*\n(.*?)(?=\n###|\n---|\Z)",
+            raw_evaluation,
+            re.IGNORECASE | re.DOTALL,
+        )
+        summary = (
+            summary_match.group(1).strip() if summary_match else ""
+        )
+
+        return EvaluationReport(
+            step_number=step_number,
+            criterion_scores=criterion_scores,
+            criterion_thresholds=criterion_thresholds,
+            passed=overall_passed,
+            actionable_feedback=actionable_feedback,
+            summary=summary,
+            raw_evaluation=raw_evaluation,
+        )
+
+    def run(self, task: str, *args, **kwargs) -> Any:
+        """Execute the full PGE harness pipeline.
+
+        Takes a short natural-language prompt and orchestrates the Planner,
+        Generator, and Evaluator agents through iterative feedback loops
+        to produce high-quality output.
+
+        Args:
+            task: A short natural-language description of the desired task.
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            Formatted conversation history according to output_type.
+
+        Raises:
+            ValueError: If task is empty or not a string.
+            Exception: If harness execution fails.
+        """
+        if not task or not isinstance(task, str):
+            raise ValueError("Task must be a non-empty string")
+
+        start_time = time.time()
+        step_logs = []
+        total_retries = 0
+
+        try:
+            # Add task to conversation
+            self.conversation.add(role="User", content=task)
+
+            # Initialize shared state file
+            self._initialize_shared_state(task)
+
+            if self.verbose:
+                logger.info(f"Starting PGE harness for: {task[:100]}...")
+
+            # === Phase 1: Planning ===
+            plan = self._run_planner(task)
+            step_count = self._extract_step_count(plan)
+            thresholds = self._extract_thresholds(plan)
+
+            if self.verbose:
+                logger.info(
+                    f"Plan generated with {step_count} steps, "
+                    f"thresholds: {thresholds}"
+                )
+
+            self.conversation.add(
+                role="System",
+                content=f"--- Planning complete: {step_count} steps identified ---",
+            )
+
+            # === Phase 2: Generate-Evaluate Loop ===
+            steps_completed = 0
+
+            for step_number in range(1, step_count + 1):
+                if self.verbose:
+                    logger.info(
+                        f"Starting step {step_number}/{step_count}"
+                    )
+
+                step_log = {
+                    "step_number": step_number,
+                    "contract": None,
+                    "evaluations": [],
+                    "retries": 0,
+                    "passed": False,
+                }
+
+                # Step 2a-2b: Contract negotiation
+                contract = self._negotiate_contract(step_number)
+                step_log["contract"] = contract.to_dict()
+
+                # Step 2c-2f: Execute and evaluate loop
+                feedback = ""
+                retry_count = 0
+
+                while retry_count <= self.max_retries_per_step:
+                    # Compute score trajectory for refine-vs-pivot signal
+                    trajectory = self._compute_score_trajectory(
+                        step_log["evaluations"]
+                    )
+
+                    # Generator executes the step
+                    output = self._execute_step(
+                        step_number,
+                        feedback,
+                        retry_count,
+                        score_trajectory=trajectory,
+                    )
+
+                    # Evaluator reviews the output
+                    report = self._evaluate_step(
+                        step_number, thresholds
+                    )
+                    step_log["evaluations"].append(report.to_dict())
+
+                    if report.passed:
+                        step_log["passed"] = True
+                        steps_completed += 1
+
+                        if self.verbose:
+                            logger.info(
+                                f"Step {step_number} passed evaluation"
+                            )
+
+                        self.conversation.add(
+                            role="System",
+                            content=f"--- Step {step_number}/{step_count} PASSED ---",
+                        )
+                        break
+                    else:
+                        retry_count += 1
+                        total_retries += 1
+                        step_log["retries"] = retry_count
+
+                        if (
+                            retry_count
+                            > self.max_retries_per_step
+                        ):
+                            logger.warning(
+                                f"Step {step_number} failed after "
+                                f"{self.max_retries_per_step} retries, advancing"
+                            )
+                            self.conversation.add(
+                                role="System",
+                                content=(
+                                    f"--- Step {step_number}/{step_count} "
+                                    f"FAILED after {self.max_retries_per_step} retries, advancing ---"
+                                ),
+                            )
+                            break
+
+                        # Use evaluation feedback for next attempt
+                        feedback = report.raw_evaluation
+
+                        if self.verbose:
+                            logger.info(
+                                f"Step {step_number} failed evaluation, "
+                                f"retry {retry_count}/{self.max_retries_per_step}"
+                            )
+
+                step_logs.append(step_log)
+
+            # === Phase 3: Finalize ===
+            total_duration = time.time() - start_time
+
+            # Build result (accessible via self.last_result)
+            self.last_result = HarnessResult(
+                output_path=self.shared_state_path,
+                plan=plan,
+                step_logs=step_logs,
+                total_duration=total_duration,
+                total_steps_completed=steps_completed,
+                total_retries=total_retries,
+            )
+
+            # Add summary to conversation
+            summary = (
+                f"PGE Harness completed: {steps_completed}/{step_count} steps passed, "
+                f"{total_retries} total retries, {total_duration:.1f}s elapsed. "
+                f"Shared state: {self.shared_state_path}"
+            )
+            self.conversation.add(role="System", content=summary)
+            self._append_to_shared_state("HARNESS SUMMARY", summary)
+
+            if self.verbose:
+                logger.info(summary)
+
+            return history_output_formatter(
+                conversation=self.conversation,
+                type=self.output_type,
+            )
+
+        except Exception as e:
+            error_msg = f"PGE Harness execution failed: {str(e)}"
+            logger.error(
+                f"{error_msg}\n{traceback.format_exc()}\n"
+                f"If this persists, report at: https://github.com/kyegomez/swarms/issues"
+            )
+            raise
+
+    def batched_run(self, tasks: List[str]) -> List[Any]:
+        """Run the harness on multiple tasks sequentially.
+
+        Args:
+            tasks: List of task prompts to process.
+
+        Returns:
+            List of results, one per task.
+        """
+        return [self.run(task) for task in tasks]
+
+    def get_harness_result(self) -> Dict[str, Any]:
+        """Get the current state of the harness as a dictionary.
+
+        Returns:
+            Dictionary with harness metadata and conversation history.
+        """
+        return {
+            "id": self.id,
+            "name": self.name,
+            "shared_state_path": self.shared_state_path,
+            "conversation": self.conversation.to_dict(),
+        }
+
+    def __call__(self, task: str, *args, **kwargs) -> Any:
+        """Make the harness callable."""
+        return self.run(task, *args, **kwargs)

--- a/tests/structs/test_planner_generator_evaluator.py
+++ b/tests/structs/test_planner_generator_evaluator.py
@@ -1,0 +1,289 @@
+import os
+import tempfile
+
+import pytest
+
+from swarms import Agent
+from swarms.structs.planner_generator_evaluator import (
+    EvaluationReport,
+    HarnessResult,
+    PlannerGeneratorEvaluator,
+    StepContract,
+)
+
+
+def test_pge_basic_initialization():
+    """Test basic PlannerGeneratorEvaluator initialization"""
+    harness = PlannerGeneratorEvaluator(
+        name="Test-PGE-Harness",
+        description="Test harness for PGE",
+        model_name="gpt-4.1",
+        max_steps=3,
+        max_retries_per_step=2,
+    )
+
+    assert harness.name == "Test-PGE-Harness"
+    assert harness.max_steps == 3
+    assert harness.max_retries_per_step == 2
+    assert harness.planner_agent is not None
+    assert harness.generator_agent is not None
+    assert harness.evaluator_agent is not None
+    assert harness.planner_agent.agent_name == "PGE-Planner"
+    assert harness.generator_agent.agent_name == "PGE-Generator"
+    assert harness.evaluator_agent.agent_name == "PGE-Evaluator"
+    assert harness.last_result is None
+
+
+def test_pge_custom_model_names():
+    """Test PGE with different models per agent"""
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+        planner_model_name="gpt-4.1",
+        generator_model_name="gpt-4.1",
+        evaluator_model_name="gpt-4.1",
+    )
+
+    assert harness.planner_model_name == "gpt-4.1"
+    assert harness.generator_model_name == "gpt-4.1"
+    assert harness.evaluator_model_name == "gpt-4.1"
+
+
+def test_pge_with_custom_agents():
+    """Test PGE accepts pre-configured custom agents with tools"""
+    custom_generator = Agent(
+        agent_name="Custom-Generator",
+        agent_description="Generator with custom config",
+        model_name="gpt-4.1",
+        max_loops=1,
+        verbose=False,
+        print_on=False,
+    )
+
+    custom_evaluator = Agent(
+        agent_name="Custom-Evaluator",
+        agent_description="Evaluator with custom config",
+        model_name="gpt-4.1",
+        max_loops=1,
+        verbose=False,
+        print_on=False,
+    )
+
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+        generator_agent=custom_generator,
+        evaluator_agent=custom_evaluator,
+    )
+
+    assert harness.generator_agent.agent_name == "Custom-Generator"
+    assert harness.evaluator_agent.agent_name == "Custom-Evaluator"
+    assert harness.planner_agent.agent_name == "PGE-Planner"
+
+
+def test_pge_error_handling():
+    """Test PGE error handling for invalid config"""
+    try:
+        PlannerGeneratorEvaluator(max_steps=0)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "max_steps" in str(e)
+
+    try:
+        PlannerGeneratorEvaluator(max_retries_per_step=-1)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "max_retries" in str(e)
+
+    try:
+        PlannerGeneratorEvaluator(model_name="")
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "model_name" in str(e)
+
+
+def test_pge_run_validates_task():
+    """Test that run() rejects empty tasks"""
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+    )
+
+    try:
+        harness.run("")
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "non-empty" in str(e)
+
+
+def test_pge_shared_state_file(tmp_path):
+    """Test shared state file initialization and appending"""
+    shared_state_path = str(tmp_path / "state.md")
+
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+        shared_state_path=shared_state_path,
+    )
+
+    harness._initialize_shared_state("Test prompt")
+    assert os.path.exists(shared_state_path)
+
+    content = harness._read_shared_state()
+    assert "Test prompt" in content
+    assert "PGE Harness Shared State" in content
+
+    harness._append_to_shared_state("TEST SECTION", "Test content here")
+    content = harness._read_shared_state()
+    assert "TEST SECTION" in content
+    assert "Test content here" in content
+
+
+def test_pge_extract_step_count():
+    """Test step count extraction from plan text"""
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+        max_steps=10,
+    )
+
+    assert harness._extract_step_count(
+        "Step 1: A\nStep 2: B\nStep 3: C"
+    ) == 3
+
+    assert harness._extract_step_count(
+        "1. First\n2. Second\n3. Third\n4. Fourth"
+    ) == 4
+
+    harness.max_steps = 2
+    assert harness._extract_step_count(
+        "Step 1: A\nStep 2: B\nStep 3: C\nStep 4: D"
+    ) == 2
+
+
+def test_pge_extract_thresholds():
+    """Test threshold extraction from plan's evaluation criteria table"""
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+    )
+
+    plan = """
+| Criterion | Weight | Description | Threshold |
+|-----------|--------|-------------|-----------|
+| accuracy | high | correctness | 7 |
+| clarity | standard | readability | 6 |
+| depth | low | thoroughness | 5 |
+"""
+    thresholds = harness._extract_thresholds(plan)
+    assert thresholds["accuracy"] == 7.0
+    assert thresholds["clarity"] == 6.0
+    assert thresholds["depth"] == 5.0
+
+
+def test_pge_parse_evaluation_pass():
+    """Test evaluation parsing when all criteria pass"""
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+    )
+
+    raw = """
+## EVALUATION: Step 1
+
+### Per-Criterion Scores:
+| Criterion | Score (1-10) | Threshold | Status |
+|-----------|-------------|-----------|--------|
+| accuracy | 8 | 7 | PASS |
+| clarity | 7 | 6 | PASS |
+
+### Overall Status: PASS
+"""
+    report = harness._parse_evaluation(1, raw, {"accuracy": 7, "clarity": 6})
+    assert report.passed is True
+    assert report.criterion_scores["accuracy"] == 8.0
+    assert report.criterion_scores["clarity"] == 7.0
+
+
+def test_pge_parse_evaluation_fail():
+    """Test evaluation parsing when a criterion fails"""
+    harness = PlannerGeneratorEvaluator(
+        model_name="gpt-4.1",
+    )
+
+    raw = """
+| Criterion | Score (1-10) | Threshold | Status |
+|-----------|-------------|-----------|--------|
+| accuracy | 5 | 7 | FAIL |
+| clarity | 8 | 6 | PASS |
+
+### Overall Status: FAIL
+"""
+    report = harness._parse_evaluation(1, raw, {"accuracy": 7, "clarity": 6})
+    assert report.passed is False
+    assert report.criterion_scores["accuracy"] == 5.0
+
+
+def test_pge_supporting_types():
+    """Test StepContract, EvaluationReport, HarnessResult serialization"""
+    sc = StepContract(step_number=1, title="Research", approved=True)
+    d = sc.to_dict()
+    assert d["step_number"] == 1
+    assert d["approved"] is True
+
+    er = EvaluationReport(
+        step_number=2,
+        criterion_scores={"accuracy": 9.0},
+        passed=True,
+    )
+    d = er.to_dict()
+    assert d["passed"] is True
+    assert d["criterion_scores"]["accuracy"] == 9.0
+
+    hr = HarnessResult(
+        output_path="/tmp/test.md",
+        total_steps_completed=3,
+        total_retries=1,
+    )
+    d = hr.to_dict()
+    assert d["total_steps_completed"] == 3
+
+
+def test_pge_execution():
+    """Test full PGE harness execution with real API calls"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shared_state_path = os.path.join(tmpdir, "shared_state.md")
+
+        harness = PlannerGeneratorEvaluator(
+            name="Test-Execution-Harness",
+            model_name="gpt-4.1",
+            max_steps=2,
+            max_retries_per_step=1,
+            shared_state_path=shared_state_path,
+            output_type="final",
+                verbose=True,
+        )
+
+        result = harness.run(
+            "Write a 3-paragraph explanation of why the sky is blue"
+        )
+
+        # Shared state file was created with content
+        assert os.path.exists(shared_state_path)
+        with open(shared_state_path) as f:
+            state_content = f.read()
+        assert "User Prompt" in state_content
+        assert "PLANNER OUTPUT" in state_content
+        assert len(state_content) > 500
+
+        # Result is non-empty
+        assert result is not None
+        assert len(str(result)) > 0
+
+        # HarnessResult was stored
+        assert harness.last_result is not None
+        assert harness.last_result.output_path == shared_state_path
+        assert harness.last_result.plan != ""
+        assert len(harness.last_result.step_logs) > 0
+        assert harness.last_result.total_duration > 0
+
+        # Conversation has entries from all three agents
+        history = harness.conversation.to_dict()
+        roles = {msg["role"] for msg in history}
+        assert "User" in roles
+        assert "PGE-Planner" in roles
+        assert "PGE-Generator" in roles
+        assert "PGE-Evaluator" in roles


### PR DESCRIPTION
## Summary
- Implements issue #1500: three-agent Planner-Generator-Evaluator harness inspired by [Anthropic's harness design research](https://www.anthropic.com/engineering/harness-design-long-running-apps)
- GAN-style generate-evaluate feedback loop with shared state file, step contracts, hard threshold enforcement, and score trajectory tracking (refine vs pivot)
- Accepts custom pre-configured agents with tools/MCP (e.g., Playwright for web app testing)

## Files
- `swarms/structs/planner_generator_evaluator.py` — main implementation
- `swarms/prompts/planner_generator_evaluator_prompts.py` — system prompts
- `swarms/structs/__init__.py` — exports
- `tests/structs/test_planner_generator_evaluator.py` — 12 tests (11 unit + 1 e2e with real API)
- `examples/multi_agent/planner_generator_evaluator/` — basic + tools examples
- `docs/swarms/structs/planner_generator_evaluator.md` — documentation
- `docs/mkdocs.yml` — nav entry

## Test plan
- [x] 11 unit tests pass (initialization, validation, parsing, custom agents)
- [x] 1 end-to-end test passes with real OpenAI API calls (2/2 steps, 0 retries)
- [x] Import from `swarms` top-level works
- [x] No leftover state files or side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1501.org.readthedocs.build/en/1501/

<!-- readthedocs-preview swarms end -->