### PR TITLE
[FEAT-UTILS][Added World Models: Collective Swarm Intelligence]

### DIFF
--- a/examples/utils/world_model/wm.py
+++ b/examples/utils/world_model/wm.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+import numpy as np
+
+from swarms import Agent
+from swarms.structs.agent_rearrange import AgentRearrange
+from swarms.utils import SwarmWorldModel
+from swarms.utils.world_model import (
+    AgentWorldModel,
+    LinearLatentDynamics,
+    attach_shared_swarm_wm,
+)
+
+try:
+    from voice_agents import StreamingTTSCallback
+except ImportError:
+    StreamingTTSCallback = None  # type: ignore[misc, assignment]
+
+_EXAMPLE_MODEL = os.environ.get("SWARMS_EXAMPLE_MODEL", "gpt-4o-mini")
+
+
+def _resolve_wm_throttle_seconds(cli_value: Optional[float]) -> float:
+    """
+    Seconds to sleep before each LLM/tool step.
+
+    CLI ``--wm-throttle-seconds`` wins when provided; else ``WM_THROTTLE_SECONDS``;
+    else ``0.5``. Use ``0`` to disable pacing.
+    """
+    if cli_value is not None:
+        return max(0.0, float(cli_value))
+    raw = os.environ.get("WM_THROTTLE_SECONDS")
+    if raw is not None and str(raw).strip() != "":
+        return max(0.0, float(raw))
+    return 0.5
+
+
+def _apply_wm_loop_throttle_to_agent(agent: Agent, seconds: float) -> None:
+    """
+    Example-only: sleep before each ``call_llm`` and ``execute_tools`` on this instance.
+
+    This keeps ``swarms/structs/agent.py`` free of demo pacing.
+    To remove throttling entirely, delete this function and every call to it below.
+    """
+    delay = float(seconds or 0.0)
+    if delay <= 0:
+        return
+    _orig_call_llm = agent.call_llm
+    _orig_execute_tools = agent.execute_tools
+
+    def call_llm_throttled(*args: Any, **kwargs: Any) -> Any:
+        time.sleep(delay)
+        return _orig_call_llm(*args, **kwargs)
+
+    def execute_tools_throttled(*args: Any, **kwargs: Any) -> Any:
+        time.sleep(delay)
+        return _orig_execute_tools(*args, **kwargs)
+
+    agent.call_llm = call_llm_throttled  # type: ignore[method-assign]
+    agent.execute_tools = execute_tools_throttled  # type: ignore[method-assign]
+
+
+AGI_TEAM_TASK = (
+    "Shared lab mission: produce a minimal, actionable AGI R&D agenda (capabilities + alignment safety).\n\n"
+    "Research Lead: You go first. You MUST start by calling create_plan with at least 3 subtasks "
+    "(e.g. measurement/benchmarks, scalable alignment, governance). Use think at least once. "
+    "Use filesystem tools: list_directory and/or create_file (e.g. write a short agi_lab_outline.md).\n"
+    "Systems Architect: Refine milestones and evaluation; use read_file/create_file/list_directory.\n"
+    "Safety Reviewer: Critique risks; use tools — not prose-only.\n\n"
+    "Everyone: use Swarms tools (create_plan, think, subtask_done, complete_task, file tools, run_bash "
+    "when appropriate). Finish with complete_task."
+)
+
+AGI_SOLO_TASK = (
+    "You are an AGI research lab assistant. Use the tool loop.\n\n"
+    "1. Call create_plan with at least 3 subtasks.\n"
+    "2. Use think at least once before completing work.\n"
+    "3. Use list_directory, read_file, or create_file (e.g. one paragraph in agi_rd_note.md).\n"
+    "4. Use subtask_done and complete_task. Do not answer with prose-only."
+)
+
+SP_RESEARCH_LEAD = (
+    "You are the Research Lead of an AGI R&D lab. You must use autonomous tools: "
+    "create_plan, think, filesystem tools, subtask_done, complete_task."
+)
+
+SP_SYSTEMS_ARCHITECT = (
+    "You are the Systems Architect. Turn research into testable milestones; use tools "
+    "(read_file, create_file, list_directory, think)."
+)
+
+SP_SAFETY_REVIEWER = (
+    "You are the Safety Reviewer. Stress-test proposals for misuse and governance gaps; use tools."
+)
+
+OBS_DIM = 8
+ACTION_DIM = 1
+LATENT_DIM = 3
+
+
+def graph_observation_vector(wm: AgentWorldModel | SwarmWorldModel) -> np.ndarray:
+    """Map current graph ``to_dict()`` to a numeric observation (length ``OBS_DIM``)."""
+    d = wm.to_dict()
+    nodes: List[Dict[str, Any]] = d["nodes"]
+    edges: List[Dict[str, Any]] = d["edges"]
+    nn, ne = len(nodes), len(edges)
+    facts = sum(1 for n in nodes if n.get("kind") == "fact")
+    hyp = sum(1 for n in nodes if n.get("kind") == "hypothesis")
+    obs_k = sum(1 for n in nodes if n.get("kind") == "observation")
+    sem = sum(1 for n in nodes if n.get("scope") == "semantic")
+    epi = sum(1 for n in nodes if n.get("scope") == "episodic")
+    density = float(ne / max(nn, 1))
+    v = [
+        float(nn),
+        float(ne),
+        float(facts),
+        float(hyp),
+        float(obs_k),
+        float(sem),
+        float(epi),
+        density,
+    ]
+    if len(v) != OBS_DIM:
+        raise RuntimeError("OBS_DIM must match graph_observation_vector length")
+    return np.array(v, dtype=np.float64)
+
+
+def make_trajectory_callback_for_wm(
+    wm: AgentWorldModel | SwarmWorldModel,
+    *,
+    action_dim: int = ACTION_DIM,
+) -> Callable[..., None]:
+    """
+    After each ``on_wm_update``, record (prev_obs, ones, obs) on ``wm.trajectory_dynamics``.
+
+    Call ``wm.init_trajectory_dynamics(...)`` before the agent runs.
+    """
+    prev: Dict[str, Optional[np.ndarray]] = {"v": None}
+    action = np.ones(action_dim, dtype=np.float64)
+
+    def on_wm_update(
+        _wm: AgentWorldModel,
+        digest: str,
+        *,
+        loop_count: Optional[int],
+        task_excerpt: str,
+    ) -> None:
+        td = wm.trajectory_dynamics
+        if td is None:
+            return
+        obs = graph_observation_vector(wm)
+        if prev["v"] is not None:
+            td.observe(prev["v"], action, obs)
+        prev["v"] = obs.copy()
+
+    return on_wm_update
+
+
+def _trajectory_summary(td: Optional[LinearLatentDynamics], label: str) -> Dict[str, Any]:
+    """Serialize trajectory dynamics state for logging."""
+    if td is None:
+        return {"label": label, "enabled": False}
+    d = td.to_dict()
+    d["label"] = label
+    d["enabled"] = True
+    d["is_fitted"] = td.is_fitted
+    return d
+
+
+def _require_llm_env() -> bool:
+    if not os.environ.get("OPENAI_API_KEY"):
+        print(
+            "Set OPENAI_API_KEY (or your provider env vars) so the agent and "
+            "world-model extract call can run.",
+        )
+        return False
+    return True
+
+
+def on_wm_update(wm: Any, digest: str, *, loop_count: Any, task_excerpt: str) -> None:
+    """Default world-model update callback: log to stdout."""
+    print(f"[wm] loop={loop_count} digest={digest!r}")
+
+
+def main(
+    *,
+    viz: bool,
+    quick: bool,
+    wm_throttle_seconds: float,
+) -> None:
+    """Run a single agent with world-model integration."""
+    if not _require_llm_env():
+        return
+
+    if quick:
+        max_loops: Any = 5 if viz else 1
+        run_task = (
+            "In three short bullets: one benefit of exercise, one of hydration, one of sleep."
+        )
+    else:
+        max_loops = "auto"
+        run_task = AGI_SOLO_TASK
+
+    agent = Agent(
+        agent_name="AGI-Lab-Solo",
+        model_name=_EXAMPLE_MODEL,
+        max_loops=max_loops,
+        selected_tools="all",
+        interactive=False,
+        system_prompt=SP_RESEARCH_LEAD,
+        wm=True,
+        wm_max_chars=4000,
+        on_wm_update=on_wm_update,
+        print_on=True,
+        verbose=True,
+    )
+    _apply_wm_loop_throttle_to_agent(agent, wm_throttle_seconds)
+
+    g = agent.world_model_graph
+    if viz and g is not None:
+        g.init_trajectory_dynamics(OBS_DIM, ACTION_DIM, LATENT_DIM, seed=42)
+        _track = make_trajectory_callback_for_wm(g)
+
+        def _wm_cb(wm: Any, digest: str, *, loop_count: Any, task_excerpt: str) -> None:
+            print(f"[wm] loop={loop_count} digest={digest!r}")
+            _track(wm, digest, loop_count=loop_count, task_excerpt=task_excerpt)
+
+        agent.on_wm_update = _wm_cb
+
+    out = agent.run(run_task)
+    print(out)
+
+    if g is not None:
+        print("--- world model (agent) ---")
+        print("digest:", g.digest_for_hook())
+        d = g.to_dict()
+        print(f"nodes: {len(d['nodes'])}, edges: {len(d['edges'])}")
+        if viz and g.trajectory_dynamics is not None:
+            ok = g.trajectory_dynamics.fit()
+            print(
+                f"trajectory_dynamics: n_samples={g.trajectory_dynamics.n_samples} "
+                f"fitted={ok}",
+            )
+
+
+def demo_rearrange_wm(
+    *,
+    voice: bool,
+    viz: bool,
+    wm_throttle_seconds: float,
+) -> None:
+    """Run a three-agent team with shared world model."""
+    if not _require_llm_env():
+        return
+
+    if voice and StreamingTTSCallback is None:
+        print(
+            "voice-agents is not installed. Install with: pip install voice-agents\n"
+            "Or run: python examples/utils/wm_example.py --rearrange --no-voice",
+        )
+        return
+
+    shared = SwarmWorldModel("agi-rd-shared-wm")
+
+    if viz:
+        shared.init_trajectory_dynamics(OBS_DIM, ACTION_DIM, LATENT_DIM, seed=42)
+        _track = make_trajectory_callback_for_wm(shared)
+
+        def wm_cb(wm: Any, digest: str, *, loop_count: Any, task_excerpt: str) -> None:
+            print(f"[wm] loop={loop_count} digest={digest!r}")
+            _track(wm, digest, loop_count=loop_count, task_excerpt=task_excerpt)
+
+    else:
+        wm_cb = on_wm_update
+
+    tts_lead = (
+        StreamingTTSCallback(voice="onyx", model="openai/tts-1")
+        if voice
+        else None
+    )
+    tts_arch = (
+        StreamingTTSCallback(voice="nova", model="openai/tts-1")
+        if voice
+        else None
+    )
+    tts_safe = (
+        StreamingTTSCallback(voice="shimmer", model="openai/tts-1")
+        if voice
+        else None
+    )
+
+    research_lead = Agent(
+        agent_name="Research Lead",
+        model_name=_EXAMPLE_MODEL,
+        max_loops="auto",
+        selected_tools="all",
+        interactive=False,
+        system_prompt=SP_RESEARCH_LEAD,
+        wm=True,
+        wm_max_chars=4000,
+        on_wm_update=wm_cb,
+        streaming_on=voice,
+        print_on=not voice,
+        verbose=True,
+        streaming_callback=tts_lead,
+    )
+    systems_architect = Agent(
+        agent_name="Systems Architect",
+        model_name=_EXAMPLE_MODEL,
+        max_loops="auto",
+        selected_tools="all",
+        interactive=False,
+        system_prompt=SP_SYSTEMS_ARCHITECT,
+        wm=True,
+        wm_max_chars=4000,
+        on_wm_update=wm_cb,
+        streaming_on=voice,
+        print_on=not voice,
+        verbose=True,
+        streaming_callback=tts_arch,
+    )
+    safety_reviewer = Agent(
+        agent_name="Safety Reviewer",
+        model_name=_EXAMPLE_MODEL,
+        max_loops="auto",
+        selected_tools="all",
+        interactive=False,
+        system_prompt=SP_SAFETY_REVIEWER,
+        wm=True,
+        wm_max_chars=4000,
+        on_wm_update=wm_cb,
+        streaming_on=voice,
+        print_on=not voice,
+        verbose=True,
+        streaming_callback=tts_safe,
+    )
+
+    for _a in (research_lead, systems_architect, safety_reviewer):
+        _apply_wm_loop_throttle_to_agent(_a, wm_throttle_seconds)
+
+    attach_shared_swarm_wm(
+        [research_lead, systems_architect, safety_reviewer],
+        shared,
+    )
+
+    swarm = AgentRearrange(
+        name="AGI-RD-Lab",
+        agents=[research_lead, systems_architect, safety_reviewer],
+        flow="Research Lead -> Systems Architect -> Safety Reviewer",
+        max_loops=1,
+        verbose=False,
+        team_awareness=False,
+        output_type="all",
+        autosave=False,
+    )
+
+    out = swarm.run(AGI_TEAM_TASK)
+    print(out)
+
+    if voice:
+        if tts_lead:
+            tts_lead.flush()
+        if tts_arch:
+            tts_arch.flush()
+        if tts_safe:
+            tts_safe.flush()
+
+    print("--- shared swarm graph ---")
+    print("digest:", shared.digest_for_hook())
+    sd = shared.to_dict()
+    print(f"nodes: {len(sd['nodes'])}, edges: {len(sd['edges'])}")
+
+    if viz and shared.trajectory_dynamics is not None:
+        ok = shared.trajectory_dynamics.fit()
+        print(
+            f"trajectory_dynamics (shared): n_samples={shared.trajectory_dynamics.n_samples} "
+            f"fitted={ok}",
+        )
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="AGI R&D lab demo (autonomous tools + world-model).",
+    )
+    p.add_argument(
+        "--rearrange",
+        action="store_true",
+        help=(
+            "Run AGI R&D team (Research Lead -> Systems Architect -> Safety Reviewer) "
+            "with max_loops='auto' and selected_tools='all'."
+        ),
+    )
+    p.add_argument(
+        "--quick",
+        action="store_true",
+        help="Solo mode only: short integer max_loops and a tiny task (no max_loops='auto').",
+    )
+    p.add_argument(
+        "--shared",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    p.add_argument(
+        "--no-voice",
+        action="store_true",
+        help="Disable TTS (no voice-agents); rearrange mode only.",
+    )
+    p.add_argument(
+        "--viz",
+        action="store_true",
+        help="Enable LinearLatentDynamics trajectory recording and fitting after run.",
+    )
+    p.add_argument(
+        "--wm-throttle-seconds",
+        type=float,
+        default=None,
+        metavar="SEC",
+        help=(
+            "Pace agent LLM/tool steps (min seconds between calls). "
+            "Default: WM_THROTTLE_SECONDS or 0.5. Use 0 to disable."
+        ),
+    )
+    return p.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = _parse_args(sys.argv[1:])
+    wm_throttle_seconds = _resolve_wm_throttle_seconds(args.wm_throttle_seconds)
+    use_rearrange = args.rearrange or args.shared
+    if use_rearrange:
+        demo_rearrange_wm(
+            voice=not args.no_voice,
+            viz=args.viz,
+            wm_throttle_seconds=wm_throttle_seconds,
+        )
+    else:
+        main(
+            viz=args.viz,
+            quick=args.quick,
+            wm_throttle_seconds=wm_throttle_seconds,
+        )

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -128,6 +128,7 @@ from swarms.utils.output_types import OutputType
 from swarms.utils.swarms_marketplace_utils import (
     add_prompt_to_marketplace,
 )
+import swarms.utils.world_model as _wm
 from swarms.utils.workspace_utils import get_workspace_dir
 
 
@@ -281,6 +282,17 @@ class Agent:
             "create_sub_agent", "assign_task".
             Defaults to "all" (all tools enabled). Pass a list of tool names to restrict tools, or "all"
             for unrestricted access. Use this to control which tools the agent can use during autonomous execution.
+        wm (bool): When True, maintains an epistemic graph (NetworkX) updated after each reasoning loop via a
+            LiteLLM JSON extract. Edge labels are automatically normalized to conservative (Pearl-style) relations
+            so chat text is not stored as proven causation. Extracted nodes may be tagged semantic vs episodic;
+            each merge records the internal loop index and a fresh ``wm_episode`` id per :meth:`run` for tracing.
+            Not an RL/physics world model.
+        wm_extract_model (Optional[str]): Model name for the extract call; defaults to the agent's current model.
+        wm_max_chars (int): Max characters of task and assistant text sent to the extract model (privacy and cost).
+        on_wm_update (Optional[Callable]): Optional callback ``(world_model, digest, *, loop_count, task_excerpt)``.
+            Use for meta-orchestration; does not mutate prompts.
+        swarm_wm (Optional[_wm.SwarmWorldModel]): Optional shared graph; same delta is merged here when set so multiple
+            agents can contribute to one graph. Pass one instance explicitly to each agent that should share it.
 
     Methods:
         run: Run the agent
@@ -449,6 +461,11 @@ class Agent:
         skills_dir: Optional[str] = None,
         selected_tools: Optional[Union[str, List[str]]] = "all",
         max_subagent_depth: int = 3,
+        wm: bool = False,
+        wm_extract_model: Optional[str] = None,
+        wm_max_chars: int = 8000,
+        on_wm_update: Optional[Callable[..., None]] = None,
+        swarm_wm: Optional[_wm.SwarmWorldModel] = None,
         *args,
         **kwargs,
     ):
