### PR TITLE
Add OpenTelemetry tracing for agents and swarms

### DIFF
--- a/examples/utils/telemetry/README.md
+++ b/examples/utils/telemetry/README.md
@@ -6,3 +6,23 @@ This directory contains examples demonstrating telemetry and monitoring capabili
 
 Telemetry examples demonstrate how to add monitoring, logging, and observability to agents. These examples show how to track agent performance, log operations, and monitor agent behavior using decorators and class methods.
 
+## OpenTelemetry
+
+Swarms can emit OpenTelemetry traces for agent and multi-agent
+execution. Tracing is off by default.
+
+Enable OTLP export with environment variables:
+
+```bash
+export SWARMS_OTEL_ENABLED=true
+export OTEL_SERVICE_NAME=swarms
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+For local debugging without an OTLP collector:
+
+```bash
+export SWARMS_OTEL_ENABLED=true
+export SWARMS_OTEL_EXPORTER=console
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ httpx = "*"
 requests = "*"
 mcp = "*"
 schedule = "*"
+opentelemetry-api = "*"
+opentelemetry-sdk = "*"
+opentelemetry-exporter-otlp = "*"
 
 [tool.poetry.scripts]
 swarms = "swarms.cli.main:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ requests
 litellm==1.76.1
 mcp
 schedule
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -96,6 +96,7 @@ from swarms.structs.transforms import (
     handle_transforms,
 )
 from swarms.telemetry.main import log_agent_data
+from swarms.telemetry.open_telemetry import trace_method
 from swarms.tools.base_tool import BaseTool
 from swarms.tools.handoffs_tool import handoff_task
 from swarms.tools.handoffs_tool_schema import get_handoff_tool_schema
@@ -4089,6 +4090,7 @@ Subtask Breakdown:
                 "".join(thinking_parts), title=title
             )
 
+    @trace_method("swarms.agent.call_llm")
     def call_llm(
         self,
         task: str,
@@ -4687,6 +4689,7 @@ Subtask Breakdown:
                     )
         return None
 
