### PR TITLE
[BUGF] namespace GraphWorkflow checkpoints by workflow and loop

### DIFF
--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -1788,12 +1788,7 @@ class GraphWorkflow:
                 execution_results = {}
                 prev_outputs = {}
 
-                # Derive a deterministic key for this task so checkpoints
-                # survive process restarts (Python's hash() is salted and
-                # is NOT stable across runs).
-                task_key = hashlib.sha256(
-                    task.encode("utf-8")
-                ).hexdigest()[:16]
+                checkpoint_prefix = self._checkpoint_prefix(task, loop)
 
                 # Seed entry-point nodes with end-point outputs from the
                 # previous loop so agents can refine iteratively.
@@ -1812,7 +1807,7 @@ class GraphWorkflow:
                     if self.checkpoint_dir:
                         checkpoint_path = (
                             Path(self.checkpoint_dir)
-                            / f"{task_key}_layer_{layer_idx}.json"
+                            / f"{checkpoint_prefix}_layer_{layer_idx}.json"
                         )
                         if checkpoint_path.exists():
                             try:
@@ -1996,7 +1991,7 @@ class GraphWorkflow:
                             cp_dir.mkdir(parents=True, exist_ok=True)
                             checkpoint_path = (
                                 cp_dir
-                                / f"{task_key}_layer_{layer_idx}.json"
+                                / f"{checkpoint_prefix}_layer_{layer_idx}.json"
                             )
                             layer_outputs = {
                                 nid: prev_outputs[nid]
@@ -2460,6 +2455,42 @@ class GraphWorkflow:
             )
             raise e
 