@@ -479,6 +496,14 @@ class Agent:
         self.system_prompt = system_prompt or ""
         self.agent_name = agent_name
         self.agent_description = agent_description
+        self.wm = wm
+        self.wm_extract_model = wm_extract_model
+        self.wm_max_chars = wm_max_chars
+        self.on_wm_update = on_wm_update
+        self.swarm_wm = swarm_wm
+        self.world_model_graph: Optional[_wm.AgentWorldModel] = (
+            _wm.AgentWorldModel(agent_name) if wm else None
+        )
         # self.saved_state_path = f"{self.agent_name}_{generate_api_key(prefix='agent-')}_state.json"
         self.saved_state_path = (
             f"{generate_api_key(prefix='agent-')}_state.json"
@@ -683,6 +708,109 @@ class Agent:
 
         if self.publish_to_marketplace is True:
             self.handle_publish_to_marketplace()
+
+    def _assistant_text_for_wm(self, response: Any) -> str:
+        """Serialize assistant output for world-model extract (bounded length)."""
+        if response is None:
+            return ""
+        if isinstance(response, str):
+            return _wm.truncate_text(response, self.wm_max_chars)
+        try:
+            return _wm.truncate_text(
+                json.dumps(response, default=str),
+                self.wm_max_chars,
+            )
+        except Exception:
+            return _wm.truncate_text(str(response), self.wm_max_chars)
+
+    def _first_user_message_excerpt_for_wm(self) -> str:
+        """First user-role message in short memory, truncated (for autonomous summary phase)."""
+        try:
+            for m in self.short_memory.messages:
+                if not isinstance(m, dict):
+                    continue
+                if m.get("role") != self.user_name:
+                    continue
+                c = m.get("content", "")
+                if isinstance(c, str) and c.strip():
+                    return _wm.truncate_text(c, self.wm_max_chars)
+        except Exception:
+            pass
+        return ""
+
+    def _update_world_model_if_enabled(
+        self,
+        task_excerpt: str,
+        assistant_reply: Any,
+        loop_count: Optional[int],
+    ) -> None:
+        """
+        Run LiteLLM extract and merge into per-agent and optional swarm graphs.
+        Never raises; logs warnings on failure.
+        """
+        if not self.wm or self.world_model_graph is None:
+            return
+        try:
+            t = _wm.truncate_text(
+                task_excerpt if isinstance(task_excerpt, str) else str(task_excerpt),
+                self.wm_max_chars,
+            )
+            r = self._assistant_text_for_wm(assistant_reply)
+            if not r.strip():
+                return
+            model = self.wm_extract_model or self.get_current_model()
+            lkw: Dict[str, Any] = {}
+            if self.llm_api_key:
+                lkw["api_key"] = self.llm_api_key
+            if self.llm_base_url:
+                lkw["base_url"] = self.llm_base_url
+            delta = _wm.extract_graph_delta(
+                task=t,
+                assistant_reply=r,
+                model=model,
+                **lkw,
+            )
+            tag = self.agent_name or "agent"
+            episode = getattr(self, "_wm_episode_id", None)
+            subtasks = getattr(self, "autonomous_subtasks", None)
+            st_list = subtasks if isinstance(subtasks, list) else []
+            st_delta = _wm.graph_delta_from_autonomous_subtasks(
+                agent_name=tag,
+                subtasks=st_list,
+                plan_task_label=t,
+                episode_id=str(episode) if episode is not None else None,
+            )
+            delta = _wm.merge_graph_deltas(delta, st_delta)
+            delta = _wm.sanitize_pearl_epistemics(delta)
+            self.world_model_graph.apply_delta(
+                delta,
+                source_tag=tag,
+                wm_loop=loop_count,
+                wm_episode=episode,
+            )
+            if self.swarm_wm is not None:
+                self.swarm_wm.apply_delta(
+                    delta,
+                    source_tag=tag,
+                    wm_loop=loop_count,
+                    wm_episode=episode,
+                )
+            digest = self.world_model_graph.digest_for_hook()
+            if self.verbose:
+                logger.debug("world_model digest: {}", digest)
+            if self.on_wm_update is not None:
+                self.on_wm_update(
+                    self.world_model_graph,
+                    digest,
+                    loop_count=loop_count,
+                    task_excerpt=t,
+                )
+        except Exception as e:
+            logger.warning(
+                "world_model update failed for agent '{}': {}",
+                self.agent_name,
+                e,
+            )
 
     def handle_publish_to_marketplace(self):
         # Join tags and capabilities into a single string
@@ -1868,6 +1996,14 @@ class Agent:
                                 loop_count=loop_count
                             )
 
