### PR TITLE
[FEAT] [HierarchicalSwarms] add per-worker timeout, heartbeat, and retry

### DIFF
--- a/examples/multi_agent/hiearchical_swarm/hierarchical_swarm_timeout_example.py
+++ b/examples/multi_agent/hiearchical_swarm/hierarchical_swarm_timeout_example.py
@@ -1,12 +1,3 @@
-import sys, io
-
-sys.stdout = io.TextIOWrapper(
-    sys.stdout.buffer, encoding="utf-8", errors="replace"
-)
-sys.stderr = io.TextIOWrapper(
-    sys.stderr.buffer, encoding="utf-8", errors="replace"
-)
-
 """
 HierarchicalSwarm — worker timeout & retry demo
 
@@ -16,7 +7,16 @@ Growth-Strategist finishes normally with a real claude-sonnet-4-5 response —
 no hung swarm.
 """
 
+import sys
+import io
 import time
+
+sys.stdout = io.TextIOWrapper(
+    sys.stdout.buffer, encoding="utf-8", errors="replace"
+)
+sys.stderr = io.TextIOWrapper(
+    sys.stderr.buffer, encoding="utf-8", errors="replace"
+)
 
 from swarms import Agent
 from swarms.structs.hiearchical_swarm import HierarchicalSwarm
@@ -75,7 +75,7 @@ def _patched_call(
 ):
     if agent_name == "Market-Analyst":
         print(
-            f"  [demo] Market-Analyst hanging (simulating stuck tool)..."
+            "  [demo] Market-Analyst hanging (simulating stuck tool)..."
         )
         time.sleep(3600)
     return _original_call(

--- a/examples/multi_agent/hiearchical_swarm/hierarchical_swarm_timeout_example.py
+++ b/examples/multi_agent/hiearchical_swarm/hierarchical_swarm_timeout_example.py
@@ -1,0 +1,91 @@
+import sys, io
+
+sys.stdout = io.TextIOWrapper(
+    sys.stdout.buffer, encoding="utf-8", errors="replace"
+)
+sys.stderr = io.TextIOWrapper(
+    sys.stderr.buffer, encoding="utf-8", errors="replace"
+)
+
+"""
+HierarchicalSwarm — worker timeout & retry demo
+
+Market-Analyst is patched to hang indefinitely, simulating a stuck MCP/tool call.
+worker_timeout=90s fires after 90 seconds, marks the agent [FAILED], and
+Growth-Strategist finishes normally with a real claude-sonnet-4-5 response —
+no hung swarm.
+"""
+
+import time
+
+from swarms import Agent
+from swarms.structs.hiearchical_swarm import HierarchicalSwarm
+
+analyst = Agent(
+    agent_name="Market-Analyst",
+    agent_description="Analyses market trends",
+    system_prompt="You are a senior market analyst. Be concise — 3 bullets max.",
+    model_name="claude-sonnet-4-5",
+    max_tokens=8000,
+    thinking_tokens=4000,
+    temperature=1,
+    max_loops=1,
+    verbose=False,
+    print_on=False,
+)
+
+strategist = Agent(
+    agent_name="Growth-Strategist",
+    agent_description="Turns market insights into growth plans",
+    system_prompt="You are a growth strategist. Propose 3 concrete initiatives.",
+    model_name="claude-sonnet-4-5",
+    max_tokens=8000,
+    thinking_tokens=4000,
+    temperature=1,
+    max_loops=1,
+    verbose=False,
+    print_on=False,
+)
+
+swarm = HierarchicalSwarm(
+    name="Timeout-Demo-Swarm",
+    description="Market analysis and strategy team.",
+    agents=[analyst, strategist],
+    max_loops=1,
+    director_model_name="claude-sonnet-4-5",
+    director_temperature=1,
+    director_top_p=None,
+    planning_enabled=False,
+    director_feedback_on=False,
+    autosave=False,
+    verbose=False,
+    worker_timeout=90,
+    heartbeat_interval=30,
+    max_retries=0,
+)
+
+_original_call = swarm.call_single_agent
+
+
+def _patched_call(
+    agent_name,
+    task,
+    streaming_callback=None,
+    _add_to_conversation=True,
+):
+    if agent_name == "Market-Analyst":
+        print(
+            f"  [demo] Market-Analyst hanging (simulating stuck tool)..."
+        )
+        time.sleep(3600)
+    return _original_call(
+        agent_name, task, streaming_callback, _add_to_conversation
+    )
+
+
+swarm.call_single_agent = _patched_call
+
+result = swarm.run(
+    "Competitive snapshot of the async-meeting-AI market for a new B2B SaaS launch."
+)
+print(result)

--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -1732,8 +1732,10 @@ class HierarchicalSwarm:
 
                 while pending:
                     next_pending = []
+                    # One thread per pending task so every future starts
+                    # immediately and worker_timeout is truly per-task.
                     executor = ThreadPoolExecutor(
-                        max_workers=max_workers
+                        max_workers=max(max_workers, len(pending))
                     )
                     future_to_meta = {}
 
@@ -1846,56 +1848,63 @@ class HierarchicalSwarm:
                             "Processing...",
                         )
 
