### PR TITLE
[BUGF] cap SequentialWorkflow drift-triggered reruns

### DIFF
--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -259,14 +259,14 @@ class SequentialWorkflow:
             if score >= self.drift_threshold:
                 logger.info(f"Drift check passed: score={score:.2f}")
                 break
-            logger.warning(
-                f"Drift detected: score={score:.2f} below threshold={self.drift_threshold}, rerunning pipeline"
-            )
             if rerun_count >= self.drift_max_reruns:
                 logger.warning(
                     "Drift detection rerun cap reached; returning latest pipeline result"
                 )
                 break
+            logger.warning(
+                f"Drift detected: score={score:.2f} below threshold={self.drift_threshold}, rerunning pipeline"
+            )
             rerun_count += 1
             result = self.agent_rearrange.run(**run_kwargs)
         return result

--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -90,6 +90,7 @@ class SequentialWorkflow:
         drift_detection: bool = False,
         drift_threshold: float = 0.75,
         drift_model: str = "claude-sonnet-4-5",
+        drift_max_reruns: int = 3,
         *args,
         **kwargs,
     ):
@@ -113,6 +114,9 @@ class SequentialWorkflow:
                 A warning is logged when the score falls below this value. Defaults to 0.75.
             drift_model (str, optional): Model used by the drift detection judge agent.
                 Defaults to "claude-sonnet-4-5".
+            drift_max_reruns (int, optional): Maximum number of pipeline reruns
+                triggered by drift detection before returning the latest result.
+                Defaults to 3.
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
@@ -131,6 +135,7 @@ class SequentialWorkflow:
         self.autosave = autosave
         self.verbose = verbose
         self.drift_threshold = drift_threshold
+        self.drift_max_reruns = drift_max_reruns
         self.drift_agent = (
             Agent(
                 agent_name="DriftDetector",
@@ -175,6 +180,9 @@ class SequentialWorkflow:
 
         if self.max_loops == 0:
             raise ValueError("max_loops cannot be 0")
+
+        if self.drift_max_reruns < 0:
+            raise ValueError("drift_max_reruns cannot be negative")
 
         if self.multi_agent_collab_prompt is True:
             for agent in self.agents:
@@ -231,6 +239,7 @@ class SequentialWorkflow:
     def _run_drift_detection(
         self, task: str, result: str, run_kwargs: dict
     ) -> str:
+        rerun_count = 0
         while True:
             try:
                 raw = self.drift_agent.run(
@@ -253,6 +262,12 @@ class SequentialWorkflow:
             logger.warning(
                 f"Drift detected: score={score:.2f} below threshold={self.drift_threshold}, rerunning pipeline"
             )
+            if rerun_count >= self.drift_max_reruns:
+                logger.warning(
+                    "Drift detection rerun cap reached; returning latest pipeline result"
+                )
+                break
+            rerun_count += 1
             result = self.agent_rearrange.run(**run_kwargs)
         return result
 
@@ -269,9 +284,9 @@ class SequentialWorkflow:
 
         If drift_detection is configured, a judge agent scores the final output's semantic
         alignment with the original task after the pipeline completes. If the score falls
-        below drift_threshold, the pipeline reruns and the cycle repeats until the score
-        meets the threshold. If the judge output cannot be parsed, drift checking is skipped
-        and the last result is returned as-is.
+        below drift_threshold, the pipeline reruns until the score meets the threshold or
+        drift_max_reruns is reached. If the judge output cannot be parsed, drift checking is
+        skipped and the last result is returned as-is.
 
         Args:
             task (str): The task for the agents to execute.

--- a/tests/structs/test_sequential_workflow.py
+++ b/tests/structs/test_sequential_workflow.py
@@ -588,3 +588,22 @@ def test_workflow_run_drift_stops_at_rerun_cap():
 
     assert result == "output-3"
     assert pipeline_call_count == 3
+
+
+def test_workflow_run_drift_zero_reruns_does_not_reinvoke_pipeline():
+    """A zero rerun cap should return the first pipeline result unchanged."""
+    wf = _make_workflow(
+        drift_detection=True,
+        drift_threshold=0.75,
+        drift_max_reruns=0,
+    )
+
+    with patch.object(
+        wf.agent_rearrange, "run", return_value="first-output"
+    ) as pipeline_run, patch.object(
+        wf.drift_agent, "run", return_value=_tool_call_response(0.1)
+    ):
+        result = wf.run("task")
+
+    assert result == "first-output"
+    assert pipeline_run.call_count == 1

--- a/tests/structs/test_sequential_workflow.py
+++ b/tests/structs/test_sequential_workflow.py
@@ -430,6 +430,11 @@ def test_workflow_drift_threshold_stored():
     assert wf.drift_threshold == 0.9
 
 
+def test_workflow_drift_max_reruns_stored():
+    wf = _make_workflow(drift_detection=True, drift_max_reruns=2)
+    assert wf.drift_max_reruns == 2
+
+
 def test_workflow_run_without_drift_returns_raw():
     wf = _make_workflow(drift_detection=False)
     fake_output = "pipeline result"
@@ -557,3 +562,29 @@ def test_workflow_run_drift_retries_until_threshold_met():
     assert result == "good output"
     assert pipeline_call_count == 3
     assert drift_call_count == 3
+
+
+def test_workflow_run_drift_stops_at_rerun_cap():
+    """Low drift scores should stop after the configured rerun cap."""
+    wf = _make_workflow(
+        drift_detection=True,
+        drift_threshold=0.75,
+        drift_max_reruns=2,
+    )
+
+    pipeline_call_count = 0
+
+    def pipeline_side_effect(**kwargs):
+        nonlocal pipeline_call_count
+        pipeline_call_count += 1
+        return f"output-{pipeline_call_count}"
+
+    with patch.object(
+        wf.agent_rearrange, "run", side_effect=pipeline_side_effect
+    ), patch.object(
+        wf.drift_agent, "run", return_value=_tool_call_response(0.1)
+    ):
+        result = wf.run("task")
+
+    assert result == "output-3"
+    assert pipeline_call_count == 3


### PR DESCRIPTION
## Description
This PR bounds drift-triggered reruns in `SequentialWorkflow`.

`_run_drift_detection()` currently reruns the pipeline in a `while True` loop until the score crosses the threshold. If the score never improves, the workflow can continue rerunning indefinitely and burn tokens without a bounded exit path.

This patch is intentionally small:
- add `drift_max_reruns` with a conservative default
- validate the new setting
- stop rerunning once the cap is reached and return the latest pipeline result
- add regression coverage for both bounded reruns and successful recovery

## Files Changed
- `swarms/structs/sequential_workflow.py`
- `tests/structs/test_sequential_workflow.py`

## Issue
Closes #1536

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Test plan
- [x] `PYTHONPATH=. python -m pytest tests/structs/test_sequential_workflow.py -k 'drift' -q`

## Why this scope
Recent merged bugfixes in this repo tend to be narrow, test-backed, and easy to reason about. This PR only adds a bounded retry guard to the confirmed infinite-rerun path and leaves the broader drift-detection feature intact.


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1540.org.readthedocs.build/en/1540/

<!-- readthedocs-preview swarms end -->