### PR TITLE
feat: add optional opentelemetry tracing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,16 @@ httpx = "*"
 requests = "*"
 mcp = "*"
 schedule = "*"
+opentelemetry-api = { version = ">=1.25,<2.0", optional = true }
+opentelemetry-sdk = { version = ">=1.25,<2.0", optional = true }
+opentelemetry-exporter-otlp-proto-http = { version = ">=1.25,<2.0", optional = true }
+
+[tool.poetry.extras]
+otel = [
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-http",
+]
 
 [tool.poetry.scripts]
 swarms = "swarms.cli.main:main"

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -96,6 +96,7 @@ from swarms.structs.transforms import (
     handle_transforms,
 )
 from swarms.telemetry.main import log_agent_data
+from swarms.telemetry.otel import traced_method
 from swarms.tools.base_tool import BaseTool
 from swarms.tools.handoffs_tool import handoff_task
 from swarms.tools.handoffs_tool_schema import get_handoff_tool_schema
@@ -4687,6 +4688,7 @@ Subtask Breakdown:
                     )
         return None
 
+    @traced_method("swarms.agent.run", component_type="agent")
     def run(
         self,
         task: Optional[Union[str, Any]] = None,
@@ -5118,6 +5120,7 @@ Subtask Breakdown:
                 **kwargs,
             )
 
