### PR TITLE
docs: add deployment solution pages

### DIFF
--- a/docs/deployment_solutions/fastapi_agent_api.md
+++ b/docs/deployment_solutions/fastapi_agent_api.md
@@ -1,0 +1,75 @@
+# FastAPI + Uvicorn
+
+FastAPI is a straightforward way to expose a Swarms agent through an HTTP API. It works well for internal tools, product backends, prototypes, and services that need a predictable request-response interface.
+
+## Install
+
+```bash
+pip install -U swarms fastapi uvicorn
+```
+
+Set the model provider credentials required by your agent:
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+```
+
+## Example API
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from swarms import Agent
+
+
+class AgentRequest(BaseModel):
+    task: str = Field(..., min_length=1)
+
+
+class AgentResponse(BaseModel):
+    result: str
+
+
+agent = Agent(
+    agent_name="API-Agent",
+    agent_description="Handles API requests with a bounded agent loop.",
+    model_name="gpt-4.1",
+    max_loops=1,
+)
+
+app = FastAPI(title="Swarms Agent API")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/run", response_model=AgentResponse)
+def run_agent(request: AgentRequest) -> AgentResponse:
+    result = agent.run(request.task)
+    return AgentResponse(result=str(result))
+```
+
+Run the service locally:
+
+```bash
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+Then call it:
+
+```bash
+curl -X POST http://localhost:8000/run \
+  -H "Content-Type: application/json" \
+  -d '{"task": "Summarize the latest customer feedback themes."}'
+```
+
+## Deployment Notes
+
+- Create the agent at startup instead of rebuilding it on every request.
+- Keep `max_loops` low for synchronous APIs.
+- Use background jobs for long-running workflows.
+- Add authentication before exposing the API publicly.
+- Log errors without printing secrets or full provider responses.
+- Put provider keys, model names, and service settings in environment variables.

--- a/docs/deployment_solutions/overview.md
+++ b/docs/deployment_solutions/overview.md
@@ -1,0 +1,38 @@
+# Deployment Solutions
+
+Swarms agents can run in notebooks, scripts, API services, scheduled jobs, and cloud platforms. This section collects deployment patterns for moving an agent or swarm from a local experiment into a repeatable production workflow.
+
+Start with the smallest deployment that gives your users a stable interface. A single FastAPI service is often enough for request-response workflows, while scheduled jobs and cloud workers are better for background tasks, monitoring, and event-driven automation.
+
+## Deployment Options
+
+| Pattern | Best for |
+| --- | --- |
+| FastAPI service | HTTP APIs, internal tools, dashboards, and application backends |
+| Cron job | Scheduled research, reporting, and recurring agent runs |
+| MCP server | Exposing an agent or tool to MCP-compatible clients |
+| Cloud Run | Containerized APIs with managed scaling |
+| Cloudflare Workers | Lightweight edge workflows and low-latency request handling |
+| Phala | Trusted execution and confidential workloads |
+
+## Production Checklist
+
+- Keep API keys and provider credentials in environment variables.
+- Set request timeouts for tools and model calls.
+- Log request IDs, agent names, and high-level run status.
+- Add health checks before putting an agent behind a load balancer.
+- Bound agent loop counts and tool calls for predictable cost.
+- Validate inputs before sending them to the agent.
+- Store long-running task state outside the process when reliability matters.
+
+## Minimal Service Shape
+
+Most deployments follow the same shape:
+
+1. Load configuration from the environment.
+2. Create the agent or swarm once during process startup.
+3. Validate incoming user input.
+4. Run the agent with bounded settings.
+5. Return a structured response to the caller.
+
+For a concrete HTTP example, see [FastAPI + Uvicorn](fastapi_agent_api.md). For scheduled jobs, see the [CronJob reference](../swarms/structs/cron_job.md).

--- a/docs/examples/mcp_ds.md
+++ b/docs/examples/mcp_ds.md
@@ -1,0 +1,51 @@
+# Agent on MCP
+
+Model Context Protocol (MCP) lets an agent workflow expose tools or capabilities to MCP-compatible clients. Use this pattern when you want another application to call a Swarms-backed capability through a standard tool interface.
+
+The Swarms docs include MCP client utilities in the [MCP client reference](../swarms/tools/mcp_client_call.md). This page shows the deployment shape for wrapping an agent workflow as a service.
+
+## When to Use MCP
+
+- You need a reusable agent capability that can be called by multiple clients.
+- You want a stable tool boundary around an internal workflow.
+- You want to separate the agent runtime from the UI or orchestration layer.
+- You need to expose selected actions without exposing the full application.
+
+## Service Pattern
+
+An MCP-style deployment usually has three pieces:
+
+1. A Swarms agent or swarm that performs the work.
+2. A small server that exposes approved tools.
+3. Client configuration that points an MCP-compatible client at the server.
+
+Keep the exported tools narrow and explicit. Each tool should validate inputs, call the agent with bounded settings, and return a compact result.
+
+## Example Tool Wrapper
+
+```python
+from swarms import Agent
+
+
+agent = Agent(
+    agent_name="MCP-Research-Agent",
+    model_name="gpt-4.1",
+    max_loops=1,
+)
+
+
+def run_research_task(topic: str) -> str:
+    """Run a bounded research task for an MCP client."""
+    return str(agent.run(f"Research this topic and return concise notes: {topic}"))
+```
+
+The wrapper can then be registered with the MCP server framework used by your deployment environment.
+
+## Deployment Checklist
+
+- Expose only the tools the client needs.
+- Validate all arguments before calling the agent.
+- Keep loop counts and tool calls bounded.
+- Store credentials in environment variables.
+- Add request logging and error handling around every exported tool.
+- Avoid returning secrets, raw stack traces, or oversized intermediate context.


### PR DESCRIPTION
## Summary

- add the missing `docs/deployment_solutions/overview.md` page referenced by the Deployment Solutions nav
- add the missing `docs/deployment_solutions/fastapi_agent_api.md` FastAPI + Uvicorn deployment guide
- add the missing `docs/examples/mcp_ds.md` Agent on MCP deployment page

## Validation

- `git diff --cached --check`
- confirmed the nav-target pages exist locally:
  - `docs/deployment_solutions/overview.md`
  - `docs/deployment_solutions/fastapi_agent_api.md`
  - `docs/examples/mcp_ds.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/structs/cron_job.md`
  - `docs/swarms/tools/mcp_client_call.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