+                        self._update_world_model_if_enabled(
+                            task_excerpt=task
+                            if isinstance(task, str)
+                            else str(task),
+                            assistant_reply=response,
+                            loop_count=loop_count,
+                        )
+
                     except (
                         BadRequestError,
                         InternalServerError,
@@ -3046,6 +3182,11 @@ class Agent:
                                 title="Task Completion Summary",
                             )
 
+                        self._update_world_model_if_enabled(
+                            task_excerpt=self._first_user_message_excerpt_for_wm(),
+                            assistant_reply=str(result),
+                            loop_count=None,
+                        )
                         return result
 
             # If complete_task wasn't called, generate summary manually
@@ -3079,6 +3220,11 @@ Subtask Breakdown:
                     title="Task Execution Summary",
                 )
 
+            self._update_world_model_if_enabled(
+                task_excerpt=self._first_user_message_excerpt_for_wm(),
+                assistant_reply=comprehensive_summary,
+                loop_count=None,
+            )
             return history_output_formatter(
                 self.short_memory, type=self.output_type
             )
@@ -4681,6 +4827,8 @@ Subtask Breakdown:
             # else: both are None, streaming_callback stays None
 
         try:
+            if self.wm and self.world_model_graph is not None:
+                self._wm_episode_id = uuid.uuid4().hex[:16]
             if self.max_loops == "auto":
                 # Use autonomous loop structure: plan -> execute subtasks -> summary
                 output = self._run_autonomous_loop(

--- a/swarms/utils/__init__.py
+++ b/swarms/utils/__init__.py
@@ -33,6 +33,11 @@ from swarms.utils.litellm_wrapper import (
 )
 from swarms.utils.output_types import HistoryOutputType
 from swarms.utils.parse_code import extract_code_from_markdown
+from swarms.utils.world_model import (
+    AgentWorldModel,
+    LinearLatentDynamics,
+    SwarmWorldModel,
+)
 
 __all__ = [
     "csv_to_text",
@@ -56,4 +61,7 @@ __all__ = [
     "LiteLLM",
     "NetworkConnectionError",
     "LiteLLMException",
+    "AgentWorldModel",
+    "LinearLatentDynamics",
+    "SwarmWorldModel",
 ]

--- a/swarms/utils/world_model.py
+++ b/swarms/utils/world_model.py
@@ -1,0 +1,801 @@
+"""
+Cognitive world model utilities for Swarms agents.
+
+This module provides a lightweight **epistemic graph** (NetworkX DiGraph) that
+summarizes task / assistant turns into nodes and edges. Edge labels follow a
+**conservative** reading aligned with observational vs causal distinction
+(Judea Pearl): we **never** store bare ``cause``/``effect`` as fact---those are
+automatically downgraded to *hypothesized* or *associational* relations unless
+stronger evidence exists (which plain chat does not provide). The graph is not
+a full structural causal model (SCM). Optionally, :class:`LinearLatentDynamics`
+fits **linear latent dynamics** from ``(observation, action, next_observation)``
+trajectories (fixed random linear encoder + least-squares transition), for
+lightweight rollouts in latent space only.
+
+Enable on an agent with ``Agent(..., wm=True)``. Optionally pass a shared
+:class:`SwarmWorldModel` as ``swarm_wm=`` so multiple agents merge into one graph.
+Use ``on_wm_update`` for hooks (e.g. meta-orchestration) without automatic
+prompt mutation.
+
+Extracted nodes carry a ``scope`` (``semantic`` vs ``episodic``) and each merge
+can record ``wm_loop`` plus a per-``run()`` ``wm_episode`` id on graph elements
+for longitudinal debugging and autonomous workflows.
+
+When an agent uses the autonomous loop, :func:`graph_delta_from_autonomous_subtasks`
+builds a deterministic :class:`GraphDelta` from ``autonomous_subtasks`` (plan
+steps) and merges it alongside LLM-extracted nodes on each world-model update.
+
+The package barrel :mod:`swarms.utils` re-exports ``AgentWorldModel``,
+``SwarmWorldModel``, and ``LinearLatentDynamics``; import other names from this
+module directly when needed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import uuid
+from typing import Any, Dict, List, Literal, Optional, Sequence, Union
+
+import litellm
+import networkx as nx
+import numpy as np
+from loguru import logger
+from pydantic import BaseModel, Field, field_validator
+
+# --- Pydantic schemas ---------------------------------------------------------
+
+
+class WMNode(BaseModel):
+    """A single concept or observation in the cognitive graph."""
+
+    id: str = Field(..., min_length=1, description="Stable id within this delta")
+    label: str = Field(..., min_length=1, description="Short human-readable text")
+    kind: str = Field(
+        default="fact",
+        description=(
+            "e.g. fact, hypothesis, action, outcome, observation (this-turn), unparsed"
+        ),
+    )
+    scope: Literal["semantic", "episodic"] = Field(
+        default="semantic",
+        description=(
+            "semantic=durable claim or definition; episodic=this-turn utterance or step"
+        ),
+    )
+
+    @field_validator("scope", mode="before")
+    @classmethod
+    def _coerce_scope(cls, v: Any) -> str:
+        if v is None or v == "":
+            return "semantic"
+        s = str(v).strip().lower()
+        if s in ("semantic", "episodic"):
+            return s
+        return "semantic"
+
+
+class WMEdge(BaseModel):
+    """Directed link between two node ids (relation is epistemically safe label)."""
+
+    src: str = Field(..., min_length=1)
+    dst: str = Field(..., min_length=1)
+    relation: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Pearl-style conservative tag: association, hypothesized_influence, "
+            "temporal_succession, evidence_supports, evidence_conflicts"
+        ),
+    )
+
+
+class GraphDelta(BaseModel):
+    """Structured graph update from one extract call."""
+
+    nodes: List[WMNode] = Field(default_factory=list)
+    edges: List[WMEdge] = Field(default_factory=list)
+
+    @field_validator("nodes", "edges", mode="before")
+    @classmethod
+    def _coerce_none(cls, v: Any) -> Any:
+        return v if v is not None else []
+
+
+# --- Trajectory: latent encoder + linear dynamics (numpy) --------------------
+
+
+_ArrayLike = Union[np.ndarray, Sequence[float]]
+
+
+class LinearLatentDynamics:
+    """
+    Trajectory model: fixed linear encoder ``z = P @ o`` and learned affine
+    dynamics ``z' ≈ [z, a, 1] @ Θ`` fitted by least squares on buffered tuples.
+
+    The encoder ``P`` is either a supplied matrix or a row-normalized random
+    Gaussian draw (Johnson–Lindenstrauss style). This is not a neural world
+    model; it is a small, dependency-light baseline for latent one-step prediction.
+    """
+
+    def __init__(
+        self,
+        obs_dim: int,
+        action_dim: int,
+        latent_dim: int,
+        *,
+        seed: int = 0,
+        max_buffer: int = 10_000,
+        projection: Optional[np.ndarray] = None,
+    ) -> None:
+        if obs_dim < 1 or action_dim < 1 or latent_dim < 1:
+            raise ValueError("obs_dim, action_dim, and latent_dim must be >= 1")
+        if max_buffer < 1:
+            raise ValueError("max_buffer must be >= 1")
+        self.obs_dim = obs_dim
+        self.action_dim = action_dim
+        self.latent_dim = latent_dim
+        self.max_buffer = max_buffer
+        self._lock = threading.Lock()
+        self._z: List[np.ndarray] = []
+        self._a: List[np.ndarray] = []
+        self._z_next: List[np.ndarray] = []
+        self._Theta: Optional[np.ndarray] = None
+
+        if projection is not None:
+            P = np.asarray(projection, dtype=np.float64)
+            if P.shape != (latent_dim, obs_dim):
+                raise ValueError(
+                    f"projection must have shape ({latent_dim}, {obs_dim}), got {P.shape}"
+                )
+            self._P = P
+        else:
+            rng = np.random.default_rng(seed)
+            P = rng.standard_normal((latent_dim, obs_dim))
+            row_norms = np.linalg.norm(P, axis=1, keepdims=True)
+            row_norms = np.maximum(row_norms, 1e-8)
+            self._P = (P / row_norms).astype(np.float64)
+
+    @property
+    def is_fitted(self) -> bool:
+        return self._Theta is not None
+
+    @property
+    def n_samples(self) -> int:
+        with self._lock:
+            return len(self._z)
+
+    def encode(self, observation: _ArrayLike) -> np.ndarray:
+        o = np.asarray(observation, dtype=np.float64).reshape(-1)
+        if o.shape[0] != self.obs_dim:
+            raise ValueError(
+                f"observation must have length {self.obs_dim}, got {o.shape[0]}"
+            )
+        return self._P @ o
+
+    def observe(
+        self,
+        observation: _ArrayLike,
+        action: _ArrayLike,
+        next_observation: _ArrayLike,
+    ) -> None:
+        z = self.encode(observation)
+        z_next = self.encode(next_observation)
+        a = np.asarray(action, dtype=np.float64).reshape(-1)
+        if a.shape[0] != self.action_dim:
+            raise ValueError(
+                f"action must have length {self.action_dim}, got {a.shape[0]}"
+            )
+        with self._lock:
+            if len(self._z) >= self.max_buffer:
+                self._z.pop(0)
+                self._a.pop(0)
+                self._z_next.pop(0)
+            self._z.append(z)
+            self._a.append(a)
+            self._z_next.append(z_next)
+
+    def fit(self) -> bool:
+        """
+        Fit Θ from buffered transitions. Returns False if there are too few samples.
+        """
+        with self._lock:
+            need = self.latent_dim + self.action_dim + 1
+            n = len(self._z)
+            if n < need:
+                logger.warning(
+                    "LinearLatentDynamics.fit: need at least {} samples, have {}",
+                    need,
+                    n,
+                )
+                return False
+            Z = np.stack(self._z, axis=0)
+            A = np.stack(self._a, axis=0)
+            Zn = np.stack(self._z_next, axis=0)
+            ones = np.ones((Z.shape[0], 1), dtype=np.float64)
+            X = np.hstack([Z, A, ones])
+            Theta, *_ = np.linalg.lstsq(X, Zn, rcond=None)
+            self._Theta = Theta
+        logger.debug(
+            "LinearLatentDynamics fit ok samples={} latent={} action={}",
+            n,
+            self.latent_dim,
+            self.action_dim,
+        )
+        return True
+
+    def predict_next_latent(
+        self,
+        latent: _ArrayLike,
+        action: _ArrayLike,
+    ) -> np.ndarray:
+        if self._Theta is None:
+            raise RuntimeError("LinearLatentDynamics: call fit() before predict_next_latent")
+        z = np.asarray(latent, dtype=np.float64).reshape(-1)
+        a = np.asarray(action, dtype=np.float64).reshape(-1)
+        if z.shape[0] != self.latent_dim:
+            raise ValueError(f"latent must have length {self.latent_dim}")
+        if a.shape[0] != self.action_dim:
+            raise ValueError(f"action must have length {self.action_dim}")
+        x = np.concatenate([z, a, np.ones(1, dtype=np.float64)])
+        return x @ self._Theta
+
+    def clear_buffer(self) -> None:
+        with self._lock:
+            self._z.clear()
+            self._a.clear()
+            self._z_next.clear()
+
+    def to_dict(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "obs_dim": self.obs_dim,
+                "action_dim": self.action_dim,
+                "latent_dim": self.latent_dim,
+                "max_buffer": self.max_buffer,
+                "P": self._P.tolist(),
+                "Theta": None if self._Theta is None else self._Theta.tolist(),
+                "n_samples": len(self._z),
+            }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LinearLatentDynamics":
+        P = np.asarray(data["P"], dtype=np.float64)
+        obs_dim = int(data["obs_dim"])
+        action_dim = int(data["action_dim"])
+        latent_dim = int(data["latent_dim"])
+        inst = cls(
+            obs_dim=obs_dim,
+            action_dim=action_dim,
+            latent_dim=latent_dim,
+            seed=0,
+            max_buffer=int(data.get("max_buffer", 10_000)),
+            projection=P,
+        )
+        if data.get("Theta") is not None:
+            inst._Theta = np.asarray(data["Theta"], dtype=np.float64)
+        return inst
+
+
+def _restore_trajectory_from_dict(holder: "_CognitiveGraphMixin", data: Dict[str, Any]) -> None:
+    raw = data.get("trajectory_dynamics")
+    if isinstance(raw, dict):
+        holder.trajectory_dynamics = LinearLatentDynamics.from_dict(raw)
+
+
+# --- Graph containers ---------------------------------------------------------
+
+
+class _CognitiveGraphMixin:
+    """Shared NetworkX-backed graph with thread-safe mutation."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._graph: nx.DiGraph = nx.DiGraph()
+        self._lock = threading.Lock()
+        self.trajectory_dynamics: Optional[LinearLatentDynamics] = None
+
+    def init_trajectory_dynamics(
+        self,
+        obs_dim: int,
+        action_dim: int,
+        latent_dim: int,
+        *,
+        seed: int = 0,
+        max_buffer: int = 10_000,
+        projection: Optional[np.ndarray] = None,
+    ) -> LinearLatentDynamics:
+        """
+        Attach a :class:`LinearLatentDynamics` model to this graph container.
+
+        Replaces any previous trajectory model on this instance.
+        """
+        self.trajectory_dynamics = LinearLatentDynamics(
+            obs_dim,
+            action_dim,
+            latent_dim,
+            seed=seed,
+            max_buffer=max_buffer,
+            projection=projection,
+        )
+        return self.trajectory_dynamics
+
+    def apply_delta(
+        self,
+        delta: GraphDelta,
+        source_tag: str,
+        *,
+        wm_loop: Optional[int] = None,
+        wm_episode: Optional[str] = None,
+    ) -> None:
+        """
+        Merge nodes and edges into the graph.
+
+        Args:
+            delta: Validated extract result.
+            source_tag: Provenance (e.g. agent name or run id).
+            wm_loop: Optional agent internal loop index for this merge.
+            wm_episode: Optional id grouping all merges from one ``Agent.run()`` call.
+        """
+        delta = sanitize_pearl_epistemics(delta)
+        merge_extras: Dict[str, Any] = {"source_tag": source_tag}
+        if wm_loop is not None:
+            merge_extras["wm_loop"] = wm_loop
+        if wm_episode is not None:
+            merge_extras["wm_episode"] = wm_episode
+        with self._lock:
+            for n in delta.nodes:
+                self._graph.add_node(
+                    n.id,
+                    label=n.label,
+                    kind=n.kind,
+                    scope=n.scope,
+                    **merge_extras,
+                )
+            for e in delta.edges:
+                if e.src not in self._graph:
+                    self._graph.add_node(
+                        e.src,
+                        label=e.src,
+                        kind="implicit",
+                        scope="episodic",
+                        **merge_extras,
+                    )
+                if e.dst not in self._graph:
+                    self._graph.add_node(
+                        e.dst,
+                        label=e.dst,
+                        kind="implicit",
+                        scope="episodic",
+                        **merge_extras,
+                    )
+                self._graph.add_edge(
+                    e.src,
+                    e.dst,
+                    relation=e.relation,
+                    **merge_extras,
+                )
+
+    def digest_for_hook(self) -> str:
+        """Compact summary for callbacks (no full text)."""
+        with self._lock:
+            nn = self._graph.number_of_nodes()
+            ne = self._graph.number_of_edges()
+            rel_counts: Dict[str, int] = {}
+            for _, _, data in self._graph.edges(data=True):
+                r = str(data.get("relation", "?"))
+                rel_counts[r] = rel_counts.get(r, 0) + 1
+            parts = [f"name={self.name}", f"nodes={nn}", f"edges={ne}"]
+            if rel_counts:
+                top = sorted(rel_counts.items(), key=lambda x: -x[1])[:6]
+                parts.append(
+                    "top_relations=" + ",".join(f"{k}:{v}" for k, v in top)
+                )
+            return "; ".join(parts)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize nodes and edges for optional persistence."""
+        with self._lock:
+            nodes_data = [
+                dict(node_id=n, **self._graph.nodes[n]) for n in self._graph.nodes()
+            ]
+            edges_data = [
+                {"src": u, "dst": v, **data}
+                for u, v, data in self._graph.edges(data=True)
+            ]
+            out: Dict[str, Any] = {
+                "name": self.name,
+                "nodes": nodes_data,
+                "edges": edges_data,
+            }
+            if self.trajectory_dynamics is not None:
+                out["trajectory_dynamics"] = self.trajectory_dynamics.to_dict()
+            return out
+
+
+def _populate_graph_from_dict(graph: nx.DiGraph, data: Dict[str, Any]) -> None:
+    graph.clear()
+    for n in data.get("nodes", []):
+        if not isinstance(n, dict) or "node_id" not in n:
+            continue
+        nid = n["node_id"]
+        attrs = {k: v for k, v in n.items() if k != "node_id"}
+        graph.add_node(nid, **attrs)
+    for e in data.get("edges", []):
+        if not isinstance(e, dict):
+            continue
+        u, v = e.get("src"), e.get("dst")
+        if u is None or v is None:
+            continue
+        rest = {k: v2 for k, v2 in e.items() if k not in ("src", "dst")}
+        graph.add_edge(u, v, **rest)
+
+
+class AgentWorldModel(_CognitiveGraphMixin):
+    """Per-agent cognitive graph."""
+
+    def __init__(self, agent_name: str) -> None:
+        super().__init__(name=agent_name)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> AgentWorldModel:
+        """Restore from :meth:`to_dict` output."""
+        inst = cls(agent_name=str(data.get("name", "restored")))
+        with inst._lock:
+            _populate_graph_from_dict(inst._graph, data)
+            _restore_trajectory_from_dict(inst, data)
+        return inst
+
+
+class SwarmWorldModel(_CognitiveGraphMixin):
+    """Optional shared graph for multiple agents."""
+
+    def __init__(self, name: str = "swarm") -> None:
+        super().__init__(name=name)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> SwarmWorldModel:
+        """Restore from :meth:`to_dict` output."""
+        inst = cls(name=str(data.get("name", "swarm")))
+        with inst._lock:
+            _populate_graph_from_dict(inst._graph, data)
+            _restore_trajectory_from_dict(inst, data)
+        return inst
+
+
+# --- Helpers ------------------------------------------------------------------
+
+
+def truncate_text(text: str, max_chars: int) -> str:
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3] + "..."
+
+
+def _wm_slug(s: str, max_len: int = 40) -> str:
+    """Stable ASCII-ish token for world-model node ids (avoids NetworkX quirks)."""
+    t = re.sub(r"[^\w\-]+", "_", str(s).strip(), flags=re.UNICODE)
+    t = re.sub(r"_+", "_", t).strip("_").lower()
+    if not t:
+        t = "x"
+    return t[:max_len]
+
+
+def graph_delta_from_autonomous_subtasks(
+    *,
+    agent_name: str,
+    subtasks: List[Dict[str, Any]],
+    plan_task_label: str = "",
+    episode_id: Optional[str] = None,
+) -> GraphDelta:
+    """
+    Build a :class:`GraphDelta` from the agent's ``autonomous_subtasks`` list.
+
+    Creates a ``kind="plan"`` root node, one ``kind="subtask"`` node per step,
+    edges from plan to each subtask (``association``), and dependency edges between
+    subtasks (``temporal_succession`` from prerequisite to dependent).
+
+    Idempotent merges: node ids are namespaced by agent slug and optional
+    ``episode_id`` (per ``Agent.run()``) so shared swarm graphs stay disjoint
+    across agents and runs.
+    """
+    if not subtasks:
+        return GraphDelta()
+    ag = _wm_slug(agent_name or "agent", 32)
+    ep = _wm_slug(episode_id, 24) if episode_id else "noep"
+    plan_id = f"wm_plan_{ag}_{ep}"
+
+    plan_label = (
+        truncate_text(plan_task_label.strip(), 120)
+        if plan_task_label and str(plan_task_label).strip()
+        else truncate_text(f"Plan — {agent_name or 'agent'}", 120)
+    )
+    nodes: List[WMNode] = [
+        WMNode(
+            id=plan_id,
+            label=plan_label,
+            kind="plan",
+            scope="episodic",
+        )
+    ]
+    edges: List[WMEdge] = []
+
+    step_to_nid: Dict[str, str] = {}
+    for st in subtasks:
+        if not isinstance(st, dict):
+            continue
+        sid = str(st.get("step_id", "")).strip()
+        if not sid:
+            continue
+        nid = f"wm_st_{ag}_{ep}_{_wm_slug(sid)}"
+        step_to_nid[sid] = nid
+        desc = str(st.get("description", ""))
+        status = str(st.get("status", "pending"))
+        label = truncate_text(f"[{status}] {desc}", 120)
+        nodes.append(
+            WMNode(
+                id=nid,
+                label=label,
+                kind="subtask",
+                scope="episodic",
+            )
+        )
+        edges.append(WMEdge(src=plan_id, dst=nid, relation="association"))
+
+    for st in subtasks:
+        if not isinstance(st, dict):
+            continue
+        sid = str(st.get("step_id", "")).strip()
+        dst = step_to_nid.get(sid)
+        if not dst:
+            continue
+        for dep in st.get("dependencies") or []:
+            dep_s = str(dep).strip()
+            src = step_to_nid.get(dep_s)
+            if src and src != dst:
+                edges.append(
+                    WMEdge(src=src, dst=dst, relation="temporal_succession")
+                )
+
+    return GraphDelta(nodes=nodes, edges=edges)
+
+
+def merge_graph_deltas(*parts: GraphDelta) -> GraphDelta:
+    """Concatenate graph deltas (later duplicates overwrite on :meth:`~_CognitiveGraphMixin.apply_delta`)."""
+    nodes: List[WMNode] = []
+    edges: List[WMEdge] = []
+    for d in parts:
+        nodes.extend(d.nodes)
+        edges.extend(d.edges)
+    return GraphDelta(nodes=nodes, edges=edges)
+
+
+def _strip_json_fence(content: str) -> str:
+    s = content.strip()
+    m = re.match(r"^```(?:json)?\s*([\s\S]*?)```\s*$", s, re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    return s
+
+
+# --- Pearl-style epistemic hygiene (automatic; no user config) ----------------
+# Closed vocabulary: text-only evidence cannot justify structural causal claims.
+
+_ALLOWED_RELATIONS: frozenset[str] = frozenset(
+    {
+        "association",
+        "hypothesized_influence",
+        "temporal_succession",
+        "evidence_supports",
+        "evidence_conflicts",
+    }
+)
+
+# Map LLM output (and legacy labels) -> allowed relation (lowercase keys).
+_RELATION_ALIASES: Dict[str, str] = {
+    # Causal overclaim -> hypothetical influence (Pearl: not identified from text)
+    "cause": "hypothesized_influence",
+    "causes": "hypothesized_influence",
+    "causal": "hypothesized_influence",
+    "causation": "hypothesized_influence",
+    "because": "hypothesized_influence",
+    "effect": "hypothesized_influence",
+    "effects": "hypothesized_influence",
+    "result": "hypothesized_influence",
+    "results": "hypothesized_influence",
+    "results_in": "hypothesized_influence",
+    "leads_to": "hypothesized_influence",
+    "leads to": "hypothesized_influence",
+    "reaction": "association",
+    "reacts": "association",
+    "response": "association",
+    # Pure order (Pearl ladder: association / time without causal ID)
+    "next": "temporal_succession",
+    "then": "temporal_succession",
+    "before": "temporal_succession",
+    "after": "temporal_succession",
+    "follows": "temporal_succession",
+    "precedes": "temporal_succession",
+    # Evidence about claims
+    "supports": "evidence_supports",
+    "support": "evidence_supports",
+    "contradicts": "evidence_conflicts",
+    "contradict": "evidence_conflicts",
+    "against": "evidence_conflicts",
+    # Associational
+    "correlates": "association",
+    "correlation": "association",
+    "associated": "association",
+    "cooccurs": "association",
+    "mentions": "association",
+    "describes": "association",
+    "related": "association",
+}
+
+
+def normalize_pearl_relation(relation: str) -> str:
+    """
+    Map any free-text relation to the closed, epistemically conservative set.
+
+    Callers normally use :func:`sanitize_pearl_epistemics`; this is public for tests.
+    """
+    key = relation.strip().lower().replace(" ", "_").replace("-", "_")
+    if not key:
+        return "association"
+    if key in _ALLOWED_RELATIONS:
+        return key
+    mapped = _RELATION_ALIASES.get(key)
+    if mapped is not None:
+        return mapped
+    # Substring fallbacks for compound junk from models
+    if "causal" in key or key.startswith("cause"):
+        return "hypothesized_influence"
+    if "effect" in key and key not in ("side_effect",):
+        return "hypothesized_influence"
+    if "next" in key or "temporal" in key or "sequence" in key:
+        return "temporal_succession"
+    if "support" in key:
+        return "evidence_supports"
+    if "contradict" in key or "conflict" in key:
+        return "evidence_conflicts"
+    return "association"
+
+
+def sanitize_pearl_epistemics(delta: GraphDelta) -> GraphDelta:
+    """
+    Rewrite edges so nothing looks like proven causation from chat text alone.
+
+    Runs automatically on every merge; users need not configure anything.
+    """
+    if not delta.edges:
+        return delta
+    new_edges: List[WMEdge] = []
+    for e in delta.edges:
+        rel = normalize_pearl_relation(e.relation)
+        new_edges.append(WMEdge(src=e.src, dst=e.dst, relation=rel))
+    return GraphDelta(nodes=delta.nodes, edges=new_edges)
+
+
+def _fallback_delta(reason: str) -> GraphDelta:
+    uid = str(uuid.uuid4())
+    return GraphDelta(
+        nodes=[
+            WMNode(
+                id=uid,
+                label=truncate_text(reason, 200),
+                kind="unparsed",
+                scope="episodic",
+            )
+        ],
+        edges=[],
+    )
+
+
+_EXTRACT_SYSTEM = """You output ONLY valid JSON (no markdown). Schema:
+{"nodes":[{"id":"string","label":"string","kind":"string","scope":"semantic|episodic"}],
+ "edges":[{"src":"id","dst":"id","relation":"string"}]}
+
+Node discipline:
+- id: stable snake_case identifier; reuse the same id when the same entity appears again.
+- kind: fact | hypothesis | action | outcome | observation | unparsed
+  Use observation for something stated only in this turn; use fact/hypothesis for claims meant to persist.
+- scope: semantic (durable beyond this turn) or episodic (this-turn utterance, step, or local detail).
+
+Relations MUST be exactly one of these (Pearl-style: text cannot prove causation):
+- association: co-occurrence or correlation, no directional claim
+- hypothesized_influence: guessed direction of influence (NOT verified intervention)
+- temporal_succession: A before B in time or narrative order only
+- evidence_supports: one statement supports another as evidence
+- evidence_conflicts: statements conflict
+
+Never use the words cause, causal, or effect as relation values.
+Hard limits: at most 20 nodes and 40 edges; labels at most 120 characters."""
+
+
+def extract_graph_delta(
+    *,
+    task: str,
+    assistant_reply: str,
+    model: str,
+    max_tokens: int = 1200,
+    temperature: float = 0.2,
+    **litellm_kwargs: Any,
+) -> GraphDelta:
+    """
+    Call LiteLLM once to parse task + reply into a :class:`GraphDelta`.
+
+    On parse or API failure, returns a single ``unparsed`` node (never raises).
+
+    Args:
+        task: User task (truncated by caller if needed).
+        assistant_reply: Assistant output text.
+        model: LiteLLM model name.
+        max_tokens: Cap for extract completion.
+        temperature: Low temperature recommended.
+        **litellm_kwargs: Passed to ``litellm.completion`` (e.g. api_key, base_url).
+
+    Returns:
+        Validated :class:`GraphDelta`.
+    """
+    user_msg = (
+        "Extract a small epistemic graph (associations, time order, hypotheses only) "
+        "from this turn. Do not assert true causal mechanisms.\n\n"
+        f"TASK:\n{task}\n\nASSISTANT:\n{assistant_reply}\n"
+    )
+    try:
+        resp = litellm.completion(
+            model=model,
+            messages=[
+                {"role": "system", "content": _EXTRACT_SYSTEM},
+                {"role": "user", "content": user_msg},
+            ],
+            max_tokens=max_tokens,
+            temperature=temperature,
+            **litellm_kwargs,
+        )
+        choice = resp.choices[0].message
+        raw = getattr(choice, "content", None) or ""
+        if not isinstance(raw, str):
+            raw = str(raw)
+        raw = _strip_json_fence(raw)
+        payload = json.loads(raw)
+        delta = GraphDelta.model_validate(payload)
+        delta = sanitize_pearl_epistemics(delta)
+        logger.debug(
+            "world_model extract ok model={} nodes={} edges={}",
+            model,
+            len(delta.nodes),
+            len(delta.edges),
+        )
+        return delta
+    except json.JSONDecodeError as e:
+        logger.warning(
+            "world_model JSON decode failed: {} (model={})",
+            e,
+            model,
+        )
+        return _fallback_delta("json_decode_error")
+    except Exception as e:
+        logger.warning(
+            "world_model extract failed: {} (model={})",
+            e,
+            model,
+        )
+        return _fallback_delta(f"extract_error: {type(e).__name__}")
+
+
+def attach_shared_swarm_wm(
+    agents: Sequence[Any],
+    shared: SwarmWorldModel,
+) -> None:
+    """
+    Set ``swarm_wm`` on agents that have ``wm=True`` and no swarm graph yet.
+
+    Args:
+        agents: Iterable of objects (typically :class:`swarms.structs.agent.Agent`).
+        shared: Shared :class:`SwarmWorldModel` instance.
+    """
+    for a in agents:
+        if getattr(a, "wm", False) and getattr(a, "swarm_wm", None) is None:
+            a.swarm_wm = shared

--- a/tests/utils/test_world_model.py
+++ b/tests/utils/test_world_model.py
@@ -1,0 +1,327 @@
+"""Tests for swarms.utils.world_model."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from swarms.utils.world_model import (
+    AgentWorldModel,
+    GraphDelta,
+    LinearLatentDynamics,
+    SwarmWorldModel,
+    WMEdge,
+    WMNode,
+    attach_shared_swarm_wm,
+    extract_graph_delta,
+    graph_delta_from_autonomous_subtasks,
+    merge_graph_deltas,
+    normalize_pearl_relation,
+    sanitize_pearl_epistemics,
+    truncate_text,
+)
+
+
+def test_truncate_text() -> None:
+    assert truncate_text("abc", 10) == "abc"
+    assert truncate_text("abcdefghij", 5) == "ab..."
+
+
+def test_graph_delta_from_autonomous_subtasks_empty() -> None:
+    d = graph_delta_from_autonomous_subtasks(
+        agent_name="A",
+        subtasks=[],
+        episode_id="e1",
+    )
+    assert d.nodes == []
+    assert d.edges == []
+
+
+def test_graph_delta_from_autonomous_subtasks_plan_and_deps() -> None:
+    d = graph_delta_from_autonomous_subtasks(
+        agent_name="Research Lead",
+        subtasks=[
+            {
+                "step_id": "s1",
+                "description": "First",
+                "status": "pending",
+                "dependencies": [],
+            },
+            {
+                "step_id": "s2",
+                "description": "Second",
+                "status": "completed",
+                "dependencies": ["s1"],
+            },
+        ],
+        plan_task_label="Build AGI",
+        episode_id="abc123",
+    )
+    kinds = {n.id: n.kind for n in d.nodes}
+    plan_ids = [nid for nid, k in kinds.items() if k == "plan"]
+    assert len(plan_ids) == 1
+    st_nodes = [n for n in d.nodes if n.kind == "subtask"]
+    assert len(st_nodes) == 2
+    assert any("[completed]" in n.label for n in st_nodes)
+    rels = {(e.src, e.dst, e.relation) for e in d.edges}
+    s1 = next(n.id for n in d.nodes if n.kind == "subtask" and "First" in n.label)
+    s2 = next(n.id for n in d.nodes if n.kind == "subtask" and "Second" in n.label)
+    assert (s1, s2, "temporal_succession") in rels
+
+
+def test_merge_graph_deltas_concat() -> None:
+    a = GraphDelta(
+        nodes=[WMNode(id="x", label="X", kind="fact")],
+        edges=[],
+    )
+    b = graph_delta_from_autonomous_subtasks(
+        agent_name="a",
+        subtasks=[
+            {"step_id": "only", "description": "d", "status": "pending", "dependencies": []}
+        ],
+        episode_id="z",
+    )
+    m = merge_graph_deltas(a, b)
+    assert len(m.nodes) == 1 + len(b.nodes)
+    assert len(m.edges) == len(b.edges)
+
+
+def test_graph_delta_validation() -> None:
+    d = GraphDelta(
+        nodes=[WMNode(id="a", label="A", kind="fact")],
+        edges=[WMEdge(src="a", dst="b", relation="next")],
+    )
+    assert len(d.nodes) == 1
+    assert d.nodes[0].scope == "semantic"
+    assert d.edges[0].relation == "next"
+
+
+def test_wm_node_scope_coercion() -> None:
+    n = WMNode.model_validate(
+        {
+            "id": "x",
+            "label": "L",
+            "kind": "observation",
+            "scope": "EPISODIC",
+        }
+    )
+    assert n.scope == "episodic"
+    n2 = WMNode.model_validate(
+        {"id": "y", "label": "M", "kind": "fact", "scope": "bogus"}
+    )
+    assert n2.scope == "semantic"
+
+
+def test_apply_delta_and_digest() -> None:
+    g = AgentWorldModel("test-agent")
+    delta = GraphDelta(
+        nodes=[
+            WMNode(id="n1", label="User asked X", kind="fact"),
+            WMNode(id="n2", label="Answer Y", kind="outcome"),
+        ],
+        edges=[WMEdge(src="n1", dst="n2", relation="effect")],
+    )
+    g.apply_delta(
+        delta,
+        source_tag="t1",
+        wm_loop=2,
+        wm_episode="ep99",
+    )
+    d = g.digest_for_hook()
+    assert "nodes=2" in d
+    assert "edges=1" in d
+    # Pearl hygiene: "effect" overclaim -> hypothesized_influence
+    assert "hypothesized_influence" in d
+    assert "effect" not in d.split("top_relations=")[-1]
+    raw = g.to_dict()
+    n1 = next(x for x in raw["nodes"] if x["node_id"] == "n1")
+    assert n1["wm_loop"] == 2
+    assert n1["wm_episode"] == "ep99"
+    assert n1["scope"] == "semantic"
+
+
+def test_pearl_normalization() -> None:
+    assert normalize_pearl_relation("cause") == "hypothesized_influence"
+    assert normalize_pearl_relation("next") == "temporal_succession"
+    assert normalize_pearl_relation("supports") == "evidence_supports"
+    assert normalize_pearl_relation("unknown_xyz") == "association"
+
+
+def test_sanitize_pearl_epistemics_idempotent() -> None:
+    d = GraphDelta(
+        nodes=[WMNode(id="a", label="A", kind="fact")],
+        edges=[WMEdge(src="a", dst="b", relation="hypothesized_influence")],
+    )
+    d2 = sanitize_pearl_epistemics(d)
+    assert d2.edges[0].relation == "hypothesized_influence"
+
+
+def test_to_dict_from_dict_roundtrip() -> None:
+    g = AgentWorldModel("a1")
+    g.apply_delta(
+        GraphDelta(
+            nodes=[WMNode(id="x", label="lx", kind="fact")],
+            edges=[],
+        ),
+        "run",
+    )
+    data = g.to_dict()
+    g2 = AgentWorldModel.from_dict(data)
+    assert g2.digest_for_hook() == g.digest_for_hook()
+
+
+def test_linear_latent_dynamics_lstsq_recovery() -> None:
+    rng = np.random.default_rng(42)
+    latent_dim, action_dim = 3, 2
+    n = 80
+    Theta_true = rng.standard_normal((latent_dim + action_dim + 1, latent_dim))
+    Z = rng.standard_normal((n, latent_dim))
+    A = rng.standard_normal((n, action_dim))
+    ones = np.ones((n, 1))
+    X = np.hstack([Z, A, ones])
+    Zn = X @ Theta_true
+
+    eye = np.eye(latent_dim)
+    dyn = LinearLatentDynamics(
+        obs_dim=latent_dim,
+        action_dim=action_dim,
+        latent_dim=latent_dim,
+        projection=eye,
+    )
+    for i in range(n):
+        dyn.observe(Z[i], A[i], Zn[i])
+    assert dyn.fit() is True
+    assert dyn.is_fitted
+    assert dyn._Theta is not None
+    err = np.linalg.norm(dyn._Theta - Theta_true)
+    assert err < 1e-9
+
+
+def test_linear_latent_dynamics_predict_and_dict_roundtrip() -> None:
+    latent_dim, action_dim = 2, 1
+    dyn = LinearLatentDynamics(
+        obs_dim=latent_dim,
+        action_dim=action_dim,
+        latent_dim=latent_dim,
+        projection=np.eye(latent_dim),
+    )
+    for t in range(20):
+        o = np.array([float(t), float(t + 1)])
+        a = np.array([0.5])
+        o2 = o + 0.1 * a[0]
+        dyn.observe(o, a, o2)
+    assert dyn.fit() is True
+    z = dyn.encode(np.array([0.0, 1.0]))
+    z_hat = dyn.predict_next_latent(z, np.array([0.5]))
+    assert z_hat.shape == (latent_dim,)
+
+    dyn2 = LinearLatentDynamics.from_dict(dyn.to_dict())
+    assert dyn2.is_fitted
+    assert np.allclose(
+        dyn.predict_next_latent(z, np.array([0.5])),
+        dyn2.predict_next_latent(z, np.array([0.5])),
+    )
+
+
+def test_agent_world_model_trajectory_in_to_dict() -> None:
+    g = AgentWorldModel("wm")
+    g.init_trajectory_dynamics(2, 1, 2, projection=np.eye(2))
+    assert g.trajectory_dynamics is not None
+    td = g.trajectory_dynamics
+    for i in range(6):
+        td.observe([float(i), float(i + 1)], [0.25], [float(i) + 0.1, float(i + 1) + 0.1])
+    assert td.fit() is True
+    raw = g.to_dict()
+    assert "trajectory_dynamics" in raw
+    g2 = AgentWorldModel.from_dict(raw)
+    assert g2.trajectory_dynamics is not None
+    assert g2.trajectory_dynamics.is_fitted
+
+
+def test_swarm_world_model_from_dict() -> None:
+    g = SwarmWorldModel("sw")
+    g.apply_delta(
+        GraphDelta(
+            nodes=[WMNode(id="s", label="shared", kind="fact")],
+            edges=[],
+        ),
+        "a",
+    )
+    g2 = SwarmWorldModel.from_dict(g.to_dict())
+    assert "nodes=1" in g2.digest_for_hook()
+
+
+def test_extract_graph_delta_mocked() -> None:
+    payload = {
+        "nodes": [{"id": "a", "label": "task", "kind": "fact"}],
+        "edges": [],
+    }
+    mock_resp = MagicMock()
+    mock_resp.choices = [
+        MagicMock(message=MagicMock(content=json.dumps(payload)))
+    ]
+    with patch("swarms.utils.world_model.litellm.completion", return_value=mock_resp):
+        delta = extract_graph_delta(
+            task="hello",
+            assistant_reply="world",
+            model="gpt-4.1",
+        )
+    assert len(delta.nodes) == 1
+    assert delta.nodes[0].id == "a"
+
+
+def test_extract_graph_delta_invalid_json_fallback() -> None:
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock(message=MagicMock(content="not json"))]
+    with patch("swarms.utils.world_model.litellm.completion", return_value=mock_resp):
+        delta = extract_graph_delta(
+            task="t",
+            assistant_reply="r",
+            model="gpt-4.1",
+        )
+    assert len(delta.nodes) == 1
+    assert delta.nodes[0].kind == "unparsed"
+    assert delta.nodes[0].scope == "episodic"
+
+
+def test_extract_graph_delta_scope_in_payload() -> None:
+    payload = {
+        "nodes": [
+            {
+                "id": "u_task",
+                "label": "User asked",
+                "kind": "observation",
+                "scope": "episodic",
+            }
+        ],
+        "edges": [],
+    }
+    mock_resp = MagicMock()
+    mock_resp.choices = [
+        MagicMock(message=MagicMock(content=json.dumps(payload)))
+    ]
+    with patch("swarms.utils.world_model.litellm.completion", return_value=mock_resp):
+        delta = extract_graph_delta(
+            task="hello",
+            assistant_reply="world",
+            model="gpt-4.1",
+        )
+    assert delta.nodes[0].scope == "episodic"
+    assert delta.nodes[0].kind == "observation"
+
+
+class _FakeAgent:
+    def __init__(self, wm: bool = True, swarm_wm=None) -> None:
+        self.wm = wm
+        self.swarm_wm = swarm_wm
+
+
+def test_attach_shared_swarm_wm() -> None:
+    shared = SwarmWorldModel("team")
+    a1 = _FakeAgent(wm=True, swarm_wm=None)
+    a2 = _FakeAgent(wm=True, swarm_wm=None)
+    a3 = _FakeAgent(wm=False, swarm_wm=None)
+    attach_shared_swarm_wm([a1, a2, a3], shared)
+    assert a1.swarm_wm is shared
+    assert a2.swarm_wm is shared
+    assert a3.swarm_wm is None