+    def _checkpoint_namespace_key(self) -> str:
+        """
+        Build a deterministic checkpoint namespace for this workflow.
+
+        The namespace intentionally excludes transient runtime state so the
+        same logical workflow can resume across process restarts while still
+        avoiding collisions with unrelated workflows sharing a checkpoint
+        directory.
+        """
+        namespace = {
+            "name": self.name,
+            "description": self.description,
+            "backend": type(self.graph_backend).__name__,
+            "nodes": sorted(self.nodes.keys()),
+            "edges": sorted(
+                (edge.source, edge.target) for edge in self.edges
+            ),
+        }
+        return hashlib.sha256(
+            json.dumps(
+                namespace,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()[:12]
+
+    def _checkpoint_prefix(self, task: str, loop: int) -> str:
+        """
+        Build a stable checkpoint prefix for a task and loop.
+        """
+        task_key = hashlib.sha256(task.encode("utf-8")).hexdigest()[
+            :16
+        ]
+        workflow_key = self._checkpoint_namespace_key()
+        return f"{workflow_key}_{task_key}_loop_{loop}"
+
     def clear_checkpoints(self, task: str) -> int:
         """
         Delete all checkpoint files written for a specific task.
@@ -2490,12 +2521,13 @@ class GraphWorkflow:
         cp_dir = Path(self.checkpoint_dir)
         if not cp_dir.exists():
             return 0
+        workflow_key = self._checkpoint_namespace_key()
         task_key = hashlib.sha256(task.encode("utf-8")).hexdigest()[
             :16
         ]
-        prefix = f"{task_key}_layer_"
+        prefix = f"{workflow_key}_{task_key}_loop_"
         deleted = 0
-        for cp_file in cp_dir.glob(f"{prefix}*.json"):
+        for cp_file in cp_dir.glob(f"{prefix}*_layer_*.json"):
             try:
                 cp_file.unlink()
                 deleted += 1

--- a/tests/structs/test_graph_workflow.py
+++ b/tests/structs/test_graph_workflow.py
@@ -560,12 +560,18 @@ def test_graph_workflow_checkpoint_writes_and_resumes(tmp_path):
     assert results["CP-Beta"] == "output-CP-Beta"
     assert results["CP-Gamma"] == "output-CP-Gamma"
 
-    task_key = hashlib.sha256(TASK.encode("utf-8")).hexdigest()[:16]
+    checkpoint_prefix = wf._checkpoint_prefix(TASK, 0)
     cp_files = list(tmp_path.glob("checkpoints/*.json"))
     assert len(cp_files) == 3
-    assert any(f"{task_key}_layer_0" in f.name for f in cp_files)
-    assert any(f"{task_key}_layer_1" in f.name for f in cp_files)
-    assert any(f"{task_key}_layer_2" in f.name for f in cp_files)
+    assert any(
+        f"{checkpoint_prefix}_layer_0" in f.name for f in cp_files
+    )
+    assert any(
+        f"{checkpoint_prefix}_layer_1" in f.name for f in cp_files
+    )
+    assert any(
+        f"{checkpoint_prefix}_layer_2" in f.name for f in cp_files
+    )
 
     # Reset call counts, then run again — all layers should be skipped
     a1.run.reset_mock()
@@ -604,8 +610,12 @@ def test_graph_workflow_checkpoint_partial_resume(tmp_path):
     wf.run(TASK)
 
     # Delete the last layer's checkpoint to simulate a crash after layer 2
-    task_key = hashlib.sha256(TASK.encode("utf-8")).hexdigest()[:16]
-    (tmp_path / "checkpoints" / f"{task_key}_layer_2.json").unlink()
+    checkpoint_prefix = wf._checkpoint_prefix(TASK, 0)
+    (
+        tmp_path
+        / "checkpoints"
+        / f"{checkpoint_prefix}_layer_2.json"
+    ).unlink()
 
     a1.run.reset_mock()
     a2.run.reset_mock()
@@ -652,10 +662,8 @@ def test_graph_workflow_clear_checkpoints(tmp_path):
     remaining = list(tmp_path.glob("checkpoints/*.json"))
     assert len(remaining) == 2  # only TASK_B files remain
 
-    task_b_key = hashlib.sha256(TASK_B.encode("utf-8")).hexdigest()[
-        :16
-    ]
-    assert all(task_b_key in f.name for f in remaining)
+    task_b_prefix = wf._checkpoint_prefix(TASK_B, 0)
+    assert all(task_b_prefix in f.name for f in remaining)
 
 
 def test_graph_workflow_clear_checkpoints_no_dir():
@@ -701,6 +709,28 @@ def test_graph_workflow_checkpoint_conversation_replay(tmp_path):
     ]
     assert "CV-Alpha" in history_roles
     assert "CV-Beta" in history_roles
+
+
+def test_graph_workflow_checkpoint_prefix_varies_by_workflow():
+    """Checkpoint prefixes should not collide across distinct workflows."""
+
+    wf_a = GraphWorkflow(name="Graph-A")
+    wf_b = GraphWorkflow(name="Graph-B")
+
+    assert (
+        wf_a._checkpoint_prefix("shared task", 0)
+        != wf_b._checkpoint_prefix("shared task", 0)
+    )
+
+
+def test_graph_workflow_checkpoint_prefix_varies_by_loop():
+    """Loop-specific checkpoint prefixes avoid stale replay across loops."""
+
+    wf = GraphWorkflow(name="Loop-Test")
+
+    assert wf._checkpoint_prefix("shared task", 0) != wf._checkpoint_prefix(
+        "shared task", 1
+    )
 
 
 def test_graph_workflow_to_spec_round_trip():

--- a/tests/structs/test_graph_workflow.py
+++ b/tests/structs/test_graph_workflow.py
@@ -733,6 +733,26 @@ def test_graph_workflow_checkpoint_prefix_varies_by_loop():
     )
 
 
+def test_graph_workflow_checkpoint_prefix_is_stable_for_same_topology():
+    """Identical workflows should keep the same checkpoint namespace."""
+
+    a1 = create_test_agent("Stable-Alpha", "First agent")
+    b1 = create_test_agent("Stable-Beta", "Second agent")
+    wf1 = GraphWorkflow(name="Stable-Workflow")
+    wf1.add_nodes([a1, b1])
+    wf1.add_edge("Stable-Alpha", "Stable-Beta")
+
+    a2 = create_test_agent("Stable-Alpha", "First agent")
+    b2 = create_test_agent("Stable-Beta", "Second agent")
+    wf2 = GraphWorkflow(name="Stable-Workflow")
+    wf2.add_nodes([a2, b2])
+    wf2.add_edge("Stable-Alpha", "Stable-Beta")
+
+    assert wf1._checkpoint_prefix(
+        "shared task", 0
+    ) == wf2._checkpoint_prefix("shared task", 0)
+
+
 def test_graph_workflow_to_spec_round_trip():
     """to_spec / from_topology_spec round-trip preserves topology and metadata."""
     a = create_test_agent("Alpha", "First agent")


### PR DESCRIPTION
## Description
This PR fixes checkpoint filename collisions in `GraphWorkflow`.

The current checkpoint path only uses the task hash and layer index, so two workflows that share a `checkpoint_dir` and task string can reuse each other's checkpoint files. The same filename pattern also ignores the loop index, so multi-loop runs can pick up stale outputs from earlier loops.

This PR keeps the change focused:
- derive a stable checkpoint namespace from workflow metadata/topology
- include the loop index in the checkpoint prefix
- update checkpoint cleanup to match the new prefix
- add regression tests for workflow-level and loop-level isolation

## Files Changed
- `swarms/structs/graph_workflow.py`
- `tests/structs/test_graph_workflow.py`

## Issue
Closes #1537

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Test plan
- [x] `PYTHONPATH=. python -m pytest tests/structs/test_graph_workflow.py -k 'checkpoint' -q`

## Why this scope
Recent merges here land best when the PR addresses one concrete failure mode, proves it with a regression test, and does not mix in unrelated refactors. This patch stays inside checkpoint naming/cleanup behavior only.


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1539.org.readthedocs.build/en/1539/

<!-- readthedocs-preview swarms end -->