### PR TITLE
[FEAT] [AgentRearrange] add per-node retry/fallback annotations to flow

### DIFF
--- a/examples/agent_rearrange_retry_fallback_example.py
+++ b/examples/agent_rearrange_retry_fallback_example.py
@@ -1,0 +1,127 @@
+"""
+AgentRearrange — per-node retry & fallback annotations
+=======================================================
+  "A -> B!3 -> C"       B retries up to 3 times on failure
+  "A -> B!3>D -> C"     B retries 3 times, then falls back to D
+  "A -> B?D -> C"       B routes to D on first failure
+
+Each example patches the middle agent to fail a controlled number of times
+so the retry and fallback behaviour is visible in the logs.
+
+Model: claude-sonnet-4-5  |  Thinking enabled  |  Temperature 1.0
+"""
+
+from unittest.mock import patch, MagicMock
+from swarms import Agent, AgentRearrange
+
+MODEL      = "claude-sonnet-4-5"
+TEMP       = 1.0
+THINK      = 8000
+MAX_TOKENS = 16000
+
+
+def make_agent(name: str, system_prompt: str) -> Agent:
+    return Agent(
+        agent_name=name,
+        system_prompt=system_prompt,
+        model_name=MODEL,
+        temperature=TEMP,
+        thinking_tokens=THINK,
+        max_tokens=MAX_TOKENS,
+        reasoning_enabled=True,
+        max_loops=1,
+        autosave=False,
+        print_on=True,
+    )
+
+
+researcher = make_agent(
+    "Researcher",
+    "You are a research analyst. Given a topic, return 3 concise bullet "
+    "points of key facts.",
+)
+fact_checker = make_agent(
+    "FactChecker",
+    "You are a fact-checker. Reply VERIFIED if the brief looks sound.",
+)
+fallback_summarizer = make_agent(
+    "FallbackSummarizer",
+    "You are a backup summarizer. Summarize the brief in 2 sentences, "
+    "noting fact-checking was skipped.",
+)
+writer = make_agent(
+    "Writer",
+    "You are a writer. Turn the brief into a polished 100-word paragraph.",
+)
+
+TASK = "The impact of large language models on software engineering productivity"
+
+
+# ── Example 1: B!3 — retry fires twice then succeeds ─────────────────────────
+print("\n" + "=" * 70)
+print("EXAMPLE 1 — FactChecker!3: fails twice, succeeds on 3rd attempt")
+print("=" * 70)
+
+_call_count = 0
+_real_run = fact_checker.run
+
+def _fail_twice(task, **kwargs):
+    global _call_count
+    _call_count += 1
+    if _call_count < 3:
+        raise RuntimeError(f"FactChecker simulated failure (attempt {_call_count})")
+    return _real_run(task=task, **kwargs)
+
+fact_checker.run = _fail_twice
+
+pipeline1 = AgentRearrange(
+    name="RetryPipeline",
+    agents=[researcher, fact_checker, writer],
+    flow="Researcher -> FactChecker!3 -> Writer",
+    max_loops=1,
+    output_type="final",
+)
+result1 = pipeline1.run(TASK)
+fact_checker.run = _real_run  # restore
+print("\n[Output]\n", result1)
+
+
+# ── Example 2: B!1>D — retries once, exhausts, falls back to FallbackSummarizer
+print("\n" + "=" * 70)
+print("EXAMPLE 2 — FactChecker!1>FallbackSummarizer: always fails, fallback runs")
+print("=" * 70)
+
+def _always_fail(task, **kwargs):
+    raise RuntimeError("FactChecker permanently down")
+
+fact_checker.run = _always_fail
+
+pipeline2 = AgentRearrange(
+    name="RetryFallbackPipeline",
+    agents=[researcher, fact_checker, fallback_summarizer, writer],
+    flow="Researcher -> FactChecker!1>FallbackSummarizer -> Writer",
+    max_loops=1,
+    output_type="final",
+)
+result2 = pipeline2.run(TASK)
+fact_checker.run = _real_run  # restore
+print("\n[Output]\n", result2)
+
+
+# ── Example 3: B?D — immediate fallback on first failure ─────────────────────
+print("\n" + "=" * 70)
+print("EXAMPLE 3 — FactChecker?FallbackSummarizer: routes to fallback immediately")
+print("=" * 70)
+
+fact_checker.run = _always_fail
+
+pipeline3 = AgentRearrange(
+    name="ImmediateFallbackPipeline",
+    agents=[researcher, fact_checker, fallback_summarizer, writer],
+    flow="Researcher -> FactChecker?FallbackSummarizer -> Writer",
+    max_loops=1,
+    output_type="final",
+)
+result3 = pipeline3.run(TASK)
+fact_checker.run = _real_run  # restore
+print("\n[Output]\n", result3)

