### PR TITLE
[BUGF] remove dynamic_temperature_enabled to fix Anthropic compatibility

### DIFF
--- a/swarms/agents/auto_generate_swarm_config.py
+++ b/swarms/agents/auto_generate_swarm_config.py
@@ -417,7 +417,6 @@ def generate_swarm_config(
                 system_prompt=AUTO_GEN_PROMPT,
                 llm=model,
                 max_loops=1,
-                dynamic_temperature_enabled=True,
                 saved_state_path="swarm_builder.json",
                 user_name="swarms_corp",
                 output_type="str",

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1009,8 +1009,12 @@ class TestCreateAgentsFromYaml:
             in str(context.exception)
         )
 
-    def test_invalid_return_type(self):
+    @patch(
+        "swarms.agents.create_agents_from_yaml.create_agent_with_retry"
+    )
+    def test_invalid_return_type(self, mock_create_agent):
         """Test handling invalid return type"""
+        mock_create_agent.return_value = MagicMock()
         yaml_string = """
 agents:
   - agent_name: Financial-Analysis-Agent

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1009,48 +1009,20 @@ class TestCreateAgentsFromYaml:
             in str(context.exception)
         )
 
-    @patch(
-        "builtins.open",
-        new_callable=unittest.mock.mock_open,
-        read_data="",
-    )
-    @patch("yaml.safe_load")
-    def test_invalid_return_type(self, mock_safe_load, mock_open):
+    def test_invalid_return_type(self):
         """Test handling invalid return type"""
-        # Mock YAML content parsing
-        mock_safe_load.return_value = {
-            "agents": [
-                {
-                    "agent_name": "Financial-Analysis-Agent",
-                    "model": {
-                        "openai_api_key": "fake-api-key",
-                        "model_name": "gpt-5.4",
-                        "temperature": 0.1,
-                        "max_tokens": 2000,
-                    },
-                    "system_prompt": "financial_agent_sys_prompt",
-                    "max_loops": 1,
-                    "autosave": True,
-                    "dashboard": False,
-                    "verbose": True,
-                    "dynamic_temperature_enabled": True,
-                    "saved_state_path": "finance_agent.json",
-                    "user_name": "swarms_corp",
-                    "retry_attempts": 1,
-                    "context_length": 200000,
-                    "return_step_meta": False,
-                    "output_type": "str",
-                    "task": "How can I establish a ROTH IRA to buy stocks and get a tax break?",
-                }
-            ]
-        }
-
-        # Test if an error is raised for invalid return_type
+        yaml_string = """
+agents:
+  - agent_name: Financial-Analysis-Agent
+    system_prompt: financial_agent_sys_prompt
+    model_name: gpt-4o
+    max_loops: 1
+"""
         with pytest.raises(ValueError) as context:
             create_agents_from_yaml(
-                "fake_yaml_path.yaml", return_type="invalid_type"
+                yaml_string=yaml_string, return_type="invalid_type"
             )
-        assert "Invalid return_type" in str(context.exception)
+        assert "Invalid return_type" in str(context.value)
 
 
 # ============================================================================


### PR DESCRIPTION
## Description
This PR fixes two bugs. First, generate_swarm_config was broken with all Anthropic models because the Auto-Swarm-Builder agent sent both temperature and top_p, which Anthropic's API rejects — removing dynamic_temperature_enabled=True fixes this. Second, create_agents_from_yaml was rejecting every return_type value including valid ones because the in operator does not work on Literal types — replaced with a plain tuple. The regression test for the latter is also fixed so it actually exercises the guard.

## Files Changed
* `swarms/agents/auto_generate_swarm_config.py`
* `swarms/agents/create_agents_from_yaml.py`
* `tests/structs/test_agent.py`

## Issue
#1488

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Twitter
@akc__2025

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1523.org.readthedocs.build/en/1523/

<!-- readthedocs-preview swarms end -->