### PR TITLE
Fix CLI .env discovery and runtime reload

### DIFF
--- a/swarms/cli/main.py
+++ b/swarms/cli/main.py
@@ -2074,6 +2074,9 @@ def main() -> None:
         purposes while maintaining a clean user experience.
     """
     try:
+        # Refresh env discovery at execution time so the CLI uses
+        # the caller's current working directory.
+        load_swarms_env()
         show_ascii_art()
 
         parser = setup_argument_parser()

--- a/swarms/cli/utils.py
+++ b/swarms/cli/utils.py
@@ -22,6 +22,7 @@ from rich.rule import Rule
 from rich.table import Table
 from rich.text import Text
 
+from swarms.env import resolve_swarms_env_path
 from swarms.utils.workspace_utils import get_workspace_dir
 
 # Initialize console with custom styling
@@ -252,8 +253,8 @@ def check_env_file() -> Tuple[bool, str, str]:
     Returns:
         Tuple containing (success, status_icon, message)
     """
-    env_path = Path(".env")
-    if env_path.exists():
+    env_path = resolve_swarms_env_path()
+    if env_path is not None:
         try:
             content = env_path.read_text().strip()
             if content:
@@ -266,18 +267,25 @@ def check_env_file() -> Tuple[bool, str, str]:
                 return (
                     True,
                     "✓",
-                    f".env file exists with {len(api_keys)} API key(s)",
+                    f".env file found at {env_path} with {len(api_keys)} API key(s)",
                 )
-            else:
-                return False, "⚠", ".env file exists but is empty"
+            return (
+                False,
+                "⚠",
+                f".env file found at {env_path} but is empty",
+            )
         except Exception as e:
             return (
                 False,
                 "✗",
-                f".env file exists but cannot be read: {str(e)}",
+                f".env file at {env_path} cannot be read: {str(e)}",
             )
-    else:
-        return False, "✗", ".env file not found in current directory"
+    return (
+        False,
+        "✗",
+        ".env file not found in current directory, its parents, "
+        "or your home directory",
+    )
 
 
 def check_swarms_version(verbose: bool = False) -> str:

--- a/swarms/env.py
+++ b/swarms/env.py
@@ -1,9 +1,13 @@
 """Environment loading helpers for Swarms."""
 
+import os
+import shutil
+import subprocess
+from io import StringIO
 from pathlib import Path
 from typing import Optional
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 
 
 def resolve_swarms_env_path() -> Optional[Path]:
@@ -29,11 +33,85 @@ def resolve_swarms_env_path() -> Optional[Path]:
     return None
 
 
+def resolve_dotenvx_binary() -> Optional[str]:
+    """Return the available ``dotenvx`` binary, if any."""
+    return shutil.which("dotenvx")
+
+
+def _env_file_looks_encrypted(dotenv_path: Path) -> bool:
+    """Detect the markers dotenvx writes into encrypted env files."""
+    try:
+        contents = dotenv_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+    return (
+        "encrypted:" in contents
+        or "DOTENV_PUBLIC_KEY=" in contents
+    )
+
+
+def load_swarms_env_with_dotenvx(
+    dotenv_path: Path,
+    *,
+    override: bool = False,
+    dotenvx_binary: Optional[str] = None,
+) -> bool:
+    """Load env values with ``dotenvx`` using its runtime precedence rules."""
+    binary = dotenvx_binary or resolve_dotenvx_binary()
+    if binary is None:
+        return False
+
+    command = [
+        binary,
+        "get",
+        "--format=eval",
+        "-f",
+        str(dotenv_path),
+    ]
+    if override:
+        command.append("--overload")
+
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    values = dotenv_values(stream=StringIO(result.stdout))
+    loaded = False
+
+    for key, value in values.items():
+        if value is None:
+            continue
+        os.environ[key] = value
+        loaded = True
+
+    return loaded
+
+
 def load_swarms_env(*, override: bool = False) -> bool:
     """Load Swarms environment variables from the resolved ``.env``."""
     dotenv_path = resolve_swarms_env_path()
 
     if dotenv_path is None:
         return False
