### PR TITLE
[BUGF] [ConcurrentWorkflow] added partial results on agent failure

### DIFF
--- a/examples/multi_agent/concurrent_examples/concurrent_workflow_on_error_example.py
+++ b/examples/multi_agent/concurrent_examples/concurrent_workflow_on_error_example.py
@@ -61,21 +61,23 @@ broken.run = lambda *a, **kw: (_ for _ in ()).throw(
 wf = ConcurrentWorkflow(
     name="ResearchTeam",
     agents=[researcher, strategist, broken],
-    on_error="store",   # default — can be omitted
+    on_error="store",  # default — can be omitted
     output_type="list",
     autosave=False,
 )
 
-result = wf.run("Summarise the current state of renewable energy adoption.")
+result = wf.run(
+    "Summarise the current state of renewable energy adoption."
+)
 
 print("\nFormatted output:")
 pprint.pprint(result)
 
 print("\nRaw conversation history:")
 for entry in wf.conversation.conversation_history:
-    role    = entry.get("role", "")
+    role = entry.get("role", "")
     content = entry.get("content", "")
-    marker  = "  *** ERROR ***" if "(failed)" in role else ""
+    marker = "  *** ERROR ***" if "(failed)" in role else ""
     print(f"  {role}: {content[:120]!r}{marker}")
 
 # ---------------------------------------------------------------------------
@@ -113,7 +115,11 @@ wf2 = ConcurrentWorkflow(
 )
 
 try:
-    wf2.run("What are the biggest trends in renewable energy investment?")
+    wf2.run(
+        "What are the biggest trends in renewable energy investment?"
+    )
 except RuntimeError as exc:
     print(f"\nCaught expected RuntimeError: {exc}")
-    print("(on_error='raise' lets the exception escape — old behaviour preserved.)")
+    print(
+        "(on_error='raise' lets the exception escape — old behaviour preserved.)"
+    )

--- a/examples/multi_agent/concurrent_examples/concurrent_workflow_on_error_example.py
+++ b/examples/multi_agent/concurrent_examples/concurrent_workflow_on_error_example.py
@@ -1,0 +1,119 @@
+"""
+ConcurrentWorkflow — on_error example
+======================================
+
+Demonstrates the two error-handling modes introduced for ConcurrentWorkflow:
+
+  on_error="store"  (default)
+      A failing agent's error is captured as a clearly-labelled entry in the
+      conversation history under the role "<agent_name> (failed)".  Sibling
+      agents that already completed successfully are not discarded.
+
+  on_error="raise"
+      The first agent exception propagates out of wf.run() immediately after
+      all futures settle, preserving the previous fail-fast behaviour.
+
+Requires ANTHROPIC_API_KEY to be set in the environment.
+"""
+
+import pprint
+
+from swarms import Agent, ConcurrentWorkflow
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — on_error="store"  (default, recommended)
+# Two real agents complete successfully; a third is sabotaged to fail so we
+# can confirm its error is stored without killing the sibling results.
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Scenario 1: on_error='store'  (default)")
+print("=" * 60)
+
+researcher = Agent(
+    agent_name="Researcher",
+    system_prompt="You are a concise research analyst. Answer in 2-3 sentences.",
+    model_name="claude-sonnet-4-5",
+    max_loops=1,
+    print_on=False,
+)
+
+strategist = Agent(
+    agent_name="Strategist",
+    system_prompt="You are a strategic advisor. Answer in 2-3 sentences.",
+    model_name="claude-sonnet-4-5",
+    max_loops=1,
+    print_on=False,
+)
+
+broken = Agent(
+    agent_name="DataFetcher",
+    system_prompt="You fetch data.",
+    model_name="claude-sonnet-4-5",
+    max_loops=1,
+    print_on=False,
+)
+# Simulate a hard failure (e.g. a broken API, bad credentials, etc.)
+broken.run = lambda *a, **kw: (_ for _ in ()).throw(
+    RuntimeError("DataFetcher: upstream API unavailable")
+)
+
+wf = ConcurrentWorkflow(
+    name="ResearchTeam",
+    agents=[researcher, strategist, broken],
+    on_error="store",   # default — can be omitted
+    output_type="list",
+    autosave=False,
+)
+
+result = wf.run("Summarise the current state of renewable energy adoption.")
+
+print("\nFormatted output:")
+pprint.pprint(result)
+
+print("\nRaw conversation history:")
+for entry in wf.conversation.conversation_history:
+    role    = entry.get("role", "")
+    content = entry.get("content", "")
+    marker  = "  *** ERROR ***" if "(failed)" in role else ""
+    print(f"  {role}: {content[:120]!r}{marker}")
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — on_error="raise"  (opt-in, preserves old fail-fast behaviour)
+# ---------------------------------------------------------------------------
+
+print("\n" + "=" * 60)
+print("Scenario 2: on_error='raise'")
+print("=" * 60)
+
+analyst = Agent(
+    agent_name="Analyst",
+    system_prompt="You are a market analyst. Answer in 2-3 sentences.",
+    model_name="claude-sonnet-4-5",
+    max_loops=1,
+    print_on=False,
+)
+
+scraper = Agent(
+    agent_name="Scraper",
+    system_prompt="You scrape data.",
+    model_name="claude-sonnet-4-5",
+    max_loops=1,
+    print_on=False,
+)
+scraper.run = lambda *a, **kw: (_ for _ in ()).throw(
+    RuntimeError("Scraper: connection timed out")
+)
+
+wf2 = ConcurrentWorkflow(
+    name="AnalysisTeam",
+    agents=[analyst, scraper],
+    on_error="raise",
+    autosave=False,
+)
+
+try:
+    wf2.run("What are the biggest trends in renewable energy investment?")
+except RuntimeError as exc:
+    print(f"\nCaught expected RuntimeError: {exc}")
+    print("(on_error='raise' lets the exception escape — old behaviour preserved.)")

--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -2,7 +2,7 @@ import concurrent.futures
 import json
 import os
 import time
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Literal, Optional, Union
 
 from loguru import logger as loguru_logger
 from swarms.structs.agent import Agent
@@ -83,6 +83,7 @@ class ConcurrentWorkflow:
         show_dashboard: bool = False,
         autosave: bool = True,
         verbose: bool = False,
+        on_error: Literal["store", "raise"] = "store",
     ):
         self.id = id if id is not None else swarm_id()
         self.name = name