--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -1,7 +1,6 @@
 import copy
 import json
 import os
-import re
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import asyncio
@@ -295,7 +294,9 @@ class AgentRearrange:
         for agent in agents:
             self.agents[agent.agent_name] = agent
 
-    def _parse_node(self, token: str) -> Tuple[str, int, Optional[str]]:
+    def _parse_node(
+        self, token: str
+    ) -> Tuple[str, int, Optional[str]]:
         """Parse a flow node token into (agent_name, retry_count, fallback_agent).
 
         Supported annotation syntax:
@@ -319,11 +320,13 @@ class AgentRearrange:
         gt_idx = token.rfind(">")
         q_idx = token.rfind("?")
         fallback_index = max(gt_idx, q_idx)
-        immediate_fallback = fallback_index != -1 and token[fallback_index] == "?"
+        immediate_fallback = (
+            fallback_index != -1 and token[fallback_index] == "?"
+        )
 
         if fallback_index != -1:
             agent_part = token[:fallback_index].strip()
-            fallback_agent = token[fallback_index + 1:].strip()
+            fallback_agent = token[fallback_index + 1 :].strip()
             if not agent_part or not fallback_agent:
                 raise ValueError(f"Cannot parse flow node: {token!r}")
         else:
@@ -332,7 +335,7 @@ class AgentRearrange:
         # Split retry count off the right of agent_part
         retry_index = agent_part.rfind("!")
         if retry_index != -1:
-            retry_suffix = agent_part[retry_index + 1:].strip()
+            retry_suffix = agent_part[retry_index + 1 :].strip()
             if retry_suffix.isdigit():
                 if immediate_fallback:
                     raise ValueError(
@@ -341,7 +344,9 @@ class AgentRearrange:
                     )
                 agent_name = agent_part[:retry_index].strip()
                 if not agent_name:
-                    raise ValueError(f"Cannot parse flow node: {token!r}")
+                    raise ValueError(
+                        f"Cannot parse flow node: {token!r}"
+                    )
                 retry_count = int(retry_suffix)
             else:
                 agent_name = agent_part.strip()
@@ -379,8 +384,13 @@ class AgentRearrange:
 
             # Loop over the node tokens
             for token in tokens:
-                agent_name, _, fallback_agent = self._parse_node(token)
-                if agent_name not in self.agents and agent_name != "H":
+                agent_name, _, fallback_agent = self._parse_node(
+                    token
+                )
+                if (
+                    agent_name not in self.agents
+                    and agent_name != "H"
+                ):
                     raise ValueError(
                         f"Agent '{agent_name}' is not registered."
                     )
@@ -812,9 +822,12 @@ class AgentRearrange:
             raise last_exc
 
         response_dict: Dict[str, str] = {}
-        with ThreadPoolExecutor(max_workers=len(node_specs)) as executor:
+        with ThreadPoolExecutor(
+            max_workers=len(node_specs)
+        ) as executor:
             futures = [
-                executor.submit(_run_node, spec) for spec in node_specs
+                executor.submit(_run_node, spec)
+                for spec in node_specs
             ]
             for future in futures:
                 name, result = future.result()
@@ -886,7 +899,8 @@ class AgentRearrange:
             c_agent_name, c_task = next(iter(custom_tasks.items()))
             position = next(
                 (
-                    i for i, t in enumerate(tasks)
+                    i
+                    for i, t in enumerate(tasks)
                     if any(
                         self._parse_node(tok)[0] == c_agent_name
                         for tok in t.split(",")
@@ -918,8 +932,7 @@ class AgentRearrange:
                 if len(node_specs) > 1:
                     # Concurrent processing — comma detected
                     has_annotations = any(
-                        retry > 0 or fb
-                        for _, retry, fb in node_specs
+                        retry > 0 or fb for _, retry, fb in node_specs
                     )
                     if has_annotations:
                         concurrent_results = (
@@ -933,7 +946,9 @@ class AgentRearrange:
                     else:
                         concurrent_results = (
                             self._run_concurrent_workflow(
-                                agent_names=[s[0] for s in node_specs],
+                                agent_names=[
+                                    s[0] for s in node_specs
+                                ],
                                 img=img,
                                 *args,
                                 **kwargs,

--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -303,21 +303,54 @@ class AgentRearrange:
           B!3      → agent B, retry up to 3 times on failure
           B!3>D    → agent B, retry 3 times, then fall back to D
           B>D      → agent B, fall back to D on first failure
-          B?D      → agent B, fall back to D on first failure (alias for >)
+          B?D      → immediate fallback to D on first failure (no retries allowed)
 
         Raises:
-            ValueError: If the token cannot be parsed or is malformed.
+            ValueError: If the token is malformed or combines !N with ?.
         """
         token = token.strip()