+    @trace_method("swarms.agent.run")
     def run(
         self,
         task: Optional[Union[str, Any]] = None,

--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -9,6 +9,7 @@ from swarms.structs.conversation import Conversation
 from swarms.structs.multi_agent_exec import run_agents_concurrently
 from swarms.structs.swarm_id import swarm_id
 from swarms.telemetry.main import log_agent_data
+from swarms.telemetry.open_telemetry import trace_method
 from swarms.utils.any_to_str import any_to_str
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
@@ -694,6 +695,7 @@ class AgentRearrange:
 
         raise e
 
+    @trace_method("swarms.agent_rearrange.run")
     def run(
         self,
         task: str = None,

--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -8,6 +8,7 @@ from loguru import logger as loguru_logger
 from swarms.structs.agent import Agent
 from swarms.structs.conversation import Conversation
 from swarms.structs.swarm_id import swarm_id
+from swarms.telemetry.open_telemetry import trace_method
 from swarms.utils.formatter import formatter
 from swarms.utils.get_cpu_cores import get_cpu_cores
 from swarms.utils.history_output_formatter import (
@@ -529,6 +530,7 @@ class ConcurrentWorkflow:
         except Exception as e:
             logger.error(f"Cleanup failed: {str(e)}")
 
+    @trace_method("swarms.concurrent_workflow.run")
     def run(
         self,
         task: str,

--- a/swarms/structs/groupchat.py
+++ b/swarms/structs/groupchat.py
@@ -16,6 +16,7 @@ from swarms.utils.history_output_formatter import (
 from swarms.prompts.multi_agent_collab_prompt import (
     MULTI_AGENT_COLLAB_PROMPT_TWO,
 )
+from swarms.telemetry.open_telemetry import trace_method
 
 SpeakerFunction = Callable[[List[str], "Agent"], bool]
 
@@ -1266,6 +1267,7 @@ class GroupChat:
         # Get response from the randomly selected agent
         self._get_agent_response(random_agent, img, imgs)
 
+    @trace_method("swarms.groupchat.run")
     def run(
         self,
         task: str,

--- a/swarms/structs/multi_agent_router.py
+++ b/swarms/structs/multi_agent_router.py
@@ -16,6 +16,7 @@ from swarms.utils.history_output_formatter import (
 )
 from swarms.utils.litellm_wrapper import LiteLLM
 from swarms.utils.output_types import OutputType
+from swarms.telemetry.open_telemetry import trace_method
 
 
 class HandOffsResponse(BaseModel):
@@ -335,6 +336,7 @@ class MultiAgentRouter:
             )
             raise
 
+    @trace_method("swarms.multi_agent_router.run")
     def run(self, task: str):
         """Route a task to the appropriate agent and return the result"""
         return self.route_task(task)

--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -10,6 +10,7 @@ from swarms.prompts.multi_agent_collab_prompt import (
 )
 from swarms.structs.agent import Agent
 from swarms.structs.agent_rearrange import AgentRearrange
+from swarms.telemetry.open_telemetry import trace_method
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.output_types import OutputType
 from swarms.utils.swarm_autosave import get_swarm_workspace_dir
@@ -256,6 +257,7 @@ class SequentialWorkflow:
             result = self.agent_rearrange.run(**run_kwargs)
         return result
 
+    @trace_method("swarms.sequential_workflow.run")
     def run(
         self,
         task: str,

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -35,6 +35,7 @@ from swarms.structs.multi_agent_router import MultiAgentRouter
 from swarms.structs.planner_worker_swarm import PlannerWorkerSwarm
 from swarms.structs.round_robin import RoundRobinSwarm
 from swarms.structs.sequential_workflow import SequentialWorkflow
+from swarms.telemetry.open_telemetry import trace_method
 from swarms.utils.generate_keys import generate_api_key
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.output_types import OutputType
@@ -823,6 +824,7 @@ class SwarmRouter:
             )
             raise e
 
+    @trace_method("swarms.swarm_router.run")
     def run(
         self,
         task: Optional[str] = None,

--- a/swarms/telemetry/__init__.py
+++ b/swarms/telemetry/__init__.py
@@ -4,10 +4,18 @@ from swarms.telemetry.main import (
     get_comprehensive_system_info,
     log_agent_data,
 )
+from swarms.telemetry.open_telemetry import (
+    open_telemetry_enabled,
+    trace_method,
+    trace_span,
+)
 
 __all__ = [
     "generate_user_id",
     "get_machine_id",
     "get_comprehensive_system_info",
     "log_agent_data",
+    "open_telemetry_enabled",
+    "trace_method",
+    "trace_span",
 ]

--- a/swarms/telemetry/open_telemetry.py
+++ b/swarms/telemetry/open_telemetry.py
@@ -1,0 +1,194 @@
+import os
+from contextlib import contextmanager
+from functools import lru_cache, wraps
+from typing import Any, Callable, Dict, Optional
+
+from loguru import logger
+
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def open_telemetry_enabled() -> bool:
+    """Return whether OpenTelemetry tracing is enabled."""
+    value = os.getenv("SWARMS_OTEL_ENABLED") or os.getenv(
+        "SWARMS_OPEN_TELEMETRY_ENABLED"
+    )
+    return str(value).lower() in TRUE_VALUES
+
+
+def _safe_attribute_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, bool, int, float)):
+        return value
+    return str(value)
+
+
+def _clean_attributes(
+    attributes: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if not attributes:
+        return {}
+    return {
+        key: _safe_attribute_value(value)
+        for key, value in attributes.items()
+        if value is not None
+    }
+
+
+def _task_attributes(args: tuple, kwargs: dict) -> Dict[str, Any]:
+    task = kwargs.get("task")
+    if task is None and len(args) > 1:
+        task = args[1]
+    if task is None:
+        return {}
+    return {
+        "swarms.task.length": len(str(task)),
+        "swarms.task.type": type(task).__name__,
+    }
+
+
+def _object_attributes(obj: Any) -> Dict[str, Any]:
+    if obj is None:
+        return {}
+
+    attrs = {
+        "swarms.component.class": obj.__class__.__name__,
+        "swarms.component.id": getattr(obj, "id", None),
+        "swarms.component.name": getattr(
+            obj,
+            "agent_name",
+            getattr(obj, "name", None),
+        ),
+        "swarms.agent.model": getattr(obj, "model_name", None),
+        "swarms.swarm.type": getattr(obj, "swarm_type", None),
+        "swarms.agent.count": (
+            len(getattr(obj, "agents", []))
+            if getattr(obj, "agents", None) is not None
+            else None
+        ),
+    }
+    return _clean_attributes(attrs)
+
+
+def build_method_attributes(
+    args: tuple,
+    kwargs: dict,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    attrs = {}
+    if args:
+        attrs.update(_object_attributes(args[0]))
+    attrs.update(_task_attributes(args, kwargs))
+    attrs.update(_clean_attributes(extra))
+    return attrs
+
+
+@lru_cache(maxsize=1)
+def _otel_components():
+    if not open_telemetry_enabled():
+        return None
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import (
+            BatchSpanProcessor,
+            ConsoleSpanExporter,
+        )
+        from opentelemetry.trace import Status, StatusCode
+    except ImportError as exc:
+        logger.warning(
+            "OpenTelemetry tracing is enabled but dependencies are "
+            f"missing: {exc}"
+        )
+        return None
+
+    provider = trace.get_tracer_provider()
+    if provider.__class__.__name__ == "ProxyTracerProvider":
+        resource = Resource.create(
+            {
+                "service.name": os.getenv(
+                    "OTEL_SERVICE_NAME", "swarms"
+                )
+            }
+        )
+        provider = TracerProvider(resource=resource)
+
+        exporter_name = os.getenv(
+            "SWARMS_OTEL_EXPORTER", "otlp"
+        ).lower()
+        if exporter_name == "console":
+            exporter = ConsoleSpanExporter()
+        else:
+            try:
+                from opentelemetry.exporter.otlp.proto.http import (
+                    trace_exporter,
+                )
+
+                exporter = trace_exporter.OTLPSpanExporter()
+            except ImportError as exc:
+                logger.warning(
+                    "OTLP exporter is unavailable; falling back to "
+                    f"console exporter: {exc}"
+                )
+                exporter = ConsoleSpanExporter()
+
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+
+    return {
+        "tracer": trace.get_tracer("swarms"),
+        "Status": Status,
+        "StatusCode": StatusCode,
+    }
+
+
+@contextmanager
+def trace_span(
+    name: str,
+    attributes: Optional[Dict[str, Any]] = None,
+):
+    components = _otel_components()
+    if components is None:
+        yield None
+        return
+
+    tracer = components["tracer"]
+    Status = components["Status"]
+    StatusCode = components["StatusCode"]
+
+    with tracer.start_as_current_span(
+        name,
+        attributes=_clean_attributes(attributes),
+    ) as span:
+        try:
+            yield span
+        except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+        else:
+            span.set_status(Status(StatusCode.OK))
+
+
+def trace_method(
+    span_name: str,
+    extra_attributes: Optional[Dict[str, Any]] = None,
+) -> Callable:
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            attrs = build_method_attributes(
+                args,
+                kwargs,
+                extra_attributes,
+            )
+            with trace_span(span_name, attrs):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/telemetry/test_open_telemetry.py
+++ b/tests/telemetry/test_open_telemetry.py
@@ -1,0 +1,47 @@
+from swarms.telemetry.open_telemetry import (
+    build_method_attributes,
+    open_telemetry_enabled,
+    trace_method,
+    trace_span,
+)
+
+
+class DummyAgent:
+    id = "agent-1"
+    agent_name = "researcher"
+    model_name = "gpt-test"
+
+
+def test_open_telemetry_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("SWARMS_OTEL_ENABLED", raising=False)
+    monkeypatch.delenv(
+        "SWARMS_OPEN_TELEMETRY_ENABLED", raising=False
+    )
+
+    assert open_telemetry_enabled() is False
+
+    with trace_span("swarms.test.disabled") as span:
+        assert span is None
+
+
+def test_trace_method_preserves_return_value(monkeypatch):
+    monkeypatch.delenv("SWARMS_OTEL_ENABLED", raising=False)
+
+    @trace_method("swarms.test.method")
+    def run(agent, task):
+        return f"{agent.agent_name}:{task}"
+
+    assert run(DummyAgent(), "hello") == "researcher:hello"
+
+
+def test_build_method_attributes_includes_agent_metadata():
+    attrs = build_method_attributes(
+        (DummyAgent(), "do work"),
+        {},
+    )
+
+    assert attrs["swarms.component.class"] == "DummyAgent"
+    assert attrs["swarms.component.id"] == "agent-1"
+    assert attrs["swarms.component.name"] == "researcher"
+    assert attrs["swarms.agent.model"] == "gpt-test"
+    assert attrs["swarms.task.length"] == len("do work")


### PR DESCRIPTION
Closes #1199

## Summary
Adds opt-in OpenTelemetry tracing for core Swarms execution paths:
- `Agent.run`
- `Agent.call_llm`
- `SwarmRouter.run`
- `AgentRearrange.run`
- `SequentialWorkflow.run`
- `ConcurrentWorkflow.run`
- `GroupChat.run`
- `MultiAgentRouter.run`

Tracing is disabled by default.

## Usage
Enable OTLP export:

~~~bash
export SWARMS_OTEL_ENABLED=true
export OTEL_SERVICE_NAME=swarms
export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
~~~

For local debugging:

~~~bash
export SWARMS_OTEL_ENABLED=true
export SWARMS_OTEL_EXPORTER=console
~~~

## Testing
~~~bash
python -m pytest tests/telemetry/test_open_telemetry.py
python -m pytest tests/telemetry/test_user_utils.py
python -m py_compile swarms/telemetry/open_telemetry.py swarms/structs/agent.py swarms/structs/swarm_router.py swarms/structs/agent_rearrange.py swarms/structs/sequential_workflow.py swarms/structs/concurrent_workflow.py swarms/structs/groupchat.py swarms/structs/multi_agent_router.py tests/telemetry/test_open_telemetry.py
~~~

All passed locally.

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1622.org.readthedocs.build/en/1622/

<!-- readthedocs-preview swarms end -->