### PR DESCRIPTION
## Description

This PR adds a cognitive world model: an epistemic graph (NetworkX) updated from task and assistant text via a LiteLLM JSON extract, optional shared swarm graph for multi-agent runs, Pearl-style relation sanitization, optional linear latent trajectory dynamics, `Agent` integration (`wm=True`), tests, and a runnable example script.

**Summary**

- `swarms/utils/world_model.py`: schemas (`WMNode`, `WMEdge`, `GraphDelta`), `AgentWorldModel` / `SwarmWorldModel`, `LinearLatentDynamics`, `extract_graph_delta`, `graph_delta_from_autonomous_subtasks`, `sanitize_pearl_epistemics`, `attach_shared_swarm_wm`, and related helpers.
- `swarms/structs/agent.py`: `wm`, `wm_extract_model`, `wm_max_chars`, `on_wm_update`, `swarm_wm`, `world_model_graph`, `_update_world_model_if_enabled`, and hooks after loop steps and autonomous summary paths.
- `swarms/utils/__init__.py`: re-exports `AgentWorldModel`, `LinearLatentDynamics`, `SwarmWorldModel`.
- `tests/utils/test_world_model.py`: unit tests with mocks where needed (no live network for core cases).
- `examples/utils/world_model/wm.py`: argparse demo (solo and rearrange team).

