### PR TITLE
[FEAT] (hierarchical_swarm) add incremental replan on judge rejection

### DIFF
--- a/examples/multi_agent/hierarchical_swarm_replan.py
+++ b/examples/multi_agent/hierarchical_swarm_replan.py
@@ -1,0 +1,78 @@
+"""
+HierarchicalSwarm — incremental replan on judge rejection
+
+When agent_as_judge=True, the judge scores every worker output after each
+step.  If the collective quality is too low the judge sets verdict="REVISE"
+and lists the failed agents in failed_subtasks.  The swarm then calls the
+director for a ReplanAction (ADD / REASSIGN / REORDER / DROP) and re-executes
+only the affected subtasks.  Successful agents are never re-run.
+
+Run:
+    python examples/multi_agent/hierarchical_swarm_replan.py
+"""
+
+from swarms import Agent
+from swarms.structs.hiearchical_swarm import HierarchicalSwarm
+
+# ---------------------------------------------------------------------------
+# Worker agents
+# ---------------------------------------------------------------------------
+
+MODEL = "claude-sonnet-4-5"
+TEMPERATURE = 1.0
+
+research_agent = Agent(
+    agent_name="ResearchAgent",
+    agent_description="Finds relevant facts and data for a given topic.",
+    model_name=MODEL,
+    max_loops=1,
+    temperature=TEMPERATURE,
+)
+
+writing_agent = Agent(
+    agent_name="WritingAgent",
+    agent_description="Turns research findings into a polished written report.",
+    model_name=MODEL,
+    max_loops=1,
+    temperature=TEMPERATURE,
+)
+
+review_agent = Agent(
+    agent_name="ReviewAgent",
+    agent_description="Critically reviews a draft report and suggests improvements.",
+    model_name=MODEL,
+    max_loops=1,
+    temperature=TEMPERATURE,
+)
+
+# ---------------------------------------------------------------------------
+# Swarm — judge enabled, up to 2 loops so the replan result feeds back in
+# ---------------------------------------------------------------------------
+
+swarm = HierarchicalSwarm(
+    name="ResearchWritingSwarm",
+    description="Research, write, and review a short report on a given topic.",
+    agents=[research_agent, writing_agent, review_agent],
+    max_loops=2,
+    agent_as_judge=True,
+    judge_agent_model_name=MODEL,
+    director_model_name=MODEL,
+    director_temperature=TEMPERATURE,
+    director_top_p=None,
+    verbose=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+result = swarm.run(
+    task=(
+        "Produce a concise 3-paragraph report on the current state of "
+        "large language model research, covering: key recent advances, "
+        "major open challenges, and promising future directions."
+    )
+)
+
+print("\n=== Final swarm output ===\n")
+print(result)

--- a/swarms/prompts/agent_judge_prompt.py
+++ b/swarms/prompts/agent_judge_prompt.py
@@ -128,7 +128,7 @@ You must return a valid `JudgeReport` using the provided tool schema. Do not inc
 The schema includes three additional fields that drive adaptation in the next loop:
 
 - **`verdict`** — Set to `"APPROVE"` if the swarm's collective output is satisfactory. Set to `"REVISE"` if the director must replan. Use `"REVISE"` whenever `overall_quality` is below 7 or any critical subtask failed outright.
-- **`feedback`** — Required when `verdict` is `"REVISE"`. Write 2–5 sentences of concrete, actionable guidance for the director: what specifically went wrong, which agents underperformed and why, and what a corrected plan should address. Do not repeat the scores — focus on what the director should *do differently*.
+- **`feedback`** — When `verdict` is `"REVISE"`, provide 2–5 sentences of concrete, actionable guidance for the director: what specifically went wrong, which agents underperformed and why, and what a corrected plan should address. Do not repeat the scores — focus on what the director should *do differently*.
 - **`failed_subtasks`** — A list of `agent_name` values (exactly as they appear in the scores) whose outputs are below acceptable quality and must be redone or reassigned. Leave empty when `verdict` is `"APPROVE"`.
 """
 

--- a/swarms/prompts/agent_judge_prompt.py
+++ b/swarms/prompts/agent_judge_prompt.py
@@ -124,6 +124,12 @@ Your `overall_quality` score must reflect the swarm's collective output quality 
 ## Output Format
 
 You must return a valid `JudgeReport` using the provided tool schema. Do not include any text outside the structured tool call.
+
+The schema includes three additional fields that drive adaptation in the next loop:
+
+- **`verdict`** — Set to `"APPROVE"` if the swarm's collective output is satisfactory. Set to `"REVISE"` if the director must replan. Use `"REVISE"` whenever `overall_quality` is below 7 or any critical subtask failed outright.
+- **`feedback`** — Required when `verdict` is `"REVISE"`. Write 2–5 sentences of concrete, actionable guidance for the director: what specifically went wrong, which agents underperformed and why, and what a corrected plan should address. Do not repeat the scores — focus on what the director should *do differently*.
+- **`failed_subtasks`** — A list of `agent_name` values (exactly as they appear in the scores) whose outputs are below acceptable quality and must be redone or reassigned. Leave empty when `verdict` is `"APPROVE"`.
 """
 
 

--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -1259,18 +1259,32 @@ class HierarchicalSwarm:
                             replan_orders,
                             streaming_callback=streaming_callback,
                         )