+
+    dotenvx_binary = resolve_dotenvx_binary()
+
+    if dotenvx_binary is not None:
+        try:
+            return load_swarms_env_with_dotenvx(
+                dotenv_path,
+                override=override,
+                dotenvx_binary=dotenvx_binary,
+            )
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+        ):
+            if _env_file_looks_encrypted(dotenv_path):
+                raise
 
     return load_dotenv(dotenv_path=dotenv_path, override=override)

--- a/swarms/env.py
+++ b/swarms/env.py
@@ -1,13 +1,39 @@
 """Environment loading helpers for Swarms."""
 
-from dotenv import find_dotenv, load_dotenv
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+
+def resolve_swarms_env_path() -> Optional[Path]:
+    """
+    Resolve the ``.env`` file used by Swarms.
+
+    Search order:
+    1. Current working directory
+    2. Parent directories of the current working directory
+    3. User home directory
+    """
+    current_dir = Path.cwd().resolve()
+
+    for directory in (current_dir, *current_dir.parents):
+        candidate = directory / ".env"
+        if candidate.is_file():
+            return candidate
+
+    home_candidate = Path.home() / ".env"
+    if home_candidate.is_file():
+        return home_candidate
+
+    return None
 
 
 def load_swarms_env(*, override: bool = False) -> bool:
-    """Load a ``.env`` file by searching upward from the current working directory."""
-    dotenv_path = find_dotenv(".env", usecwd=True)
+    """Load Swarms environment variables from the resolved ``.env``."""
+    dotenv_path = resolve_swarms_env_path()
 