+    @traced_method("swarms.agent.run_batched", component_type="agent")
     def run_batched(
         self,
         tasks: List[str],

--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -8,6 +8,7 @@ from loguru import logger as loguru_logger
 from swarms.structs.agent import Agent
 from swarms.structs.conversation import Conversation
 from swarms.structs.swarm_id import swarm_id
+from swarms.telemetry.otel import traced_method
 from swarms.utils.formatter import formatter
 from swarms.utils.get_cpu_cores import get_cpu_cores
 from swarms.utils.history_output_formatter import (
@@ -529,6 +530,10 @@ class ConcurrentWorkflow:
         except Exception as e:
             logger.error(f"Cleanup failed: {str(e)}")
 
+    @traced_method(
+        "swarms.concurrent_workflow.run",
+        component_type="workflow",
+    )
     def run(
         self,
         task: str,
@@ -593,6 +598,10 @@ class ConcurrentWorkflow:
             # Always cleanup resources
             self.cleanup()
 
+    @traced_method(
+        "swarms.concurrent_workflow.batch_run",
+        component_type="workflow",
+    )
     def batch_run(
         self,
         tasks: List[str],

--- a/swarms/structs/mixture_of_agents.py
+++ b/swarms/structs/mixture_of_agents.py
@@ -8,6 +8,7 @@ from swarms.structs.agent import Agent
 from swarms.structs.conversation import Conversation
 from swarms.structs.ma_utils import list_all_agents
 from swarms.structs.multi_agent_exec import run_agents_concurrently
+from swarms.telemetry.otel import traced_method
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
 )
@@ -194,6 +195,10 @@ class MixtureOfAgents:
             conversation=self.conversation, type=self.output_type
         )
 
+    @traced_method(
+        "swarms.mixture_of_agents.run",
+        component_type="workflow",
+    )
     def run(
         self,
         task: str,
@@ -205,6 +210,10 @@ class MixtureOfAgents:
             logger.error(f"Error running Mixture of Agents: {e}")
             return f"Error: {e}"
 
+    @traced_method(
+        "swarms.mixture_of_agents.run_batched",
+        component_type="workflow",
+    )
     def run_batched(self, tasks: List[str]) -> List[str]:
         """
         Run the mixture of agents for a batch of tasks.
@@ -217,6 +226,10 @@ class MixtureOfAgents:
         """
         return [self.run(task) for task in tasks]
 
+    @traced_method(
+        "swarms.mixture_of_agents.run_concurrently",
+        component_type="workflow",
+    )
     def run_concurrently(self, tasks: List[str]) -> List[str]:
         """
         Run the mixture of agents for a batch of tasks concurrently.

--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -10,6 +10,7 @@ from swarms.prompts.multi_agent_collab_prompt import (
 )
 from swarms.structs.agent import Agent
 from swarms.structs.agent_rearrange import AgentRearrange
+from swarms.telemetry.otel import traced_method
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.output_types import OutputType
 from swarms.utils.swarm_autosave import get_swarm_workspace_dir
@@ -256,6 +257,10 @@ class SequentialWorkflow:
             result = self.agent_rearrange.run(**run_kwargs)
         return result
 
+    @traced_method(
+        "swarms.sequential_workflow.run",
+        component_type="workflow",
+    )
     def run(
         self,
         task: str,
@@ -415,6 +420,10 @@ class SequentialWorkflow:
         """
         return self.run(task, *args, **kwargs)
 
+    @traced_method(
+        "swarms.sequential_workflow.run_batched",
+        component_type="workflow",
+    )
     def run_batched(self, tasks: List[str]) -> List[str]:
         """
         Executes a batch of tasks through the agents in the dynamically constructed flow.

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -35,6 +35,7 @@ from swarms.structs.multi_agent_router import MultiAgentRouter
 from swarms.structs.planner_worker_swarm import PlannerWorkerSwarm
 from swarms.structs.round_robin import RoundRobinSwarm
 from swarms.structs.sequential_workflow import SequentialWorkflow
+from swarms.telemetry.otel import traced_method
 from swarms.utils.generate_keys import generate_api_key
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.output_types import OutputType
@@ -823,6 +824,10 @@ class SwarmRouter:
             )
             raise e
 
+    @traced_method(
+        "swarms.swarm_router.run",
+        component_type="swarm_router",
+    )
     def run(
         self,
         task: Optional[str] = None,
@@ -893,6 +898,10 @@ class SwarmRouter:
             task=task, img=img, imgs=imgs, *args, **kwargs
         )
 
+    @traced_method(
+        "swarms.swarm_router.batch_run",
+        component_type="swarm_router",
+    )
     def batch_run(
         self,
         tasks: List[str],

--- a/swarms/telemetry/__init__.py
+++ b/swarms/telemetry/__init__.py
@@ -4,10 +4,20 @@ from swarms.telemetry.main import (
     get_comprehensive_system_info,
     log_agent_data,
 )
+from swarms.telemetry.otel import (
+    otel_enabled,
+    span_attributes,
+    start_span,
+    traced_method,
+)
 
 __all__ = [
     "generate_user_id",
     "get_machine_id",
     "get_comprehensive_system_info",
     "log_agent_data",
+    "otel_enabled",
+    "span_attributes",
+    "start_span",
+    "traced_method",
 ]

--- a/swarms/telemetry/otel.py
+++ b/swarms/telemetry/otel.py
@@ -1,0 +1,160 @@
+import os
+from contextlib import nullcontext
+from functools import wraps
+from typing import Any, Callable, Dict, Optional
+
+
+_TRACER = None
+_CONFIGURED = False
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _truthy_env(name: str) -> bool:
+    value = os.getenv(name, "")
+    return value.strip().lower() in _TRUE_VALUES
+
+
+def otel_enabled() -> bool:
+    """Return whether OpenTelemetry tracing should be active."""
+    return _truthy_env("SWARMS_OTEL_ENABLED") or bool(
+        os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+    )
+
+
+def _safe_attribute_value(value: Any) -> Optional[Any]:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        return value[:128]
+    return None
+
+
+def span_attributes(
+    component: Any,
+    component_type: str,
+) -> Dict[str, Any]:
+    """Build safe metadata-only span attributes for a component.
+
+    This deliberately avoids task, prompt, message, tool argument, and
+    response content. Spans should identify the component that ran, not
+    export user data.
+    """
+    attributes: Dict[str, Any] = {
+        "swarms.component_class": component.__class__.__name__,
+    }
+
+    component_id = _safe_attribute_value(
+        getattr(component, "id", None)
+    )
+    if component_id is not None:
+        attributes["swarms.component_id"] = component_id
+
+    component_name = _safe_attribute_value(
+        getattr(component, "agent_name", None)
+        or getattr(component, "name", None)
+    )
+    if component_name is not None:
+        attributes["swarms.component_name"] = component_name
+
+    attributes["swarms.component_type"] = component_type
+
+    agents = getattr(component, "agents", None)
+    if isinstance(agents, (list, tuple)):
+        attributes["swarms.agent_count"] = len(agents)
+
+    return attributes
+
+
+def _configure_provider():
+    global _CONFIGURED
+
+    if _CONFIGURED:
+        return
+
+    _CONFIGURED = True
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+
+    if not endpoint:
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        resource = Resource.create(
+            {
+                "service.name": os.getenv(
+                    "OTEL_SERVICE_NAME", "swarms"
+                )
+            }
+        )
+        provider = TracerProvider(resource=resource)
+        provider.add_span_processor(
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
+        )
+        trace.set_tracer_provider(provider)
+    except Exception:
+        return
+
+
+def _get_tracer():
+    global _TRACER
+
+    if _TRACER is not None:
+        return _TRACER
+
+    if not otel_enabled():
+        return None
+
+    try:
+        _configure_provider()
+        from opentelemetry import trace
+
+        _TRACER = trace.get_tracer("swarms")
+        return _TRACER
+    except Exception:
+        return None
+
+
+def start_span(span_name: str, attributes: Dict[str, Any]):
+    if not otel_enabled():
+        return nullcontext()
+
+    tracer = _get_tracer()
+    if tracer is None:
+        return nullcontext()
+
+    try:
+        return tracer.start_as_current_span(
+            span_name,
+            attributes=attributes,
+        )
+    except Exception:
+        return nullcontext()
+
+
+def traced_method(
+    span_name: str,
+    component_type: str = "component",
+) -> Callable:
+    """Trace a method with safe component metadata when OTEL is enabled."""
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            with start_span(
+                span_name,
+                span_attributes(self, component_type),
+            ):
+                return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/telemetry/test_otel_instrumentation.py
+++ b/tests/telemetry/test_otel_instrumentation.py
@@ -1,0 +1,104 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_otel_module():
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "swarms"
+        / "telemetry"
+        / "otel.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "swarms_otel_under_test", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeSpanContext:
+    def __init__(self, tracer, name, attributes):
+        self.tracer = tracer
+        self.name = name
+        self.attributes = attributes
+
+    def __enter__(self):
+        self.tracer.spans.append((self.name, self.attributes))
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeTracer:
+    def __init__(self):
+        self.spans = []
+
+    def start_as_current_span(self, name, attributes=None):
+        return FakeSpanContext(self, name, attributes)
+
+
+class ExampleAgent:
+    agent_name = "researcher"
+    id = "agent-1"
+
+
+class ExampleWorkflow:
+    name = "workflow"
+    id = "workflow-1"
+    agents = [ExampleAgent(), ExampleAgent()]
+
+
+def test_otel_is_disabled_by_default(monkeypatch):
+    otel = load_otel_module()
+    monkeypatch.delenv("SWARMS_OTEL_ENABLED", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    assert otel.otel_enabled() is False
+
+    def run(agent, task):
+        return f"ran {task}"
+
+    wrapped = otel.traced_method("swarms.agent.run")(run)
+    assert wrapped(ExampleAgent(), "private task text") == (
+        "ran private task text"
+    )
+
+
+def test_traced_method_records_safe_metadata_only(monkeypatch):
+    otel = load_otel_module()
+    tracer = FakeTracer()
+    monkeypatch.setenv("SWARMS_OTEL_ENABLED", "true")
+    monkeypatch.setattr(otel, "_TRACER", tracer)
+
+    def run(workflow, task, prompt=None):
+        assert task == "secret customer problem"
+        assert prompt == "do not export me"
+        return "ok"
+
+    wrapped = otel.traced_method(
+        "swarms.workflow.run",
+        component_type="workflow",
+    )(run)
+
+    assert wrapped(
+        ExampleWorkflow(),
+        "secret customer problem",
+        prompt="do not export me",
+    ) == "ok"
+
+    assert tracer.spans == [
+        (
+            "swarms.workflow.run",
+            {
+                "swarms.component_class": "ExampleWorkflow",
+                "swarms.component_id": "workflow-1",
+                "swarms.component_name": "workflow",
+                "swarms.component_type": "workflow",
+                "swarms.agent_count": 2,
+            },
+        )
+    ]
+    assert "secret customer problem" not in repr(tracer.spans)
+    assert "do not export me" not in repr(tracer.spans)


### PR DESCRIPTION
/claim #1199

## Summary
- Adds `swarms.telemetry.otel`, an optional OpenTelemetry helper that is disabled by default and no-ops cleanly when OTEL dependencies are not installed.
- Enables OTLP trace export through standard env vars: `SWARMS_OTEL_ENABLED=true` and/or `OTEL_EXPORTER_OTLP_ENDPOINT`.
- Instruments `Agent.run`, `Agent.run_batched`, `SequentialWorkflow`, `ConcurrentWorkflow`, `SwarmRouter`, and `MixtureOfAgents` run entrypoints with safe metadata-only spans.
- Adds an optional Poetry extra, `otel`, for users who want to install the OpenTelemetry API/SDK/OTLP HTTP exporter.

## Privacy / safety
The span attributes intentionally avoid task text, prompts, tool arguments, messages, and model responses. They only include component class/name/id/type and agent count where applicable, so enabling tracing does not export user prompt content by default.

## Validation
- `python -m pytest tests\telemetry\test_otel_instrumentation.py -q` -> 2 passed.
- `python -m py_compile swarms\telemetry\otel.py swarms\structs\agent.py swarms\structs\sequential_workflow.py swarms\structs\concurrent_workflow.py swarms\structs\swarm_router.py swarms\structs\mixture_of_agents.py tests\telemetry\test_otel_instrumentation.py` -> passed.
- `python -m ruff check pyproject.toml swarms\telemetry\otel.py swarms\telemetry\__init__.py swarms\structs\agent.py swarms\structs\sequential_workflow.py swarms\structs\concurrent_workflow.py swarms\structs\swarm_router.py swarms\structs\mixture_of_agents.py tests\telemetry\test_otel_instrumentation.py` -> passed.
- `git diff --check HEAD~1 HEAD` -> passed.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1616.org.readthedocs.build/en/1616/

<!-- readthedocs-preview swarms end -->