-                        # Merge: replace outputs for re-run agents, append new ones
-                        agent_to_output = {
-                            order.agent_name: out
-                            for order, out in zip(orders, outputs)
+                        # Merge: keep original outputs indexed by position,
+                        # replace entries for re-run agents by order index.
+                        # Using a list (not dict) avoids silent overwrites when
+                        # the director issues multiple orders to the same agent.
+                        merged = list(outputs)
+                        replan_map = {
+                            ro.agent_name: ro_out
+                            for ro, ro_out in zip(
+                                replan_orders, replan_outputs
+                            )
                         }
-                        for replan_order, replan_out in zip(
+                        for i, order in enumerate(orders):
+                            if order.agent_name in replan_map:
+                                merged[i] = replan_map[
+                                    order.agent_name
+                                ]
+                        # Append any brand-new agents not in the original orders
+                        original_names = {
+                            o.agent_name for o in orders
+                        }
+                        for ro, ro_out in zip(
                             replan_orders, replan_outputs
                         ):
-                            agent_to_output[
-                                replan_order.agent_name
-                            ] = replan_out
-                        feedback = list(agent_to_output.values())
+                            if ro.agent_name not in original_names:
+                                merged.append(ro_out)
+                        feedback = merged
                     else:
                         feedback = judge_result
                 else:
@@ -1624,7 +1638,7 @@ class HierarchicalSwarm:
                 return action.orders
             except Exception as parse_err:
                 logger.warning(
-                    f"Failed to parse ReplanAction ({parse_err}); falling back to re-running failed subtasks on original agents."
+                    f"Failed to parse ReplanAction ({parse_err}); no replan orders generated — failed subtasks will not be re-executed."
                 )
                 return []
 

--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -26,7 +26,8 @@ import os
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Callable, List, Optional, Union
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -644,6 +645,40 @@ class JudgeReport(BaseModel):
     overall_quality: int = Field(..., ge=0, le=10)
     scores: List[AgentScore]
     summary: str
+    verdict: str = Field(
+        default="APPROVE",
+        description="APPROVE if the swarm output is satisfactory. REVISE if the director should replan.",
+    )
+    feedback: str = Field(
+        default="",
+        description="Actionable feedback for the director explaining what went wrong and how to fix it.",
+    )
+    failed_subtasks: List[str] = Field(
+        default_factory=list,
+        description="Agent names whose outputs failed or must be redone.",
+    )
+
+
+class ReplanActionType(str, Enum):
+    ADD = "ADD"
+    REASSIGN = "REASSIGN"
+    REORDER = "REORDER"
+    DROP = "DROP"
+
+
+class ReplanAction(BaseModel):
+    action_type: ReplanActionType = Field(
+        ...,
+        description="ADD new subtasks, REASSIGN failed ones to different agents, REORDER remaining subtasks, or DROP unnecessary ones.",
+    )
+    orders: List[HierarchicalOrder] = Field(
+        default_factory=list,
+        description="New or revised orders to execute as part of this replan.",
+    )
+    reasoning: str = Field(
+        ...,
+        description="Why this replan action was chosen and what it addresses.",
+    )
 
 
 class HierarchicalSwarm:
@@ -1196,7 +1231,51 @@ class HierarchicalSwarm:
             )
 
             if self.agent_as_judge:
-                feedback = self.run_judge_agent(outputs)
+                judge_result = self.run_judge_agent(outputs)
+                report = self._parse_judge_report(judge_result)
+
+                if (
+                    report is not None
+                    and report.verdict.upper() == "REVISE"
+                ):
+                    logger.info(
+                        f"Judge verdict: REVISE — triggering replan. "
+                        f"Failed subtasks: {report.failed_subtasks}"
+                    )
+                    # Build a result map so the director has per-agent context
+                    subtask_results = {
+                        order.agent_name: out
+                        for order, out in zip(orders, outputs)
+                        if out is not None
+                    }
+                    replan_orders = self._replan(
+                        original_task=task,
+                        judge_feedback=report.feedback,
+                        failed_subtasks=report.failed_subtasks,
+                        subtask_results=subtask_results,
+                    )
+                    if replan_orders:
+                        replan_outputs = self.execute_orders(
+                            replan_orders,
+                            streaming_callback=streaming_callback,
+                        )
+                        # Merge: replace outputs for re-run agents, append new ones
+                        agent_to_output = {
+                            order.agent_name: out
+                            for order, out in zip(orders, outputs)
+                        }
+                        for replan_order, replan_out in zip(
+                            replan_orders, replan_outputs
+                        ):
+                            agent_to_output[
+                                replan_order.agent_name
+                            ] = replan_out
+                        feedback = list(agent_to_output.values())
+                    else:
+                        feedback = judge_result
+                else:
+                    feedback = judge_result
+
             elif self.director_feedback_on is True:
                 feedback = self.feedback_director(outputs)
             else:
@@ -1457,6 +1536,103 @@ class HierarchicalSwarm:
                 f"[ERROR] run_judge_agent failed: {str(e)}\n[TRACE] {traceback.format_exc()}"
             )
             return str(outputs)