-    if not dotenv_path:
+    if dotenv_path is None:
         return False
 
     return load_dotenv(dotenv_path=dotenv_path, override=override)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ Run with: pytest tests/test_cli.py -v
 """
 
 import argparse
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -655,6 +656,27 @@ class TestMain:
         with patch("sys.argv", ["swarms", "bad-command"]):
             with pytest.raises(SystemExit):
                 main()
+
+    @patch("swarms.cli.main.route_command")
+    @patch("swarms.cli.main.show_ascii_art")
+    def test_main_reloads_env_from_current_working_directory(
+        self, mock_art, mock_route, monkeypatch, tmp_path
+    ):
+        from swarms.cli.main import main
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / ".env").write_text(
+            "OPENAI_API_KEY=from-current-cwd\n"
+        )
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.chdir(project_dir)
+
+        with patch("sys.argv", ["swarms", "setup-check"]):
+            main()
+
+        assert os.getenv("OPENAI_API_KEY") == "from-current-cwd"
 
     @patch(
         "swarms.cli.main.route_command",

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,36 @@
+import os
+
+from swarms.env import load_swarms_env, resolve_swarms_env_path
+
+
+def test_resolve_swarms_env_path_prefers_cwd_tree(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    (home_dir / ".env").write_text("OPENAI_API_KEY=home-key\n")
+
+    project_dir = tmp_path / "project"
+    nested_dir = project_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    project_env = project_dir / ".env"
+    project_env.write_text("OPENAI_API_KEY=project-key\n")
+
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.chdir(nested_dir)
+
+    assert resolve_swarms_env_path() == project_env
+
+
+def test_load_swarms_env_uses_home_fallback(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    (home_dir / ".env").write_text("OPENAI_API_KEY=home-key\n")
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.chdir(project_dir)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert load_swarms_env() is True
+    assert os.getenv("OPENAI_API_KEY") == "home-key"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,6 +1,14 @@
 import os
+import subprocess
+from unittest.mock import Mock
 
-from swarms.env import load_swarms_env, resolve_swarms_env_path
+import pytest
+
+from swarms.env import (
+    load_swarms_env,
+    load_swarms_env_with_dotenvx,
+    resolve_swarms_env_path,
+)
 
 
 def test_resolve_swarms_env_path_prefers_cwd_tree(tmp_path, monkeypatch):
@@ -34,3 +42,129 @@ def test_load_swarms_env_uses_home_fallback(tmp_path, monkeypatch):
 
     assert load_swarms_env() is True
     assert os.getenv("OPENAI_API_KEY") == "home-key"
+
+
+def test_load_swarms_env_prefers_dotenvx_when_available(
+    tmp_path, monkeypatch
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / ".env").write_text("OPENAI_API_KEY=project-key\n")
+
+    monkeypatch.chdir(project_dir)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "swarms.env.resolve_dotenvx_binary",
+        lambda: "/usr/local/bin/dotenvx",
+    )
+
+    command_result = Mock(stdout='OPENAI_API_KEY="dotenvx-key"\n')
+    run_mock = Mock(return_value=command_result)
+    monkeypatch.setattr("swarms.env.subprocess.run", run_mock)
+
+    assert load_swarms_env() is True
+    assert os.getenv("OPENAI_API_KEY") == "dotenvx-key"
+    run_mock.assert_called_once_with(
+        [
+            "/usr/local/bin/dotenvx",
+            "get",
+            "--format=eval",
+            "-f",
+            str(project_dir / ".env"),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_load_swarms_env_with_dotenvx_overrides_when_requested(
+    tmp_path, monkeypatch
+):
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text("OPENAI_API_KEY=project-key\n")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "existing")
+
+    command_result = Mock(stdout='OPENAI_API_KEY="dotenvx-key"\n')
+    run_mock = Mock(return_value=command_result)
+    monkeypatch.setattr("swarms.env.subprocess.run", run_mock)
+
+    assert (
+        load_swarms_env_with_dotenvx(
+            dotenv_path,
+            override=True,
+            dotenvx_binary="/usr/local/bin/dotenvx",
+        )
+        is True
+    )
+    assert os.getenv("OPENAI_API_KEY") == "dotenvx-key"
+    run_mock.assert_called_once_with(
+        [
+            "/usr/local/bin/dotenvx",
+            "get",
+            "--format=eval",
+            "-f",
+            str(dotenv_path),
+            "--overload",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_load_swarms_env_falls_back_when_plain_dotenvx_load_fails(
+    tmp_path, monkeypatch
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / ".env").write_text("OPENAI_API_KEY=plain-key\n")
+
+    monkeypatch.chdir(project_dir)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "swarms.env.resolve_dotenvx_binary",
+        lambda: "/usr/local/bin/dotenvx",
+    )
+
+    error = subprocess.CalledProcessError(
+        1,
+        ["/usr/local/bin/dotenvx", "get"],
+    )
+    monkeypatch.setattr(
+        "swarms.env.subprocess.run",
+        Mock(side_effect=error),
+    )
+
+    assert load_swarms_env() is True
+    assert os.getenv("OPENAI_API_KEY") == "plain-key"
+
+
+def test_load_swarms_env_raises_for_encrypted_dotenvx_failure(
+    tmp_path, monkeypatch
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / ".env").write_text(
+        "DOTENV_PUBLIC_KEY=public-key\n"
+        "OPENAI_API_KEY=encrypted:abc123\n"
+    )
+
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(
+        "swarms.env.resolve_dotenvx_binary",
+        lambda: "/usr/local/bin/dotenvx",
+    )
+
+    error = subprocess.CalledProcessError(
+        1,
+        ["/usr/local/bin/dotenvx", "get"],
+    )
+    monkeypatch.setattr(
+        "swarms.env.subprocess.run",
+        Mock(side_effect=error),
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        load_swarms_env()


### PR DESCRIPTION
## Summary
- reload `.env` discovery when the CLI entrypoint runs so commands use the caller current working directory
- resolve `.env` deterministically from the current directory tree first, then fall back to the user home directory
- reuse the same resolver in `setup-check` and add regression tests for home fallback and runtime reload behavior

## Testing
- `. .venv/bin/activate && pytest tests/test_env.py tests/test_cli.py -q`
- manual repro: verified home-only `.env` fallback loads `OPENAI_API_KEY`
- manual repro: verified `main()` reloads `.env` after changing into a project directory

Fixes #1541


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1547.org.readthedocs.build/en/1547/

<!-- readthedocs-preview swarms end -->