-                    output = None
-                    for attempt in range(self.max_retries + 1):
-                        seq_executor = ThreadPoolExecutor(
-                            max_workers=1
-                        )
-                        future = seq_executor.submit(
-                            self.call_single_agent,
+                    if self.worker_timeout is None:
+                        output = self.call_single_agent(
                             order.agent_name,
                             order.task,
                             streaming_callback,
                         )
-                        try:
-                            output = future.result(
-                                timeout=self.worker_timeout
+                    else:
+                        output = None
+                        for attempt in range(self.max_retries + 1):
+                            seq_executor = ThreadPoolExecutor(
+                                max_workers=1
                             )
-                            seq_executor.shutdown(wait=False)
-                            break
-                        except ConcurrentTimeoutError:
-                            seq_executor.shutdown(wait=False)
-                            logger.warning(
-                                f"[TIMEOUT] Worker '{order.agent_name}' exceeded "
-                                f"{self.worker_timeout}s timeout "
-                                f"(attempt {attempt + 1}/{self.max_retries + 1}). "
-                                f"Task: {order.task[:80]}"
+                            future = seq_executor.submit(
+                                self.call_single_agent,
+                                order.agent_name,
+                                order.task,
+                                streaming_callback,
                             )
-                            if attempt < self.max_retries:
-                                if (
-                                    self.interactive
-                                    and self.dashboard
-                                ):
-                                    self.dashboard.update_agent_status(
-                                        order.agent_name,
-                                        "TIMEOUT",
-                                        order.task,
-                                        f"Timed out — retrying (attempt {attempt + 1})",
-                                    )
-                            else:
-                                output = (
-                                    f"[FAILED] Worker '{order.agent_name}' timed out "
-                                    f"after {self.max_retries + 1} attempt(s). "
+                            try:
+                                output = future.result(
+                                    timeout=self.worker_timeout
+                                )
+                                seq_executor.shutdown(wait=False)
+                                break
+                            except ConcurrentTimeoutError:
+                                seq_executor.shutdown(wait=False)
+                                logger.warning(
+                                    f"[TIMEOUT] Worker '{order.agent_name}' exceeded "
+                                    f"{self.worker_timeout}s timeout "
+                                    f"(attempt {attempt + 1}/{self.max_retries + 1}). "
                                     f"Task: {order.task[:80]}"
                                 )
-                                logger.error(output)
-                        except Exception as e:
-                            seq_executor.shutdown(wait=False)
-                            logger.error(
-                                f"[ERROR] Worker '{order.agent_name}' raised: {e}\n"
-                                f"[TRACE] {traceback.format_exc()}"
-                            )
-                            break
+                                if attempt < self.max_retries:
+                                    if (
+                                        self.interactive
+                                        and self.dashboard
+                                    ):
+                                        self.dashboard.update_agent_status(
+                                            order.agent_name,
+                                            "TIMEOUT",
+                                            order.task,
+                                            f"Timed out — retrying (attempt {attempt + 1})",
+                                        )
+                                else:
+                                    output = (
+                                        f"[FAILED] Worker '{order.agent_name}' timed out "
+                                        f"after {self.max_retries + 1} attempt(s). "
+                                        f"Task: {order.task[:80]}"
+                                    )
+                                    logger.error(output)
+                            except Exception as e:
+                                seq_executor.shutdown(wait=False)
+                                logger.error(
+                                    f"[ERROR] Worker '{order.agent_name}' raised: {e}\n"
+                                    f"[TRACE] {traceback.format_exc()}"
+                                )
+                                break
 
                     if self.interactive and self.dashboard:
                         status = (

--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -25,7 +25,11 @@ import json
 import os
 import time
 import traceback
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    wait as cf_wait,
+    TimeoutError as ConcurrentTimeoutError,
+)
 from typing import Any, Callable, List, Optional, Union
 
 from loguru import logger
@@ -696,6 +700,9 @@ class HierarchicalSwarm:
         autosave: bool = True,
         verbose: bool = False,
         parallel_execution: bool = True,
+        worker_timeout: Optional[int] = None,
+        heartbeat_interval: int = 30,
+        max_retries: int = 2,
         agent_as_judge: bool = False,
         judge_agent_model_name: str = "gpt-5.4",
         *args,
@@ -757,6 +764,9 @@ class HierarchicalSwarm:
         self.autosave = autosave
         self.verbose = verbose
         self.parallel_execution = parallel_execution
+        self.worker_timeout = worker_timeout
+        self.heartbeat_interval = heartbeat_interval
+        self.max_retries = max_retries
         self.agent_as_judge = agent_as_judge
         self.judge_agent_model_name = judge_agent_model_name
         self.swarm_workspace_dir = None
@@ -1713,13 +1723,21 @@ class HierarchicalSwarm:
         try:
             if self.parallel_execution:
                 max_workers = max(1, int(os.cpu_count() * 0.75))
-                futures_map = {}
                 results = [None] * len(orders)
 
-                with ThreadPoolExecutor(
-                    max_workers=max_workers
-                ) as executor:
-                    for i, order in enumerate(orders):
+                # pending: (original_index, order, retry_count)
+                pending = [
+                    (i, order, 0) for i, order in enumerate(orders)
+                ]
+
+                while pending:
+                    next_pending = []
+                    executor = ThreadPoolExecutor(
+                        max_workers=max_workers
+                    )
+                    future_to_meta = {}
+
+                    for idx, order, retry_count in pending:
                         if self.interactive and self.dashboard:
                             self.dashboard.update_agent_status(
                                 order.agent_name,
@@ -1734,20 +1752,79 @@ class HierarchicalSwarm:
                             streaming_callback,
                             False,  # _add_to_conversation=False
                         )
-                        futures_map[future] = (i, order)
+                        future_to_meta[future] = (
+                            idx,
+                            order,
+                            retry_count,
+                        )
 
-                    for future in as_completed(futures_map):
-                        idx, order = futures_map[future]
-                        output = future.result()
-                        results[idx] = output
+                    done, not_done = cf_wait(
+                        future_to_meta.keys(),
+                        timeout=self.worker_timeout,
+                    )
 
-                        if self.interactive and self.dashboard:
-                            self.dashboard.update_agent_status(
-                                order.agent_name,
-                                "COMPLETED",
-                                order.task,
-                                str(output),
+                    for future in done:
+                        idx, order, retry_count = future_to_meta[
+                            future
+                        ]
+                        try:
+                            output = future.result()
+                            results[idx] = output
+                            if self.interactive and self.dashboard:
+                                self.dashboard.update_agent_status(
+                                    order.agent_name,
+                                    "COMPLETED",
+                                    order.task,
+                                    str(output),
+                                )
+                        except Exception as e:
+                            logger.error(
+                                f"[ERROR] Worker '{order.agent_name}' raised: {e}\n"
+                                f"[TRACE] {traceback.format_exc()}"
                             )
+                            results[idx] = None
+
+                    for future in not_done:
+                        idx, order, retry_count = future_to_meta[
+                            future
+                        ]
+                        logger.warning(
+                            f"[TIMEOUT] Worker '{order.agent_name}' exceeded "
+                            f"{self.worker_timeout}s timeout "
+                            f"(attempt {retry_count + 1}/{self.max_retries + 1}). "
+                            f"Task: {order.task[:80]}"
+                        )
+                        if retry_count < self.max_retries:
+                            if self.interactive and self.dashboard:
+                                self.dashboard.update_agent_status(
+                                    order.agent_name,
+                                    "TIMEOUT",
+                                    order.task,
+                                    f"Timed out — retrying (attempt {retry_count + 1})",
+                                )
+                            next_pending.append(
+                                (idx, order, retry_count + 1)
+                            )
+                        else:
+                            fail_msg = (
+                                f"[FAILED] Worker '{order.agent_name}' timed out "
+                                f"after {self.max_retries + 1} attempt(s). "
+                                f"Task: {order.task[:80]}"
+                            )
+                            logger.error(fail_msg)
+                            results[idx] = fail_msg
+                            if self.interactive and self.dashboard:
+                                self.dashboard.update_agent_status(
+                                    order.agent_name,
+                                    "FAILED",
+                                    order.task,
+                                    fail_msg,
+                                )
+
+                    # Don't block on hung threads — they are daemon threads
+                    # and will be cleaned up when the process exits.
+                    executor.shutdown(wait=False)
+                    pending = next_pending
 
                 # Write outputs to conversation in submission order
                 for i, order in enumerate(orders):
@@ -1761,7 +1838,6 @@ class HierarchicalSwarm:
             else:
                 outputs = []
                 for i, order in enumerate(orders):
-                    # Update dashboard for agent execution
                     if self.interactive and self.dashboard:
                         self.dashboard.update_agent_status(
                             order.agent_name,
@@ -1770,22 +1846,69 @@ class HierarchicalSwarm:
                             "Processing...",
                         )
 
-                    output = self.call_single_agent(
-                        order.agent_name,
-                        order.task,
-                        streaming_callback=streaming_callback,
-                    )
+                    output = None
+                    for attempt in range(self.max_retries + 1):
+                        seq_executor = ThreadPoolExecutor(
+                            max_workers=1
+                        )
+                        future = seq_executor.submit(
+                            self.call_single_agent,
+                            order.agent_name,
+                            order.task,
+                            streaming_callback,
+                        )
+                        try:
+                            output = future.result(
+                                timeout=self.worker_timeout
+                            )
+                            seq_executor.shutdown(wait=False)
+                            break
+                        except ConcurrentTimeoutError:
+                            seq_executor.shutdown(wait=False)
+                            logger.warning(
+                                f"[TIMEOUT] Worker '{order.agent_name}' exceeded "
+                                f"{self.worker_timeout}s timeout "
+                                f"(attempt {attempt + 1}/{self.max_retries + 1}). "
+                                f"Task: {order.task[:80]}"
+                            )
+                            if attempt < self.max_retries:
+                                if (
+                                    self.interactive
+                                    and self.dashboard
+                                ):
+                                    self.dashboard.update_agent_status(
+                                        order.agent_name,
+                                        "TIMEOUT",
+                                        order.task,
+                                        f"Timed out — retrying (attempt {attempt + 1})",
+                                    )
+                            else:
+                                output = (
+                                    f"[FAILED] Worker '{order.agent_name}' timed out "
+                                    f"after {self.max_retries + 1} attempt(s). "
+                                    f"Task: {order.task[:80]}"
+                                )
+                                logger.error(output)
+                        except Exception as e:
+                            seq_executor.shutdown(wait=False)
+                            logger.error(
+                                f"[ERROR] Worker '{order.agent_name}' raised: {e}\n"
+                                f"[TRACE] {traceback.format_exc()}"
+                            )
+                            break
 
-                    # Update dashboard with completed status
                     if self.interactive and self.dashboard:
-                        # Always show full output without truncation
-                        output_display = str(output)
-
+                        status = (
+                            "FAILED"
+                            if isinstance(output, str)
+                            and output.startswith("[FAILED]")
+                            else "COMPLETED"
+                        )
                         self.dashboard.update_agent_status(
                             order.agent_name,
-                            "COMPLETED",
+                            status,
                             order.task,
-                            output_display,
+                            str(output),
                         )
 
                     outputs.append(output)

--- a/tests/structs/test_hierarchical_swarm_timeout.py
+++ b/tests/structs/test_hierarchical_swarm_timeout.py
@@ -1,0 +1,235 @@
+"""
+Unit tests for HierarchicalSwarm worker timeout and retry.
+No real LLM calls — all agents are patched.
+"""
+
+import time
+import pytest
+from unittest.mock import MagicMock, patch
+
+from swarms.structs.hiearchical_swarm import (
+    HierarchicalSwarm,
+    HierarchicalOrder,
+)
+
+
+def _make_swarm(**kwargs) -> HierarchicalSwarm:
+    agent_a = MagicMock()
+    agent_a.agent_name = "AgentA"
+    agent_b = MagicMock()
+    agent_b.agent_name = "AgentB"
+
+    swarm = HierarchicalSwarm.__new__(HierarchicalSwarm)
+    swarm.name = "TestSwarm"
+    swarm.description = "test"
+    swarm.agents = [agent_a, agent_b]
+    swarm.agent_map = {"AgentA": agent_a, "AgentB": agent_b}
+    swarm.max_loops = 1
+    swarm.output_type = "dict-all-except-first"
+    swarm.director = MagicMock()
+    swarm.director.agent_name = "Director"
+    swarm.add_collaboration_prompt = False
+    swarm.director_feedback_on = False
+    swarm.interactive = False
+    swarm.dashboard = None
+    swarm.multi_agent_prompt_improvements = False
+    swarm.director_temperature = 0.7
+    swarm.director_top_p = 0.9
+    swarm.planning_enabled = False
+    swarm.autosave = False
+    swarm.verbose = False
+    swarm.parallel_execution = kwargs.get("parallel_execution", True)
+    swarm.worker_timeout = kwargs.get("worker_timeout", None)
+    swarm.heartbeat_interval = kwargs.get("heartbeat_interval", 30)
+    swarm.max_retries = kwargs.get("max_retries", 2)
+    swarm.agent_as_judge = False
+    swarm.judge_agent_model_name = "gpt-5.4"
+    swarm.swarm_workspace_dir = None
+    swarm.feedback_director_model_name = "gpt-5.4"
+    swarm.director_name = "Director"
+    swarm.director_model_name = "gpt-5.4"
+    swarm.director_system_prompt = ""
+
+    from swarms.structs.conversation import Conversation
+
+    swarm.conversation = Conversation(time_enabled=False)
+
+    return swarm
+
+
+def _orders(*pairs):
+    return [HierarchicalOrder(agent_name=n, task=t) for n, t in pairs]
+
+
+# ---------------------------------------------------------------------------
+# Backward compat — no timeout set, original behaviour preserved
+# ---------------------------------------------------------------------------
+
+
+def test_no_timeout_parallel():
+    swarm = _make_swarm(worker_timeout=None, parallel_execution=True)
+    swarm.call_single_agent = (
+        lambda name, task, cb=None, add=True: f"done:{name}"
+    )
+    results = swarm.execute_orders(
+        _orders(("AgentA", "t1"), ("AgentB", "t2"))
+    )
+    assert results[0] == "done:AgentA"
+    assert results[1] == "done:AgentB"
+
+
+def test_no_timeout_sequential():
+    swarm = _make_swarm(worker_timeout=None, parallel_execution=False)
+    swarm.call_single_agent = (
+        lambda name, task, cb=None, add=True: f"done:{name}"
+    )
+    results = swarm.execute_orders(
+        _orders(("AgentA", "t1"), ("AgentB", "t2"))
+    )
+    assert results[0] == "done:AgentA"
+    assert results[1] == "done:AgentB"
+
+
+# ---------------------------------------------------------------------------
+# Timeout fires and produces [FAILED] after max_retries exhausted
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_timeout_fails():
+    swarm = _make_swarm(
+        worker_timeout=1, max_retries=0, parallel_execution=True
+    )
+
+    def _call(name, task, cb=None, add=True):
+        if name == "AgentA":
+            time.sleep(60)
+        return "ok"
+
+    swarm.call_single_agent = _call
+    results = swarm.execute_orders(
+        _orders(("AgentA", "slow"), ("AgentB", "fast"))
+    )
+    assert results[0].startswith("[FAILED]")
+    assert "AgentA" in results[0]
+    assert results[1] == "ok"
+
+
+def test_sequential_timeout_fails():
+    swarm = _make_swarm(
+        worker_timeout=1, max_retries=0, parallel_execution=False
+    )
+
+    def _call(name, task, cb=None, add=True):
+        if name == "AgentA":
+            time.sleep(60)
+        return "ok"
+
+    swarm.call_single_agent = _call
+    results = swarm.execute_orders(
+        _orders(("AgentA", "slow"), ("AgentB", "fast"))
+    )
+    assert results[0].startswith("[FAILED]")
+    assert results[1] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Retry — agent recovers on 3rd attempt (max_retries=2)
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_retry_recovers():
+    attempt = {"n": 0}
+
+    def _call(name, task, cb=None, add=True):
+        attempt["n"] += 1
+        if attempt["n"] < 3:
+            time.sleep(60)
+        return "recovered"
+
+    swarm = _make_swarm(
+        worker_timeout=1, max_retries=2, parallel_execution=True
+    )
+    swarm.call_single_agent = _call
+    results = swarm.execute_orders(_orders(("AgentA", "flaky")))
+    assert results[0] == "recovered"
+    assert attempt["n"] == 3
+
+
+def test_sequential_retry_recovers():
+    attempt = {"n": 0}
+
+    def _call(name, task, cb=None, add=True):
+        attempt["n"] += 1
+        if attempt["n"] < 3:
+            time.sleep(60)
+        return "recovered"
+
+    swarm = _make_swarm(
+        worker_timeout=1, max_retries=2, parallel_execution=False
+    )
+    swarm.call_single_agent = _call
+    results = swarm.execute_orders(_orders(("AgentA", "flaky")))
+    assert results[0] == "recovered"
+    assert attempt["n"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Exhausted retries → correct attempt count in [FAILED] message
+# ---------------------------------------------------------------------------
+
+
+def test_exhausted_retries_message():
+    swarm = _make_swarm(
+        worker_timeout=1, max_retries=1, parallel_execution=True
+    )
+    swarm.call_single_agent = (
+        lambda name, task, cb=None, add=True: time.sleep(60)
+    )
+    results = swarm.execute_orders(_orders(("AgentA", "impossible")))
+    assert results[0].startswith("[FAILED]")
+    assert (
+        "2 attempt" in results[0]
+    )  # max_retries=1 → 2 total attempts
+
+
+# ---------------------------------------------------------------------------
+# Healthy sibling completes even when another worker is stuck
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_sibling_unaffected():
+    swarm = _make_swarm(
+        worker_timeout=1, max_retries=0, parallel_execution=True
+    )
+
+    def _call(name, task, cb=None, add=True):
+        if name == "AgentB":
+            time.sleep(60)
+        return "fast"
+
+    swarm.call_single_agent = _call
+    results = swarm.execute_orders(
+        _orders(("AgentA", "fast"), ("AgentB", "slow"))
+    )
+    assert results[0] == "fast"
+    assert results[1].startswith("[FAILED]")
+
+
+# ---------------------------------------------------------------------------
+# Successful outputs written to conversation
+# ---------------------------------------------------------------------------
+
+
+def test_conversation_written():
+    swarm = _make_swarm(
+        worker_timeout=5, max_retries=0, parallel_execution=True
+    )
+    swarm.call_single_agent = (
+        lambda name, task, cb=None, add=True: f"out:{name}"
+    )
+    swarm.execute_orders(_orders(("AgentA", "t1"), ("AgentB", "t2")))
+    roles = [
+        m["role"] for m in swarm.conversation.conversation_history
+    ]
+    assert "AgentA" in roles
+    assert "AgentB" in roles

--- a/tests/structs/test_hierarchical_swarm_timeout.py
+++ b/tests/structs/test_hierarchical_swarm_timeout.py
@@ -4,13 +4,15 @@ No real LLM calls — all agents are patched.
 """
 
 import time
-import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from swarms.structs.hiearchical_swarm import (
     HierarchicalSwarm,
     HierarchicalOrder,
 )
+
+_TIMEOUT = 1
+_HANG = 1.5  # just past _TIMEOUT so the stuck thread exits quickly
 
 
 def _make_swarm(**kwargs) -> HierarchicalSwarm:
@@ -97,12 +99,14 @@ def test_no_timeout_sequential():
 
 def test_parallel_timeout_fails():
     swarm = _make_swarm(
-        worker_timeout=1, max_retries=0, parallel_execution=True
+        worker_timeout=_TIMEOUT,
+        max_retries=0,
+        parallel_execution=True,
     )
 
     def _call(name, task, cb=None, add=True):
         if name == "AgentA":
-            time.sleep(60)
+            time.sleep(_HANG)
         return "ok"
 
     swarm.call_single_agent = _call
@@ -116,12 +120,14 @@ def test_parallel_timeout_fails():
 
 def test_sequential_timeout_fails():
     swarm = _make_swarm(
-        worker_timeout=1, max_retries=0, parallel_execution=False
+        worker_timeout=_TIMEOUT,
+        max_retries=0,
+        parallel_execution=False,
     )
 
     def _call(name, task, cb=None, add=True):
         if name == "AgentA":
-            time.sleep(60)
+            time.sleep(_HANG)
         return "ok"
 
     swarm.call_single_agent = _call
@@ -143,11 +149,13 @@ def test_parallel_retry_recovers():
     def _call(name, task, cb=None, add=True):
         attempt["n"] += 1
         if attempt["n"] < 3:
-            time.sleep(60)
+            time.sleep(_HANG)
         return "recovered"
 
     swarm = _make_swarm(
-        worker_timeout=1, max_retries=2, parallel_execution=True
+        worker_timeout=_TIMEOUT,
+        max_retries=2,
+        parallel_execution=True,
     )
     swarm.call_single_agent = _call
     results = swarm.execute_orders(_orders(("AgentA", "flaky")))
@@ -161,11 +169,13 @@ def test_sequential_retry_recovers():
     def _call(name, task, cb=None, add=True):
         attempt["n"] += 1
         if attempt["n"] < 3:
-            time.sleep(60)
+            time.sleep(_HANG)
         return "recovered"
 
     swarm = _make_swarm(
-        worker_timeout=1, max_retries=2, parallel_execution=False
+        worker_timeout=_TIMEOUT,
+        max_retries=2,
+        parallel_execution=False,
     )
     swarm.call_single_agent = _call
     results = swarm.execute_orders(_orders(("AgentA", "flaky")))
@@ -180,10 +190,12 @@ def test_sequential_retry_recovers():
 
 def test_exhausted_retries_message():
     swarm = _make_swarm(
-        worker_timeout=1, max_retries=1, parallel_execution=True
+        worker_timeout=_TIMEOUT,
+        max_retries=1,
+        parallel_execution=True,
     )
     swarm.call_single_agent = (
-        lambda name, task, cb=None, add=True: time.sleep(60)
+        lambda name, task, cb=None, add=True: time.sleep(_HANG)
     )
     results = swarm.execute_orders(_orders(("AgentA", "impossible")))
     assert results[0].startswith("[FAILED]")
@@ -199,12 +211,14 @@ def test_exhausted_retries_message():
 
 def test_healthy_sibling_unaffected():
     swarm = _make_swarm(
-        worker_timeout=1, max_retries=0, parallel_execution=True
+        worker_timeout=_TIMEOUT,
+        max_retries=0,
+        parallel_execution=True,
     )
 
     def _call(name, task, cb=None, add=True):
         if name == "AgentB":
-            time.sleep(60)
+            time.sleep(_HANG)
         return "fast"
 
     swarm.call_single_agent = _call


### PR DESCRIPTION
## Description
Adds worker_timeout, heartbeat_interval, and max_retries to HierarchicalSwarm. On timeout the subtask retries up to max_retries times then surfaces [FAILED] in the output — the swarm continues instead of hanging forever. Default worker_timeout=None preserves existing behaviour.

## Files Changed
* `swarms/structs/hiearchical_swarm.py`
* `tests/structs/test_hierarchical_swarm_timeout.py`
* `examples/multi_agent/hiearchical_swarm/hierarchical_swarm_timeout_example.py`

## Issue
#1554

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Twitter
[@akc__2025](https://x.com/akc__2025)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1568.org.readthedocs.build/en/1568/

<!-- readthedocs-preview swarms end -->