-        m = re.match(
-            r"^([\w][\w\s\-]*)(?:!(\d+))?(?:[>?]([\w][\w\s\-]*))?$",
-            token,
-        )
-        if not m:
+        if not token:
             raise ValueError(f"Cannot parse flow node: {token!r}")
-        agent_name = m.group(1).strip()
-        retry_count = int(m.group(2)) if m.group(2) else 0
-        fallback_agent = m.group(3).strip() if m.group(3) else None
+
+        retry_count = 0
+        fallback_agent = None
+
+        # Split fallback off the right using the last > or ?
+        gt_idx = token.rfind(">")
+        q_idx = token.rfind("?")
+        fallback_index = max(gt_idx, q_idx)
+        immediate_fallback = fallback_index != -1 and token[fallback_index] == "?"
+
+        if fallback_index != -1:
+            agent_part = token[:fallback_index].strip()
+            fallback_agent = token[fallback_index + 1:].strip()
+            if not agent_part or not fallback_agent:
+                raise ValueError(f"Cannot parse flow node: {token!r}")
+        else:
+            agent_part = token
+
+        # Split retry count off the right of agent_part
+        retry_index = agent_part.rfind("!")
+        if retry_index != -1:
+            retry_suffix = agent_part[retry_index + 1:].strip()
+            if retry_suffix.isdigit():
+                if immediate_fallback:
+                    raise ValueError(
+                        f"Cannot combine retry count (!N) with immediate "
+                        f"fallback (?): {token!r}. Use > for retry-then-fallback."
+                    )
+                agent_name = agent_part[:retry_index].strip()
+                if not agent_name:
+                    raise ValueError(f"Cannot parse flow node: {token!r}")
+                retry_count = int(retry_suffix)
+            else:
+                agent_name = agent_part.strip()
+        else:
+            agent_name = agent_part.strip()
+
+        if not agent_name:
+            raise ValueError(f"Cannot parse flow node: {token!r}")
+
         return agent_name, retry_count, fallback_agent
 
     def validate_flow(self):
@@ -351,14 +384,15 @@ class AgentRearrange:
                     raise ValueError(
                         f"Agent '{agent_name}' is not registered."
                     )
-                if (
-                    fallback_agent
-                    and fallback_agent not in self.agents
-                    and fallback_agent != "H"
-                ):
-                    raise ValueError(
-                        f"Fallback agent '{fallback_agent}' is not registered."
-                    )
+                if fallback_agent:
+                    if fallback_agent == "H":
+                        raise ValueError(
+                            "'H' cannot be used as a fallback agent."
+                        )
+                    if fallback_agent not in self.agents:
+                        raise ValueError(
+                            f"Fallback agent '{fallback_agent}' is not registered."
+                        )
                 agents_in_flow.append(agent_name)
 
         logger.info(f"Flow: {self.flow} is valid.")
@@ -699,6 +733,11 @@ class AgentRearrange:
                 f"attempt(s). Routing to fallback '{fallback_agent}'."
             )
             fb = self.agents[fallback_agent]
