### PR TITLE
docs: add Swarms tools guide pages

### DIFF
--- a/docs/swarms_tools/finance.md
+++ b/docs/swarms_tools/finance.md
@@ -1,0 +1,153 @@
+# Finance Tools
+
+Finance tools let Swarms agents retrieve market data, normalize financial records, and run deterministic calculations before producing a recommendation. They are useful for research assistants, analyst copilots, reporting agents, and monitoring workflows where the model needs fresh numbers instead of relying on stale training data.
+
+Financial tools should be designed conservatively. Separate data retrieval from interpretation, return timestamps and sources, and make calculations explicit. The agent can explain tradeoffs, but a tool should provide the auditable inputs.
+
+## Common Use Cases
+
+- Retrieve quote, volume, market-cap, or fundamentals data from a provider.
+- Summarize a watchlist with current prices and percentage moves.
+- Calculate allocation drift, exposure, drawdown, or risk budget.
+- Build a report from transaction exports or account snapshots.
+- Compare market news against a portfolio or sector list.
+
+Avoid tools that execute trades unless you have a tested confirmation flow, account-level permissions, and operational monitoring. A research tool and a trading tool should never share the same callable.
+
+## Read-Only Market Snapshot
+
+The example below shows a read-only finance tool with a stable output shape. Replace the mocked data access with your provider client.
+
+```python
+from datetime import datetime, timezone
+from swarms import Agent
+
+
+def get_market_snapshot(symbols: list[str]) -> dict:
+    """Return current market snapshot data for a list of symbols."""
+    normalized = [symbol.upper().strip() for symbol in symbols]
+    return {
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "provider": "example-market-data-provider",
+        "symbols": [
+            {
+                "symbol": symbol,
+                "price": 100.0,
+                "currency": "USD",
+                "day_change_percent": 0.8,
+                "source": "mock",
+            }
+            for symbol in normalized
+        ],
+    }
+
+
+agent = Agent(
+    agent_name="Market Research Agent",
+    system_prompt=(
+        "Use market tools for current prices. "
+        "Mention the provider and checked_at timestamp when summarizing results."
+    ),
+    tools=[get_market_snapshot],
+    max_loops=2,
+)
+
+print(agent.run("Check AAPL, MSFT, and NVDA and summarize the biggest mover."))
+```
+
+This pattern keeps the tool read-only and gives the final answer enough metadata for the user to judge freshness.
+
+## Deterministic Risk Calculation
+
+When the result is math-heavy, put the calculation in the tool. The agent can describe the result, but the tool should compute it.
+
+```python
+def calculate_position_risk(position_value: float, portfolio_value: float, max_weight: float = 0.15) -> dict:
+    """Calculate position weight and whether it exceeds a maximum allocation."""
+    if portfolio_value <= 0:
+        raise ValueError("portfolio_value must be greater than zero")
+
+    weight = position_value / portfolio_value
+    excess_value = max(0.0, position_value - (portfolio_value * max_weight))
+
+    return {
+        "position_value": position_value,
+        "portfolio_value": portfolio_value,
+        "weight": weight,
+        "max_weight": max_weight,
+        "is_over_limit": weight > max_weight,
+        "excess_value": excess_value,
+    }
+```
+
+Use this style for allocation, exposure, value-at-risk approximations, tax lots, or drawdown math. It prevents the agent from doing arithmetic in free text.
+
+## Credential Handling
+
+Most market data providers require keys. Load them from environment variables and report missing configuration clearly.
+
+```python
+import os
+
+
+def get_finance_api_key() -> str:
+    api_key = os.getenv("FINANCIAL_DATA_API_KEY")
+    if not api_key:
+        raise RuntimeError("Set FINANCIAL_DATA_API_KEY before running finance tools")
+    return api_key
+```
+
+Recommended environment variables:
+
+- `FINANCIAL_DATA_API_KEY` for a generic market data provider.
+- `NEWS_API_KEY` for financial news enrichment.
+- `PORTFOLIO_EXPORT_PATH` for local CSV-based portfolio analysis.
+- `FINANCE_TOOL_TIMEOUT_SECONDS` for network-bound tools.
+
+Do not return secrets from a tool. If the agent needs to confirm configuration, return a boolean such as `{"configured": true, "provider": "..."}`.
+
+## Portfolio Report Pattern
+
+A portfolio report agent usually needs three tools:
+
+| Tool | Responsibility |
+| --- | --- |
+| `load_positions` | Read positions from a trusted export or API. |
+| `get_market_snapshot` | Retrieve current prices and market movement. |
+| `calculate_exposure` | Compute allocations, concentration, and drift. |
+
+The agent prompt should require source attribution:
+
+```python
+system_prompt = """
+You are a portfolio reporting agent.
+Use tools for all numeric values.
+Do not invent prices, balances, or returns.
+In the final answer, include the checked_at timestamp and any rows that could not be priced.
+"""
+```
+
+## Safety Guidelines
+
+- Treat all prices as time-sensitive. Include `checked_at`.
+- Distinguish realized account data from derived calculations.
+- Return provider errors instead of substituting model guesses.
+- Keep trade execution out of research agents.
+- Add tests for edge cases such as empty portfolios, zero balances, missing symbols, and unsupported currencies.
+
+## Example Output Contract
+
+Finance tools work best when every result follows a predictable contract:
+
+```json
+{
+  "ok": true,
+  "checked_at": "2026-01-01T00:00:00Z",
+  "provider": "example-market-data-provider",
+  "data": [],
+  "warnings": []
+}
+```
+
+If `ok` is false, the agent should stop and explain what failed instead of producing a market conclusion from incomplete data.
+

