### PR TITLE
docs: add missing protocol and bounty pages

### DIFF
--- a/docs/governance/bounty_program.md
+++ b/docs/governance/bounty_program.md
@@ -1,0 +1,40 @@
+# Documentation Bounty Program
+
+The Swarms documentation bounty program rewards contributors who improve the
+clarity, accuracy, and usefulness of the documentation. Eligible work includes
+fixing broken documentation paths, adding focused examples, improving tutorials,
+and documenting user-facing behavior that is missing from the current site.
+
+## Eligible Contributions
+
+Examples of bounty-eligible documentation work include:
+
+- Broken links, missing navigation pages, and stale references.
+- Small examples that clarify an existing agent, swarm, or tool API.
+- Tutorials that help users complete a real workflow.
+- Updates that align docs with current code behavior.
+- Contributor-facing guides that make the project easier to maintain.
+
+Routine typo fixes are welcome, but very small changes may be grouped with
+other improvements before they are considered for a reward.
+
+## Reward Tiers
+
+| Tier | Scope | Typical Reward |
+| --- | --- | --- |
+| Bronze | Typos, small wording fixes, or very small link repairs | $1 - $5 |
+| Silver | Focused examples, small tutorials, or 100-500 word improvements | $5 - $20 |
+| Gold | Major guides, broad rewrites, or more than 500 words of new material | $20 - $50 |
+
+Final reward decisions are made by the maintainers after review and merge.
+
+## Claim Process
+
+1. Open a pull request with a clear description of the documentation problem.
+2. Add `bounty-eligible` to the PR body or request it during review.
+3. Include validation notes, such as link checks or pages reviewed.
+4. Wait for maintainer review and merge.
+5. Coordinate the preferred payout method after approval.
+
+Supported payout methods may include PayPal, crypto, or wire transfer,
+depending on maintainer approval and contributor eligibility.

--- a/docs/protocol/overview.md
+++ b/docs/protocol/overview.md
@@ -1,0 +1,30 @@
+# Swarms Protocol Overview
+
+The Swarms protocol documents describe how contributors propose, review, and
+standardize changes that affect the public behavior of the Swarms framework.
+They are intended for changes that need more coordination than a normal pull
+request, such as new agent patterns, changes to orchestration semantics, shared
+tooling conventions, or compatibility rules for ecosystem integrations.
+
+Use the protocol process when a change affects more than one page, package, or
+user-facing workflow. Small documentation edits, typo fixes, and isolated
+examples should still go directly through the standard pull request process.
+
+## What Belongs In A Protocol Proposal
+
+A strong proposal should include:
+
+- A clear problem statement and the users affected by it.
+- The proposed behavior, API, or documentation contract.
+- Compatibility notes for existing users and examples.
+- Alternatives considered and why they were not selected.
+- A rollout plan, including docs, tests, and migration notes when needed.
+
+## Review Flow
+
+1. Open a GitHub issue or discussion describing the change.
+2. Draft a Swarms Improvement Proposal using the SIP guidelines.
+3. Link any implementation pull requests back to the proposal.
+4. Incorporate maintainer feedback before treating the proposal as accepted.
+
+See the [SIP guidelines](sip.md) for the recommended proposal structure.