+            fb_awareness = self._get_sequential_awareness(
+                fallback_agent, tasks, task_idx=task_idx
+            )
+            if fb_awareness:
+                self.conversation.add("system", fb_awareness)
             result = fb.run(
                 task=self.conversation.get_str(),
                 img=img,
@@ -845,8 +884,20 @@ class AgentRearrange:
         if custom_tasks is not None:
             logger.info("Processing custom tasks")
             c_agent_name, c_task = next(iter(custom_tasks.items()))
-            position = tasks.index(c_agent_name)
-
+            position = next(
+                (
+                    i for i, t in enumerate(tasks)
+                    if any(
+                        self._parse_node(tok)[0] == c_agent_name
+                        for tok in t.split(",")
+                    )
+                ),
+                None,
+            )
+            if position is None:
+                raise ValueError(
+                    f"Custom task agent '{c_agent_name}' not found in flow."
+                )
             if position > 0:
                 tasks[position - 1] += "->" + c_task
             else:

--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -1,8 +1,9 @@
 import copy
 import json
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import asyncio
 from swarms.structs.agent import Agent
 from swarms.structs.conversation import Conversation
@@ -294,6 +295,31 @@ class AgentRearrange:
         for agent in agents:
             self.agents[agent.agent_name] = agent
 
+    def _parse_node(self, token: str) -> Tuple[str, int, Optional[str]]:
+        """Parse a flow node token into (agent_name, retry_count, fallback_agent).
+
+        Supported annotation syntax:
+          B        → agent B, no retries, no fallback
+          B!3      → agent B, retry up to 3 times on failure
+          B!3>D    → agent B, retry 3 times, then fall back to D
+          B>D      → agent B, fall back to D on first failure
+          B?D      → agent B, fall back to D on first failure (alias for >)
+
+        Raises:
+            ValueError: If the token cannot be parsed or is malformed.
+        """
+        token = token.strip()
+        m = re.match(
+            r"^([\w][\w\s\-]*)(?:!(\d+))?(?:[>?]([\w][\w\s\-]*))?$",
+            token,
+        )
+        if not m:
+            raise ValueError(f"Cannot parse flow node: {token!r}")
+        agent_name = m.group(1).strip()
+        retry_count = int(m.group(2)) if m.group(2) else 0
+        fallback_agent = m.group(3).strip() if m.group(3) else None
+        return agent_name, retry_count, fallback_agent
+
     def validate_flow(self):
         """
         Validates the flow pattern.
@@ -316,16 +342,22 @@ class AgentRearrange:
 
         # For the task in tasks
         for task in tasks:
-            agent_names = [name.strip() for name in task.split(",")]
+            tokens = [name.strip() for name in task.split(",")]
 
-            # Loop over the agent names
-            for agent_name in agent_names:
-                if (
-                    agent_name not in self.agents
-                    and agent_name != "H"
-                ):
+            # Loop over the node tokens
+            for token in tokens:
+                agent_name, _, fallback_agent = self._parse_node(token)
+                if agent_name not in self.agents and agent_name != "H":
                     raise ValueError(
                         f"Agent '{agent_name}' is not registered."
+                    )
+                if (
+                    fallback_agent
+                    and fallback_agent not in self.agents
+                    and fallback_agent != "H"
+                ):
+                    raise ValueError(
+                        f"Fallback agent '{fallback_agent}' is not registered."
                     )
                 agents_in_flow.append(agent_name)
 
@@ -359,7 +391,7 @@ class AgentRearrange:
             agent_position = None
             for i, task in enumerate(tasks):
                 agent_names = [
-                    name.strip() for name in task.split(",")
+                    self._parse_node(t)[0] for t in task.split(",")
                 ]
                 if agent_name in agent_names:
                     agent_position = i
@@ -374,7 +406,7 @@ class AgentRearrange:
         if agent_position > 0:
             prev_task = tasks[agent_position - 1]
             prev_agents = [
-                name.strip() for name in prev_task.split(",")
+                self._parse_node(t)[0] for t in prev_task.split(",")
             ]
             if (
                 prev_agents and prev_agents[0] != "H"
@@ -387,7 +419,7 @@ class AgentRearrange:
         if agent_position < len(tasks) - 1:
             next_task = tasks[agent_position + 1]
             next_agents = [
-                name.strip() for name in next_task.split(",")
+                self._parse_node(t)[0] for t in next_task.split(",")
             ]
             if (
                 next_agents and next_agents[0] != "H"
@@ -416,7 +448,9 @@ class AgentRearrange:
         flow_info = []
 
         for i, task in enumerate(tasks):
-            agent_names = [name.strip() for name in task.split(",")]
+            agent_names = [
+                self._parse_node(t)[0] for t in task.split(",")
+            ]
             if (
                 agent_names and agent_names[0] != "H"
             ):  # Skip human agents
@@ -426,7 +460,8 @@ class AgentRearrange:
                 if i > 0:
                     prev_task = tasks[i - 1]
                     prev_agents = [
-                        name.strip() for name in prev_task.split(",")
+                        self._parse_node(t)[0]
+                        for t in prev_task.split(",")
                     ]
                     if prev_agents and prev_agents[0] != "H":
                         position_info += (
@@ -435,7 +470,8 @@ class AgentRearrange:
                 if i < len(tasks) - 1:
                     next_task = tasks[i + 1]
                     next_agents = [
-                        name.strip() for name in next_task.split(",")
+                        self._parse_node(t)[0]
+                        for t in next_task.split(",")
                     ]
                     if next_agents and next_agents[0] != "H":
                         position_info += (
@@ -592,6 +628,163 @@ class AgentRearrange:
 
         return current_task
 
+    def _execute_with_retry(
+        self,
+        agent_name: str,
+        retry_count: int,
+        fallback_agent: Optional[str],
+        tasks: List[str],
+        task_idx: int,
+        img: str = None,
+        *args,
+        **kwargs,
+    ) -> str:
+        """Execute an agent with per-node retry and optional fallback routing.
+
+        Adds sequential awareness once, then attempts the agent up to
+        ``retry_count + 1`` times.  If every attempt fails and a fallback
+        agent was specified, the fallback runs instead.  If no fallback is
+        given the last exception is re-raised.
+
+        Args:
+            agent_name: Name of the primary agent to run.
+            retry_count: Number of *extra* attempts after the first failure.
+                0 means run once (no retries).
+            fallback_agent: Name of an agent to invoke when all retries are
+                exhausted.  ``None`` means raise on final failure.
+            tasks: Full task list from the flow split on ``->``.
+            task_idx: Position of this node in *tasks*.
+            img: Optional image path forwarded to the agent.
+        """
+        logger.info(
+            f"Running agent '{agent_name}' "
+            f"(retries={retry_count}, fallback={fallback_agent})"
+        )
+        agent = self.agents[agent_name]
+
+        awareness_info = self._get_sequential_awareness(
+            agent_name, tasks, task_idx=task_idx
+        )
+        if awareness_info:
+            self.conversation.add("system", awareness_info)
+            logger.info(
+                f"Added sequential awareness for {agent_name}: {awareness_info}"
+            )
+
+        last_exc: Optional[Exception] = None
+        for attempt in range(retry_count + 1):
+            try:
+                result = agent.run(
+                    task=self.conversation.get_str(),
+                    img=img,
+                    *args,
+                    **kwargs,
+                )
+                if not isinstance(result, str):
+                    result = any_to_str(result)
+                self.conversation.add(agent.agent_name, result)
+                return result
+            except Exception as exc:
+                last_exc = exc
+                if attempt < retry_count:
+                    logger.warning(
+                        f"Agent '{agent_name}' attempt "
+                        f"{attempt + 1}/{retry_count + 1} failed: {exc}. "
+                        f"Retrying..."
+                    )
+
+        if fallback_agent is not None:
+            logger.warning(
+                f"Agent '{agent_name}' exhausted {retry_count + 1} "
+                f"attempt(s). Routing to fallback '{fallback_agent}'."
+            )
+            fb = self.agents[fallback_agent]
+            result = fb.run(
+                task=self.conversation.get_str(),
+                img=img,
+                *args,
+                **kwargs,
+            )
+            if not isinstance(result, str):
+                result = any_to_str(result)
+            self.conversation.add(fb.agent_name, result)
+            return result
+
+        raise last_exc
+
+    def _run_concurrent_workflow_with_retry(
+        self,
+        node_specs: List[Tuple[str, int, Optional[str]]],
+        img: str = None,
+        *args,
+        **kwargs,
+    ) -> Dict[str, str]:
+        """Run concurrent nodes where one or more carry retry/fallback annotations.
+
+        Takes a snapshot of the conversation before launching threads so every
+        concurrent agent sees the same context.  Results are folded back into
+        the conversation sequentially after all workers finish.
+
+        Args:
+            node_specs: List of ``(agent_name, retry_count, fallback_agent)``
+                tuples produced by :meth:`_parse_node`.
+            img: Optional image path forwarded to each agent.
+        """
+        logger.info(
+            f"Running agents concurrently with retry: "
+            f"{[s[0] for s in node_specs]}"
+        )
+        task_snapshot = self.conversation.get_str()
+
+        def _run_node(
+            spec: Tuple[str, int, Optional[str]],
+        ) -> Tuple[str, str]:
+            agent_name, retry_count, fallback_agent = spec
+            agent = self.agents[agent_name]
+            last_exc: Optional[Exception] = None
+            for attempt in range(retry_count + 1):
+                try:
+                    result = agent.run(
+                        task=task_snapshot, img=img, *args, **kwargs
+                    )
+                    if not isinstance(result, str):
+                        result = any_to_str(result)
+                    return agent_name, result
+                except Exception as exc:
+                    last_exc = exc
+                    if attempt < retry_count:
+                        logger.warning(
+                            f"Agent '{agent_name}' attempt "
+                            f"{attempt + 1}/{retry_count + 1} failed: "
+                            f"{exc}. Retrying..."
+                        )
+            if fallback_agent is not None:
+                logger.warning(
+                    f"Agent '{agent_name}' exhausted {retry_count + 1} "
+                    f"attempt(s). Routing to fallback '{fallback_agent}'."
+                )
+                fb = self.agents[fallback_agent]
+                result = fb.run(
+                    task=task_snapshot, img=img, *args, **kwargs
+                )
+                if not isinstance(result, str):
+                    result = any_to_str(result)
+                return fallback_agent, result
+            raise last_exc
+
+        response_dict: Dict[str, str] = {}
+        with ThreadPoolExecutor(max_workers=len(node_specs)) as executor:
+            futures = [
+                executor.submit(_run_node, spec) for spec in node_specs
+            ]
+            for future in futures:
+                name, result = future.result()
+                self.conversation.add(name, result)
+                response_dict[name] = result
+                logger.debug(f"Agent {name} output: {result}")
+
+        return response_dict
+
     def _run(
         self,
         task: str = None,
@@ -666,27 +859,46 @@ class AgentRearrange:
             )
 
             for task_idx, task in enumerate(tasks):
-                agent_names = [
-                    name.strip() for name in task.split(",")
+                node_tokens = [t.strip() for t in task.split(",")]
+                node_specs = [
+                    self._parse_node(t) for t in node_tokens
                 ]
 
-                if len(agent_names) > 1:
-                    # Concurrent processing - comma detected
-                    concurrent_results = (
-                        self._run_concurrent_workflow(
-                            agent_names=agent_names,
-                            img=img,
-                            *args,
-                            **kwargs,
-                        )
+                if len(node_specs) > 1:
+                    # Concurrent processing — comma detected
+                    has_annotations = any(
+                        retry > 0 or fb
+                        for _, retry, fb in node_specs
                     )
+                    if has_annotations:
+                        concurrent_results = (
+                            self._run_concurrent_workflow_with_retry(
+                                node_specs=node_specs,
+                                img=img,
+                                *args,
+                                **kwargs,
+                            )
+                        )
+                    else:
+                        concurrent_results = (
+                            self._run_concurrent_workflow(
+                                agent_names=[s[0] for s in node_specs],
+                                img=img,
+                                *args,
+                                **kwargs,
+                            )
+                        )
                     response_dict.update(concurrent_results)
 
                 else:
                     # Sequential processing
-                    agent_name = agent_names[0]
-                    result = self._run_sequential_workflow(
+                    agent_name, retry_count, fallback_agent = (
+                        node_specs[0]
+                    )
+                    result = self._execute_with_retry(
                         agent_name=agent_name,
+                        retry_count=retry_count,
+                        fallback_agent=fallback_agent,
                         tasks=tasks,
                         task_idx=task_idx,
                         img=img,

--- a/tests/structs/test_agent_rearrange.py
+++ b/tests/structs/test_agent_rearrange.py
@@ -877,5 +877,93 @@ def main():
     print("=" * 60)
 
 
+# ============================================================================
+# Per-node Retry & Fallback Annotation Tests
+# ============================================================================
+
+
+def _mock_agent(name: str) -> Agent:
+    return Agent(agent_name=name, model_name="gpt-4o-mini", max_loops=1)
+
+
+def test_parse_node_variants():
+    """_parse_node correctly handles all annotation forms."""
+    agents = create_sample_agents()
+    ar = AgentRearrange(
+        agents=agents,
+        flow="ResearchAgent -> WriterAgent",
+    )
+    assert ar._parse_node("ResearchAgent") == ("ResearchAgent", 0, None)
+    assert ar._parse_node("ResearchAgent!3") == ("ResearchAgent", 3, None)
+    assert ar._parse_node("ResearchAgent!3>WriterAgent") == ("ResearchAgent", 3, "WriterAgent")
+    assert ar._parse_node("ResearchAgent>WriterAgent") == ("ResearchAgent", 0, "WriterAgent")
+    assert ar._parse_node("ResearchAgent?WriterAgent") == ("ResearchAgent", 0, "WriterAgent")
+
+
+def test_validate_flow_rejects_unknown_fallback():
+    """validate_flow raises ValueError for an unregistered fallback agent."""
+    agents = create_sample_agents()
+    ar = AgentRearrange(
+        agents=agents,
+        flow="ResearchAgent -> WriterAgent",
+    )
+    ar.flow = "ResearchAgent -> WriterAgent!2>Ghost"
+    with pytest.raises(ValueError, match="Ghost"):
+        ar.validate_flow()
+
+
+def test_execute_with_retry_retries_correct_number_of_times():
+    """_execute_with_retry calls agent.run exactly retry_count+1 times on repeated failure."""
+    from unittest.mock import MagicMock, patch
+
+    agents = create_sample_agents()
+    ar = AgentRearrange(
+        agents=agents,
+        flow="ResearchAgent -> WriterAgent -> ReviewerAgent",
+    )
+
+    call_count = 0
+
+    def always_fail(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("boom")
+
+    ar.agents["WriterAgent"].run = always_fail
+
+    with pytest.raises(RuntimeError, match="boom"):
+        ar._execute_with_retry(
+            agent_name="WriterAgent",
+            retry_count=2,
+            fallback_agent=None,
+            tasks=["ResearchAgent", "WriterAgent", "ReviewerAgent"],
+            task_idx=1,
+        )
+
+    assert call_count == 3  # 1 initial + 2 retries
+
+
+def test_execute_with_retry_uses_fallback_after_exhaustion():
+    """_execute_with_retry routes to the fallback agent when all retries fail."""
+    agents = create_sample_agents()
+    ar = AgentRearrange(
+        agents=agents,
+        flow="ResearchAgent -> WriterAgent -> ReviewerAgent",
+    )
+
+    ar.agents["WriterAgent"].run = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("fail"))
+    ar.agents["ReviewerAgent"].run = lambda *a, **kw: "fallback result"
+
+    result = ar._execute_with_retry(
+        agent_name="WriterAgent",
+        retry_count=1,
+        fallback_agent="ReviewerAgent",
+        tasks=["ResearchAgent", "WriterAgent", "ReviewerAgent"],
+        task_idx=1,
+    )
+
+    assert result == "fallback result"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description
Adds per-node retry and fallback annotations to the `AgentRearrange` flow DSL, so error handling lives next to the node that can fail rather than in every caller's try/except.

Supported syntax:
"A -> B!3 -> C"       # retry B up to 3 times
"A -> B!3>D -> C"     # retry B 3 times, fall back to D
"A -> B?D -> C"       # route to D on first failure

Fallback agents are resolved from the same agents list and validated at parse time — unknown names raise `ValueError` before execution starts. Plain flows with no annotations are completely unchanged.

## Files Changed
* `swarms/structs/agent_rearrange.py`
* `tests/structs/test_agent_rearrange.py`
* `examples/agent_rearrange_retry_fallback_example.py`

## Issue
#1556

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Twitter
[@akc__2025](https://x.com/akc__2025)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1565.org.readthedocs.build/en/1565/

<!-- readthedocs-preview swarms end -->