@@ -95,6 +96,7 @@ class ConcurrentWorkflow:
         self.show_dashboard = show_dashboard
         self.autosave = autosave
         self.verbose = verbose
+        self.on_error = on_error
         self.swarm_workspace_dir = None
         self.metadata_output_path = (
             f"concurrent_workflow_name_{name}_id_{self.id}.json"
@@ -332,6 +334,8 @@ class ConcurrentWorkflow:
 
                     raise
 
+            first_error: Optional[Exception] = None
+
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=max_workers
             ) as executor:
@@ -351,12 +355,22 @@ class ConcurrentWorkflow:
                         logger.error(
                             f"Agent {agent.agent_name} failed: {str(e)}"
                         )
+                        if first_error is None:
+                            first_error = e
                         results.append(
-                            (agent.agent_name, f"Error: {str(e)}")
+                            (
+                                f"{agent.agent_name} (failed)"
+                                if self.on_error == "store"
+                                else agent.agent_name,
+                                f"Error: {str(e)}",
+                            )
                         )
 
             for agent_name, output in results:
                 self.conversation.add(role=agent_name, content=output)
+
+            if self.on_error == "raise" and first_error is not None:
+                raise first_error
 
             if self.show_dashboard:
                 self.display_agent_dashboard(
@@ -419,10 +433,21 @@ class ConcurrentWorkflow:
                 future_to_agent
             ):
                 agent = future_to_agent[future]