**Theory**

Each turn is treated as evidence, not as ground truth for causal laws. Nodes are concepts or observations; edges use conservative relation labels (association, temporal_succession, hypothesized_influence, evidence_supports, evidence_conflicts, and so on). `sanitize_pearl_epistemics` downgrades unsafe causal wording so chat-derived graphs do not claim proven causation. The graph is a lightweight epistemic summary, not a full structural causal model.

**Practice**

When `wm` is enabled, the agent truncates task and assistant text, calls `extract_graph_delta`, merges a deterministic delta from `autonomous_subtasks` when present, sanitizes relations, applies the merged delta to `AgentWorldModel` and optionally `SwarmWorldModel`, computes a digest, and calls `on_wm_update(world_model_graph, digest, loop_count=..., task_excerpt=...)` if set. At the start of `run()`, a per-run `_wm_episode_id` is set so episodic nodes can be traced across loops inside one run.

**Flow**

```mermaid
flowchart TD
  A[User task] --> B[Agent.run]
  B --> C{wm True?}
  C -->|no| Z[Normal agent path]
  C -->|yes| D[Set _wm_episode_id]
  D --> E[Reasoning loop or autonomous loop]
  E --> F[Assistant response for step]
  F --> G[_update_world_model_if_enabled]
  G --> H[extract_graph_delta via LiteLLM]
  G --> I[graph_delta_from_autonomous_subtasks]
  H --> J[merge_graph_deltas]
  I --> J
  J --> K[sanitize_pearl_epistemics]
  K --> L[AgentWorldModel.apply_delta]
  K --> M[SwarmWorldModel.apply_delta optional]
  L --> N[on_wm_update callback optional]
  M --> N
```

