### PR TITLE
docs: fix broken cross-links

### DIFF
--- a/docs/swarms/agents/agent_skills.md
+++ b/docs/swarms/agents/agent_skills.md
@@ -307,7 +307,7 @@ skills/
 
 ## Examples
 
-See the [Agent Skills Examples](/en/latest/swarms/examples/agent_skills_overview/) section for:
+See the [Agent Skills Examples](../examples/agent_skills_overview.md) section for:
 - Basic usage tutorial
 - Creating custom skills
 - Using multiple skills

--- a/docs/swarms/agents/reasoning_agents_overview.md
+++ b/docs/swarms/agents/reasoning_agents_overview.md
@@ -30,7 +30,7 @@ These agents are inspired by cognitive science and human reasoning processes, in
 | **Reflexion Agent** | Self-reflective | [Reflexion: Language Agents with Verbal Reinforcement Learning](https://arxiv.org/abs/2303.11366) (Shinn et al., 2023) | • Self-evaluation<br/>• Experience memory<br/>• Adaptive improvement<br/>• Learning from failures | • Continuous improvement tasks<br/>• Long-term projects<br/>• Learning scenarios<br/>• Quality refinement | `ReflexionAgent` | [Guide](reflexion_agent.md) |
 | **GKP Agent** | Knowledge-based | [Generated Knowledge Prompting](https://arxiv.org/abs/2110.08387) (Liu et al., 2022) | • Knowledge generation<br/>• Multi-perspective reasoning<br/>• Information synthesis<br/>• Fact integration | • Knowledge-intensive tasks<br/>• Research questions<br/>• Fact-based reasoning<br/>• Information synthesis | `GKPAgent` | [Guide](gkp_agent.md) |
 | **Agent Judge** | Evaluation | [Agent-as-a-Judge: Evaluate Agents with Agents](https://arxiv.org/abs/2410.10934) | • Quality assessment<br/>• Structured evaluation<br/>• Performance metrics<br/>• Feedback generation | • Quality control<br/>• Output evaluation<br/>• Performance assessment<br/>• Model comparison | `AgentJudge` | [Guide](agent_judge.md) |
-| **REACT Agent** | Action-based | [ReAct: Synergizing Reasoning and Acting](https://arxiv.org/abs/2210.03629) (Yao et al., 2022) | • Reason-Act-Observe cycle<br/>• Memory integration<br/>• Action planning<br/>• Experience building | • Interactive tasks<br/>• Tool usage scenarios<br/>• Planning problems<br/>• Learning environments | `ReactAgent` | [Guide](react_agent.md) |
+| **REACT Agent** | Action-based | [ReAct: Synergizing Reasoning and Acting](https://arxiv.org/abs/2210.03629) (Yao et al., 2022) | • Reason-Act-Observe cycle<br/>• Memory integration<br/>• Action planning<br/>• Experience building | • Interactive tasks<br/>• Tool usage scenarios<br/>• Planning problems<br/>• Learning environments | `ReactAgent` | [Guide](../examples/react_agent_tutorial.md) |
 
 ## Agent Architectures
 
@@ -339,7 +339,7 @@ graph TD
 
 **Implementation**: `ReactAgent`
 
-**Documentation**: [REACT Agent Guide](react_agent.md)
+**Documentation**: [REACT Agent Guide](../examples/react_agent_tutorial.md)
 
 
 ## Implementation Guide
@@ -423,4 +423,4 @@ For comprehensive technical documentation on each reasoning agent implementation
 
 ---
 
-Reasoning agents represent a significant advancement in enterprise agent capabilities, implementing sophisticated cognitive architectures that deliver enhanced reliability, consistency, and performance compared to traditional language model implementations. 
+Reasoning agents represent a significant advancement in enterprise agent capabilities, implementing sophisticated cognitive architectures that deliver enhanced reliability, consistency, and performance compared to traditional language model implementations.

--- a/docs/swarms/cli/cli_agent_guide.md
+++ b/docs/swarms/cli/cli_agent_guide.md
@@ -237,6 +237,6 @@ done
 ## Next Steps
 
 - [CLI YAML Configuration](./cli_yaml_guide.md) - Run agents from YAML files
-- [CLI Multi-Agent Guide](../examples/cli_multi_agent_quickstart.md) - LLM Council and Heavy Swarm
+- [CLI LLM Council Guide](./cli_llm_council_guide.md) - Run collaborative multi-agent council workflows
 - [CLI Reference](./cli_reference.md) - Complete command documentation
 

--- a/docs/swarms/cli/cli_llm_council_guide.md
+++ b/docs/swarms/cli/cli_llm_council_guide.md
@@ -158,5 +158,5 @@ swarms llm-council --task "<query>" [--verbose]
 
 - [CLI Heavy Swarm Guide](./cli_heavy_swarm_guide.md) - Complex task analysis
 - [CLI Reference](./cli_reference.md) - Complete command documentation
-- [LLM Council Python API](../examples/llm_council_quickstart.md) - Programmatic usage
+- [LLM Council Examples](../examples/llm_council_examples.md) - Programmatic usage
 

--- a/docs/swarms/cli/cli_quickstart.md
+++ b/docs/swarms/cli/cli_quickstart.md
@@ -110,6 +110,6 @@ swarms llm-council --task "What are the best practices for code review?"
 ## Next Steps
 
 - [CLI Agent Guide](./cli_agent_guide.md) - Create custom agents from CLI
-- [CLI Multi-Agent Guide](../examples/cli_multi_agent_quickstart.md) - Run LLM Council and Heavy Swarm
+- [CLI LLM Council Guide](./cli_llm_council_guide.md) - Run collaborative multi-agent council workflows
 - [CLI Reference](./cli_reference.md) - Complete command documentation
 

--- a/docs/swarms/cli/cli_yaml_guide.md
+++ b/docs/swarms/cli/cli_yaml_guide.md
@@ -315,6 +315,6 @@ swarms load-markdown --markdown-path ./agents/ --concurrent
 ## Next Steps
 
 - [CLI Agent Guide](./cli_agent_guide.md) - Create agents from command line
-- [CLI Multi-Agent Guide](../examples/cli_multi_agent_quickstart.md) - LLM Council and Heavy Swarm
+- [CLI LLM Council Guide](./cli_llm_council_guide.md) - Run collaborative multi-agent council workflows
 - [CLI Reference](./cli_reference.md) - Complete command documentation
 

--- a/docs/swarms/examples/auto_swarm_builder_example.md
+++ b/docs/swarms/examples/auto_swarm_builder_example.md
@@ -419,5 +419,5 @@ task = "Create cross-functional team: technical, business, creative, operational
 ## Next Steps
 
 - See [GitHub Examples](https://github.com/kyegomez/swarms/tree/master/examples/multi_agent/asb)
-- Learn about [Agent Design Principles](../concept/agent_design.md)
+- Learn about [Agent Architecture Concepts](../framework/agents_explained.md)
 - Try [SwarmRouter](./swarm_router.md) for task routing

--- a/docs/swarms/examples/council_as_judge_example.md
+++ b/docs/swarms/examples/council_as_judge_example.md
@@ -477,12 +477,12 @@ RECOMMENDATIONS
 |--------------|---------------------|
 | **[MajorityVoting](./majority_voting_example.md)** | When you need multiple agents to independently solve a task and build consensus |
 | **[LLMCouncil](./llm_council_examples.md)** | When you want agents to rank each other's generated responses |
-| **[DebateWithJudge](../examples/debate_quickstart.md)** | When you want two agents to argue opposing viewpoints |
+| **[DebateWithJudge](../structs/debate_with_judge.md)** | When you want two agents to argue opposing viewpoints |
 
 ---
 
 ## Next Steps
 
 - See [GitHub Examples](https://github.com/kyegomez/swarms/tree/master/examples/multi_agent/council_of_judges)
-- Learn about [Multi-Agent Evaluation Patterns](../examples/multi_agent_architectures_overview.md)
+- Learn about [Multi-Agent Evaluation Patterns](../structs/overview.md)
 - Try [MajorityVoting](./majority_voting_example.md) for consensus-based generation

--- a/docs/swarms/examples/hierarchical_swarm_example.md
+++ b/docs/swarms/examples/hierarchical_swarm_example.md
@@ -266,4 +266,4 @@ This will output a visual tree structure showing the Director and all worker age
 5. **Context Preservation**: The swarm maintains full conversation history automatically
 6. **Hierarchy Visualization**: Use `display_hierarchy()` to visualize swarm structure before execution
 
-For more detailed information about the `HierarchicalSwarm` API and advanced usage patterns, see the [main documentation](hierarchical_swarm.md). 
+For more detailed information about the `HierarchicalSwarm` API and advanced usage patterns, see the [main documentation](../structs/hierarchical_swarm.md).

--- a/docs/swarms/examples/majority_voting_example.md
+++ b/docs/swarms/examples/majority_voting_example.md
@@ -521,7 +521,7 @@ analysis = MajorityVoting(agents=agents, max_loops=1)
 |--------------|---------------------|
 | **[LLMCouncil](./llm_council_examples.md)** | When you want agents to rank each other's responses and a chairman to synthesize |
 | **[CouncilAsAJudge](./council_as_judge_example.md)** | When you need multi-dimensional evaluation (accuracy, helpfulness, etc.) with specialized judges |
-| **[DebateWithJudge](../examples/debate_quickstart.md)** | When you want adversarial debate between two opposing positions |
+| **[DebateWithJudge](../structs/debate_with_judge.md)** | When you want adversarial debate between two opposing positions |
 | **[ConcurrentWorkflow](./concurrent_workflow.md)** | When agents work on different tasks rather than the same task |
 | **[SequentialWorkflow](./sequential_example.md)** | When tasks need to flow sequentially through agents |
 
@@ -530,5 +530,5 @@ analysis = MajorityVoting(agents=agents, max_loops=1)
 ## Next Steps
 
 - See [GitHub Examples](https://github.com/kyegomez/swarms/tree/master/examples/multi_agent/majority_voting) for more use cases
-- Learn about [Consensus Mechanisms](../concept/consensus_mechanisms.md) in multi-agent systems
+- Learn about [Swarm Architecture Patterns](../concept/swarm_architectures.md) in multi-agent systems
 - Try [CouncilAsAJudge](./council_as_judge_example.md) for multi-dimensional evaluation

--- a/docs/swarms/examples/pydantic_structured_outputs_tutorial.md
+++ b/docs/swarms/examples/pydantic_structured_outputs_tutorial.md
@@ -562,7 +562,7 @@ This tutorial covered the following topics:
 
 - Explore [Agent Reference Documentation](../structs/agent.md) for advanced configuration options
 - Learn about [Tools and MCP Integration](../tools/tools_examples.md)
-- Review [Additional Examples](../../examples/index.md) for more use cases
+- Review [Model Provider Examples](model_providers.md) for more use cases
 
 !!! question "Support and Resources"
     For additional assistance:

--- a/docs/swarms/examples/roundrobin_example.md
+++ b/docs/swarms/examples/roundrobin_example.md
@@ -339,12 +339,12 @@ swarm = RoundRobinSwarm(
 | **[SequentialWorkflow](./sequential_example.md)** | When tasks must flow in fixed order |
 | **[GroupChat](./groupchat_comprehensive_examples.md)** | For real-time interactive discussions |
 | **[MajorityVoting](./majority_voting_example.md)** | When you need consensus via voting |
-| **[GroupChat](./groupchat_example.md)** | For expertise-based speaker selection |
+| **[GroupChat Reference](../structs/group_chat.md)** | For expertise-based speaker selection |
 
 ---
 
 ## Next Steps
 
-- Explore [RoundRobinSwarm Quickstart](../../examples/roundrobin_quickstart.md)
+- Explore the [RoundRobinSwarm Reference](../structs/round_robin_swarm.md)
 - See [GitHub Examples](https://github.com/kyegomez/swarms/tree/master/examples/multi_agent/groupchat)
-- Learn about [Group Communication Patterns](../../examples/multi_agent_architectures_overview.md)
+- Learn about [Group Communication Patterns](../structs/agent_multi_agent_communication.md)

--- a/docs/swarms/examples/social_algorithms_example.md
+++ b/docs/swarms/examples/social_algorithms_example.md
@@ -484,7 +484,7 @@ print(f"Failed: {result.failed_steps}")
 
 ## Next Steps
 
-- Explore [SocialAlgorithms Quickstart](../../examples/social_algorithms_quickstart.md)
+- Explore the [SocialAlgorithms Reference](../structs/social_algorithms.md)
 - See [12+ Algorithm Examples](https://github.com/kyegomez/swarms/tree/master/examples/multi_agent/social_algorithms_examples)
 - Study patterns: Consensus, Negotiation, Peer Review, Auction, Hierarchical
 - Design your own custom communication protocols

--- a/docs/swarms/examples/x402_tools_agent.md
+++ b/docs/swarms/examples/x402_tools_agent.md
@@ -728,7 +728,7 @@ print(result)
 
 
 For more detailed information about X402 integration, see:
-- [X402 Payment Integration](../examples/x402_payment_integration.md)
-- [X402 Discovery Query](../examples/x402_discovery_query.md)
+- [X402 Service Purchase Agent](#example-2-x402-service-purchase-agent)
+- [X402 Discovery Agent](#example-1-x402-discovery-agent)
 - [X402 Documentation](https://docs.cdp.coinbase.com/x402)
 

--- a/docs/swarms/structs/custom_swarm.md
+++ b/docs/swarms/structs/custom_swarm.md
@@ -699,7 +699,7 @@ def run_batch_analysis():
 
 ## Conversation Management Integration
 
-The swarm uses the Swarms framework's [Conversation structure](../conversation/) for comprehensive message storage and management. This provides:
+The swarm uses the Swarms framework's [Conversation structure](conversation.md) for comprehensive message storage and management. This provides:
 
 ### Key Features
 
@@ -753,7 +753,7 @@ stats = swarm.conversation.count_messages_by_role()
 token_usage = swarm.conversation.export_and_count_categories()
 ```
 
-For complete documentation on conversation management, see the [Conversation Structure Documentation](../conversation/).
+For complete documentation on conversation management, see the [Conversation Structure Documentation](conversation.md).
 
 
 ---
@@ -784,18 +784,18 @@ By following the patterns and best practices outlined in this guide, you can cre
 5. **Test thoroughly** with unit tests and integration tests
 6. **Configure appropriately** for your deployment environment
 
-For more advanced patterns and examples, explore the [Swarms Examples](../../examples/) and consider contributing your custom swarms back to the community by submitting a pull request to the [Swarms repository](https://github.com/kyegomez/swarms).
+For more advanced patterns and examples, explore the [Swarms Examples](../examples/unique_swarms.md) and consider contributing your custom swarms back to the community by submitting a pull request to the [Swarms repository](https://github.com/kyegomez/swarms).
 
 ---
 
 ## Additional Resources
 
-- [Conversation Structure Documentation](../conversation/) - Complete guide to conversation management
+- [Conversation Structure Documentation](conversation.md) - Complete guide to conversation management
 
-- [Agent Documentation](../../agents/) - Learn about creating and configuring agents
+- [Agent Documentation](../agents/index.md) - Learn about creating and configuring agents
 
-- [Multi-Agent Architectures](../overview/) - Explore other swarm patterns and architectures
+- [Multi-Agent Architectures](overview.md) - Explore other swarm patterns and architectures
 
-- [Examples Repository](../../examples/) - Real-world swarm implementations
+- [Examples Repository](../examples/unique_swarms.md) - Real-world swarm implementations
 
 - [Swarms Framework GitHub](https://github.com/kyegomez/swarms) - Source code and contributions

--- a/docs/swarms/structs/overview.md
+++ b/docs/swarms/structs/overview.md
@@ -8,7 +8,7 @@ This page provides a comprehensive overview of all available multi-agent archite
     | Architecture | Use Case | Key Functionality | Documentation |
     |-------------|----------|-------------------|---------------|
     | MajorityVoting | Decision making through consensus | Combines multiple agent opinions and selects the most common answer | [Docs](majorityvoting.md) |
-    | MAKER | Long-horizon precision | Step-wise decomposition with first-to-ahead-by-k voting and red-flagging per step | [Docs](maker.md) |
+    | MAKER | Long-horizon precision | Step-wise decomposition with first-to-ahead-by-k voting and red-flagging per step | Planned docs |
     | AgentRearrange | Optimizing agent order | Dynamically reorders agents based on task requirements | [Docs](agent_rearrange.md) |
     | RoundRobin | Equal task distribution | Cycles through agents in a fixed order | [Docs](round_robin_swarm.md) |
     | Mixture of Agents | Complex problem solving | Combines diverse expert agents for comprehensive analysis | [Docs](moa.md) |


### PR DESCRIPTION
## Summary

- Fix broken relative links across CLI, examples, agent, and structs documentation pages.
- Replace links to missing quickstart pages with existing reference/example pages.
- Convert missing X402 cross-links to same-page anchors and mark the missing MAKER docs link as planned.
- Leave the `support.md` SIP links alone because an existing open PR already adds that SIP page.

## Validation

- `git diff --check`
- Ran a local Markdown relative-link check. Result: only the three existing `docs/swarms/support.md` SIP links remain, and those are already covered by another open PR.

## Documentation bounty

Please consider this PR for the Swarms Documentation Bounty Program.

Expected tier: Silver ($5-$20), if maintainers agree after review/merge.

Preferred payout method if awarded: PayPal.
PayPal: https://paypal.me/ShaimaaElkadi