--- a/docs/swarms_tools/overview.md
+++ b/docs/swarms_tools/overview.md
@@ -1,0 +1,150 @@
+# Swarms Tools Overview
+
+Swarms agents can call external functions, API wrappers, and structured utilities through the tool system. A tool is any callable that gives an agent a bounded capability: search the web, inspect a financial data source, post to a social platform, run a script, query a database, or transform a file. This section explains how to choose, configure, and operate those tools without turning an agent into an uncontrolled script runner.
+
+Use this page as the entry point for the `swarms_tools` navigation section. The lower-level `BaseTool` reference explains schema conversion and execution internals. These guides focus on practical operating patterns: which tool belongs in an agent, what credentials it needs, how to keep outputs auditable, and how to verify that the agent actually used the tool result.
+
+## When to Use Tools
+
+Add a tool when the agent needs information or an action that is not already in the prompt. Common cases include:
+
+- Fresh data such as web pages, financial quotes, social posts, tickets, or documentation.
+- Deterministic calculations that should not be left to model reasoning alone.
+- External side effects such as publishing, notification, or database writes.
+- Local automation such as file conversion, browser interaction, or command execution.
+
+Do not add a tool just because it is available. Every tool expands the agent's authority. Prefer the smallest callable that returns the exact information required for the next decision.
+
+## Basic Function Tool
+
+The simplest tool is a typed Python function with a clear docstring. Type hints and docstrings help the schema generator expose the function safely to the model.
+
+```python
+from swarms import Agent
+
+
+def summarize_ticket(ticket_id: str, include_comments: bool = True) -> dict:
+    """Return a normalized support-ticket summary for an internal ticket ID."""
+    return {
+        "ticket_id": ticket_id,
+        "status": "open",
+        "priority": "high",
+        "summary": "Customer cannot complete onboarding.",
+        "comments_included": include_comments,
+    }
+
+
+agent = Agent(
+    agent_name="Support Operations Agent",
+    system_prompt="Summarize support tickets and recommend the next operational step.",
+    tools=[summarize_ticket],
+    max_loops=1,
+)
+
+result = agent.run("Summarize ticket SUP-1042 and identify the next owner.")
+print(result)
+```
+
+Keep the callable narrow. A `summarize_ticket` tool is easier to validate than a generic `run_any_support_action` tool.
+
+## Tool Selection Checklist
+
+Before wiring a tool into an agent, answer these questions:
+
+| Question | Why it matters |
+| --- | --- |
+| What action or data does the tool expose? | Prevents hidden broad authority. |
+| Is the tool read-only or write-capable? | Write-capable tools need stronger prompts and confirmation gates. |
+| Which environment variables are required? | Makes deployments reproducible. |
+| What should happen on timeout or partial failure? | Prevents the agent from hallucinating missing results. |
+| What output shape should the agent expect? | Keeps downstream reasoning stable. |
+| How will you verify the result? | Tool calls should leave logs, return metadata, or produce testable artifacts. |
+
+## Recommended Structure
+
+For production agents, separate tool configuration from agent orchestration:
+
+```python
+import os
+from swarms import Agent
+
+
+def get_customer_profile(customer_id: str) -> dict:
+    """Fetch a customer profile from the configured customer API."""
+    api_base = os.environ["CUSTOMER_API_BASE_URL"]
+    # Replace this example with a real client call in production.
+    return {"customer_id": customer_id, "source": api_base, "plan": "team"}
+
+
+def build_agent() -> Agent:
+    return Agent(
+        agent_name="Customer Success Agent",
+        system_prompt=(
+            "Use tools only when customer data is needed. "
+            "Cite the returned source fields in the final answer."
+        ),
+        tools=[get_customer_profile],
+        max_loops=2,
+    )
+```
+
+This pattern keeps secrets in the environment, makes the tool easy to test independently, and gives the agent a specific instruction for how to use the returned evidence.
+
+## Environment Variables
+
+Tools often need credentials. Use environment variables and fail fast when a required value is missing.
+
+```python
+import os
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+```
+
+Recommended conventions:
+
+- Use one variable per provider, such as `EXA_API_KEY`, `FIRECRAWL_API_KEY`, `TWITTER_BEARER_TOKEN`, or `FINANCIAL_DATA_API_KEY`.
+- Do not hard-code API keys in examples, prompts, notebooks, or committed files.
+- Return a clear error when a credential is missing instead of silently returning fake data.
+- In write-capable tools, include the target account, workspace, or project ID in the returned metadata.
+
+## Read-Only vs Write-Capable Tools
+
+Read-only tools retrieve information. They can usually run autonomously if they are rate-limited and their outputs are checked. Write-capable tools create, update, delete, publish, or spend resources. They need additional safeguards:
+
+- Validate the target identifier before executing.
+- Make the tool idempotent where possible.
+- Return the created resource URL or ID.
+- Log enough metadata to audit what happened.
+- Consider adding a separate dry-run function for previews.
+
+For example, a social-media agent should use a read-only search tool for research and a separate posting tool for publication. The posting tool should require the exact text, account, and destination.
+
+## Tool Result Design
+
+Return structured data instead of raw strings whenever possible.
+
+```python
+def get_page_status(url: str) -> dict:
+    """Check whether a page is reachable and return basic response metadata."""
+    return {
+        "url": url,
+        "ok": True,
+        "status_code": 200,
+        "checked_at": "2026-01-01T00:00:00Z",
+    }
+```
+
+Structured outputs let the agent distinguish facts from commentary, and they make tests easier to write.
+
+## Related Guides
+
+- [Finance Tools](finance.md): build agents that retrieve market data, run portfolio checks, and separate calculations from recommendations.
+- [Search Tools](search.md): combine web search, page extraction, and source-aware synthesis.
+- [Twitter Tools](twitter.md): design social-media research and publishing workflows with account safety.
+- [BaseTool Reference](../swarms/tools/base_tool.md): inspect schema conversion, validation, and execution utilities.
+