-                output = future.result()
-                self.conversation.add(
-                    role=agent.agent_name, content=output
-                )
+                try:
+                    output = future.result()
+                    self.conversation.add(
+                        role=agent.agent_name, content=output
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Agent {agent.agent_name} failed: {str(e)}"
+                    )
+                    if self.on_error == "raise":
+                        raise
+                    self.conversation.add(
+                        role=f"{agent.agent_name} (failed)",
+                        content=f"Error: {str(e)}",
+                    )
 
         return history_output_formatter(
             conversation=self.conversation, type=self.output_type

--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -39,6 +39,14 @@ class ConcurrentWorkflow:
         max_loops (int): Maximum number of execution loops (currently unused)
         auto_generate_prompts (bool): Whether to enable automatic prompt engineering
         show_dashboard (bool): Whether to display real-time dashboard during execution
+        on_error (str): How to handle individual agent failures.
+            ``"store"`` (default) — captures each failure as a conversation entry
+            whose role is ``"<agent_name> (failed)"`` and whose content is
+            ``"Error: <message>"``.  Sibling agents that completed successfully
+            are unaffected and their outputs are preserved.
+            ``"raise"`` — after all futures have settled, re-raises the first
+            exception with its original traceback, reproducing the old
+            fail-fast behaviour.
         agent_statuses (dict): Dictionary tracking status and output of each agent
         metadata_output_path (str): Path for saving workflow metadata
         conversation (Conversation): Conversation object for storing agent interactions
@@ -60,10 +68,10 @@ class ConcurrentWorkflow:
         >>> agent1 = Agent(llm=llm, agent_name="Agent1")
         >>> agent2 = Agent(llm=llm, agent_name="Agent2")
         >>>
-        >>> # Create workflow
+        >>> # Create workflow — one agent failure won't discard the others
         >>> workflow = ConcurrentWorkflow(
         ...     agents=[agent1, agent2],
-        ...     show_dashboard=True
+        ...     on_error="store",   # default
         ... )
         >>>
         >>> # Run workflow
@@ -85,6 +93,39 @@ class ConcurrentWorkflow:
         verbose: bool = False,
         on_error: Literal["store", "raise"] = "store",
     ):
+        """
+        Initialise ConcurrentWorkflow.
+
+        Args:
+            id (str): Optional unique identifier; auto-generated when omitted.
+            name (str): Human-readable workflow name.
+            description (str): Short description of the workflow's purpose.
+            agents (List[Union[Agent, Callable]]): Agents to run concurrently.
+            auto_save (bool): Whether to save workflow metadata.
+            output_type (str): Output format passed to ``history_output_formatter``.
+            max_loops (int): Reserved for future multi-loop support.
+            auto_generate_prompts (bool): Enable automatic prompt engineering.
+            show_dashboard (bool): Show a real-time status dashboard during execution.
+            autosave (bool): Persist conversation history to disk after each run.
+            verbose (bool): Emit extra log messages.
+            on_error (Literal["store", "raise"]): Agent-failure policy.
+                ``"store"`` (default) — per-agent errors are written to the
+                conversation history under the role
+                ``"<agent_name> (failed)"`` so callers can inspect them;
+                successful siblings are always preserved.
+                ``"raise"`` — after all futures settle the first exception is
+                re-raised with its original traceback (fail-fast, old behaviour).
+
+        Raises:
+            ValueError: If ``agents`` is ``None`` or empty, or if ``on_error``
+                is not one of ``"store"`` or ``"raise"``.
+        """
+        if on_error not in ("store", "raise"):
+            raise ValueError(
+                f"ConcurrentWorkflow: invalid on_error={on_error!r}. "
+                "Expected 'store' or 'raise'."
+            )
+
         self.id = id if id is not None else swarm_id()
         self.name = name
         self.description = description
@@ -122,6 +163,20 @@ class ConcurrentWorkflow:
         # Setup autosave workspace if enabled
         if self.autosave:
             self._setup_autosave()
