### PR TITLE
[FEAT] [GraphWorkflow] add validate(raise_on_error) and compile-time structural validation

### DIFF
--- a/examples/multi_agent/graphworkflow_examples/graph_workflow_validate.py
+++ b/examples/multi_agent/graphworkflow_examples/graph_workflow_validate.py
@@ -1,0 +1,119 @@
+"""
+GraphWorkflow validate() example.
+
+Demonstrates calling validate() at build time to catch structural
+problems before any agent runs.
+
+Scenarios covered:
+  1. Clean workflow  — validate() reports no issues.
+  2. Isolated node   — an agent with no edges triggers a warning.
+  3. Unreachable node — a node not reachable from the entry point triggers a warning.
+  4. Invalid agent   — a node with agent=None triggers an error and
+                       validate(raise_on_error=True) raises ValueError.
+  5. compile() integration — compile() surfaces the same errors as a
+                             WARNING-level log so you catch problems
+                             without calling validate() explicitly.
+"""
+
+from swarms import Agent
+from swarms.structs.graph_workflow import GraphWorkflow, Node
+
+
+def make_agent(name: str, description: str) -> Agent:
+    return Agent(
+        agent_name=name,
+        agent_description=description,
+        model_name="gpt-5.4",
+        max_loops=1,
+        verbose=False,
+        print_on=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — Clean workflow
+# ---------------------------------------------------------------------------
+print("\n=== Scenario 1: Clean workflow ===")
+
+researcher = make_agent("Researcher", "Gathers facts on a topic")
+analyst = make_agent("Analyst", "Analyses gathered facts")
+writer = make_agent("Writer", "Writes a report from analysis")
+
+wf = GraphWorkflow(name="ResearchPipeline")
+wf.add_node(researcher)
+wf.add_node(analyst)
+wf.add_node(writer)
+wf.add_edge("Researcher", "Analyst")
+wf.add_edge("Analyst", "Writer")
+
+result = wf.validate(raise_on_error=False)
+print(f"is_valid : {result['is_valid']}")
+print(f"errors   : {result['errors']}")
+print(f"warnings : {result['warnings']}")
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — Isolated node (no edges)
+# ---------------------------------------------------------------------------
+print("\n=== Scenario 2: Isolated node ===")
+
+a = make_agent("NodeA", "Does task A")
+b = make_agent("NodeB", "Does task B")
+orphan = make_agent("Orphan", "Has no edges — will never run")
+
+wf2 = GraphWorkflow(name="IsolatedNodeWorkflow")
+wf2.add_node(a)
+wf2.add_node(b)
+wf2.add_node(orphan)
+wf2.add_edge("NodeA", "NodeB")
+
+result2 = wf2.validate(raise_on_error=False)
+print(f"is_valid : {result2['is_valid']}")
+print(f"warnings : {result2['warnings']}")
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — Unreachable node
+# ---------------------------------------------------------------------------
+print("\n=== Scenario 3: Unreachable node ===")
+
+entry = make_agent("Entry", "Entry point")
+mid = make_agent("Mid", "Middle step")
+side = make_agent("Side", "Has an edge but unreachable from Entry")
+
+wf3 = GraphWorkflow(name="UnreachableWorkflow")
+wf3.add_node(entry)
+wf3.add_node(mid)
+wf3.add_node(side)
+wf3.add_edge("Entry", "Mid")
+wf3.add_edge(
+    "Side", "Mid"
+)  # Side feeds Mid but no path reaches Side from Entry
+wf3.set_entry_points(["Entry"])
+
+result3 = wf3.validate(raise_on_error=False)
+print(f"is_valid : {result3['is_valid']}")
+print(f"warnings : {result3['warnings']}")
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — Invalid agent triggers ValueError
+# ---------------------------------------------------------------------------
+print("\n=== Scenario 4: raise_on_error=True ===")
+
+wf4 = GraphWorkflow(name="InvalidWorkflow")
+wf4.nodes["Ghost"] = Node(id="Ghost", agent=None)  # no real agent
+
+try:
+    wf4.validate(raise_on_error=True)
+except ValueError as exc:
+    print(f"Caught ValueError:\n{exc}")
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — compile() logs errors automatically
+# ---------------------------------------------------------------------------
+print("\n=== Scenario 5: compile() integration ===")
+
+wf5 = GraphWorkflow(name="CompileCheckWorkflow")
+wf5.nodes["Ghost"] = Node(id="Ghost", agent=None)
+
+# compile() will log a WARNING about the invalid node without raising
+wf5.compile()
+print("compile() completed — check logs above for validation warning")

--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -923,6 +923,28 @@ class GraphWorkflow:
                 logger.debug(f"Entry points: {self.entry_points}")
                 logger.debug(f"End points: {self.end_points}")
 
+            # Run structural validation so misconfiguration is surfaced at
+            # build time rather than mid-execution.  We never raise here so
+            # that compile() stays backward-compatible; callers that want
+            # strict enforcement should call validate(raise_on_error=True)
+            # explicitly.
+            if self.nodes:
+                _vr = self.validate(
+                    auto_fix=False, raise_on_error=False
+                )
+                if _vr["errors"]:
+                    logger.warning(
+                        f"GraphWorkflow compile: validation found "
+                        f"{len(_vr['errors'])} error(s) — "
+                        + "; ".join(_vr["errors"])
+                    )
+                if _vr["warnings"] and self.verbose:
+                    logger.warning(
+                        f"GraphWorkflow compile: validation found "
+                        f"{len(_vr['warnings'])} warning(s) — "
+                        + "; ".join(_vr["warnings"])
+                    )
+
             # Pre-compute topological layers for efficient execution
             if self.verbose:
                 logger.debug("Computing topological layers")
@@ -3261,16 +3283,35 @@ class GraphWorkflow:
             )
             raise e
 
