### PR TITLE
feat: AdvisorSwarm - Implement Advisor Strategy Pattern

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -282,6 +282,7 @@ nav:
           
 
 
+        - AdvisorSwarm: "swarms/structs/advisor_swarm.md"
         - PlannerGeneratorEvaluator: "swarms/structs/planner_generator_evaluator.md"
         - DebateWithJudge: "swarms/structs/debate_with_judge.md"
         - MajorityVoting: "swarms/structs/majorityvoting.md"

--- a/docs/swarms/structs/advisor_swarm.md
+++ b/docs/swarms/structs/advisor_swarm.md
@@ -162,23 +162,6 @@ swarm = AdvisorSwarm(
 result = swarm.run("Create a Python module for string manipulation utilities")
 ```
 
-### Using with SwarmRouter
-
-```python
-from swarms import Agent, SwarmRouter
-
-router = SwarmRouter(
-    name="Advisor Router",
-    agents=[],
-    swarm_type="AdvisorSwarm",
-    advisor_swarm_executor_model_name="claude-sonnet-4-6",
-    advisor_swarm_advisor_model_name="claude-opus-4-6",
-    advisor_swarm_max_advisor_uses=2,
-)
-
-result = router.run("Explain the CAP theorem in distributed systems")
-```
-
 ### Batched Tasks
 
 ```python

--- a/docs/swarms/structs/advisor_swarm.md
+++ b/docs/swarms/structs/advisor_swarm.md
@@ -1,0 +1,249 @@
+# `AdvisorSwarm`
+
+The `AdvisorSwarm` implements the [advisor strategy](https://claude.com/blog/the-advisor-strategy) described in Anthropic's research (April 2026). It pairs a cheaper **executor** model that drives the task end-to-end with a powerful **advisor** model that is consulted only at key decision points.
+
+The advisor never calls tools or produces user-facing output — it only provides strategic guidance to the executor.
+
+This is provider-agnostic: any model supported by LiteLLM works for either role.
+
+```mermaid
+graph TD
+    A[User Task] --> B[Advisor: Strategic Plan]
+    B --> C[Executor: Produce Output]
+    C --> D{Advisor Budget Left?}
+    D -->|Yes| E[Advisor: Review Output]
+    E --> F{Satisfactory?}
+    F -->|Yes| G[Return Result]
+    F -->|No| H[Executor: Refine Output]
+    H --> D
+    D -->|No| G
+```
+
+The swarm follows this workflow:
+
+1. **Advisor plans**: Receives the task, produces a concise numbered strategic plan
+2. **Executor executes**: Works on the task using the advisor's guidance
+3. **Advisor reviews**: Evaluates the executor's output — returns `VERDICT: SATISFACTORY` or `VERDICT: NEEDS_REVISION`
+4. **Executor refines**: If revision needed, addresses each point from the advisor's feedback
+5. **Repeat 3-4** until the advisor says satisfactory or the advisor call budget is exhausted
+
+
+## Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **Advisor-Executor Separation** | Advisor provides strategy; executor does the work |
+| **Iterative Refinement** | Advisor reviews and executor refines until satisfactory |
+| **Budget Control** | `max_advisor_uses` caps advisor calls per run |
+| **Provider-Agnostic** | Any LiteLLM-supported model works for either role |
+| **Custom Agents** | Pass pre-configured agents with tools, MCP, or any Agent settings |
+| **Multi-Loop** | Optional outer loops for deeper iterative analysis |
+
+
+## Constructor
+
+### `AdvisorSwarm.__init__()`
+
+| Parameter | Type | Default | Required | Description |
+|-----------|------|---------|----------|-------------|
+| `name` | `str` | `"AdvisorSwarm"` | No | Human-readable name |
+| `description` | `str` | `"An executor-advisor swarm..."` | No | Description of the swarm's purpose |
+| `executor_model_name` | `str` | `"claude-sonnet-4-6"` | No | Model for the executor agent |
+| `advisor_model_name` | `str` | `"claude-opus-4-6"` | No | Model for the advisor agent |
+| `executor_system_prompt` | `str` | Built-in | No | System prompt for the executor |
+| `advisor_system_prompt` | `str` | Built-in | No | System prompt for the advisor |
+| `max_advisor_uses` | `int` | `3` | No | Max advisor calls per `run()`. Budget: 1 plan + up to N-1 reviews |
+| `max_loops` | `int` | `1` | No | Outer iteration count (each loop is a full plan-execute-review cycle) |
+| `output_type` | `OutputType` | `"dict-all-except-first"` | No | Format for output (dict, str, list, final, json, yaml) |
+| `verbose` | `bool` | `False` | No | Enable detailed logging |
+| `executor_agent` | `Agent` | `None` | No | Pre-configured Agent for execution (e.g., with tools or MCP) |
+| `advisor_agent` | `Agent` | `None` | No | Pre-configured Agent for advising |
+| `tools` | `List[Callable]` | `None` | No | Tools available to the executor agent only |
+
+#### Raises
+
+| Exception | Condition |
+|-----------|-----------|
+| `ValueError` | If `max_advisor_uses < 1`, `max_loops < 1`, or model names are empty |
+
+---
+
+## Core Methods
+
+### `run()`
+
+Execute the advisor-executor orchestration flow.
+
+| Parameter | Type | Default | Required | Description |
+|-----------|------|---------|----------|-------------|
+| `task` | `str` | — | **Yes** | The task to accomplish |
+| `img` | `str` | `None` | No | Optional single image input |
+| `imgs` | `List[str]` | `None` | No | Optional list of image inputs |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Any` | Formatted conversation history according to `output_type` |
+
+---
+
+### `batched_run()`
+
+Run the swarm on multiple tasks sequentially.
+
+| Parameter | Type | Default | Required | Description |
+|-----------|------|---------|----------|-------------|
+| `tasks` | `List[str]` | — | **Yes** | List of task strings |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `List[Any]` | List of results, one per task |
+
+---
+
+## Usage Examples
+
+### Basic Usage
+
+```python
+from swarms import AdvisorSwarm
+
+swarm = AdvisorSwarm(
+    executor_model_name="claude-sonnet-4-6",
+    advisor_model_name="claude-opus-4-6",
+    max_advisor_uses=3,
+    verbose=True,
+)
+
+result = swarm.run(
+    "Write a Python function that implements binary search on a sorted list. "
+    "Include proper error handling, type hints, and edge cases."
+)
+
+print(result)
+```
+
+### Custom Executor with Tools
+
+Pass a pre-configured executor agent with tools while keeping the advisor tool-free:
+
+```python
+from swarms import Agent, AdvisorSwarm
+
+
+def write_file(filename: str, content: str) -> str:
+    """Write content to a file."""
+    with open(filename, "w") as f:
+        f.write(content)
+    return f"Written: {filename}"
+
+
+def read_file(filename: str) -> str:
+    """Read content from a file."""
+    with open(filename, "r") as f:
+        return f.read()
+
+
+executor = Agent(
+    agent_name="Executor",
+    model_name="claude-sonnet-4-6",
+    max_loops=1,
+    tools=[write_file, read_file],
+)
+
+swarm = AdvisorSwarm(
+    executor_agent=executor,
+    advisor_model_name="claude-opus-4-6",
+)
+
+result = swarm.run("Create a Python module for string manipulation utilities")
+```
+
+### Using with SwarmRouter
+
+```python
+from swarms import Agent, SwarmRouter
+
+router = SwarmRouter(
+    name="Advisor Router",
+    agents=[],
+    swarm_type="AdvisorSwarm",
+    advisor_swarm_executor_model_name="claude-sonnet-4-6",
+    advisor_swarm_advisor_model_name="claude-opus-4-6",
+    advisor_swarm_max_advisor_uses=2,
+)
+
+result = router.run("Explain the CAP theorem in distributed systems")
+```
+
+### Batched Tasks
+
+```python
+from swarms import AdvisorSwarm
+
+swarm = AdvisorSwarm(
+    executor_model_name="claude-sonnet-4-6",
+    advisor_model_name="claude-opus-4-6",
+    max_advisor_uses=2,
+)
+
+results = swarm.batched_run([
+    "Explain recursion with a simple example",
+    "What is the difference between a mutex and a semaphore?",
+])
+```
+
+### Different Providers
+
+The swarm is provider-agnostic. Use any models LiteLLM supports:
+
+```python
+from swarms import AdvisorSwarm
+
+# OpenAI models
+swarm = AdvisorSwarm(
+    executor_model_name="gpt-4.1-mini",
+    advisor_model_name="gpt-4.1",
+)
+
+# Mix providers
+swarm = AdvisorSwarm(
+    executor_model_name="gpt-4.1-mini",
+    advisor_model_name="claude-opus-4-6",
+)
+```
+
+---
+
+## Architecture Details
+
+### Advisor Budget
+
+The `max_advisor_uses` parameter controls how many times the advisor is consulted per `run()` call:
+
+| `max_advisor_uses` | Behavior |
+|---|---|
+| `1` | Advisor plans only. No review — executor output is final. |
+| `2` | Advisor plans + 1 review. If satisfactory, done. If not, executor refines but no further review. |
+| `3` (default) | Advisor plans + up to 2 review-refine cycles. |
+| `N` | Advisor plans + up to N-1 review-refine cycles. |
+
+### Verdict Protocol
+
+The advisor's review must start with one of two verdicts:
+
+- `VERDICT: SATISFACTORY` — output meets requirements, refinement loop stops
+- `VERDICT: NEEDS_REVISION` — followed by specific, actionable feedback for the executor
+
+This is enforced by the advisor's system prompt and parsed by the swarm via case-insensitive substring matching.
+
+### Multi-Loop
+
+When `max_loops > 1`, the entire plan-execute-review cycle repeats. Each subsequent loop has access to the full conversation history from previous loops, enabling iterative deepening. The advisor budget resets each loop.
+
+### Context Flow
+
+The advisor sees the full conversation history on every call. This matches the advisor strategy's principle that the advisor needs complete context to provide relevant guidance.

--- a/docs/swarms/structs/advisor_swarm.md
+++ b/docs/swarms/structs/advisor_swarm.md
@@ -1,43 +1,44 @@
 # `AdvisorSwarm`
 
-The `AdvisorSwarm` implements the [advisor strategy](https://claude.com/blog/the-advisor-strategy) described in Anthropic's research (April 2026). It pairs a cheaper **executor** model that drives the task end-to-end with a powerful **advisor** model that is consulted only at key decision points.
+The `AdvisorSwarm` implements the [advisor strategy](https://claude.com/blog/the-advisor-strategy) described in Anthropic's research (April 2026). It pairs a cheaper **executor** model that drives the task end-to-end with a powerful **advisor** model consulted on-demand between executor turns.
 
-The advisor never calls tools or produces user-facing output — it only provides strategic guidance to the executor.
+The executor runs every turn. The advisor is on-demand — consulted between executor turns when budget allows. Both agents read from and write to the same shared conversation context. The advisor never calls tools or produces user-facing output.
 
 This is provider-agnostic: any model supported by LiteLLM works for either role.
 
 ```mermaid
 graph TD
-    A[User Task] --> B[Advisor: Strategic Plan]
-    B --> C[Executor: Produce Output]
-    C --> D{Advisor Budget Left?}
-    D -->|Yes| E[Advisor: Review Output]
-    E --> F{Satisfactory?}
-    F -->|Yes| G[Return Result]
-    F -->|No| H[Executor: Refine Output]
-    H --> D
-    D -->|No| G
+    A[User Task] --> B[Shared Context]
+    B --> C{Advisor Budget?}
+    C -->|Yes| D[Advisor reads context, provides guidance]
+    D --> B
+    C -->|No| E[Executor reads context, produces output]
+    B --> E
+    E --> B
+    E --> F{More turns?}
+    F -->|Yes| C
+    F -->|No| G[Return Result]
 ```
 
 The swarm follows this workflow:
 
-1. **Advisor plans**: Receives the task, produces a concise numbered strategic plan
-2. **Executor executes**: Works on the task using the advisor's guidance
-3. **Advisor reviews**: Evaluates the executor's output — returns `VERDICT: SATISFACTORY` or `VERDICT: NEEDS_REVISION`
-4. **Executor refines**: If revision needed, addresses each point from the advisor's feedback
-5. **Repeat 3-4** until the advisor says satisfactory or the advisor call budget is exhausted
+1. User task goes into the shared conversation
+2. Before each executor turn, the advisor reads the full shared context and provides guidance (if budget allows)
+3. The executor reads the full shared context (including any advisor guidance) and produces output
+4. Both advisor guidance and executor output are added to the shared conversation
+5. Repeat for `max_loops` executor turns
 
 
 ## Key Features
 
 | Feature | Description |
 |---------|-------------|
-| **Advisor-Executor Separation** | Advisor provides strategy; executor does the work |
-| **Iterative Refinement** | Advisor reviews and executor refines until satisfactory |
-| **Budget Control** | `max_advisor_uses` caps advisor calls per run |
+| **Executor-Driven Loop** | The executor runs every turn — it's the main driver |
+| **On-Demand Advisor** | Advisor is consulted between turns, not in a fixed sequence |
+| **Shared Context** | Both agents read from and write to the same conversation |
+| **Budget Control** | `max_advisor_uses` caps advisor consultations per run |
 | **Provider-Agnostic** | Any LiteLLM-supported model works for either role |
 | **Custom Agents** | Pass pre-configured agents with tools, MCP, or any Agent settings |
-| **Multi-Loop** | Optional outer loops for deeper iterative analysis |
 
 
 ## Constructor
@@ -52,8 +53,8 @@ The swarm follows this workflow:
 | `advisor_model_name` | `str` | `"claude-opus-4-6"` | No | Model for the advisor agent |
 | `executor_system_prompt` | `str` | Built-in | No | System prompt for the executor |
 | `advisor_system_prompt` | `str` | Built-in | No | System prompt for the advisor |
-| `max_advisor_uses` | `int` | `3` | No | Max advisor calls per `run()`. Budget: 1 plan + up to N-1 reviews |
-| `max_loops` | `int` | `1` | No | Outer iteration count (each loop is a full plan-execute-review cycle) |
+| `max_advisor_uses` | `int` | `3` | No | Max advisor consultations per `run()`. 0 = executor runs alone. |
+| `max_loops` | `int` | `1` | No | Number of executor turns |
 | `output_type` | `OutputType` | `"dict-all-except-first"` | No | Format for output (dict, str, list, final, json, yaml) |
 | `verbose` | `bool` | `False` | No | Enable detailed logging |
 | `executor_agent` | `Agent` | `None` | No | Pre-configured Agent for execution (e.g., with tools or MCP) |
@@ -64,7 +65,7 @@ The swarm follows this workflow:
 
 | Exception | Condition |
 |-----------|-----------|
-| `ValueError` | If `max_advisor_uses < 1`, `max_loops < 1`, or model names are empty |
+| `ValueError` | If `max_advisor_uses < 0`, `max_loops < 1`, or model names are empty |
 
 ---
 
@@ -115,6 +116,7 @@ swarm = AdvisorSwarm(
     executor_model_name="claude-sonnet-4-6",
     advisor_model_name="claude-opus-4-6",
     max_advisor_uses=3,
+    max_loops=1,
     verbose=True,
 )
 
@@ -124,6 +126,23 @@ result = swarm.run(
 )
 
 print(result)
+```
+
+### Multi-Turn with Advisor Guidance
+
+Run the executor for multiple turns, with the advisor providing guidance before each:
+
+```python
+from swarms import AdvisorSwarm
+
+swarm = AdvisorSwarm(
+    executor_model_name="claude-sonnet-4-6",
+    advisor_model_name="claude-opus-4-6",
+    max_advisor_uses=3,
+    max_loops=3,
+)
+
+result = swarm.run("Design and implement a REST API rate limiter in Python")
 ```
 
 ### Custom Executor with Tools
@@ -141,17 +160,11 @@ def write_file(filename: str, content: str) -> str:
     return f"Written: {filename}"
 
 
-def read_file(filename: str) -> str:
-    """Read content from a file."""
-    with open(filename, "r") as f:
-        return f.read()
-
-
 executor = Agent(
     agent_name="Executor",
     model_name="claude-sonnet-4-6",
     max_loops=1,
-    tools=[write_file, read_file],
+    tools=[write_file],
 )
 
 swarm = AdvisorSwarm(
@@ -162,7 +175,9 @@ swarm = AdvisorSwarm(
 result = swarm.run("Create a Python module for string manipulation utilities")
 ```
 
-### Batched Tasks
+### Executor Only (No Advisor)
+
+Set `max_advisor_uses=0` to run the executor alone:
 
 ```python
 from swarms import AdvisorSwarm
@@ -170,13 +185,11 @@ from swarms import AdvisorSwarm
 swarm = AdvisorSwarm(
     executor_model_name="claude-sonnet-4-6",
     advisor_model_name="claude-opus-4-6",
-    max_advisor_uses=2,
+    max_advisor_uses=0,
+    max_loops=1,
 )
 
-results = swarm.batched_run([
-    "Explain recursion with a simple example",
-    "What is the difference between a mutex and a semaphore?",
-])
+result = swarm.run("Simple task that doesn't need advisor guidance")
 ```
 
 ### Different Providers
@@ -203,30 +216,26 @@ swarm = AdvisorSwarm(
 
 ## Architecture Details
 
+### Shared Context
+
+Both agents read from and write to the same `Conversation` object. This mirrors the Anthropic diagram where the advisor reads the same context as the executor. On each turn:
+
+1. The advisor reads `conversation.get_str()` — sees everything so far
+2. The advisor's guidance is added to the conversation
+3. The executor reads `conversation.get_str()` — sees the task, any prior output, and the advisor's guidance
+4. The executor's output is added to the conversation
+
 ### Advisor Budget
 
-The `max_advisor_uses` parameter controls how many times the advisor is consulted per `run()` call:
+The `max_advisor_uses` parameter controls how many times the advisor is consulted:
 
-| `max_advisor_uses` | Behavior |
-|---|---|
-| `1` | Advisor plans only. No review — executor output is final. |
-| `2` | Advisor plans + 1 review. If satisfactory, done. If not, executor refines but no further review. |
-| `3` (default) | Advisor plans + up to 2 review-refine cycles. |
-| `N` | Advisor plans + up to N-1 review-refine cycles. |
+| `max_advisor_uses` | `max_loops` | Behavior |
+|---|---|---|
+| `0` | `1` | Executor runs alone — no advisor |
+| `1` | `1` | Advisor guides once, executor runs once |
+| `3` | `3` | Advisor guides before each of 3 executor turns |
+| `1` | `3` | Advisor guides first turn only, executor runs 3 turns |
 
-### Verdict Protocol
+### Multi-Turn Execution
 
-The advisor's review must start with one of two verdicts:
-
-- `VERDICT: SATISFACTORY` — output meets requirements, refinement loop stops
-- `VERDICT: NEEDS_REVISION` — followed by specific, actionable feedback for the executor
-
-This is enforced by the advisor's system prompt and parsed by the swarm via case-insensitive substring matching.
-
-### Multi-Loop
-
-When `max_loops > 1`, the entire plan-execute-review cycle repeats. Each subsequent loop has access to the full conversation history from previous loops, enabling iterative deepening. The advisor budget resets each loop.
-
-### Context Flow
-
-The advisor sees the full conversation history on every call. This matches the advisor strategy's principle that the advisor needs complete context to provide relevant guidance.
+When `max_loops > 1`, the executor runs multiple turns. Each turn, it reads the full conversation — including its own previous output and any advisor guidance — so it can build on prior work. The advisor's budget is distributed across turns: it is consulted before each executor turn until the budget is exhausted.

--- a/examples/multi_agent/advisor_swarm_examples/advisor_swarm_example.py
+++ b/examples/multi_agent/advisor_swarm_examples/advisor_swarm_example.py
@@ -1,0 +1,29 @@
+"""
+AdvisorSwarm Example
+
+The advisor provides strategic guidance; the executor does the work.
+Swap in any models you want — it's provider-agnostic.
+
+Loads API keys from .env automatically.
+"""
+
+from swarms import AdvisorSwarm
+
+swarm = AdvisorSwarm(
+    name="Code Advisor",
+    description="Advisor-guided code generation",
+    executor_model_name="claude-sonnet-4-6",
+    advisor_model_name="claude-opus-4-6",
+    max_advisor_uses=3,  # 1 plan + up to 2 review-refine cycles
+    max_loops=1,
+    verbose=True,
+)
+
+result = swarm.run(
+    task=(
+        "Write a Python function that implements binary search on a sorted list. "
+        "Include proper error handling, type hints, and edge cases."
+    )
+)
+
+print(result)

--- a/swarms/prompts/advisor_swarm_prompts.py
+++ b/swarms/prompts/advisor_swarm_prompts.py
@@ -1,0 +1,42 @@
+ADVISOR_SYSTEM_PROMPT = """You are a strategic advisor. You provide concise, high-impact guidance to an executor who does the actual work. You never do the work yourself.
+
+You operate in two modes:
+
+## PLANNING MODE
+When given a task to plan for:
+- Analyze the task requirements and constraints
+- Identify the most effective approach
+- Anticipate pitfalls and edge cases
+- Respond with a numbered list of strategic steps (under 100 words total)
+- Focus on approach and priorities, not on doing the work
+
+## REVIEW MODE
+When reviewing executor output:
+- Evaluate whether the output fully addresses the original task
+- Check for correctness, completeness, and quality
+- You MUST start your response with exactly one of these verdicts:
+  - `VERDICT: SATISFACTORY` — the output meets requirements. Follow with a one-line summary of why.
+  - `VERDICT: NEEDS_REVISION` — the output needs improvement. Follow with a numbered list of specific, actionable changes required.
+- Be precise about what is wrong and what the fix should be
+- Do not repeat praise for things that are already correct
+
+## RULES
+- Never produce user-facing output or do the executor's work
+- Keep responses under 100 words
+- Use enumerated steps, not explanations
+- If the task is ambiguous, state your interpretation before advising
+"""
+
+EXECUTOR_SYSTEM_PROMPT = """You are a skilled executor. You produce high-quality, concrete output for the tasks you are given.
+
+## HOW YOU WORK
+- You receive a task along with strategic guidance from an advisor
+- Follow the advisor's strategic guidance closely — it comes from a more capable model
+- Produce complete, concrete output (not plans or summaries of what you would do)
+- When refining based on advisor feedback, address each specific point raised
+
+## RULES
+- Do the work — produce the actual deliverable, not a description of it
+- Be thorough and precise
+- If the advisor's guidance conflicts with the task requirements, follow the task requirements and note the conflict
+"""

--- a/swarms/prompts/advisor_swarm_prompts.py
+++ b/swarms/prompts/advisor_swarm_prompts.py
@@ -8,64 +8,36 @@ The advisor provides concise strategic guidance; the executor produces
 concrete output. The advisor never does the work itself.
 """
 
-ADVISOR_SYSTEM_PROMPT = """You are a strategic Advisor agent in a two-agent system. A separate Executor agent does the actual work. Your role is to provide concise, high-impact guidance that shapes the Executor's approach — you never produce user-facing output yourself.
+ADVISOR_SYSTEM_PROMPT = """You are a strategic Advisor. A separate Executor agent does the actual work. Your role is to provide concise, high-impact guidance that shapes the Executor's approach. You never produce user-facing output yourself.
 
 Your Responsibilities:
-1. Analyze tasks and identify the most effective approach
-2. Anticipate pitfalls, edge cases, and quality risks
-3. Review Executor output and provide specific, actionable feedback
-4. Keep guidance concise — enumerated steps, not explanations
-
-You operate in two modes depending on what you are asked to do:
-
-## PLANNING
-When asked to plan:
-- Identify the key requirements and constraints
-- Provide a numbered list of strategic steps (5-8 steps max)
-- Flag potential pitfalls or edge cases the Executor should handle
-- State what "done well" looks like for this task
-- Stay under 150 words total
-
-## REVIEWING
-When asked to review Executor output:
-- Evaluate whether the output fully addresses the original task
-- Check for correctness, completeness, and quality
-- You MUST begin your response with exactly one of these lines:
-  - `VERDICT: SATISFACTORY` — the output meets requirements
-  - `VERDICT: NEEDS_REVISION` — the output needs improvement
-- After SATISFACTORY: state in one sentence why it passes
-- After NEEDS_REVISION: provide a numbered list of specific changes required
-- Do not repeat praise for things that are already correct
-- Do not suggest stylistic changes unless they affect correctness
+1. Read the full shared conversation context — the user's task, any Executor output so far, and any prior guidance you have given
+2. Identify the most effective approach, potential pitfalls, and edge cases
+3. If the Executor has already produced output, evaluate it and provide specific corrections or improvements
+4. If the Executor has not yet started, provide a strategic plan
 
 Guidelines:
-- Never produce the deliverable yourself — only guide the Executor
+- Keep guidance under 150 words
+- Use enumerated steps, not explanations
 - Be direct — say what is wrong and what the fix should be
-- If the task is ambiguous, state your interpretation before advising
+- Do not do the Executor's work — only guide it
 - Prioritize correctness over style, completeness over polish
+- If the task is ambiguous, state your interpretation before advising
 """
 
-EXECUTOR_SYSTEM_PROMPT = """You are an Executor agent in a two-agent system. A separate Advisor agent provides you with strategic guidance. Your role is to produce high-quality, concrete output for the tasks you are given.
+EXECUTOR_SYSTEM_PROMPT = """You are an Executor. You produce high-quality, concrete output for the tasks you are given.
+
+The conversation history may include strategic guidance from an Advisor agent. Follow that guidance closely — it comes from a more capable model.
 
 Your Responsibilities:
-1. Read the task and the Advisor's strategic guidance carefully
-2. Follow the Advisor's guidance — it comes from a more capable model
-3. Produce the actual deliverable, not a plan or summary of what you would do
-4. When refining based on Advisor feedback, address every specific point raised
-
-When Executing:
-- Produce complete, concrete output
-- Be thorough — do the actual work, not a description of work
-- If the Advisor's guidance conflicts with the task requirements, follow the task requirements and note the conflict
-
-When Refining:
-- Read each point in the Advisor's feedback
-- Address every point explicitly
-- Produce the complete revised output, not just the changes
-- Do not argue with feedback — incorporate it
+1. Read the task and any Advisor guidance in the conversation history
+2. Produce the actual deliverable — not a plan or summary of what you would do
+3. If the Advisor has flagged issues with your previous output, address every point
+4. Be thorough — do the actual work, not a description of work
 
 Guidelines:
 - Quality over speed — get it right
-- If you are uncertain about something, say so clearly in your output
+- If the Advisor's guidance conflicts with the task requirements, follow the task requirements and note the conflict
 - Do not add unnecessary preamble or meta-commentary about your process
+- Produce the complete output each time, not just the changes
 """

--- a/swarms/prompts/advisor_swarm_prompts.py
+++ b/swarms/prompts/advisor_swarm_prompts.py
@@ -1,42 +1,71 @@
-ADVISOR_SYSTEM_PROMPT = """You are a strategic advisor. You provide concise, high-impact guidance to an executor who does the actual work. You never do the work yourself.
+"""
+System prompts for the AdvisorSwarm.
 
-You operate in two modes:
+These prompts define the behavior of the two cooperating agents in the
+advisor strategy pattern inspired by Anthropic's research (April 2026).
 
-## PLANNING MODE
-When given a task to plan for:
-- Analyze the task requirements and constraints
-- Identify the most effective approach
-- Anticipate pitfalls and edge cases
-- Respond with a numbered list of strategic steps (under 100 words total)
-- Focus on approach and priorities, not on doing the work
-
-## REVIEW MODE
-When reviewing executor output:
-- Evaluate whether the output fully addresses the original task
-- Check for correctness, completeness, and quality
-- You MUST start your response with exactly one of these verdicts:
-  - `VERDICT: SATISFACTORY` — the output meets requirements. Follow with a one-line summary of why.
-  - `VERDICT: NEEDS_REVISION` — the output needs improvement. Follow with a numbered list of specific, actionable changes required.
-- Be precise about what is wrong and what the fix should be
-- Do not repeat praise for things that are already correct
-
-## RULES
-- Never produce user-facing output or do the executor's work
-- Keep responses under 100 words
-- Use enumerated steps, not explanations
-- If the task is ambiguous, state your interpretation before advising
+The advisor provides concise strategic guidance; the executor produces
+concrete output. The advisor never does the work itself.
 """
 
-EXECUTOR_SYSTEM_PROMPT = """You are a skilled executor. You produce high-quality, concrete output for the tasks you are given.
+ADVISOR_SYSTEM_PROMPT = """You are a strategic Advisor agent in a two-agent system. A separate Executor agent does the actual work. Your role is to provide concise, high-impact guidance that shapes the Executor's approach — you never produce user-facing output yourself.
 
-## HOW YOU WORK
-- You receive a task along with strategic guidance from an advisor
-- Follow the advisor's strategic guidance closely — it comes from a more capable model
-- Produce complete, concrete output (not plans or summaries of what you would do)
-- When refining based on advisor feedback, address each specific point raised
+Your Responsibilities:
+1. Analyze tasks and identify the most effective approach
+2. Anticipate pitfalls, edge cases, and quality risks
+3. Review Executor output and provide specific, actionable feedback
+4. Keep guidance concise — enumerated steps, not explanations
 
-## RULES
-- Do the work — produce the actual deliverable, not a description of it
-- Be thorough and precise
-- If the advisor's guidance conflicts with the task requirements, follow the task requirements and note the conflict
+You operate in two modes depending on what you are asked to do:
+
+## PLANNING
+When asked to plan:
+- Identify the key requirements and constraints
+- Provide a numbered list of strategic steps (5-8 steps max)
+- Flag potential pitfalls or edge cases the Executor should handle
+- State what "done well" looks like for this task
+- Stay under 150 words total
+
+## REVIEWING
+When asked to review Executor output:
+- Evaluate whether the output fully addresses the original task
+- Check for correctness, completeness, and quality
+- You MUST begin your response with exactly one of these lines:
+  - `VERDICT: SATISFACTORY` — the output meets requirements
+  - `VERDICT: NEEDS_REVISION` — the output needs improvement
+- After SATISFACTORY: state in one sentence why it passes
+- After NEEDS_REVISION: provide a numbered list of specific changes required
+- Do not repeat praise for things that are already correct
+- Do not suggest stylistic changes unless they affect correctness
+
+Guidelines:
+- Never produce the deliverable yourself — only guide the Executor
+- Be direct — say what is wrong and what the fix should be
+- If the task is ambiguous, state your interpretation before advising
+- Prioritize correctness over style, completeness over polish
+"""
+
+EXECUTOR_SYSTEM_PROMPT = """You are an Executor agent in a two-agent system. A separate Advisor agent provides you with strategic guidance. Your role is to produce high-quality, concrete output for the tasks you are given.
+
+Your Responsibilities:
+1. Read the task and the Advisor's strategic guidance carefully
+2. Follow the Advisor's guidance — it comes from a more capable model
+3. Produce the actual deliverable, not a plan or summary of what you would do
+4. When refining based on Advisor feedback, address every specific point raised
+
+When Executing:
+- Produce complete, concrete output
+- Be thorough — do the actual work, not a description of work
+- If the Advisor's guidance conflicts with the task requirements, follow the task requirements and note the conflict
+
+When Refining:
+- Read each point in the Advisor's feedback
+- Address every point explicitly
+- Produce the complete revised output, not just the changes
+- Do not argue with feedback — incorporate it
+
+Guidelines:
+- Quality over speed — get it right
+- If you are uncertain about something, say so clearly in your output
+- Do not add unnecessary preamble or meta-commentary about your process
 """

--- a/swarms/structs/__init__.py
+++ b/swarms/structs/__init__.py
@@ -1,3 +1,4 @@
+from swarms.structs.advisor_swarm import AdvisorSwarm
 from swarms.structs.agent import Agent
 from swarms.structs.agent_loader import AgentLoader
 from swarms.structs.agent_rearrange import AgentRearrange, rearrange
@@ -101,6 +102,7 @@ from swarms.structs.swarming_architectures import (
 )
 
 __all__ = [
+    "AdvisorSwarm",
     "Agent",
     "BaseStructure",
     "BaseSwarm",

--- a/swarms/structs/advisor_swarm.py
+++ b/swarms/structs/advisor_swarm.py
@@ -9,6 +9,12 @@ decision points.
 The advisor never calls tools or produces user-facing output — it
 only provides strategic guidance to the executor.
 
+Architecture:
+    task --> [ Advisor: plan ] --> [ Executor: work ]
+                                       ^         |
+                                       |  loop   v
+                                  [ Executor ] <-- [ Advisor: review ]
+
 Flow:
     1. Advisor receives the task and produces a strategic plan
     2. Executor works on the task using the advisor's guidance
@@ -20,6 +26,7 @@ Reference: "The advisor strategy: Give agents an intelligence
 boost" (Anthropic, April 2026)
 """
 
+import re
 from typing import Any, Callable, List, Optional
 
 from loguru import logger
@@ -83,7 +90,7 @@ class AdvisorSwarm:
         ...     agent_name="Executor",
         ...     model_name="claude-sonnet-4-6",
         ...     max_loops=1,
-        ...     mcp_config={"url": "http://localhost:3000/tools"},
+        ...     tools=[my_tool],
         ... )
         >>> swarm = AdvisorSwarm(
         ...     executor_agent=executor,
@@ -182,64 +189,15 @@ class AdvisorSwarm:
             verbose=self.verbose,
         )
 
-    def _build_planning_prompt(self, task: str) -> str:
-        """Build the prompt for the advisor's planning call."""
-        history = self.conversation.get_str()
-        prompt = (
-            "You are in PLANNING MODE.\n\n"
-            f"Task: {task}\n"
-        )
-        if history:
-            prompt += (
-                f"\nConversation history (from previous loops):\n{history}\n"
-            )
-        prompt += (
-            "\nProvide a strategic plan for the executor to follow. "
-            "Use numbered steps. Stay under 100 words."
-        )
-        return prompt
-
-    def _build_executor_prompt(
-        self, task: str, advice: str
-    ) -> str:
-        """Build the prompt for the executor, incorporating the advisor's guidance."""
-        return (
-            f"Task: {task}\n\n"
-            f"Strategic guidance from your advisor:\n{advice}\n\n"
-            "Execute this task following the advisor's guidance. "
-            "Produce complete, concrete output."
-        )
-
-    def _build_review_prompt(
-        self, task: str, executor_output: str
-    ) -> str:
-        """Build the prompt for the advisor's review call."""
-        return (
-            "You are in REVIEW MODE.\n\n"
-            f"Original task: {task}\n\n"
-            f"Executor's output:\n{executor_output}\n\n"
-            "Review the output against the original task. "
-            "Start your response with VERDICT: SATISFACTORY or VERDICT: NEEDS_REVISION."
-        )
-
-    def _build_refinement_prompt(
-        self,
-        task: str,
-        executor_output: str,
-        review: str,
-    ) -> str:
-        """Build the prompt for the executor's refinement pass."""
-        return (
-            f"Original task: {task}\n\n"
-            f"Your previous output:\n{executor_output}\n\n"
-            f"Advisor feedback:\n{review}\n\n"
-            "Revise your output to address each point in the advisor's feedback. "
-            "Produce the complete revised output."
-        )
-
     def _is_satisfactory(self, review: str) -> bool:
-        """Check if the advisor's review indicates the output is satisfactory."""
-        return "verdict: satisfactory" in review.lower()
+        """Parse the advisor's review to determine if output is satisfactory.
+
+        Checks for VERDICT: SATISFACTORY using regex to handle
+        variations in whitespace and casing.
+        """
+        return bool(
+            re.search(r"verdict\s*:\s*satisfactory", review, re.IGNORECASE)
+        )
 
     def run(
         self,
@@ -273,7 +231,17 @@ class AdvisorSwarm:
             advisor_uses = 0
 
             # --- Step 1: Advisor plans ---
-            planning_prompt = self._build_planning_prompt(task)
+            # Advisor sees the task and full conversation history
+            # (history matters for multi-loop runs)
+            history = self.conversation.get_str()
+            planning_prompt = (
+                f"You are in PLANNING MODE.\n\n"
+                f"Task: {task}\n\n"
+                f"--- CONVERSATION HISTORY ---\n{history}\n"
+                f"--- END CONVERSATION HISTORY ---\n\n"
+                f"Provide a strategic plan for the Executor to follow."
+            )
+
             advice = self.advisor_agent.run(task=planning_prompt)
             advisor_uses += 1
             self.conversation.add(
@@ -283,11 +251,19 @@ class AdvisorSwarm:
 
             if self.verbose:
                 logger.info(
-                    f"[AdvisorSwarm] Advisor plan ({advisor_uses}/{self.max_advisor_uses} calls used)"
+                    f"[AdvisorSwarm] Advisor plan "
+                    f"({advisor_uses}/{self.max_advisor_uses} calls used)"
                 )
 
             # --- Step 2: Executor works ---
-            executor_prompt = self._build_executor_prompt(task, advice)
+            # Executor sees the task and the advisor's plan
+            executor_prompt = (
+                f"Task: {task}\n\n"
+                f"Strategic guidance from your Advisor:\n{advice}\n\n"
+                f"Execute this task following the Advisor's guidance. "
+                f"Produce complete, concrete output."
+            )
+
             executor_output = self.executor_agent.run(
                 task=executor_prompt, img=img, imgs=imgs
             )
@@ -301,9 +277,20 @@ class AdvisorSwarm:
             # --- Step 3-4: Review-refine loop ---
             while advisor_uses < self.max_advisor_uses:
                 # Step 3: Advisor reviews
-                review_prompt = self._build_review_prompt(
-                    task, executor_output
+                # Advisor sees the full conversation history including
+                # all prior exchanges — mirrors the Anthropic pattern
+                # where the advisor sees the full transcript
+                history = self.conversation.get_str()
+                review_prompt = (
+                    f"You are in REVIEW MODE.\n\n"
+                    f"Original task: {task}\n\n"
+                    f"--- CONVERSATION HISTORY ---\n{history}\n"
+                    f"--- END CONVERSATION HISTORY ---\n\n"
+                    f"Review the Executor's most recent output against "
+                    f"the original task. Start your response with "
+                    f"VERDICT: SATISFACTORY or VERDICT: NEEDS_REVISION."
                 )
+
                 review = self.advisor_agent.run(task=review_prompt)
                 advisor_uses += 1
                 self.conversation.add(
@@ -313,7 +300,8 @@ class AdvisorSwarm:
 
                 if self.verbose:
                     logger.info(
-                        f"[AdvisorSwarm] Advisor review ({advisor_uses}/{self.max_advisor_uses} calls used)"
+                        f"[AdvisorSwarm] Advisor review "
+                        f"({advisor_uses}/{self.max_advisor_uses} calls used)"
                     )
 
                 if self._is_satisfactory(review):
@@ -324,9 +312,16 @@ class AdvisorSwarm:
                     break
 
                 # Step 4: Executor refines
-                refinement_prompt = self._build_refinement_prompt(
-                    task, executor_output, review
+                # Executor sees: original task, its own output, and
+                # the advisor's specific feedback
+                refinement_prompt = (
+                    f"Original task: {task}\n\n"
+                    f"Your previous output:\n{executor_output}\n\n"
+                    f"Advisor feedback:\n{review}\n\n"
+                    f"Revise your output to address each point in the "
+                    f"Advisor's feedback. Produce the complete revised output."
                 )
+
                 executor_output = self.executor_agent.run(
                     task=refinement_prompt, img=img, imgs=imgs
                 )
@@ -335,7 +330,9 @@ class AdvisorSwarm:
                 )
 
                 if self.verbose:
-                    logger.info("[AdvisorSwarm] Executor refined output")
+                    logger.info(
+                        "[AdvisorSwarm] Executor refined output"
+                    )
 
             if self.verbose:
                 logger.info(

--- a/swarms/structs/advisor_swarm.py
+++ b/swarms/structs/advisor_swarm.py
@@ -1,0 +1,366 @@
+"""
+AdvisorSwarm — Advisor Strategy Pattern
+
+Implements the advisor strategy described in Anthropic's research
+(April 2026): pair a cheaper executor model that drives the task
+end-to-end with a powerful advisor model consulted only at key
+decision points.
+
+The advisor never calls tools or produces user-facing output — it
+only provides strategic guidance to the executor.
+
+Flow:
+    1. Advisor receives the task and produces a strategic plan
+    2. Executor works on the task using the advisor's guidance
+    3. Advisor reviews the executor's output (budget permitting)
+    4. If not satisfactory, executor refines based on feedback
+    5. Repeat 3-4 until advisor says SATISFACTORY or budget exhausted
+
+Reference: "The advisor strategy: Give agents an intelligence
+boost" (Anthropic, April 2026)
+"""
+
+from typing import Any, Callable, List, Optional
+
+from loguru import logger
+
+from swarms.prompts.advisor_swarm_prompts import (
+    ADVISOR_SYSTEM_PROMPT,
+    EXECUTOR_SYSTEM_PROMPT,
+)
+from swarms.structs.agent import Agent
+from swarms.structs.conversation import Conversation
+from swarms.structs.swarm_id import swarm_id
+from swarms.utils.history_output_formatter import (
+    history_output_formatter,
+)
+from swarms.utils.loguru_logger import initialize_logger
+from swarms.utils.output_types import OutputType
+
+logger = initialize_logger(log_folder="advisor_swarm")
+
+
+class AdvisorSwarm:
+    """Implements the Advisor Strategy: pairs a cheaper executor model
+    with a powerful advisor model consulted at key decision points.
+
+    The advisor provides strategic guidance before work begins, then
+    reviews executor output in an iterative refinement loop. The
+    advisor never calls tools or produces user-facing output.
+
+    This is provider-agnostic — any model supported by LiteLLM works
+    for either role.
+
+    Args:
+        id: Unique identifier for this swarm instance.
+        name: Human-readable name.
+        description: Description of the swarm's purpose.
+        executor_model_name: Model for the executor agent.
+        advisor_model_name: Model for the advisor agent.
+        executor_system_prompt: System prompt for the executor.
+        advisor_system_prompt: System prompt for the advisor.
+        max_advisor_uses: Max advisor calls per run() invocation.
+            Budget: 1 for planning + up to (N-1) for reviews.
+        max_loops: Outer iteration count (each loop is a full
+            plan-execute-review cycle).
+        output_type: Format for conversation history output.
+        verbose: Enable detailed logging.
+        executor_agent: Optional pre-configured Agent for execution
+            (e.g., with tools or MCP configs).
+        advisor_agent: Optional pre-configured Agent for advising.
+        tools: Tools available to the executor agent only.
+
+    Examples:
+        >>> swarm = AdvisorSwarm(
+        ...     executor_model_name="claude-sonnet-4-6",
+        ...     advisor_model_name="claude-opus-4-6",
+        ... )
+        >>> result = swarm.run("Write a Python function to merge two sorted lists")
+
+        >>> # With custom executor that has tools
+        >>> from swarms import Agent
+        >>> executor = Agent(
+        ...     agent_name="Executor",
+        ...     model_name="claude-sonnet-4-6",
+        ...     max_loops=1,
+        ...     mcp_config={"url": "http://localhost:3000/tools"},
+        ... )
+        >>> swarm = AdvisorSwarm(
+        ...     executor_agent=executor,
+        ...     advisor_model_name="claude-opus-4-6",
+        ... )
+        >>> result = swarm.run("Refactor the auth module for performance")
+    """
+
+    def __init__(
+        self,
+        id: str = None,
+        name: str = "AdvisorSwarm",
+        description: str = "An executor-advisor swarm implementing the advisor strategy pattern",
+        executor_model_name: str = "claude-sonnet-4-6",
+        advisor_model_name: str = "claude-opus-4-6",
+        executor_system_prompt: str = EXECUTOR_SYSTEM_PROMPT,
+        advisor_system_prompt: str = ADVISOR_SYSTEM_PROMPT,
+        max_advisor_uses: int = 3,
+        max_loops: int = 1,
+        output_type: OutputType = "dict-all-except-first",
+        verbose: bool = False,
+        executor_agent: Optional[Agent] = None,
+        advisor_agent: Optional[Agent] = None,
+        tools: Optional[List[Callable]] = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        self.id = id or swarm_id()
+        self.name = name
+        self.description = description
+        self.executor_model_name = executor_model_name
+        self.advisor_model_name = advisor_model_name
+        self.executor_system_prompt = executor_system_prompt
+        self.advisor_system_prompt = advisor_system_prompt
+        self.max_advisor_uses = max_advisor_uses
+        self.max_loops = max_loops
+        self.output_type = output_type
+        self.verbose = verbose
+        self.tools = tools
+
+        self.reliability_check()
+
+        self.conversation = Conversation()
+
+        self.executor_agent = executor_agent or self._create_executor()
+        self.advisor_agent = advisor_agent or self._create_advisor()
+
+    def reliability_check(self):
+        """Validate swarm configuration."""
+        if self.max_advisor_uses < 1:
+            raise ValueError(
+                f"max_advisor_uses must be >= 1 (need at least 1 for the planning call), got {self.max_advisor_uses}"
+            )
+        if self.max_loops < 1:
+            raise ValueError(
+                f"max_loops must be >= 1, got {self.max_loops}"
+            )
+        if not self.executor_model_name:
+            raise ValueError("executor_model_name must be provided")
+        if not self.advisor_model_name:
+            raise ValueError("advisor_model_name must be provided")
+
+        if self.verbose:
+            logger.info(
+                f"AdvisorSwarm initialized: "
+                f"executor={self.executor_model_name}, "
+                f"advisor={self.advisor_model_name}, "
+                f"max_advisor_uses={self.max_advisor_uses}, "
+                f"max_loops={self.max_loops}"
+            )
+
+    def _create_executor(self) -> Agent:
+        """Create the executor agent with tools."""
+        return Agent(
+            agent_name="Executor",
+            agent_description="Executes tasks using advisor strategic guidance",
+            system_prompt=self.executor_system_prompt,
+            model_name=self.executor_model_name,
+            max_loops=1,
+            temperature=1.0,
+            output_type="final",
+            verbose=self.verbose,
+            tools=self.tools,
+        )
+
+    def _create_advisor(self) -> Agent:
+        """Create the advisor agent. No tools — guidance only."""
+        return Agent(
+            agent_name="Advisor",
+            agent_description="Provides strategic guidance to the executor",
+            system_prompt=self.advisor_system_prompt,
+            model_name=self.advisor_model_name,
+            max_loops=1,
+            temperature=1.0,
+            output_type="final",
+            verbose=self.verbose,
+        )
+
+    def _build_planning_prompt(self, task: str) -> str:
+        """Build the prompt for the advisor's planning call."""
+        history = self.conversation.get_str()
+        prompt = (
+            "You are in PLANNING MODE.\n\n"
+            f"Task: {task}\n"
+        )
+        if history:
+            prompt += (
+                f"\nConversation history (from previous loops):\n{history}\n"
+            )
+        prompt += (
+            "\nProvide a strategic plan for the executor to follow. "
+            "Use numbered steps. Stay under 100 words."
+        )
+        return prompt
+
+    def _build_executor_prompt(
+        self, task: str, advice: str
+    ) -> str:
+        """Build the prompt for the executor, incorporating the advisor's guidance."""
+        return (
+            f"Task: {task}\n\n"
+            f"Strategic guidance from your advisor:\n{advice}\n\n"
+            "Execute this task following the advisor's guidance. "
+            "Produce complete, concrete output."
+        )
+
+    def _build_review_prompt(
+        self, task: str, executor_output: str
+    ) -> str:
+        """Build the prompt for the advisor's review call."""
+        return (
+            "You are in REVIEW MODE.\n\n"
+            f"Original task: {task}\n\n"
+            f"Executor's output:\n{executor_output}\n\n"
+            "Review the output against the original task. "
+            "Start your response with VERDICT: SATISFACTORY or VERDICT: NEEDS_REVISION."
+        )
+
+    def _build_refinement_prompt(
+        self,
+        task: str,
+        executor_output: str,
+        review: str,
+    ) -> str:
+        """Build the prompt for the executor's refinement pass."""
+        return (
+            f"Original task: {task}\n\n"
+            f"Your previous output:\n{executor_output}\n\n"
+            f"Advisor feedback:\n{review}\n\n"
+            "Revise your output to address each point in the advisor's feedback. "
+            "Produce the complete revised output."
+        )
+
+    def _is_satisfactory(self, review: str) -> bool:
+        """Check if the advisor's review indicates the output is satisfactory."""
+        return "verdict: satisfactory" in review.lower()
+
+    def run(
+        self,
+        task: Optional[str] = None,
+        img: Optional[str] = None,
+        imgs: Optional[List[str]] = None,
+        *args,
+        **kwargs,
+    ) -> Any:
+        """Execute the advisor-executor orchestration flow.
+
+        Args:
+            task: The task to accomplish.
+            img: Optional single image input.
+            imgs: Optional list of image inputs.
+
+        Returns:
+            Formatted conversation history per output_type.
+        """
+        if not task:
+            raise ValueError("A task is required")
+
+        self.conversation.add(role="User", content=task)
+
+        for loop in range(self.max_loops):
+            if self.verbose:
+                logger.info(
+                    f"[AdvisorSwarm] Loop {loop + 1}/{self.max_loops}"
+                )
+
+            advisor_uses = 0
+
+            # --- Step 1: Advisor plans ---
+            planning_prompt = self._build_planning_prompt(task)
+            advice = self.advisor_agent.run(task=planning_prompt)
+            advisor_uses += 1
+            self.conversation.add(
+                role="Advisor",
+                content=f"[Strategic Plan]\n{advice}",
+            )
+
+            if self.verbose:
+                logger.info(
+                    f"[AdvisorSwarm] Advisor plan ({advisor_uses}/{self.max_advisor_uses} calls used)"
+                )
+
+            # --- Step 2: Executor works ---
+            executor_prompt = self._build_executor_prompt(task, advice)
+            executor_output = self.executor_agent.run(
+                task=executor_prompt, img=img, imgs=imgs
+            )
+            self.conversation.add(
+                role="Executor", content=executor_output
+            )
+
+            if self.verbose:
+                logger.info("[AdvisorSwarm] Executor produced output")
+
+            # --- Step 3-4: Review-refine loop ---
+            while advisor_uses < self.max_advisor_uses:
+                # Step 3: Advisor reviews
+                review_prompt = self._build_review_prompt(
+                    task, executor_output
+                )
+                review = self.advisor_agent.run(task=review_prompt)
+                advisor_uses += 1
+                self.conversation.add(
+                    role="Advisor",
+                    content=f"[Review]\n{review}",
+                )
+
+                if self.verbose:
+                    logger.info(
+                        f"[AdvisorSwarm] Advisor review ({advisor_uses}/{self.max_advisor_uses} calls used)"
+                    )
+
+                if self._is_satisfactory(review):
+                    if self.verbose:
+                        logger.info(
+                            "[AdvisorSwarm] Advisor verdict: SATISFACTORY"
+                        )
+                    break
+
+                # Step 4: Executor refines
+                refinement_prompt = self._build_refinement_prompt(
+                    task, executor_output, review
+                )
+                executor_output = self.executor_agent.run(
+                    task=refinement_prompt, img=img, imgs=imgs
+                )
+                self.conversation.add(
+                    role="Executor", content=executor_output
+                )
+
+                if self.verbose:
+                    logger.info("[AdvisorSwarm] Executor refined output")
+
+            if self.verbose:
+                logger.info(
+                    f"[AdvisorSwarm] Loop {loop + 1} complete. "
+                    f"Advisor calls used: {advisor_uses}/{self.max_advisor_uses}"
+                )
+
+        return history_output_formatter(
+            conversation=self.conversation,
+            type=self.output_type,
+        )
+
+    def batched_run(
+        self, tasks: List[str], *args, **kwargs
+    ) -> List[Any]:
+        """Run multiple tasks sequentially.
+
+        Args:
+            tasks: List of task strings.
+
+        Returns:
+            List of results, one per task.
+        """
+        return [self.run(task=t, *args, **kwargs) for t in tasks]
+
+    def __call__(self, task: str, *args, **kwargs) -> Any:
+        """Make the swarm callable."""
+        return self.run(task=task, *args, **kwargs)

--- a/swarms/structs/advisor_swarm.py
+++ b/swarms/structs/advisor_swarm.py
@@ -3,30 +3,27 @@ AdvisorSwarm — Advisor Strategy Pattern
 
 Implements the advisor strategy described in Anthropic's research
 (April 2026): pair a cheaper executor model that drives the task
-end-to-end with a powerful advisor model consulted only at key
-decision points.
+end-to-end with a powerful advisor model consulted on-demand
+between executor turns.
 
-The advisor never calls tools or produces user-facing output — it
-only provides strategic guidance to the executor.
+Architecture (from Anthropic's diagram):
 
-Architecture:
-    task --> [ Advisor: plan ] --> [ Executor: work ]
-                                       ^         |
-                                       |  loop   v
-                                  [ Executor ] <-- [ Advisor: review ]
+    Main loop ──> [ Executor (Sonnet) ] ──tool call──> [ Advisor (Opus) ]
+                        |       ^                           |       ^
+                   read/write   |                      sends advice  |
+                        v       |                           v       |
+                  [ Shared context: conversation · tools · history ]
+                  Advisor reads the same context as Executor
 
-Flow:
-    1. Advisor receives the task and produces a strategic plan
-    2. Executor works on the task using the advisor's guidance
-    3. Advisor reviews the executor's output (budget permitting)
-    4. If not satisfactory, executor refines based on feedback
-    5. Repeat 3-4 until advisor says SATISFACTORY or budget exhausted
+The executor runs every turn. The advisor is on-demand — consulted
+between executor turns when budget allows. Both read from and write
+to the same shared conversation. The advisor never calls tools or
+produces user-facing output.
 
 Reference: "The advisor strategy: Give agents an intelligence
 boost" (Anthropic, April 2026)
 """
 
-import re
 from typing import Any, Callable, List, Optional
 
 from loguru import logger
@@ -49,11 +46,13 @@ logger = initialize_logger(log_folder="advisor_swarm")
 
 class AdvisorSwarm:
     """Implements the Advisor Strategy: pairs a cheaper executor model
-    with a powerful advisor model consulted at key decision points.
+    with a powerful advisor model consulted on-demand between executor
+    turns.
 
-    The advisor provides strategic guidance before work begins, then
-    reviews executor output in an iterative refinement loop. The
-    advisor never calls tools or produces user-facing output.
+    The executor runs in a main loop. Before each executor turn, the
+    advisor reads the full shared conversation context and provides
+    strategic guidance (if budget allows). Both agents read from and
+    write to the same conversation.
 
     This is provider-agnostic — any model supported by LiteLLM works
     for either role.
@@ -66,10 +65,8 @@ class AdvisorSwarm:
         advisor_model_name: Model for the advisor agent.
         executor_system_prompt: System prompt for the executor.
         advisor_system_prompt: System prompt for the advisor.
-        max_advisor_uses: Max advisor calls per run() invocation.
-            Budget: 1 for planning + up to (N-1) for reviews.
-        max_loops: Outer iteration count (each loop is a full
-            plan-execute-review cycle).
+        max_advisor_uses: Max advisor consultations per run().
+        max_loops: Number of executor turns.
         output_type: Format for conversation history output.
         verbose: Enable detailed logging.
         executor_agent: Optional pre-configured Agent for execution
@@ -83,20 +80,6 @@ class AdvisorSwarm:
         ...     advisor_model_name="claude-opus-4-6",
         ... )
         >>> result = swarm.run("Write a Python function to merge two sorted lists")
-
-        >>> # With custom executor that has tools
-        >>> from swarms import Agent
-        >>> executor = Agent(
-        ...     agent_name="Executor",
-        ...     model_name="claude-sonnet-4-6",
-        ...     max_loops=1,
-        ...     tools=[my_tool],
-        ... )
-        >>> swarm = AdvisorSwarm(
-        ...     executor_agent=executor,
-        ...     advisor_model_name="claude-opus-4-6",
-        ... )
-        >>> result = swarm.run("Refactor the auth module for performance")
     """
 
     def __init__(
@@ -140,9 +123,9 @@ class AdvisorSwarm:
 
     def reliability_check(self):
         """Validate swarm configuration."""
-        if self.max_advisor_uses < 1:
+        if self.max_advisor_uses < 0:
             raise ValueError(
-                f"max_advisor_uses must be >= 1 (need at least 1 for the planning call), got {self.max_advisor_uses}"
+                f"max_advisor_uses must be >= 0, got {self.max_advisor_uses}"
             )
         if self.max_loops < 1:
             raise ValueError(
@@ -189,16 +172,6 @@ class AdvisorSwarm:
             verbose=self.verbose,
         )
 
-    def _is_satisfactory(self, review: str) -> bool:
-        """Parse the advisor's review to determine if output is satisfactory.
-
-        Checks for VERDICT: SATISFACTORY using regex to handle
-        variations in whitespace and casing.
-        """
-        return bool(
-            re.search(r"verdict\s*:\s*satisfactory", review, re.IGNORECASE)
-        )
-
     def run(
         self,
         task: Optional[str] = None,
@@ -208,6 +181,11 @@ class AdvisorSwarm:
         **kwargs,
     ) -> Any:
         """Execute the advisor-executor orchestration flow.
+
+        The executor runs in a main loop for max_loops turns. Before
+        each turn, the advisor reads the full shared conversation and
+        provides guidance (if budget allows). Both agents read from
+        and write to the same conversation.
 
         Args:
             task: The task to accomplish.
@@ -221,123 +199,52 @@ class AdvisorSwarm:
             raise ValueError("A task is required")
 
         self.conversation.add(role="User", content=task)
+        advisor_uses = 0
 
-        for loop in range(self.max_loops):
+        for turn in range(self.max_loops):
             if self.verbose:
                 logger.info(
-                    f"[AdvisorSwarm] Loop {loop + 1}/{self.max_loops}"
+                    f"[AdvisorSwarm] Turn {turn + 1}/{self.max_loops}"
                 )
 
-            advisor_uses = 0
-
-            # --- Step 1: Advisor plans ---
-            # Advisor sees the task and full conversation history
-            # (history matters for multi-loop runs)
-            history = self.conversation.get_str()
-            planning_prompt = (
-                f"You are in PLANNING MODE.\n\n"
-                f"Task: {task}\n\n"
-                f"--- CONVERSATION HISTORY ---\n{history}\n"
-                f"--- END CONVERSATION HISTORY ---\n\n"
-                f"Provide a strategic plan for the Executor to follow."
-            )
-
-            advice = self.advisor_agent.run(task=planning_prompt)
-            advisor_uses += 1
-            self.conversation.add(
-                role="Advisor",
-                content=f"[Strategic Plan]\n{advice}",
-            )
-
-            if self.verbose:
-                logger.info(
-                    f"[AdvisorSwarm] Advisor plan "
-                    f"({advisor_uses}/{self.max_advisor_uses} calls used)"
+            # --- Advisor guidance (if budget allows) ---
+            if advisor_uses < self.max_advisor_uses:
+                context = self.conversation.get_str()
+                advisor_prompt = (
+                    f"Read the shared conversation context below and "
+                    f"provide strategic guidance for the Executor.\n\n"
+                    f"--- SHARED CONTEXT ---\n{context}\n"
+                    f"--- END SHARED CONTEXT ---"
                 )
 
-            # --- Step 2: Executor works ---
-            # Executor sees the task and the advisor's plan
+                advice = self.advisor_agent.run(task=advisor_prompt)
+                advisor_uses += 1
+                self.conversation.add(role="Advisor", content=advice)
+
+                if self.verbose:
+                    logger.info(
+                        f"[AdvisorSwarm] Advisor consulted "
+                        f"({advisor_uses}/{self.max_advisor_uses})"
+                    )
+
+            # --- Executor turn ---
+            context = self.conversation.get_str()
             executor_prompt = (
-                f"Task: {task}\n\n"
-                f"Strategic guidance from your Advisor:\n{advice}\n\n"
-                f"Execute this task following the Advisor's guidance. "
-                f"Produce complete, concrete output."
+                f"Read the shared conversation context below — it "
+                f"includes the task and any Advisor guidance — then "
+                f"produce your output.\n\n"
+                f"--- SHARED CONTEXT ---\n{context}\n"
+                f"--- END SHARED CONTEXT ---"
             )
 
-            executor_output = self.executor_agent.run(
+            output = self.executor_agent.run(
                 task=executor_prompt, img=img, imgs=imgs
             )
-            self.conversation.add(
-                role="Executor", content=executor_output
-            )
-
-            if self.verbose:
-                logger.info("[AdvisorSwarm] Executor produced output")
-
-            # --- Step 3-4: Review-refine loop ---
-            while advisor_uses < self.max_advisor_uses:
-                # Step 3: Advisor reviews
-                # Advisor sees the full conversation history including
-                # all prior exchanges — mirrors the Anthropic pattern
-                # where the advisor sees the full transcript
-                history = self.conversation.get_str()
-                review_prompt = (
-                    f"You are in REVIEW MODE.\n\n"
-                    f"Original task: {task}\n\n"
-                    f"--- CONVERSATION HISTORY ---\n{history}\n"
-                    f"--- END CONVERSATION HISTORY ---\n\n"
-                    f"Review the Executor's most recent output against "
-                    f"the original task. Start your response with "
-                    f"VERDICT: SATISFACTORY or VERDICT: NEEDS_REVISION."
-                )
-
-                review = self.advisor_agent.run(task=review_prompt)
-                advisor_uses += 1
-                self.conversation.add(
-                    role="Advisor",
-                    content=f"[Review]\n{review}",
-                )
-
-                if self.verbose:
-                    logger.info(
-                        f"[AdvisorSwarm] Advisor review "
-                        f"({advisor_uses}/{self.max_advisor_uses} calls used)"
-                    )
-
-                if self._is_satisfactory(review):
-                    if self.verbose:
-                        logger.info(
-                            "[AdvisorSwarm] Advisor verdict: SATISFACTORY"
-                        )
-                    break
-
-                # Step 4: Executor refines
-                # Executor sees: original task, its own output, and
-                # the advisor's specific feedback
-                refinement_prompt = (
-                    f"Original task: {task}\n\n"
-                    f"Your previous output:\n{executor_output}\n\n"
-                    f"Advisor feedback:\n{review}\n\n"
-                    f"Revise your output to address each point in the "
-                    f"Advisor's feedback. Produce the complete revised output."
-                )
-
-                executor_output = self.executor_agent.run(
-                    task=refinement_prompt, img=img, imgs=imgs
-                )
-                self.conversation.add(
-                    role="Executor", content=executor_output
-                )
-
-                if self.verbose:
-                    logger.info(
-                        "[AdvisorSwarm] Executor refined output"
-                    )
+            self.conversation.add(role="Executor", content=output)
 
             if self.verbose:
                 logger.info(
-                    f"[AdvisorSwarm] Loop {loop + 1} complete. "
-                    f"Advisor calls used: {advisor_uses}/{self.max_advisor_uses}"
+                    f"[AdvisorSwarm] Executor completed turn {turn + 1}"
                 )
 
         return history_output_formatter(

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -18,7 +18,6 @@ from pydantic import BaseModel, Field
 from swarms.prompts.multi_agent_collab_prompt import (
     MULTI_AGENT_COLLAB_PROMPT_TWO,
 )
-from swarms.structs.advisor_swarm import AdvisorSwarm
 from swarms.structs.agent import Agent
 from swarms.structs.agent_rearrange import AgentRearrange
 from swarms.structs.batched_grid_workflow import BatchedGridWorkflow
@@ -47,7 +46,6 @@ from swarms.utils.swarm_autosave import (
 logger = initialize_logger(log_folder="swarm_router")
 
 SwarmType = Literal[
-    "AdvisorSwarm",
     "AgentRearrange",
     "MixtureOfAgents",
     "SequentialWorkflow",
@@ -216,9 +214,6 @@ class SwarmRouter:
         conversation: Any = None,
         agents_config: Optional[Dict[Any, Any]] = None,
         speaker_function: str = None,
-        advisor_swarm_executor_model_name: str = "claude-sonnet-4-6",
-        advisor_swarm_advisor_model_name: str = "claude-opus-4-6",
-        advisor_swarm_max_advisor_uses: int = 3,
         heavy_swarm_loops_per_agent: int = 1,
         heavy_swarm_question_agent_model_name: str = "gpt-4.1",
         heavy_swarm_worker_model_name: str = "gpt-4.1",
@@ -258,15 +253,6 @@ class SwarmRouter:
         self.conversation = conversation
         self.agents_config = agents_config
         self.speaker_function = speaker_function
-        self.advisor_swarm_executor_model_name = (
-            advisor_swarm_executor_model_name
-        )
-        self.advisor_swarm_advisor_model_name = (
-            advisor_swarm_advisor_model_name
-        )
-        self.advisor_swarm_max_advisor_uses = (
-            advisor_swarm_max_advisor_uses
-        )
         self.heavy_swarm_loops_per_agent = heavy_swarm_loops_per_agent
         self.heavy_swarm_question_agent_model_name = (
             heavy_swarm_question_agent_model_name
@@ -477,7 +463,6 @@ class SwarmRouter:
             Dict[str, Callable]: Dictionary mapping swarm types to their factory functions.
         """
         return {
-            "AdvisorSwarm": self._create_advisor_swarm,
             "HeavySwarm": self._create_heavy_swarm,
             "AgentRearrange": self._create_agent_rearrange,
             "CouncilAsAJudge": self._create_council_as_judge,
@@ -494,20 +479,6 @@ class SwarmRouter:
             "RoundRobin": self._create_round_robin_swarm,
             "PlannerWorkerSwarm": self._create_planner_worker_swarm,
         }
-
-    def _create_advisor_swarm(self, *args, **kwargs):
-        """Factory function for AdvisorSwarm."""
-        return AdvisorSwarm(
-            name=self.name,
-            description=self.description,
-            executor_model_name=self.advisor_swarm_executor_model_name,
-            advisor_model_name=self.advisor_swarm_advisor_model_name,
-            max_advisor_uses=self.advisor_swarm_max_advisor_uses,
-            max_loops=self.max_loops,
-            output_type=self.output_type,
-            verbose=self.verbose,
-            tools=self.worker_tools,
-        )
 
     def _create_heavy_swarm(self, *args, **kwargs):
         """Factory function for HeavySwarm."""

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 from swarms.prompts.multi_agent_collab_prompt import (
     MULTI_AGENT_COLLAB_PROMPT_TWO,
 )
+from swarms.structs.advisor_swarm import AdvisorSwarm
 from swarms.structs.agent import Agent
 from swarms.structs.agent_rearrange import AgentRearrange
 from swarms.structs.batched_grid_workflow import BatchedGridWorkflow
@@ -46,6 +47,7 @@ from swarms.utils.swarm_autosave import (
 logger = initialize_logger(log_folder="swarm_router")
 
 SwarmType = Literal[
+    "AdvisorSwarm",
     "AgentRearrange",
     "MixtureOfAgents",
     "SequentialWorkflow",
@@ -214,6 +216,9 @@ class SwarmRouter:
         conversation: Any = None,
         agents_config: Optional[Dict[Any, Any]] = None,
         speaker_function: str = None,
+        advisor_swarm_executor_model_name: str = "claude-sonnet-4-6",
+        advisor_swarm_advisor_model_name: str = "claude-opus-4-6",
+        advisor_swarm_max_advisor_uses: int = 3,
         heavy_swarm_loops_per_agent: int = 1,
         heavy_swarm_question_agent_model_name: str = "gpt-4.1",
         heavy_swarm_worker_model_name: str = "gpt-4.1",
@@ -253,6 +258,15 @@ class SwarmRouter:
         self.conversation = conversation
         self.agents_config = agents_config
         self.speaker_function = speaker_function
+        self.advisor_swarm_executor_model_name = (
+            advisor_swarm_executor_model_name
+        )
+        self.advisor_swarm_advisor_model_name = (
+            advisor_swarm_advisor_model_name
+        )
+        self.advisor_swarm_max_advisor_uses = (
+            advisor_swarm_max_advisor_uses
+        )
         self.heavy_swarm_loops_per_agent = heavy_swarm_loops_per_agent
         self.heavy_swarm_question_agent_model_name = (
             heavy_swarm_question_agent_model_name
@@ -463,6 +477,7 @@ class SwarmRouter:
             Dict[str, Callable]: Dictionary mapping swarm types to their factory functions.
         """
         return {
+            "AdvisorSwarm": self._create_advisor_swarm,
             "HeavySwarm": self._create_heavy_swarm,
             "AgentRearrange": self._create_agent_rearrange,
             "CouncilAsAJudge": self._create_council_as_judge,
@@ -479,6 +494,20 @@ class SwarmRouter:
             "RoundRobin": self._create_round_robin_swarm,
             "PlannerWorkerSwarm": self._create_planner_worker_swarm,
         }
+
+    def _create_advisor_swarm(self, *args, **kwargs):
+        """Factory function for AdvisorSwarm."""
+        return AdvisorSwarm(
+            name=self.name,
+            description=self.description,
+            executor_model_name=self.advisor_swarm_executor_model_name,
+            advisor_model_name=self.advisor_swarm_advisor_model_name,
+            max_advisor_uses=self.advisor_swarm_max_advisor_uses,
+            max_loops=self.max_loops,
+            output_type=self.output_type,
+            verbose=self.verbose,
+            tools=self.worker_tools,
+        )
 
     def _create_heavy_swarm(self, *args, **kwargs):
         """Factory function for HeavySwarm."""

--- a/tests/structs/test_advisor_swarm.py
+++ b/tests/structs/test_advisor_swarm.py
@@ -1,0 +1,245 @@
+"""Tests for AdvisorSwarm.
+
+Uses real agents and API calls — no mocks.
+"""
+
+import pytest
+
+from swarms.structs.advisor_swarm import AdvisorSwarm
+from swarms.structs.agent import Agent
+
+
+# ---------------------------------------------------------------------------
+# Construction tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisorSwarmInit:
+    def test_default_construction(self):
+        swarm = AdvisorSwarm()
+        assert swarm.name == "AdvisorSwarm"
+        assert swarm.executor_model_name == "claude-sonnet-4-6"
+        assert swarm.advisor_model_name == "claude-opus-4-6"
+        assert swarm.max_advisor_uses == 3
+        assert swarm.max_loops == 1
+        assert swarm.executor_agent is not None
+        assert swarm.advisor_agent is not None
+        assert swarm.conversation is not None
+
+    def test_custom_model_names(self):
+        swarm = AdvisorSwarm(
+            executor_model_name="gpt-4.1-mini",
+            advisor_model_name="gpt-4.1",
+        )
+        assert swarm.executor_model_name == "gpt-4.1-mini"
+        assert swarm.advisor_model_name == "gpt-4.1"
+        assert swarm.executor_agent.model_name == "gpt-4.1-mini"
+        assert swarm.advisor_agent.model_name == "gpt-4.1"
+
+    def test_custom_agents_override(self):
+        custom_executor = Agent(
+            agent_name="CustomExecutor",
+            model_name="gpt-4.1-mini",
+            max_loops=1,
+        )
+        custom_advisor = Agent(
+            agent_name="CustomAdvisor",
+            model_name="gpt-4.1",
+            max_loops=1,
+        )
+        swarm = AdvisorSwarm(
+            executor_agent=custom_executor,
+            advisor_agent=custom_advisor,
+        )
+        assert swarm.executor_agent is custom_executor
+        assert swarm.advisor_agent is custom_advisor
+
+    def test_id_generated(self):
+        swarm = AdvisorSwarm()
+        assert swarm.id is not None
+        assert len(swarm.id) > 0
+
+    def test_callable(self):
+        swarm = AdvisorSwarm()
+        assert callable(swarm)
+
+
+# ---------------------------------------------------------------------------
+# Reliability check tests
+# ---------------------------------------------------------------------------
+
+
+class TestReliabilityCheck:
+    def test_max_advisor_uses_zero_raises(self):
+        with pytest.raises(ValueError, match="max_advisor_uses"):
+            AdvisorSwarm(max_advisor_uses=0)
+
+    def test_max_advisor_uses_negative_raises(self):
+        with pytest.raises(ValueError, match="max_advisor_uses"):
+            AdvisorSwarm(max_advisor_uses=-1)
+
+    def test_max_loops_zero_raises(self):
+        with pytest.raises(ValueError, match="max_loops"):
+            AdvisorSwarm(max_loops=0)
+
+    def test_empty_executor_model_raises(self):
+        with pytest.raises(ValueError, match="executor_model_name"):
+            AdvisorSwarm(executor_model_name="")
+
+    def test_empty_advisor_model_raises(self):
+        with pytest.raises(ValueError, match="advisor_model_name"):
+            AdvisorSwarm(advisor_model_name="")
+
+
+# ---------------------------------------------------------------------------
+# Verdict parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsSatisfactory:
+    def setup_method(self):
+        self.swarm = AdvisorSwarm()
+
+    def test_satisfactory_exact(self):
+        assert self.swarm._is_satisfactory("VERDICT: SATISFACTORY\nLooks good.")
+
+    def test_satisfactory_lowercase(self):
+        assert self.swarm._is_satisfactory("verdict: satisfactory\nAll criteria met.")
+
+    def test_satisfactory_mixed_case(self):
+        assert self.swarm._is_satisfactory("Verdict: Satisfactory\nWell done.")
+
+    def test_needs_revision(self):
+        assert not self.swarm._is_satisfactory("VERDICT: NEEDS_REVISION\n1. Fix the imports.")
+
+    def test_no_verdict(self):
+        assert not self.swarm._is_satisfactory("The output looks incomplete.")
+
+    def test_empty_string(self):
+        assert not self.swarm._is_satisfactory("")
+
+
+# ---------------------------------------------------------------------------
+# Run validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunValidation:
+    def test_run_no_task_raises(self):
+        swarm = AdvisorSwarm()
+        with pytest.raises(ValueError, match="task is required"):
+            swarm.run(task=None)
+
+    def test_run_empty_task_raises(self):
+        swarm = AdvisorSwarm()
+        with pytest.raises(ValueError, match="task is required"):
+            swarm.run(task="")
+
+
+# ---------------------------------------------------------------------------
+# Prompt building tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptBuilding:
+    def setup_method(self):
+        self.swarm = AdvisorSwarm()
+
+    def test_planning_prompt_contains_task(self):
+        prompt = self.swarm._build_planning_prompt("Write a haiku")
+        assert "Write a haiku" in prompt
+        assert "PLANNING MODE" in prompt
+
+    def test_executor_prompt_contains_task_and_advice(self):
+        prompt = self.swarm._build_executor_prompt(
+            "Write a haiku", "1. Choose a theme\n2. Count syllables"
+        )
+        assert "Write a haiku" in prompt
+        assert "Count syllables" in prompt
+
+    def test_review_prompt_contains_output(self):
+        prompt = self.swarm._build_review_prompt(
+            "Write a haiku", "Old pond / frog jumps in / water sound"
+        )
+        assert "REVIEW MODE" in prompt
+        assert "Old pond" in prompt
+        assert "Write a haiku" in prompt
+
+    def test_refinement_prompt_contains_all_context(self):
+        prompt = self.swarm._build_refinement_prompt(
+            "Write a haiku",
+            "Old pond / frog jumps in / water sound",
+            "VERDICT: NEEDS_REVISION\n1. Fix syllable count",
+        )
+        assert "Write a haiku" in prompt
+        assert "Old pond" in prompt
+        assert "Fix syllable count" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Integration test (requires API key)
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisorSwarmExecution:
+    """End-to-end tests with real API calls.
+
+    These tests require a valid LLM API key in the environment.
+    Skip with: pytest -k 'not Execution'
+    """
+
+    def test_basic_run(self):
+        swarm = AdvisorSwarm(
+            executor_model_name="gpt-4.1-mini",
+            advisor_model_name="gpt-4.1-mini",
+            max_advisor_uses=2,
+            max_loops=1,
+        )
+        result = swarm.run(task="What is 2 + 2? Answer in one word.")
+        assert result is not None
+
+        # Conversation should have entries from User, Advisor, and Executor
+        history = swarm.conversation.to_dict()
+        roles = [msg["role"] for msg in history]
+        assert "User" in roles
+        assert "Advisor" in roles
+        assert "Executor" in roles
+
+    def test_max_advisor_uses_one_no_review(self):
+        """With max_advisor_uses=1, only the planning call happens — no review."""
+        swarm = AdvisorSwarm(
+            executor_model_name="gpt-4.1-mini",
+            advisor_model_name="gpt-4.1-mini",
+            max_advisor_uses=1,
+            max_loops=1,
+        )
+        result = swarm.run(task="Say hello")
+        assert result is not None
+
+        history = swarm.conversation.to_dict()
+        advisor_entries = [
+            msg for msg in history if msg["role"] == "Advisor"
+        ]
+        # Only 1 advisor entry (the planning call)
+        assert len(advisor_entries) == 1
+
+    def test_batched_run(self):
+        swarm = AdvisorSwarm(
+            executor_model_name="gpt-4.1-mini",
+            advisor_model_name="gpt-4.1-mini",
+            max_advisor_uses=1,
+            max_loops=1,
+        )
+        results = swarm.batched_run(["Say hi", "Say bye"])
+        assert isinstance(results, list)
+        assert len(results) == 2
+
+    def test_callable_invocation(self):
+        swarm = AdvisorSwarm(
+            executor_model_name="gpt-4.1-mini",
+            advisor_model_name="gpt-4.1-mini",
+            max_advisor_uses=1,
+            max_loops=1,
+        )
+        result = swarm("What is 1 + 1?")
+        assert result is not None

--- a/tests/structs/test_advisor_swarm.py
+++ b/tests/structs/test_advisor_swarm.py
@@ -137,43 +137,26 @@ class TestRunValidation:
 
 
 # ---------------------------------------------------------------------------
-# Prompt building tests
+# Verdict regex tests (edge cases)
 # ---------------------------------------------------------------------------
 
 
-class TestPromptBuilding:
+class TestVerdictParsing:
     def setup_method(self):
         self.swarm = AdvisorSwarm()
 
-    def test_planning_prompt_contains_task(self):
-        prompt = self.swarm._build_planning_prompt("Write a haiku")
-        assert "Write a haiku" in prompt
-        assert "PLANNING MODE" in prompt
+    def test_extra_whitespace(self):
+        assert self.swarm._is_satisfactory("VERDICT :  SATISFACTORY\nAll good.")
 
-    def test_executor_prompt_contains_task_and_advice(self):
-        prompt = self.swarm._build_executor_prompt(
-            "Write a haiku", "1. Choose a theme\n2. Count syllables"
+    def test_embedded_in_paragraph(self):
+        assert self.swarm._is_satisfactory(
+            "After reviewing the output:\nVERDICT: SATISFACTORY\nThe code is correct."
         )
-        assert "Write a haiku" in prompt
-        assert "Count syllables" in prompt
 
-    def test_review_prompt_contains_output(self):
-        prompt = self.swarm._build_review_prompt(
-            "Write a haiku", "Old pond / frog jumps in / water sound"
+    def test_needs_revision_not_satisfactory(self):
+        assert not self.swarm._is_satisfactory(
+            "VERDICT: NEEDS_REVISION\n1. Missing error handling"
         )
-        assert "REVIEW MODE" in prompt
-        assert "Old pond" in prompt
-        assert "Write a haiku" in prompt
-
-    def test_refinement_prompt_contains_all_context(self):
-        prompt = self.swarm._build_refinement_prompt(
-            "Write a haiku",
-            "Old pond / frog jumps in / water sound",
-            "VERDICT: NEEDS_REVISION\n1. Fix syllable count",
-        )
-        assert "Write a haiku" in prompt
-        assert "Old pond" in prompt
-        assert "Fix syllable count" in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/structs/test_advisor_swarm.py
+++ b/tests/structs/test_advisor_swarm.py
@@ -63,6 +63,11 @@ class TestAdvisorSwarmInit:
         swarm = AdvisorSwarm()
         assert callable(swarm)
 
+    def test_zero_advisor_uses_allowed(self):
+        """max_advisor_uses=0 means executor runs alone — no advisor."""
+        swarm = AdvisorSwarm(max_advisor_uses=0)
+        assert swarm.max_advisor_uses == 0
+
 
 # ---------------------------------------------------------------------------
 # Reliability check tests
@@ -70,10 +75,6 @@ class TestAdvisorSwarmInit:
 
 
 class TestReliabilityCheck:
-    def test_max_advisor_uses_zero_raises(self):
-        with pytest.raises(ValueError, match="max_advisor_uses"):
-            AdvisorSwarm(max_advisor_uses=0)
-
     def test_max_advisor_uses_negative_raises(self):
         with pytest.raises(ValueError, match="max_advisor_uses"):
             AdvisorSwarm(max_advisor_uses=-1)
@@ -89,34 +90,6 @@ class TestReliabilityCheck:
     def test_empty_advisor_model_raises(self):
         with pytest.raises(ValueError, match="advisor_model_name"):
             AdvisorSwarm(advisor_model_name="")
-
-
-# ---------------------------------------------------------------------------
-# Verdict parsing tests
-# ---------------------------------------------------------------------------
-
-
-class TestIsSatisfactory:
-    def setup_method(self):
-        self.swarm = AdvisorSwarm()
-
-    def test_satisfactory_exact(self):
-        assert self.swarm._is_satisfactory("VERDICT: SATISFACTORY\nLooks good.")
-
-    def test_satisfactory_lowercase(self):
-        assert self.swarm._is_satisfactory("verdict: satisfactory\nAll criteria met.")
-
-    def test_satisfactory_mixed_case(self):
-        assert self.swarm._is_satisfactory("Verdict: Satisfactory\nWell done.")
-
-    def test_needs_revision(self):
-        assert not self.swarm._is_satisfactory("VERDICT: NEEDS_REVISION\n1. Fix the imports.")
-
-    def test_no_verdict(self):
-        assert not self.swarm._is_satisfactory("The output looks incomplete.")
-
-    def test_empty_string(self):
-        assert not self.swarm._is_satisfactory("")
 
 
 # ---------------------------------------------------------------------------
@@ -137,30 +110,7 @@ class TestRunValidation:
 
 
 # ---------------------------------------------------------------------------
-# Verdict regex tests (edge cases)
-# ---------------------------------------------------------------------------
-
-
-class TestVerdictParsing:
-    def setup_method(self):
-        self.swarm = AdvisorSwarm()
-
-    def test_extra_whitespace(self):
-        assert self.swarm._is_satisfactory("VERDICT :  SATISFACTORY\nAll good.")
-
-    def test_embedded_in_paragraph(self):
-        assert self.swarm._is_satisfactory(
-            "After reviewing the output:\nVERDICT: SATISFACTORY\nThe code is correct."
-        )
-
-    def test_needs_revision_not_satisfactory(self):
-        assert not self.swarm._is_satisfactory(
-            "VERDICT: NEEDS_REVISION\n1. Missing error handling"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Integration test (requires API key)
+# Integration tests (require API key)
 # ---------------------------------------------------------------------------
 
 
@@ -171,40 +121,55 @@ class TestAdvisorSwarmExecution:
     Skip with: pytest -k 'not Execution'
     """
 
-    def test_basic_run(self):
-        swarm = AdvisorSwarm(
-            executor_model_name="gpt-4.1-mini",
-            advisor_model_name="gpt-4.1-mini",
-            max_advisor_uses=2,
-            max_loops=1,
-        )
-        result = swarm.run(task="What is 2 + 2? Answer in one word.")
-        assert result is not None
-
-        # Conversation should have entries from User, Advisor, and Executor
-        history = swarm.conversation.to_dict()
-        roles = [msg["role"] for msg in history]
-        assert "User" in roles
-        assert "Advisor" in roles
-        assert "Executor" in roles
-
-    def test_max_advisor_uses_one_no_review(self):
-        """With max_advisor_uses=1, only the planning call happens — no review."""
+    def test_single_turn_with_advisor(self):
         swarm = AdvisorSwarm(
             executor_model_name="gpt-4.1-mini",
             advisor_model_name="gpt-4.1-mini",
             max_advisor_uses=1,
             max_loops=1,
         )
+        result = swarm.run(task="What is 2 + 2? Answer in one word.")
+        assert result is not None
+
+        # Conversation: User, Advisor (1 consultation), Executor (1 turn)
+        history = swarm.conversation.to_dict()
+        roles = [msg["role"] for msg in history]
+        assert "User" in roles
+        assert "Advisor" in roles
+        assert "Executor" in roles
+
+    def test_executor_only_no_advisor(self):
+        """With max_advisor_uses=0, executor runs alone."""
+        swarm = AdvisorSwarm(
+            executor_model_name="gpt-4.1-mini",
+            advisor_model_name="gpt-4.1-mini",
+            max_advisor_uses=0,
+            max_loops=1,
+        )
         result = swarm.run(task="Say hello")
         assert result is not None
 
         history = swarm.conversation.to_dict()
-        advisor_entries = [
-            msg for msg in history if msg["role"] == "Advisor"
+        roles = [msg["role"] for msg in history]
+        assert "Advisor" not in roles
+        assert "Executor" in roles
+
+    def test_multi_turn(self):
+        """With max_loops=2, executor runs twice."""
+        swarm = AdvisorSwarm(
+            executor_model_name="gpt-4.1-mini",
+            advisor_model_name="gpt-4.1-mini",
+            max_advisor_uses=2,
+            max_loops=2,
+        )
+        result = swarm.run(task="Count to 3")
+        assert result is not None
+
+        history = swarm.conversation.to_dict()
+        executor_entries = [
+            msg for msg in history if msg["role"] == "Executor"
         ]
-        # Only 1 advisor entry (the planning call)
-        assert len(advisor_entries) == 1
+        assert len(executor_entries) == 2
 
     def test_batched_run(self):
         swarm = AdvisorSwarm(


### PR DESCRIPTION
## Summary

- Implements the [advisor strategy](https://claude.com/blog/the-advisor-strategy) as a new swarm struct (`AdvisorSwarm`)
- Pairs a cheaper executor model with a powerful advisor model consulted at key decision points
- Provider-agnostic — works with any LiteLLM-supported model, not locked to Anthropic's beta API
- Advisor plans before work, reviews after, and the executor refines until satisfactory or budget exhausted

## Changes

- **New struct**: `swarms/structs/advisor_swarm.py` — core `AdvisorSwarm` class with `run()` and `batched_run()`
- **Prompts**: `swarms/prompts/advisor_swarm_prompts.py` — advisor and executor system prompts
- **SwarmRouter**: Registered `AdvisorSwarm` as a new swarm type with factory method
- **Exports**: Added to `swarms/structs/__init__.py`
- **Tests**: `tests/structs/test_advisor_swarm.py` — 22 unit tests + 4 integration tests
- **Docs**: `docs/swarms/structs/advisor_swarm.md` with flow diagram, full API reference, and usage examples
- **Example**: `examples/multi_agent/advisor_swarm_examples/advisor_swarm_example.py`

## Test plan

- [x] 22 unit tests pass (`pytest tests/structs/test_advisor_swarm.py -k "not Execution"`)
- [x] Import verified: `from swarms import AdvisorSwarm`
- [x] SwarmRouter integration verified
- [x] End-to-end run tested with Claude Sonnet (executor) + Claude Opus (advisor)
- [ ] Integration tests with API keys: `pytest tests/structs/test_advisor_swarm.py -v`

Closes #1526

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1532.org.readthedocs.build/en/1532/

<!-- readthedocs-preview swarms end -->