**Code references**

Package re-exports (`swarms/utils/__init__.py`):

```36:40:swarms/utils/__init__.py
from swarms.utils.world_model import (
    AgentWorldModel,
    LinearLatentDynamics,
    SwarmWorldModel,
)
```

Agent flags and graph handles (`swarms/structs/agent.py`):

```499:506:swarms/structs/agent.py
        self.wm = wm
        self.wm_extract_model = wm_extract_model
        self.wm_max_chars = wm_max_chars
        self.on_wm_update = on_wm_update
        self.swarm_wm = swarm_wm
        self.world_model_graph: Optional[_wm.AgentWorldModel] = (
            _wm.AgentWorldModel(agent_name) if wm else None
        )
```

Per-run episode id (`swarms/structs/agent.py`):

```4829:4832:swarms/structs/agent.py
        try:
            if self.wm and self.world_model_graph is not None:
                self._wm_episode_id = uuid.uuid4().hex[:16]
            if self.max_loops == "auto":
```

Core merge and callback path (`swarms/structs/agent.py`):

```767:807:swarms/structs/agent.py
            delta = _wm.extract_graph_delta(
                task=t,
                assistant_reply=r,
                model=model,
                **lkw,
            )
            tag = self.agent_name or "agent"
            episode = getattr(self, "_wm_episode_id", None)
            subtasks = getattr(self, "autonomous_subtasks", None)
            st_list = subtasks if isinstance(subtasks, list) else []
            st_delta = _wm.graph_delta_from_autonomous_subtasks(
                agent_name=tag,
                subtasks=st_list,
                plan_task_label=t,
                episode_id=str(episode) if episode is not None else None,
            )
            delta = _wm.merge_graph_deltas(delta, st_delta)
            delta = _wm.sanitize_pearl_epistemics(delta)
            self.world_model_graph.apply_delta(
                delta,
                source_tag=tag,
                wm_loop=loop_count,
                wm_episode=episode,
            )
            if self.swarm_wm is not None:
                self.swarm_wm.apply_delta(
                    delta,
                    source_tag=tag,
                    wm_loop=loop_count,
                    wm_episode=episode,
                )
            digest = self.world_model_graph.digest_for_hook()
            if self.verbose:
                logger.debug("world_model digest: {}", digest)
            if self.on_wm_update is not None:
                self.on_wm_update(
                    self.world_model_graph,
                    digest,
                    loop_count=loop_count,
                    task_excerpt=t,
                )
```

