### PR TITLE
docs: add home and quickstart pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+# Swarms Documentation
+
+Swarms is a production-ready framework for building, running, and coordinating
+multi-agent systems. The documentation covers installation, agent construction,
+multi-agent orchestration patterns, model provider configuration, tools,
+deployment workflows, and contribution guidelines.
+
+## Start Here
+
+- [Installation](swarms/install/install.md): install Swarms and prepare your environment.
+- [Quickstart](quickstart.md): create a first agent and run a simple task.
+- [Agents](swarms/agents/index.md): learn the core agent APIs and configuration options.
+- [Multi-Agent Architectures](swarms/structs/index.md): explore swarms, routers, councils, workflows, and group chat patterns.
+- [Examples](swarms/examples/basic_agent.md): use runnable examples as starting points for your own applications.
+
+## What You Can Build
+
+Swarms supports single-agent applications, collaborative multi-agent teams,
+structured workflows, routing systems, tool-using agents, and production
+automation patterns. You can start with a single agent and gradually add
+conversation memory, tools, structured outputs, concurrent execution, or a
+larger orchestration layer as your use case grows.
+
+## Contributing
+
+Documentation improvements, examples, issue reports, and code contributions are
+welcome. See the [documentation contributor guide](contributors/docs.md) for
+style expectations, review flow, and bounty eligibility.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart
+
+This quickstart creates a Swarms agent, sends it a task, and prints the result.
+It is the shortest path from a fresh environment to a working local agent.
+
+## Install
+
+```bash
+pip install swarms
+```
+
+Set an API key for the model provider you want to use. For OpenAI-compatible
+models, export `OPENAI_API_KEY` before running the example.
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+```
+
+## Create An Agent
+
+```python
+from swarms import Agent
+
+agent = Agent(
+    agent_name="Research-Agent",
+    system_prompt="You are a concise research assistant.",
+    model_name="gpt-4o-mini",
+    max_loops=1,
+)
+
+response = agent.run("List three practical uses for multi-agent workflows.")
+print(response)
+```
+
+## Next Steps
+
+- Configure environment variables with the [environment setup guide](swarms/install/env.md).
+- Explore model choices in the [model providers guide](swarms/examples/model_providers.md).
+- Add tools with the [tools documentation](swarms/tools/main.md).
+- Move from one agent to teams with the [multi-agent architecture guide](swarms/structs/index.md).


### PR DESCRIPTION
## Summary

- add the missing `docs/index.md` page referenced by the Home overview nav
- add the missing `docs/quickstart.md` page referenced by the onboarding nav
- include short paths into installation, environment setup, examples, tools, and multi-agent architecture docs

## Validation

- `git diff --cached --check`
- confirmed linked local docs pages exist:
  - `docs/swarms/examples/basic_agent.md`
  - `docs/swarms/install/env.md`
  - `docs/swarms/tools/main.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
