### PR TITLE
docs: fix example syntax snippets

### DIFF
--- a/docs/swarms/examples/council_as_judge_example.md
+++ b/docs/swarms/examples/council_as_judge_example.md
@@ -211,7 +211,7 @@ print(eval_b)
 
 ### Example 3: Evaluating Technical Documentation
 
-```python
+````python
 from swarms import CouncilAsAJudge
 
 # Council for technical documentation
@@ -281,7 +281,7 @@ evaluation = council.run(task=api_docs)
 print("DOCUMENTATION QUALITY EVALUATION:")
 print("="*60)
 print(evaluation)
-```
+````
 
 ---
 

--- a/docs/swarms/examples/react_agent_tutorial.md
+++ b/docs/swarms/examples/react_agent_tutorial.md
@@ -267,7 +267,7 @@ my_tool_schema = {
 }
 
 self.agent = Agent(
-    ...
+    ...,
     tools_list_dictionary=[react_agent_schema, my_tool_schema],
 )
 ```

--- a/docs/swarms/examples/unique_swarms.md
+++ b/docs/swarms/examples/unique_swarms.md
@@ -28,7 +28,8 @@ Return types are generally `Union[dict, List[str]]`, where:
 
 ### Circular Swarm
 ```python
-def circular_swarm(agents: AgentListType, tasks: List[str], return_full_history: bool = True)
+def circular_swarm(agents: AgentListType, tasks: List[str], return_full_history: bool = True):
+    ...
 ```
 
 **Information Flow:**
@@ -63,7 +64,8 @@ flowchart LR
 
 ### Star Swarm
 ```python
-def star_swarm(agents: AgentListType, tasks: List[str], return_full_history: bool = True)
+def star_swarm(agents: AgentListType, tasks: List[str], return_full_history: bool = True):
+    ...
 ```
 
 **Information Flow:**
@@ -97,7 +99,8 @@ flowchart TD
 
 ### Mesh Swarm
 ```python
-def mesh_swarm(agents: AgentListType, tasks: List[str], return_full_history: bool = True)
+def mesh_swarm(agents: AgentListType, tasks: List[str], return_full_history: bool = True):
+    ...
 ```
 
 **Information Flow:**
@@ -134,7 +137,8 @@ flowchart TD
 
 ### Pyramid Swarm
 ```python
-def pyramid_swarm(agents: AgentListType, tasks: List[str], return_full_history: bool = True)
+def pyramid_swarm(agents: AgentListType, tasks: List[str], return_full_history: bool = True):
+    ...
 ```
 
 **Information Flow:**
@@ -176,7 +180,8 @@ flowchart TD
 
 ### One-to-One Communication
 ```python
-def one_to_one(sender: Agent, receiver: Agent, task: str, max_loops: int = 1) -> str
+def one_to_one(sender: Agent, receiver: Agent, task: str, max_loops: int = 1) -> str:
+    ...
 ```
 
 **Information Flow:**
@@ -197,7 +202,8 @@ flowchart LR
 
 ### Broadcast Communication
 ```python
-async def broadcast(sender: Agent, agents: AgentListType, task: str) -> None
+async def broadcast(sender: Agent, agents: AgentListType, task: str) -> None:
+    ...
 ```
 
 **Information Flow:**


### PR DESCRIPTION
## Summary

- Fix six `unique_swarms` Python signature snippets so they are valid skeleton definitions.
- Add the missing comma after `...` in the React agent tutorial's `Agent(...)` example.
- Use a four-backtick Python fence for the Council-as-Judge example that embeds JSON code fences inside a triple-quoted string.

## Validation

- `git diff --check`
- Parsed every Python/py fenced block in the three changed documentation files with `ast.parse`; all passed.

## Documentation bounty

Please consider this PR for the Swarms Documentation Bounty Program.

Expected tier: Silver ($5-$20), if maintainers agree after review/merge.

Preferred payout method if awarded: PayPal.
PayPal: https://paypal.me/ShaimaaElkadi