Shared swarm attachment (`swarms/utils/world_model.py`):

```788:801:swarms/utils/world_model.py
def attach_shared_swarm_wm(
    agents: Sequence[Any],
    shared: SwarmWorldModel,
) -> None:
    """
    Set ``swarm_wm`` on agents that have ``wm=True`` and no swarm graph yet.

    Args:
        agents: Iterable of objects (typically :class:`swarms.structs.agent.Agent`).
        shared: Shared :class:`SwarmWorldModel` instance.
    """
    for a in agents:
        if getattr(a, "wm", False) and getattr(a, "swarm_wm", None) is None:
            a.swarm_wm = shared
```

**Usage example**

```python
agent = Agent(
    agent_name="AGI-Lab-Solo",
    model_name=gpt-4.1,
    max_loops="auto",
    selected_tools="all",
    interactive=False,
    system_prompt="You are a research assistant. Use tools.",
    wm=True,
    wm_max_chars=4000,
    on_wm_update=lambda wm, digest, **kw: print(kw.get("loop_count"), digest[:16]),
    print_on=True,
    verbose=True,
)
agent.run("Your task here")
d = agent.world_model_graph.to_dict() if agent.world_model_graph else {}
print(len(d.get("nodes", [])), "nodes")
```

Commands (requires API keys such as `OPENAI_API_KEY`):

- `python examples/utils/world_model/wm.py --quick` *For a single agent run*
- `python examples/utils/world_model/wm.py --rearrange` *For a swarm run*

**Tests**

`tests/utils/test_world_model.py` covers truncation, subtask deltas, merge and sanitize behavior, `attach_shared_swarm_wm`, and mocked `extract_graph_delta` paths without live network calls for those cases.

Video:  

https://github.com/user-attachments/assets/b0a75a08-d2e5-4392-8e2a-82e26b0bbde7



As seen in the video, each agent in a swarm share a single worldModel; however each agent possesses an individual worldModel aswell.

## Issue

None (no linked issue).

## Dependencies

Runtime builds on the existing Swarms stack. The world model uses NetworkX (`networkx`), NumPy (`numpy`), Pydantic (`pydantic`), LiteLLM (`litellm`), and Loguru (`loguru`) for graph storage, validation, extraction, and logging. Ensure `networkx` (and other deps) match your project pins.

## Tag maintainer

@kyegomez 

## Twitter handle

@Euroswarms

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1525.org.readthedocs.build/en/1525/

<!-- readthedocs-preview swarms end -->