### PR TITLE
Added max_parallel_nodes to constructor

### DIFF
--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -721,8 +721,7 @@ class GraphWorkflow:
         task (str): The task to be executed by the workflow.
         _compiled (bool): Whether the graph has been compiled for optimization.
         _sorted_layers (List[List[str]]): Pre-computed topological layers for faster execution.
-        _max_workers (int): Pre-computed max workers for thread pool.
-        max_parallel_nodes (Optional[int]): Maximum number of nodes to execute concurrently. Defaults to CPU count.
+        _max_workers (int): Maximum nodes executed concurrently. Set from max_parallel_nodes if provided, otherwise int(get_cpu_cores() * 0.95) with a minimum of 1.
         verbose (bool): Whether to enable verbose logging.
     """
 
@@ -789,6 +788,7 @@ class GraphWorkflow:
         # Private optimization attributes
         self._compiled = False
         self._sorted_layers = []
+        self.max_parallel_nodes = max_parallel_nodes
         self._max_workers = (
             max(1, max_parallel_nodes)
             if max_parallel_nodes is not None

--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -722,6 +722,7 @@ class GraphWorkflow:
         _compiled (bool): Whether the graph has been compiled for optimization.
         _sorted_layers (List[List[str]]): Pre-computed topological layers for faster execution.
         _max_workers (int): Pre-computed max workers for thread pool.
+        max_parallel_nodes (Optional[int]): Maximum number of nodes to execute concurrently. Defaults to CPU count.
         verbose (bool): Whether to enable verbose logging.
     """
 
@@ -743,6 +744,7 @@ class GraphWorkflow:
         backend: str = "networkx",
         checkpoint_dir: Optional[str] = None,
         on_node_complete: Optional[Callable[[str, Any], None]] = None,
+        max_parallel_nodes: Optional[int] = None,
     ):
         self.id = id
         self.verbose = verbose
@@ -787,7 +789,11 @@ class GraphWorkflow:
         # Private optimization attributes
         self._compiled = False
         self._sorted_layers = []
-        self._max_workers = max(1, int(get_cpu_cores() * 0.95))
+        self._max_workers = (
+            max(1, max_parallel_nodes)
+            if max_parallel_nodes is not None
+            else max(1, int(get_cpu_cores() * 0.95))
+        )
         self._compilation_timestamp = None
 
         if self.verbose:


### PR DESCRIPTION
## Description
This PR adds a `max_parallel_nodes` constructor parameter to `GraphWorkflow`, giving callers explicit control over how many nodes execute concurrently. When omitted, behavior is unchanged — concurrency defaults to ~95% of CPU core count as before.

## Files Changed
* `swarms/structs/graph_workflow.py`

## Issue
#1559

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Twitter
[@akc__2025](https://x.com/akc__2025)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1605.org.readthedocs.build/en/1605/

<!-- readthedocs-preview swarms end -->