+
+    def _parse_judge_report(
+        self, result: Any
+    ) -> Optional[JudgeReport]:
+        """Parse a judge agent result into a JudgeReport, returning None on failure."""
+        try:
+            if isinstance(result, JudgeReport):
+                return result
+            if isinstance(result, dict):
+                return JudgeReport(**result)
+            if isinstance(result, str):
+                return JudgeReport(**json.loads(result))
+        except Exception as e:
+            logger.warning(f"Could not parse JudgeReport: {e}")
+        return None
+
+    def _replan(
+        self,
+        original_task: str,
+        judge_feedback: str,
+        failed_subtasks: List[str],
+        subtask_results: Dict[str, Any],
+    ) -> List[HierarchicalOrder]:
+        """
+        Call the director to produce revised orders for failed subtasks.
+
+        The director receives the original task, judge feedback, the list of
+        failed agent names, and their previous outputs.  It returns a
+        ReplanAction whose ``orders`` are the only subtasks that will be
+        re-executed; successful subtasks are left untouched.
+
+        Args:
+            original_task: The top-level task the swarm was given.
+            judge_feedback: Actionable feedback string from the JudgeReport.
+            failed_subtasks: Agent names whose outputs were rejected.
+            subtask_results: Mapping of agent_name -> previous output for context.
+
+        Returns:
+            List of HierarchicalOrder objects to re-execute.
+        """
+        try:
+            schema = BaseTool().base_model_to_dict(ReplanAction)
+
+            replan_director = Agent(
+                agent_name="Director-Replan",
+                agent_description="Director replanning based on judge feedback",
+                model_name=self.director_model_name,
+                max_loops=1,
+                base_model=ReplanAction,
+                tools_list_dictionary=[schema],
+                output_type="final",
+            )
+
+            available_agents = self.list_worker_agents()
+            replan_prompt = (
+                f"The judge has reviewed the swarm's output and requires a revision.\n\n"
+                f"Original task: {original_task}\n\n"
+                f"Judge feedback: {judge_feedback}\n\n"
+                f"Failed subtasks (agents that need to be re-run or replaced): {failed_subtasks}\n\n"
+                f"Previous subtask results:\n{json.dumps(subtask_results, default=str)}\n\n"
+                f"Available worker agents:\n{available_agents}\n\n"
+                f"Conversation history:\n{self.conversation.get_str()}\n\n"
+                "Produce a ReplanAction. Choose ADD to issue brand-new subtasks, "
+                "REASSIGN to re-run failed subtasks on different agents, "
+                "REORDER to change execution order, or DROP to remove unnecessary subtasks. "
+                "Only include orders that must be (re-)executed — successful subtasks do not need to be repeated."
+            )
+
+            result = replan_director.run(task=replan_prompt)
+            self.conversation.add(
+                role="Director-Replan", content=result
+            )
+            logger.info(f"Replan action from director:\n{result}")
+
+            # Parse the ReplanAction
+            try:
+                if isinstance(result, ReplanAction):
+                    action = result
+                elif isinstance(result, dict):
+                    action = ReplanAction(**result)
+                else:
+                    action = ReplanAction(**json.loads(result))
+                logger.info(
+                    f"Replan action type: {action.action_type}, orders: {len(action.orders)}"
+                )
+                return action.orders
+            except Exception as parse_err:
+                logger.warning(
+                    f"Failed to parse ReplanAction ({parse_err}); falling back to re-running failed subtasks on original agents."
+                )
+                return []
+
+        except Exception as e:
+            logger.error(
+                f"[ERROR] _replan failed: {str(e)}\n[TRACE] {traceback.format_exc()}"
+            )
+            return []
 
     def call_single_agent(
         self,

--- a/tests/structs/test_hierarchical_swarm_replan.py
+++ b/tests/structs/test_hierarchical_swarm_replan.py
@@ -1,0 +1,206 @@
+"""
+Tests for HierarchicalSwarm incremental replan on judge rejection.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from swarms.structs.hiearchical_swarm import (
+    AgentScore,
+    HierarchicalOrder,
+    HierarchicalSwarm,
+    JudgeReport,
+    ReplanAction,
+    ReplanActionType,
+)
+
+
+def _make_swarm(**kwargs) -> HierarchicalSwarm:
+    worker = MagicMock()
+    worker.agent_name = "WorkerA"
+    defaults = dict(
+        agents=[worker],
+        autosave=False,
+        agent_as_judge=True,
+        verbose=False,
+        interactive=False,
+    )
+    defaults.update(kwargs)
+    with patch.object(
+        HierarchicalSwarm, "init_swarm", return_value=None
+    ):
+        swarm = HierarchicalSwarm(**defaults)
+    swarm.conversation = MagicMock()
+    swarm.conversation.get_str.return_value = ""
+    return swarm
+
+
+def _revise_report(failed: list) -> str:
+    return JudgeReport(
+        overall_quality=3,
+        scores=[
+            AgentScore(
+                agent_name=n, score=3, reasoning="r", suggestions="s"
+            )
+            for n in failed
+        ],
+        summary="needs work",
+        verdict="REVISE",
+        feedback="Outputs were incomplete.",
+        failed_subtasks=failed,
+    ).model_dump_json()
+
+
+def _approve_report() -> str:
+    return JudgeReport(
+        overall_quality=9,
+        scores=[
+            AgentScore(
+                agent_name="WorkerA",
+                score=9,
+                reasoning="r",
+                suggestions="s",
+            )
+        ],
+        summary="great",
+        verdict="APPROVE",
+    ).model_dump_json()
+
+
+# -- _parse_judge_report ------------------------------------------------------
+
+
+def test_parse_judge_report_from_json_string():
+    swarm = _make_swarm()
+    report = swarm._parse_judge_report(_revise_report(["WorkerA"]))
+    assert report is not None
+    assert report.verdict == "REVISE"
+    assert report.failed_subtasks == ["WorkerA"]
+
+
+def test_parse_judge_report_returns_none_on_garbage():
+    swarm = _make_swarm()
+    assert swarm._parse_judge_report("not json {{{{") is None
+
+
+# -- _replan ------------------------------------------------------------------
+
+
+def test_replan_returns_orders_on_success():
+    swarm = _make_swarm()
+    swarm.list_worker_agents = MagicMock(return_value="WorkerA")
+
+    replan_action = ReplanAction(
+        action_type=ReplanActionType.REASSIGN,
+        orders=[
+            HierarchicalOrder(
+                agent_name="WorkerA", task="Retry", context=""
+            )
+        ],
+        reasoning="failed",
+    ).model_dump_json()
+
+    mock_agent = MagicMock()
+    mock_agent.run.return_value = replan_action
+
+    with patch(
+        "swarms.structs.hiearchical_swarm.Agent",
+        return_value=mock_agent,
+    ):
+        orders = swarm._replan(
+            "task", "bad output", ["WorkerA"], {"WorkerA": "bad"}
+        )
+
+    assert len(orders) == 1
+    assert orders[0].agent_name == "WorkerA"
+
+
+def test_replan_returns_empty_on_failure():
+    swarm = _make_swarm()
+    swarm.list_worker_agents = MagicMock(return_value="WorkerA")
+
+    with patch(
+        "swarms.structs.hiearchical_swarm.Agent",
+        side_effect=RuntimeError("down"),
+    ):
+        orders = swarm._replan("task", "bad", ["WorkerA"], {})
+
+    assert orders == []
+
+
+# -- step() -------------------------------------------------------------------
+
+
+def test_step_triggers_replan_on_revise():
+    swarm = _make_swarm()
+    swarm.run_director = MagicMock(return_value={})
+    swarm.list_worker_agents = MagicMock(return_value="WorkerA")
+
+    order = HierarchicalOrder(
+        agent_name="WorkerA", task="t", context=""
+    )
+    swarm.parse_orders = MagicMock(return_value=("plan", [order]))
+    swarm.execute_orders = MagicMock(side_effect=[["bad"], ["good"]])
+    swarm.run_judge_agent = MagicMock(
+        return_value=_revise_report(["WorkerA"])
+    )
+    swarm._replan = MagicMock(return_value=[order])
+
+    swarm.step(task="do something")
+
+    swarm._replan.assert_called_once()
+    assert swarm.execute_orders.call_count == 2
+
+
+def test_step_skips_replan_on_approve():
+    swarm = _make_swarm()
+    swarm.run_director = MagicMock(return_value={})
+
+    order = HierarchicalOrder(
+        agent_name="WorkerA", task="t", context=""
+    )
+    swarm.parse_orders = MagicMock(return_value=("plan", [order]))
+    swarm.execute_orders = MagicMock(return_value=["good"])
+    swarm.run_judge_agent = MagicMock(return_value=_approve_report())
+    swarm._replan = MagicMock()
+
+    swarm.step(task="do something")
+
+    swarm._replan.assert_not_called()
+
+
+def test_step_merges_outputs_after_replan():
+    swarm = _make_swarm()
+    worker_b = MagicMock()
+    worker_b.agent_name = "WorkerB"
+    swarm.agents.append(worker_b)
+    swarm.run_director = MagicMock(return_value={})
+    swarm.list_worker_agents = MagicMock(
+        return_value="WorkerA, WorkerB"
+    )
+
+    orders = [
+        HierarchicalOrder(
+            agent_name="WorkerA", task="t1", context=""
+        ),
+        HierarchicalOrder(
+            agent_name="WorkerB", task="t2", context=""
+        ),
+    ]
+    replan_order = HierarchicalOrder(
+        agent_name="WorkerA", task="retry", context=""
+    )
+
+    swarm.parse_orders = MagicMock(return_value=("plan", orders))
+    swarm.execute_orders = MagicMock(
+        side_effect=[["bad_A", "good_B"], ["fixed_A"]]
+    )
+    swarm.run_judge_agent = MagicMock(
+        return_value=_revise_report(["WorkerA"])
+    )
+    swarm._replan = MagicMock(return_value=[replan_order])
+
+    result = swarm.step(task="do something")
+
+    assert "fixed_A" in result
+    assert "good_B" in result

--- a/tests/structs/test_hierarchical_swarm_replan.py
+++ b/tests/structs/test_hierarchical_swarm_replan.py
@@ -2,7 +2,6 @@
 Tests for HierarchicalSwarm incremental replan on judge rejection.
 """
 
-import json
 from unittest.mock import MagicMock, patch
 
 from swarms.structs.hiearchical_swarm import (


### PR DESCRIPTION
## Description
Adds incremental replan support to HierarchicalSwarm when the judge returns a low score. The `JudgeReport` schema gains `verdict`, `feedback`, and `failed_subtasks` fields. On a REVISE verdict, the director is called with the judge feedback and previous per-agent outputs and returns a `ReplanAction` (ADD / REASSIGN / REORDER / DROP) whose orders are the only subtasks re-executed. Successful agents are never re-run. Includes 7 unit tests and a runnable example.

## Files Changed
* `swarms/structs/hiearchical_swarm.py`
* `swarms/prompts/agent_judge_prompt.py`
* `tests/structs/test_hierarchical_swarm_replan.py`
* `examples/multi_agent/hierarchical_swarm_replan.py`

## Issue
#1553

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Twitter
[@akc__2025](https://x.com/akc__2025)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1606.org.readthedocs.build/en/1606/

<!-- readthedocs-preview swarms end -->