### PR TITLE
docs: add ScopeBlind integration guide (signed decision receipts for tools)

### DIFF
--- a/docs/integrations/scopeblind.md
+++ b/docs/integrations/scopeblind.md
@@ -1,0 +1,150 @@
+# Signed decision receipts for Swarms — ScopeBlind integration
+
+Add **Ed25519-signed, tamper-evident, offline-verifiable receipts** to every tool call a Swarms agent makes. Matches the [Veritas Acta receipt format](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) used by Microsoft Agent Governance Toolkit, protect-mcp, sb-runtime, hermes-decision-receipts (aeoess), Signet (Prismer-AI), and the broader agent-governance ecosystem.
+
+No fork of Swarms is required. No ScopeBlind infrastructure is in the verification path. Receipts verify with `npx @veritasacta/verify` against a public key the operator publishes out-of-band.
+
+## What this gives you
+
+- **Cryptographic evidence** of which tool your agent called, with what arguments hash, at what time, under what policy, with what result hash.
+- **Chain linkage** across successive tool calls — tampering with any intermediate receipt breaks the chain at verification time.
+- **Offline verification** with no dependency on Swarms, ScopeBlind, or any runtime service. Auditors get the receipts and a public key; they verify independently.
+- **Compliance-ready audit trails** aligned with SOC 2 / ISO 42001 / EU AI Act requirements for agent-action logging.
+- **Zero lock-in.** Apache-2.0 verifier, IETF-draft-spec'd receipt format, MIT adapter.
+
+## Install
+
+```bash
+pip install scopeblind-swarms swarms
+```
+
+## Quick start
+
+```python
+from swarms import Agent
+from scopeblind_swarms import ReceiptChain, sign_tool
+
+# 1. Create a receipt chain (one per agent or per session)
+chain = ReceiptChain.from_key_file(
+    signer_key_path="/etc/scopeblind/issuer.key",
+    agent_id="did:swarms:researcher",
+    policy_id="allow-web-read",
+)
+
+# 2. Define tools as usual
+def web_search(query: str) -> str:
+    # your search logic
+    return f"search results for {query}"
+
+# 3. Wrap the tool to emit signed receipts
+signed_search = sign_tool(web_search, chain=chain)
+
+# 4. Use the wrapped tool in your Agent
+agent = Agent(
+    agent_name="researcher",
+    tools=[signed_search],
+    model_name="gpt-4",
+    # ... rest of your Agent config
+)
+agent.run("find recent papers on agent governance")
+
+# Every tool invocation now has a signed receipt:
+print(signed_search.last_receipt)
+print(f"Chain tip hash: {chain.current_tip}")
+```
+
+### Bulk wrapping
+
+```python
+from scopeblind_swarms import sign_tools
+
+agent = Agent(
+    agent_name="researcher",
+    tools=sign_tools([web_search, summarize, post_draft], chain=chain),
+    ...,
+)
+```
+
+### Decorator form
+
+```python
+from scopeblind_swarms import ReceiptChain, sign_tool
+
+chain = ReceiptChain.from_key_file("/etc/scopeblind/issuer.key", agent_id="did:swarms:writer")
+
+@sign_tool(chain=chain, policy_id="allow-draft-only")
+def post_draft(content: str) -> str:
+    return f"drafted: {content[:50]}..."
+```
+
+## What's in a receipt
+
+```json
+{
+  "payload": {
+    "type": "scopeblind:swarms:tool-call",
+    "agent_id": "did:swarms:researcher",
+    "issuer_id": "swarms:agent:HJY4k2aN",
+    "tool_name": "web_search",
+    "action": "swarms:tool:web_search",
+    "action_ref": "sha256:a8f3...c91e",
+    "decision": "allow",
+    "policy_id": "allow-web-read",
+    "result_hash": "sha256:4b2c...d71f",
+    "issued_at": "2026-04-19T15:42:01.773Z",
+    "previousReceiptHash": "Zk4p..."
+  },
+  "signature": {
+    "alg": "EdDSA",
+    "kid": "HJY4k2aNqRwXcdEfGh...",
+    "sig": "..."
+  }
+}
+```
+
+The `action_ref` is a SHA-256 of the JCS-canonicalized tool arguments — use it to correlate the same tool invocation across different audit systems. The `result_hash` is a SHA-256 of the tool's return value so the receipt attests to what came back without storing the raw output (privacy default).
+
+## Offline verification
+
+Any receipt verifies with the canonical verifier, zero dependencies on Swarms:
+
+```bash
+npx @veritasacta/verify receipt.json --key operator-public.pem
+```
+
+Exit code `0` = valid; `1` = proven tampering; `2` = undecidable.
+
+Your operator public key is published via one of:
+
+- An operator-signed JWKS URL (verifier: `--jwks https://you.example/jwks`)
+- A DID document service endpoint (use any W3C DID resolver)
+- A pinned trust anchor file
+- Your GitHub release SBOM
+
+Never embedded in the receipt itself (per draft-farley-acta-signed-receipts-02 §9).
+
+## Composition with other Swarms-ecosystem components
+
+`scopeblind-swarms` covers the **decision-receipt layer**. For full defense-in-depth, compose with:
+
+- **Kernel sandboxing** — `sb-runtime` (Landlock+seccomp, Apache-2.0) or `nono` (capability-based). Your tool runs inside the sandbox; the sandbox backend is recorded in the receipt.
+- **Policy evaluation** — `bindu-scopeblind` ships a Cedar evaluator; or call `cedarpy` directly before passing the decision into `sign_tool`.
+- **Transparency-log anchoring** — submit receipts to Sigstore Rekor for timestamped immutability (DSSE wrapper; see `@veritasacta/verify --anchor rekor`).
+
+## Thread safety
+
+Swarms' async agents often run tools concurrently. `ReceiptChain` is safe to share across parallel tool invocations within a single agent; chain integrity is preserved via an internal lock. Successive receipts chain correctly even under concurrent signing.
+
+## Related
+
+| Resource | URL |
+|---|---|
+| `scopeblind-swarms` source | [github.com/ScopeBlind/scopeblind-gateway](https://github.com/ScopeBlind/scopeblind-gateway) (under `packages/verify-cli/ecosystem/adapters/swarms/`) |
+| Reference verifier | [`@veritasacta/verify`](https://github.com/ScopeBlind/verify) (Apache-2.0, offline) |
+| Receipt format spec | [draft-farley-acta-signed-receipts-02](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) |
+| Conformance profile | [VeritasActa/agt-integration-profile](https://github.com/VeritasActa/agt-integration-profile) |
+| Microsoft AGT integration | [docs/integrations/sb-runtime.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/integrations/sb-runtime.md) (PR [#1202](https://github.com/microsoft/agent-governance-toolkit/pull/1202) merged) |
+
+## License
+
+MIT.


### PR DESCRIPTION
## Summary

Adds an integration guide at `docs/integrations/scopeblind.md` for [scopeblind-swarms](https://pypi.org/project/scopeblind-swarms/) — a Python package that wraps any Swarms tool with Ed25519-signed, tamper-evident, offline-verifiable decision receipts in the [Veritas Acta format](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/).

The same receipt format is used by:

- Microsoft Agent Governance Toolkit (see https://github.com/microsoft/agent-governance-toolkit/pull/1197#event-24645816036; https://github.com/microsoft/agent-governance-toolkit/pull/1201#event-24656938875; https://github.com/microsoft/agent-governance-toolkit/pull/1202#event-24656940870; https://github.com/microsoft/agent-governance-toolkit/pull/1203#event-24656943948; https://github.com/microsoft/agent-governance-toolkit/pull/1186#event-24589499692;
https://github.com/microsoft/agent-governance-toolkit/pull/1168#event-24576585104;
https://github.com/microsoft/agent-governance-toolkit/pull/1159#event-24549617835;
https://github.com/microsoft/agent-governance-toolkit/pull/667#issuecomment-4181923007)

- protect-mcp / protect-mcp-adk (MCP + Google ADK)
- sb-runtime (Rust runtime backend)
- hermes-decision-receipts (aeoess / Agent Passport System bridge)
- Signet (Prismer-AI, maintainer-self-certified)
- bindu-scopeblind (Bindu / GetBindu)

15 implementations in total on the draft-02 IETF Implementation Status appendix. This PR brings Swarms into that cross-verifying ecosystem.

## What's in the PR

Doc-only. One new file: `docs/integrations/scopeblind.md`. No changes to Swarms core or to any existing file.

The guide covers:

- One-liner install (`pip install scopeblind-swarms swarms`)
- Quick start (3 code blocks: create chain, wrap tool, use in Agent)
- Receipt payload shape (`tool_name`, `action_ref`, `result_hash`, `policy_id`, `previousReceiptHash`, Ed25519 signature)
- Offline verification (`npx @veritasacta/verify receipt.json --key operator.pem`)
- Composition with other ecosystem components (sandbox backends, policy engines, transparency logs)
- Thread-safety note for async Swarms agents

## Design note on the extension point

Swarms does not expose pre/post tool hooks. The canonical interception point per upstream guidance (BaseTool's `_execute_single_function_call` discussion in existing tool docs) is wrapping the tool callable before passing it to `Agent(tools=[...])`. `scopeblind-swarms` uses that extension point exactly; it does not patch Swarms internals, subclass Agent, or modify any Swarms code path.

## Related

- `scopeblind-swarms` PyPI page: https://pypi.org/project/scopeblind-swarms/
- Source: [ScopeBlind/scopeblind-gateway](https://github.com/ScopeBlind/scopeblind-gateway/tree/main/packages/verify-cli/ecosystem/adapters/swarms) (MIT)
- Reference verifier: [`@veritasacta/verify`](https://www.npmjs.com/package/@veritasacta/verify) (Apache-2.0, offline, zero dependencies on ScopeBlind or Swarms)
- IETF draft: [draft-farley-acta-signed-receipts-02](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/)
- Microsoft AGT integration docs (parallel shape): [docs/integrations/sb-runtime.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/integrations/sb-runtime.md)

## Test plan

- [x] Markdown renders correctly (local preview)
- [x] All cross-links resolve
- [x] Python examples are copy-pasteable and match the installed `scopeblind-swarms@0.1.0` API
- [x] Companion package has 17/17 tests passing (receipt signing, chain linkage, tamper detection, thread-safety under concurrent signing, decorator form, bulk wrapping, embedded-key rejection)

Cc @kyegomez — the receipt-layer primitive composes cleanly with existing Swarms tool machinery. Happy to iterate on scope, style, or framing if there's anything you'd like adjusted. The only ask is a doc link; the adapter itself lives on PyPI and the ScopeBlind monorepo, not in swarms-core.


<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1548.org.readthedocs.build/en/1548/

<!-- readthedocs-preview swarms end -->