--- a/docs/protocol/sip.md
+++ b/docs/protocol/sip.md
@@ -1,0 +1,51 @@
+# Swarms Improvement Proposals
+
+Swarms Improvement Proposals, or SIPs, are lightweight design documents for
+changes that need shared agreement before implementation. They help contributors
+explain the motivation, expected behavior, and migration impact of larger
+changes before code or documentation is split across several pull requests.
+
+## When To Write An SIP
+
+Write an SIP for:
+
+- New public agent, swarm, or workflow abstractions.
+- Changes to existing public APIs or configuration behavior.
+- Cross-repository integrations that need a stable contract.
+- Major documentation reorganizations or new contributor programs.
+- Changes that require coordinated examples, tests, and migration guidance.
+
+You do not need an SIP for small bug fixes, typo corrections, narrow examples,
+or documentation pages that clarify existing behavior.
+
+## Suggested Template
+
+```markdown
+# SIP: Short Title
+
+## Summary
+One or two paragraphs explaining the proposed change.
+
+## Motivation
+Why this change matters and which users it helps.
+
+## Detailed Design
+The API, behavior, documentation structure, or process being proposed.
+
+## Compatibility
+Expected migration impact, deprecations, or backwards-compatibility notes.
+
+## Alternatives
+Other options considered and why this proposal is preferred.
+
+## Rollout Plan
+Implementation steps, documentation updates, tests, and follow-up work.
+```
+
+## Submission Checklist
+
+- Link the SIP to the related issue, discussion, or pull request.
+- Keep the first version concise enough for maintainers to review quickly.
+- Call out breaking changes explicitly.
+- Include examples when the proposal changes developer-facing behavior.
+- Update the SIP after review so the accepted decision is easy to find later.

--- a/docs/swarms/support.md
+++ b/docs/swarms/support.md
@@ -15,7 +15,7 @@ The Swarms team is committed to providing exceptional technical support to help 
 | **Support Type** | **Best For** | **Response Time** | **Channel** |
 |------------------|--------------|-------------------|-------------|
 | **Bug Reports** | Code issues, errors, unexpected behavior | < 24 hours | [GitHub Issues](https://github.com/kyegomez/swarms/issues) |
-| **Major Features (SIPs)** | New agent types, core changes, integrations | 1-2 weeks | [SIP Guidelines](protocol/sip.md) |
+| **Major Features (SIPs)** | New agent types, core changes, integrations | 1-2 weeks | [SIP Guidelines](../protocol/sip.md) |
 | **Minor Features** | Small enhancements, straightforward additions | < 48 hours | [GitHub Issues](https://github.com/kyegomez/swarms/issues) |
 | **Private Issues** | Security concerns, enterprise consulting | < 4 hours | [Book Support Call](https://cal.com/swarms/swarms-technical-support?overlayCalendar=true) |
 | **Real-time Help** | Quick questions, community discussions | Immediate | [Discord Community](https://discord.gg/EamjgSaEQf) |
@@ -239,7 +239,7 @@ The primary way to propose new features and significant enhancements to the Swar
 3. **Community Review**: Engage with feedback and iterate on the proposal
 4. **Implementation**: Once accepted, work on the implementation
 
-For detailed guidelines on creating and submitting SIPs, visit our [SIP Guidelines](protocol/sip.md).
+For detailed guidelines on creating and submitting SIPs, visit our [SIP Guidelines](../protocol/sip.md).
 
 ### **Other Feature Requests**
 
@@ -370,7 +370,7 @@ Help improve support for everyone:
 | **Emergency** | [Book Immediate Call](https://cal.com/swarms/swarms-technical-support?overlayCalendar=true) |
 | **Urgent** | [Discord #technical-support](https://discord.gg/EamjgSaEQf) |
 | **Standard** | [GitHub Issues](https://github.com/kyegomez/swarms/issues) |
-| **Major Features** | [SIP Guidelines](protocol/sip.md) |
+| **Major Features** | [SIP Guidelines](../protocol/sip.md) |
 | **Minor Features** | [GitHub Issues](https://github.com/kyegomez/swarms/issues) |
 
 **We're here to help you succeed with Swarms.**


### PR DESCRIPTION
## Summary

- add the missing `docs/protocol/overview.md` and `docs/protocol/sip.md` pages referenced by the docs navigation
- add the missing `docs/governance/bounty_program.md` page referenced by the docs navigation
- update support-page SIP links so they resolve to the new SIP guidelines page

## Validation

- `git diff --cached --check`
- local link scan confirms the touched SIP/support links now resolve

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