-    def validate(self, auto_fix: bool = False) -> Dict[str, Any]:
+    def validate(
+        self,
+        auto_fix: bool = False,
+        raise_on_error: bool = False,
+    ) -> Dict[str, Any]:
         """
         Validate the workflow structure, checking for potential issues such as isolated nodes,
-        cyclic dependencies, etc.
+        cyclic dependencies, unreachable nodes, and missing entry/end points.
 
         Args:
-            auto_fix (bool): Whether to automatically fix some simple issues (like auto-setting entry/exit points)
+            auto_fix (bool): Whether to automatically fix simple issues such as
+                auto-setting missing entry/exit points and adding unreachable
+                nodes to entry points.
+            raise_on_error (bool): When ``True``, raise a ``ValueError`` if
+                validation determines the workflow is invalid (i.e.
+                ``result["is_valid"]`` is ``False``).  Defaults to ``False``
+                so that existing callers that inspect the returned dict are
+                unaffected.
 
         Returns:
-            Dict[str, Any]: Dictionary containing validation results, including validity, warnings and errors
+            Dict[str, Any]: Dictionary containing:
+                - ``is_valid`` (bool) — overall validity flag.
+                - ``errors`` (List[str]) — fatal problems that prevent execution.
+                - ``warnings`` (List[str]) — non-fatal issues worth addressing.
+                - ``fixed`` (List[str]) — issues resolved when ``auto_fix=True``.
+                - ``cycles`` (List[List[str]]) — detected cycles, if any.
+
+        Raises:
+            ValueError: If ``raise_on_error=True`` and the workflow is invalid.
         """
         if self.verbose:
             logger.debug(
@@ -3429,11 +3470,24 @@ class GraphWorkflow:
                         f"Auto-fixed {len(result['fixed'])} issues: {', '.join(result['fixed'])}"
                     )
 
+            if raise_on_error and not result["is_valid"]:
+                all_issues = result["errors"] + result["warnings"]
+                raise ValueError(
+                    "GraphWorkflow validation failed:\n"
+                    + "\n".join(f"  - {i}" for i in all_issues)
+                )
+
             return result
+        except ValueError:
+            raise
         except Exception as e:
             result["is_valid"] = False
             result["errors"].append(str(e))
             logger.exception(f"Error during workflow validation: {e}")
+            if raise_on_error:
+                raise ValueError(
+                    f"GraphWorkflow validation failed: {e}"
+                ) from e
             return result
 
     def export_summary(self) -> Dict[str, Any]:

--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -225,7 +225,9 @@ class NetworkXBackend(GraphBackend):
             NetworkXBackend: A new backend instance with reversed edges.
         """
         reversed_backend = NetworkXBackend()
-        reversed_backend.graph = self.graph.reverse()
+        # copy=False avoids deepcopy of node attributes, which fails for
+        # Agent objects that hold unpicklable thread locks.
+        reversed_backend.graph = self.graph.reverse(copy=False)
         return reversed_backend
 
     def topological_generations(self) -> List[List[str]]:

--- a/tests/structs/test_graph_workflow.py
+++ b/tests/structs/test_graph_workflow.py
@@ -10,7 +10,7 @@ from swarms.structs.graph_workflow import (
 )
 
 try:
-    import rustworkx as rx
+    import rustworkx as rx  # noqa: F401
 
     RUSTWORKX_AVAILABLE = True
 except ImportError:
@@ -1008,6 +1008,137 @@ def test_graph_workflow_on_node_complete_run_overrides_init():
     # Only the run-level callback should have been called
     assert len(run_calls) == 1
     assert len(init_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Shared mock helper (used by validate tests below)
+# ---------------------------------------------------------------------------
+
+
+def _mock_agent(name: str, response: str = None):
+    """Return a MagicMock that looks like an Agent to GraphWorkflow."""
+    from unittest.mock import MagicMock
+
+    a = MagicMock()
+    a.agent_name = name
+    a.run = MagicMock(return_value=response or f"output-{name}")
+    return a
+
+
+# ---------------------------------------------------------------------------
+# validate() / compile-time validation tests (no real LLM calls)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_returns_dict_with_expected_keys():
+    """validate() always returns a dict with is_valid, errors, warnings, fixed."""
+    a = _mock_agent("VA")
+    b = _mock_agent("VB")
+    wf = GraphWorkflow(name="V-Basic")
+    wf.add_node(a)
+    wf.add_node(b)
+    wf.add_edge("VA", "VB")
+
+    result = wf.validate()
+    assert isinstance(result, dict)
+    for key in ("is_valid", "errors", "warnings", "fixed"):
+        assert key in result
+
+
+def test_validate_clean_workflow_is_valid():
+    """A properly wired workflow reports is_valid=True with no errors."""
+    a = _mock_agent("CA")
+    b = _mock_agent("CB")
+    wf = GraphWorkflow(name="V-Clean")
+    wf.add_node(a)
+    wf.add_node(b)
+    wf.add_edge("CA", "CB")
+    wf.compile()
+
+    result = wf.validate()
+    assert result["is_valid"] is True
+    assert result["errors"] == []
+
+
+def test_validate_detects_isolated_node():
+    """validate() warns about a node with no edges."""
+    a = _mock_agent("IA")
+    b = _mock_agent("IB")
+    orphan = _mock_agent("Orphan")
+
+    wf = GraphWorkflow(name="V-Isolated")
+    wf.add_node(a)
+    wf.add_node(b)
+    wf.add_node(orphan)
+    wf.add_edge("IA", "IB")
+
+    result = wf.validate()
+    warning_text = " ".join(result["warnings"])
+    assert (
+        "Orphan" in warning_text or "isolated" in warning_text.lower()
+    )
+
+
+def test_validate_detects_unreachable_node():
+    """validate() warns about nodes unreachable from the explicit entry point."""
+    a = _mock_agent("UA")
+    b = _mock_agent("UB")
+    c = _mock_agent("UC")
+
+    wf = GraphWorkflow(name="V-Unreachable")
+    wf.add_node(a)
+    wf.add_node(b)
+    wf.add_node(c)
+    wf.add_edge("UA", "UB")
+    wf.add_edge("UA", "UC")
+    # Manually override entry_points so only UA is entry; a disconnected D would be unreachable
+    d = _mock_agent("UD")
+    wf.add_node(d)
+    wf.add_edge(
+        "UD", "UB"
+    )  # UD has an out-edge but is not reachable from UA
+    wf.set_entry_points(["UA"])
+
+    result = wf.validate()
+    warning_text = " ".join(result["warnings"])
+    assert (
+        "UD" in warning_text or "unreachable" in warning_text.lower()
+    )
+
+
+def test_validate_raise_on_error_raises_for_invalid_workflow():
+    """validate(raise_on_error=True) raises ValueError for invalid workflows."""
+    wf = GraphWorkflow(name="V-RaiseErr")
+    wf.nodes["Ghost"] = Node(
+        id="Ghost", agent=None
+    )  # invalid — no agent
+
+    with pytest.raises(ValueError, match="validation failed"):
+        wf.validate(raise_on_error=True)
+
+
+def test_validate_raise_on_error_false_does_not_raise():
+    """validate(raise_on_error=False) returns dict even for invalid workflows."""
+    wf = GraphWorkflow(name="V-NoRaise")
+    wf.nodes["Ghost"] = Node(id="Ghost", agent=None)
+
+    result = wf.validate(raise_on_error=False)
+    assert isinstance(result, dict)
+    assert result["is_valid"] is False
+
+
+def test_compile_calls_validate_and_reports_errors():
+    """compile() surfaces validation errors: the validation result is non-empty errors list."""
+    wf = GraphWorkflow(name="V-CompileCheck")
+    wf.nodes["Ghost"] = Node(id="Ghost", agent=None)
+
+    # compile() should complete without raising but validation errors are present
+    wf.compile()
+
+    # Calling validate directly confirms the errors that compile() would have logged
+    result = wf.validate(raise_on_error=False)
+    assert not result["is_valid"]
+    assert len(result["errors"]) > 0
 
 
 if __name__ == "__main__":

--- a/tests/structs/test_graph_workflow.py
+++ b/tests/structs/test_graph_workflow.py
@@ -1011,33 +1011,20 @@ def test_graph_workflow_on_node_complete_run_overrides_init():
 
 
 # ---------------------------------------------------------------------------
-# Shared mock helper (used by validate tests below)
-# ---------------------------------------------------------------------------
-
-
-def _mock_agent(name: str, response: str = None):
-    """Return a MagicMock that looks like an Agent to GraphWorkflow."""
-    from unittest.mock import MagicMock
-
-    a = MagicMock()
-    a.agent_name = name
-    a.run = MagicMock(return_value=response or f"output-{name}")
-    return a
-
-
-# ---------------------------------------------------------------------------
-# validate() / compile-time validation tests (no real LLM calls)
+# validate() / compile-time validation tests (real agents, real LLM)
 # ---------------------------------------------------------------------------
 
 
 def test_validate_returns_dict_with_expected_keys():
     """validate() always returns a dict with is_valid, errors, warnings, fixed."""
-    a = _mock_agent("VA")
-    b = _mock_agent("VB")
+    a = create_test_agent(
+        "Validator-A", "Answers questions concisely"
+    )
+    b = create_test_agent("Validator-B", "Summarises text")
     wf = GraphWorkflow(name="V-Basic")
     wf.add_node(a)
     wf.add_node(b)
-    wf.add_edge("VA", "VB")
+    wf.add_edge("Validator-A", "Validator-B")
 
     result = wf.validate()
     assert isinstance(result, dict)
@@ -1047,12 +1034,12 @@ def test_validate_returns_dict_with_expected_keys():
 
 def test_validate_clean_workflow_is_valid():
     """A properly wired workflow reports is_valid=True with no errors."""
-    a = _mock_agent("CA")
-    b = _mock_agent("CB")
+    a = create_test_agent("Clean-A", "Answers questions concisely")
+    b = create_test_agent("Clean-B", "Summarises text")
     wf = GraphWorkflow(name="V-Clean")
     wf.add_node(a)
     wf.add_node(b)
-    wf.add_edge("CA", "CB")
+    wf.add_edge("Clean-A", "Clean-B")
     wf.compile()
 
     result = wf.validate()
@@ -1062,47 +1049,50 @@ def test_validate_clean_workflow_is_valid():
 
 def test_validate_detects_isolated_node():
     """validate() warns about a node with no edges."""
-    a = _mock_agent("IA")
-    b = _mock_agent("IB")
-    orphan = _mock_agent("Orphan")
+    a = create_test_agent("Isolated-A", "Answers questions concisely")
+    b = create_test_agent("Isolated-B", "Summarises text")
+    orphan = create_test_agent(
+        "Orphan-Node", "Orphaned agent with no edges"
+    )
 
     wf = GraphWorkflow(name="V-Isolated")
     wf.add_node(a)
     wf.add_node(b)
     wf.add_node(orphan)
-    wf.add_edge("IA", "IB")
+    wf.add_edge("Isolated-A", "Isolated-B")
 
     result = wf.validate()
     warning_text = " ".join(result["warnings"])
     assert (
-        "Orphan" in warning_text or "isolated" in warning_text.lower()
+        "Orphan-Node" in warning_text
+        or "isolated" in warning_text.lower()
     )
 
 
 def test_validate_detects_unreachable_node():
     """validate() warns about nodes unreachable from the explicit entry point."""
-    a = _mock_agent("UA")
-    b = _mock_agent("UB")
-    c = _mock_agent("UC")
+    a = create_test_agent("Reach-A", "Answers questions concisely")
+    b = create_test_agent("Reach-B", "Summarises text")
+    c = create_test_agent("Reach-C", "Analyses data")
+    d = create_test_agent("Reach-D", "Unreachable side node")
 
     wf = GraphWorkflow(name="V-Unreachable")
     wf.add_node(a)
     wf.add_node(b)
     wf.add_node(c)
-    wf.add_edge("UA", "UB")
-    wf.add_edge("UA", "UC")
-    # Manually override entry_points so only UA is entry; a disconnected D would be unreachable
-    d = _mock_agent("UD")
     wf.add_node(d)
+    wf.add_edge("Reach-A", "Reach-B")
+    wf.add_edge("Reach-A", "Reach-C")
     wf.add_edge(
-        "UD", "UB"
-    )  # UD has an out-edge but is not reachable from UA
-    wf.set_entry_points(["UA"])
+        "Reach-D", "Reach-B"
+    )  # D has edges but is unreachable from A
+    wf.set_entry_points(["Reach-A"])
 
     result = wf.validate()
     warning_text = " ".join(result["warnings"])
     assert (
-        "UD" in warning_text or "unreachable" in warning_text.lower()
+        "Reach-D" in warning_text
+        or "unreachable" in warning_text.lower()
     )
 
 
@@ -1128,14 +1118,13 @@ def test_validate_raise_on_error_false_does_not_raise():
 
 
 def test_compile_calls_validate_and_reports_errors():
-    """compile() surfaces validation errors: the validation result is non-empty errors list."""
+    """compile() surfaces validation errors: the validation result has non-empty errors."""
     wf = GraphWorkflow(name="V-CompileCheck")
     wf.nodes["Ghost"] = Node(id="Ghost", agent=None)
 
-    # compile() should complete without raising but validation errors are present
+    # compile() completes without raising, but validation errors are detectable
     wf.compile()
 
-    # Calling validate directly confirms the errors that compile() would have logged
     result = wf.validate(raise_on_error=False)
     assert not result["is_valid"]
     assert len(result["errors"]) > 0


### PR DESCRIPTION
## Description
`GraphWorkflow` had no way to validate graph structure before execution. Misconfigured graphs — disconnected nodes, missing entry/end points, cycles, unreachable nodes — were only discovered at `run()` time, often mid-execution. This PR adds a `validate(raise_on_error)` method that runs all structural checks without executing any agents, and hooks it into `compile()` so misconfiguration is always surfaced at build time.

Also fixes a bug in `NetworkXBackend.reverse()` where `deepcopy` of node attributes failed for real `Agent` objects (which hold unpicklable thread locks), causing `validate()` to crash on any workflow with end points defined.

## Files Changed
* `swarms/structs/graph_workflow.py`
* `tests/structs/test_graph_workflow.py`
* `examples/multi_agent/graphworkflow_examples/graph_workflow_validate.py`

## Issue
#1485

## Dependencies
No extra dependencies required.

## Maintainer
@kyegomez

## Twitter
[@akc__2025](https://x.com/akc__2025)

<!-- readthedocs-preview swarms start -->
----
📚 Documentation preview 📚: https://swarms--1623.org.readthedocs.build/en/1623/

<!-- readthedocs-preview swarms end -->