### PR TITLE
Fix invalid Python snippets in docs

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: docs/mkdocs.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+# Swarms Documentation
+
+Swarms is a production-oriented framework for building, orchestrating,
+and evaluating single-agent and multi-agent systems.
+
+## Start Here
+
+- [Installation](swarms/install/install.md)
+- [Environment Configuration](swarms/install/env.md)
+- [Agents](swarms/agents/index.md)
+- [Multi-Agent Architectures](swarms/structs/index.md)
+
+## Core References
+
+- [Agent API](swarms/structs/agent.md)
+- [Swarm Router](swarms/structs/swarm_router.md)
+- [Tools and MCP](swarms/tools/tools_examples.md)
+- [Examples](swarms/examples/basic_agent.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -121,7 +121,6 @@ extra:
 
 theme:
   name: material
-  custom_dir: overrides
   logo: assets/img/swarms-logo.png
   palette:
     - scheme: default

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,8 @@
+mkdocs<1.6
+mkdocs-material
+mkdocs-git-authors-plugin
+mkdocs-jupyter==0.16.0
+lxml_html_clean
+mkdocstrings[python]
+mkdocs-git-committers-plugin
+mkdocs-git-revision-date-localized-plugin

--- a/docs/swarms/agents/agent_judge.md
+++ b/docs/swarms/agents/agent_judge.md
@@ -55,7 +55,7 @@ graph TD
 
 ### Constructor
 
-```python
+```text
 AgentJudge(
     id: str = str(uuid.uuid4()),
     agent_name: str = "Agent Judge",
@@ -89,7 +89,7 @@ AgentJudge(
 
 #### step()
 
-```python
+```text
 step(
     task: str = None,
     img: Optional[str] = None
@@ -109,7 +109,7 @@ Processes a single task and returns the agent's evaluation.
 
 #### run()
 
-```python
+```text
 run(
     task: str = None,
     img: Optional[str] = None
@@ -129,7 +129,7 @@ Executes evaluation in multiple iterations with context building.
 
 #### run_batched()
 
-```python
+```text
 run_batched(
     tasks: Optional[List[str]] = None
 ) -> List[Union[str, int]]

--- a/docs/swarms/agents/reflexion_agent.md
+++ b/docs/swarms/agents/reflexion_agent.md
@@ -39,7 +39,7 @@ agent = ReflexionAgent(
 
 Generates a response to the given task using the actor agent.
 
-```python
+```text
 response = agent.act(task: str, relevant_memories: List[Dict[str, Any]] = None) -> str
 ```
 
@@ -52,7 +52,7 @@ response = agent.act(task: str, relevant_memories: List[Dict[str, Any]] = None) 
 
 Evaluates the quality of a response to a task.
 
-```python
+```text
 evaluation, score = agent.evaluate(task: str, response: str) -> Tuple[str, float]
 ```
 
@@ -69,7 +69,7 @@ Returns:
 
 Generates a self-reflection based on the task, response, and evaluation.
 
-```python
+```text
 reflection = agent.reflect(task: str, response: str, evaluation: str) -> str
 ```
 
@@ -83,7 +83,7 @@ reflection = agent.reflect(task: str, response: str, evaluation: str) -> str
 
 Refines the original response based on evaluation and reflection.
 
-```python
+```text
 refined_response = agent.refine(
     task: str,
     original_response: str,
@@ -103,7 +103,7 @@ refined_response = agent.refine(
 
 Processes a single task through one iteration of the Reflexion process.
 
-```python
+```text
 result = agent.step(
     task: str,
     iteration: int = 0,
@@ -129,7 +129,7 @@ Returns a dictionary containing:
 
 Executes the Reflexion process for a list of tasks.
 
-```python
+```text
 results = agent.run(
     tasks: List[str],
     include_intermediates: bool = False

--- a/docs/swarms/structs/swarm_matcher.md
+++ b/docs/swarms/structs/swarm_matcher.md
@@ -51,8 +51,12 @@ print(f"Selected swarm type: {swarm_type}")
 For more control over the matching process, you can create and configure your own SwarmMatcher instance:
 
 ```python
-from swarms_utils.swarm_matcher import SwarmMatcher, SwarmMatcherConfig, SwarmType
-, initialize_swarm_types
+from swarms_utils.swarm_matcher import (
+    SwarmMatcher,
+    SwarmMatcherConfig,
+    SwarmType,
+    initialize_swarm_types,
+)
 
 # Create a configuration
 config = SwarmMatcherConfig(

--- a/docs/swarms/tools/main.md
+++ b/docs/swarms/tools/main.md
@@ -295,9 +295,7 @@ class AdvancedAccountingAgent(Agent):
         print("Executing custom behavior")
 
     def another_custom_method(self):
-        print("Another
-
- custom method")
+        print("Another custom method")
 
 # Initialize the advanced agent
 advanced_agent = AdvancedAccountingAgent(


### PR DESCRIPTION
## Summary
- Fixed a broken Python string literal in the tools guide.
- Fixed the SwarmMatcher advanced import example so it is valid copy/paste Python.
- Retagged ReflexionAgent and AgentJudge API signature blocks as text instead of executable Python fences.
- Added the missing ReadTheDocs config at `docs/.readthedocs.yaml`, pinned the docs build dependencies, and removed the stale missing `theme.custom_dir` setting so docs previews can render.
- Added `docs/index.md` so ReadTheDocs generates the required root `index.html`.

## Proof
- Parsed all Python fenced blocks in the four touched docs files with `ast.parse`; no invalid Python fences remained.
- Ran `git diff --check`.
- Ran `/tmp/swarms-docs-venv/bin/python -m mkdocs build -f docs/mkdocs.yml --site-dir /tmp/swarms-site-preview`; the docs build completed successfully and generated `/tmp/swarms-site-preview/index.html`.

## Bounty / payment
This is a focused documentation-quality fix and I am submitting it for Swarms documentation bounty consideration. Expected tier: Silver ($5-$20), if maintainers agree after review/merge.

Preferred payout method for legitimate completed/merged work:
PayPal: https://www.paypal.com/paypalme/MouadBERQIA