+
+    # ------------------------------------------------------------------
+    # Private helpers shared by both execution paths
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _failed_role(agent_name: str) -> str:
+        """Return the conversation role label for a failed agent."""
+        return f"{agent_name} (failed)"
+
+    @staticmethod
+    def _format_agent_error(e: Exception) -> str:
+        """Return the conversation content string for a failed agent."""
+        return f"Error: {str(e)}"
 
     def fix_agents(self):
         """
@@ -335,6 +390,7 @@ class ConcurrentWorkflow:
                     raise
 
             first_error: Optional[Exception] = None
+            first_tb = None
 
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=max_workers
@@ -357,22 +413,21 @@ class ConcurrentWorkflow:
                         )
                         if first_error is None:
                             first_error = e
+                            first_tb = e.__traceback__
+                        role = (
+                            self._failed_role(agent.agent_name)
+                            if self.on_error == "store"
+                            else agent.agent_name
+                        )
                         results.append(
-                            (
-                                (
-                                    f"{agent.agent_name} (failed)"
-                                    if self.on_error == "store"
-                                    else agent.agent_name
-                                ),
-                                f"Error: {str(e)}",
-                            )
+                            (role, self._format_agent_error(e))
                         )
 
             for agent_name, output in results:
                 self.conversation.add(role=agent_name, content=output)
 
             if self.on_error == "raise" and first_error is not None:
-                raise first_error
+                raise first_error.with_traceback(first_tb)
 
             if self.show_dashboard:
                 self.display_agent_dashboard(
@@ -447,8 +502,8 @@ class ConcurrentWorkflow:
                     if self.on_error == "raise":
                         raise
                     self.conversation.add(
-                        role=f"{agent.agent_name} (failed)",
-                        content=f"Error: {str(e)}",
+                        role=self._failed_role(agent.agent_name),
+                        content=self._format_agent_error(e),
                     )
 
         return history_output_formatter(

--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -359,9 +359,11 @@ class ConcurrentWorkflow:
                             first_error = e
                         results.append(
                             (
-                                f"{agent.agent_name} (failed)"
-                                if self.on_error == "store"
-                                else agent.agent_name,
+                                (
+                                    f"{agent.agent_name} (failed)"
+                                    if self.on_error == "store"
+                                    else agent.agent_name
+                                ),
                                 f"Error: {str(e)}",
                             )
                         )

--- a/tests/structs/test_concurrent_workflow.py
+++ b/tests/structs/test_concurrent_workflow.py
@@ -565,5 +565,92 @@ def test_concurrent_workflow_on_error_raise_propagates():
         wf.run("test task")
 
 
+def test_concurrent_workflow_invalid_on_error_raises_value_error():
+    """Unsupported on_error value must raise ValueError at construction time."""
+    with pytest.raises(ValueError, match="on_error"):
+        ConcurrentWorkflow(
+            agents=[_MockAgent("A"), _MockAgent("B")],
+            on_error="ignore",  # invalid
+            autosave=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard-path tests (show_dashboard=True, renderer stubbed out)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_workflow_dashboard_partial_results_on_agent_failure(
+    monkeypatch,
+):
+    """Dashboard path: failing agent must not discard passing siblings."""
+    good1 = _MockAgent("Good-1", "result-1")
+    good2 = _MockAgent("Good-2", "result-2")
+    bad = _FailingAgent("Bad")
+
+    # Stub out all dashboard rendering so no terminal UI code runs.
+    monkeypatch.setattr(
+        "swarms.structs.concurrent_workflow.formatter",
+        _NullFormatter(),
+        raising=False,
+    )
+
+    wf = ConcurrentWorkflow(
+        agents=[good1, good2, bad],
+        on_error="store",
+        show_dashboard=True,
+        autosave=False,
+    )
+    result = wf.run("test task")
+
+    assert result is not None
+
+    history = wf.conversation.conversation_history
+    roles = [entry.get("role", "") for entry in history]
+    contents = [entry.get("content", "") for entry in history]
+
+    assert any("Good-1" in r for r in roles), "Good-1 output missing"
+    assert any("Good-2" in r for r in roles), "Good-2 output missing"
+    assert any(
+        "Bad" in r and "failed" in r for r in roles
+    ), "Failed-agent error entry missing"
+    assert any(
+        "exploded" in c for c in contents
+    ), "Error message not stored"
+
+
+def test_concurrent_workflow_dashboard_on_error_raise_propagates(
+    monkeypatch,
+):
+    """Dashboard path: on_error='raise' must propagate the exception."""
+    good = _MockAgent("Good", "ok")
+    bad = _FailingAgent("Bad")
+
+    monkeypatch.setattr(
+        "swarms.structs.concurrent_workflow.formatter",
+        _NullFormatter(),
+        raising=False,
+    )
+
+    wf = ConcurrentWorkflow(
+        agents=[good, bad],
+        on_error="raise",
+        show_dashboard=True,
+        autosave=False,
+    )
+    with pytest.raises(RuntimeError, match="exploded"):
+        wf.run("test task")
+
+
+class _NullFormatter:
+    """Drop-in for ``formatter`` that silently ignores all dashboard calls."""
+
+    def print_agent_dashboard(self, *a, **kw):
+        pass
+
+    def stop_dashboard(self, *a, **kw):
+        pass
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/structs/test_concurrent_workflow.py
+++ b/tests/structs/test_concurrent_workflow.py
@@ -490,5 +490,80 @@ def test_concurrent_workflow_autosave_saves_conversation_after_run(
     get_workspace_dir.cache_clear()
 
 
+class _MockAgent:
+    """Minimal stand-in that looks like an Agent to ConcurrentWorkflow."""
+
+    def __init__(self, name: str, response: str = "ok"):
+        self.agent_name = name
+        self._response = response
+        self.print_on = True
+
+    def run(self, task=None, img=None, imgs=None, **kwargs):
+        return self._response
+
+    def cleanup(self):
+        pass
+
+
+class _FailingAgent(_MockAgent):
+    def run(self, task=None, img=None, imgs=None, **kwargs):
+        raise RuntimeError(f"{self.agent_name} exploded")
+
+
+# ---------------------------------------------------------------------------
+# on_error tests (no real LLM calls)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_workflow_partial_results_on_agent_failure():
+    """One failing agent must not discard outputs from passing siblings."""
+    good1 = _MockAgent("Good-1", "result-1")
+    good2 = _MockAgent("Good-2", "result-2")
+    bad = _FailingAgent("Bad")
+
+    wf = ConcurrentWorkflow(
+        agents=[good1, good2, bad],
+        on_error="store",
+        autosave=False,
+    )
+    result = wf.run("test task")
+
+    # Must not raise — partial results are returned
+    assert result is not None
+
+    # Inspect the raw conversation history so no formatter slicing can hide entries.
+    history = wf.conversation.conversation_history
+    roles = [entry.get("role", "") for entry in history]
+    contents = [entry.get("content", "") for entry in history]
+
+    # Both passing agents must appear
+    assert any("Good-1" in r for r in roles), "Good-1 output missing"
+    assert any("Good-2" in r for r in roles), "Good-2 output missing"
+
+    # The failing agent must appear under the "(failed)" marker
+    assert any(
+        "Bad" in r and "failed" in r for r in roles
+    ), "Failed-agent error entry missing"
+
+    # Error content stored
+    assert any("exploded" in c for c in contents), (
+        "Error message not stored in conversation"
+    )
+
+
+def test_concurrent_workflow_on_error_raise_propagates():
+    """on_error='raise' must let the exception escape."""
+    good = _MockAgent("Good", "ok")
+    bad = _FailingAgent("Bad")
+
+    wf = ConcurrentWorkflow(
+        agents=[good, bad],
+        on_error="raise",
+        autosave=False,
+    )
+    with pytest.raises(RuntimeError, match="exploded"):
+        wf.run("test task")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/structs/test_concurrent_workflow.py
+++ b/tests/structs/test_concurrent_workflow.py
@@ -546,9 +546,9 @@ def test_concurrent_workflow_partial_results_on_agent_failure():
     ), "Failed-agent error entry missing"
 
     # Error content stored
-    assert any("exploded" in c for c in contents), (
-        "Error message not stored in conversation"
-    )
+    assert any(
+        "exploded" in c for c in contents
+    ), "Error message not stored in conversation"
 
 
 def test_concurrent_workflow_on_error_raise_propagates():


### PR DESCRIPTION
## Description
Fixes `ConcurrentWorkflow` silently killing sibling agent outputs when one agent fails. The non-dashboard `_run` path was missing the try/except already present in the dashboard path. Both paths now catch per-agent exceptions and store them as `<agent_name> (failed)` conversation entries, keeping successful results intact. Adds an `on_error` flag (`"store"` default / `"raise"` for old fail-fast behaviour) with `ValueError` validation, shared error-formatting helpers to eliminate duplication, traceback preservation on re-raise, updated docstrings, and five regression tests covering both execution paths.

## Files Changed
* `swarms/structs/concurrent_workflow.py`
* `tests/structs/test_concurrent_workflow.py`
* `examples/multi_agent/concurrent_examples/concurrent_workflow_on_error_example.py`

## Issue
#1613

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Twitter
[@akc__2025](https://x.com/akc__2025)