--- a/docs/swarms_tools/search.md
+++ b/docs/swarms_tools/search.md
@@ -1,0 +1,160 @@
+# Search Tools
+
+Search tools give Swarms agents access to current external information. They are useful for research agents, competitive analysis, market monitoring, documentation assistants, and workflows that need source-backed answers. A good search workflow separates discovery, extraction, and synthesis so the final response can cite where each claim came from.
+
+Swarms can use any typed callable as a search tool. Common integrations include Exa, Firecrawl, custom HTTP clients, internal document search, and MCP-based retrieval systems.
+
+## Search Workflow
+
+A reliable search agent usually follows this sequence:
+
+1. Generate focused queries from the user task.
+2. Retrieve candidate sources with a search provider.
+3. Fetch or extract the most relevant pages.
+4. Remove duplicates and low-quality pages.
+5. Summarize only from retrieved source text.
+6. Return source URLs, dates, and confidence notes.
+
+The model should not blur search results and synthesis. Tool outputs should contain enough metadata for the final answer to explain what was found and what remains uncertain.
+
+## Minimal Search Tool
+
+This example shows a small search wrapper with a structured output. Replace the mocked result with a real provider call.
+
+```python
+from datetime import datetime, timezone
+from swarms import Agent
+
+
+def web_search(query: str, max_results: int = 5) -> dict:
+    """Search the web for a query and return ranked result metadata."""
+    return {
+        "query": query,
+        "searched_at": datetime.now(timezone.utc).isoformat(),
+        "results": [
+            {
+                "title": "Example source",
+                "url": "https://example.com/source",
+                "snippet": "A concise summary from the provider.",
+                "rank": 1,
+            }
+        ][:max_results],
+    }
+
+
+agent = Agent(
+    agent_name="Source-Aware Research Agent",
+    system_prompt=(
+        "Use the search tool before answering questions about current events. "
+        "Base factual claims on returned URLs and say when evidence is thin."
+    ),
+    tools=[web_search],
+    max_loops=3,
+)
+```
+
+## Exa Search Pattern
+
+The examples directory includes Exa search agents. A typical production wrapper should:
+
+- Accept a plain query and optional domain filters.
+- Limit result count by default.
+- Return title, URL, snippet, published date if available, and provider score.
+- Fail clearly when `EXA_API_KEY` is missing.
+
+```python
+import os
+
+
+def require_exa_key() -> str:
+    key = os.getenv("EXA_API_KEY")
+    if not key:
+        raise RuntimeError("Set EXA_API_KEY before using Exa search tools")
+    return key
+```
+
+Use Exa-style search when you need semantic discovery across the public web. For a small known site, a direct crawler or internal index may be more predictable.
+
+## Page Extraction
+
+Search snippets are not enough for high-quality answers. Add a second tool that fetches and extracts page content.
+
+```python
+def extract_page(url: str) -> dict:
+    """Extract readable content from a URL for source-grounded synthesis."""
+    return {
+        "url": url,
+        "title": "Example page",
+        "content": "Clean article or documentation text goes here.",
+        "extracted_at": "2026-01-01T00:00:00Z",
+    }
+```
+
+The agent can call `web_search` to discover URLs and `extract_page` to inspect the strongest sources. This two-step pattern reduces hallucination because the synthesis step sees full source text.
+
+## Query Planning
+
+For difficult research tasks, give the agent an explicit query plan:
+
+```text
+Before searching, break the task into 2-4 search questions.
+Run one focused query per question.
+Prefer primary sources, official documentation, issue threads, papers, and changelogs.
+Discard sources that do not directly answer the question.
+```
+
+Examples:
+
+| Task | Better query |
+| --- | --- |
+| "How does this library deploy?" | `site:docs.example.com deployment environment variables` |
+| "What changed in the latest version?" | `example project release notes 2026 changelog` |
+| "Find implementation examples" | `site:github.com/example-org/example repo \"Agent(\" tools` |
+
+## Source Quality Rules
+
+Not all search results are equal. Prefer:
+
+- Official docs, repositories, changelogs, and standards.
+- Maintainer comments in issues or pull requests.
+- Primary research papers or dataset pages.
+- Recent pages when the topic is time-sensitive.
+
+Avoid relying on:
+
+- SEO copies of documentation.
+- Old forum posts for fast-moving libraries.
+- Snippets without page extraction.
+- Aggregators that do not link to primary sources.
+
+## Output Contract
+
+Search tools should return a predictable shape:
+
+```json
+{
+  "ok": true,
+  "query": "example query",
+  "searched_at": "2026-01-01T00:00:00Z",
+  "results": [
+    {
+      "title": "Result title",
+      "url": "https://example.com",
+      "snippet": "Short source snippet",
+      "published_at": null,
+      "score": 0.91
+    }
+  ],
+  "warnings": []
+}
+```
+
+If the search provider times out or returns no results, the final answer should say that the search failed or was inconclusive. Do not let the agent answer as if live evidence was retrieved.
+
+## Related Examples
+
+- `examples/tools/exa_search_agent.py`
+- `examples/tools/exa_search_agent_quant.py`
+- `examples/guides/web_scraper_agents/web_scraper_agent.py`
+- `examples/tools/firecrawl_agents_example.py`
+

--- a/docs/swarms_tools/twitter.md
+++ b/docs/swarms_tools/twitter.md
@@ -1,0 +1,163 @@
+# Twitter Tools
+
+Twitter, X, and other social-media tools let Swarms agents monitor public conversation, draft posts, classify replies, and publish updates. These tools are powerful because they interact with public identity and audience trust. Keep read-only monitoring separate from write-capable posting, and make every write action explicit.
+
+This guide uses "Twitter" to match the navigation label, but the same patterns apply to X API clients and internal social publishing tools.
+
+## Read-Only Monitoring
+
+Start with read-only tools. They are useful for:
+
+- Tracking mentions of a product, repository, or release.
+- Finding questions that need a support reply.
+- Monitoring competitor announcements.
+- Summarizing community feedback after a launch.
+- Building a list of source posts for a human review queue.
+
+```python
+from datetime import datetime, timezone
+from swarms import Agent
+
+
+def search_social_posts(query: str, max_results: int = 10) -> dict:
+    """Search public social posts and return normalized metadata."""
+    return {
+        "query": query,
+        "searched_at": datetime.now(timezone.utc).isoformat(),
+        "posts": [
+            {
+                "id": "post_123",
+                "author": "example_user",
+                "url": "https://x.com/example_user/status/123",
+                "text": "Example post text",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ][:max_results],
+    }
+
+
+agent = Agent(
+    agent_name="Community Monitor",
+    system_prompt=(
+        "Use social search to find relevant public posts. "
+        "Summarize sentiment and include URLs for every quoted or paraphrased post."
+    ),
+    tools=[search_social_posts],
+    max_loops=2,
+)
+```
+
+The agent can now gather public context without the ability to post.
+
+## Drafting Replies
+
+A drafting tool does not need account credentials. It can take source posts and produce candidate replies for review.
+
+```python
+def draft_reply(post_text: str, tone: str = "helpful") -> dict:
+    """Draft a social reply without publishing it."""
+    return {
+        "tone": tone,
+        "draft": "Thanks for flagging this. We are checking the behavior and will follow up with details.",
+        "requires_review": True,
+    }
+```
+
+Drafting is safer than direct publishing because it lets you keep brand voice, legal claims, and support promises under review.
+
+## Write-Capable Posting
+
+Only add a publishing tool when the workflow genuinely needs autonomous posting. Make the tool strict: it should require the final post text, destination account, and an idempotency key.
+
+```python
+def publish_post(account_id: str, text: str, idempotency_key: str) -> dict:
+    """Publish a post to a configured social account."""
+    if len(text) > 280:
+        raise ValueError("Post text is too long for this account configuration")
+
+    return {
+        "ok": True,
+        "account_id": account_id,
+        "post_url": "https://x.com/example/status/456",
+        "idempotency_key": idempotency_key,
+    }
+```
+
+Recommended safeguards:
+
+- Require exact `account_id` rather than relying on a default.
+- Validate post length and media count before sending.
+- Return the published URL.
+- Keep credentials in environment variables.
+- Log request metadata, but never log access tokens.
+- Use a dry-run mode during development.
+
+## Environment Variables
+
+Typical variables for an X API integration:
+
+- `TWITTER_BEARER_TOKEN` for read-only API access.
+- `TWITTER_API_KEY` and `TWITTER_API_SECRET` for OAuth flows.
+- `TWITTER_ACCESS_TOKEN` and `TWITTER_ACCESS_TOKEN_SECRET` for account posting.
+- `SOCIAL_POST_DRY_RUN=true` while testing.
+
+When credentials are missing, the tool should raise a clear configuration error. Do not let an agent infer that a post was published.
+
+## Monitoring Agent Prompt
+
+Use a prompt that constrains claims and prevents accidental publishing:
+
+```text
+You are a social monitoring agent.
+Use read-only tools to collect public posts.
+Do not publish, like, repost, follow, or DM.
+For each recommended reply, include the source post URL and the exact draft text.
+Flag legal, pricing, security, or refund questions for human review.
+```
+
+For write-capable agents, add account and policy constraints:
+
+```text
+Only publish when the user has provided final approved text in the task.
+Do not alter names, prices, promises, or dates.
+Return the post URL after publishing.
+If publication fails, report the provider error exactly.
+```
+
+## Output Contract
+
+Social tools should return structured results:
+
+```json
+{
+  "ok": true,
+  "action": "search",
+  "account_id": null,
+  "checked_at": "2026-01-01T00:00:00Z",
+  "items": [],
+  "warnings": []
+}
+```
+
+For publishing:
+
+```json
+{
+  "ok": true,
+  "action": "publish",
+  "account_id": "product-main",
+  "post_url": "https://x.com/example/status/456",
+  "idempotency_key": "launch-2026-01-01-post-1"
+}
+```
+
+## Common Failure Modes
+
+- The agent drafts a reply without reading the source post.
+- A write-capable tool is exposed to a broad research agent.
+- Missing credentials are hidden behind a fake success response.
+- Duplicate posts are created because there is no idempotency key.
+- The final answer quotes social posts without URLs.
+
+Design tools so these failures are hard to trigger. Small, explicit tools are easier to trust than one large social-media automation function.
+


### PR DESCRIPTION
## Summary

- Add four missing Swarms Tools documentation pages that are already referenced by `docs/mkdocs.yml`
- Cover the tools overview, finance tools, search tools, and Twitter/social tools
- Provide practical setup patterns, environment-variable guidance, structured output contracts, safety notes, and runnable-style Python examples

## Bounty eligibility

- Label requested: `bounty-eligible`
- Expected tier: Platinum
- Rationale: this is a new multi-page documentation vertical with 3,043 total words across four linked pages, all filling existing MkDocs navigation targets

## Verification

- Counted 3,043 words across the new pages
- Confirmed all Markdown code fences are balanced
- Confirmed the new files are ASCII-only and contain no local/private brand references
- Ran `git diff --check`
- Confirmed the four `swarms_tools/*.md` targets no longer appear in the missing-nav check
- Attempted `mkdocs build --strict`; it is still blocked before content validation because this fresh checkout is missing the configured `docs/overrides` theme directory

## Added pages

- `docs/swarms_tools/overview.md`
- `docs/swarms_tools/finance.md`
- `docs/swarms_tools/search.md`
- `docs/swarms_tools/twitter.md`

📚 Documentation preview 📚: https://swarms--1603.org.readthedocs.build/en/1603/
