### PR TITLE
docs: add cloud deployment pages

### DIFF
--- a/docs/swarms_cloud/cloud_run.md
+++ b/docs/swarms_cloud/cloud_run.md
@@ -1,0 +1,48 @@
+# Deploy on Google Cloud Run
+
+Google Cloud Run is a good target for containerized Swarms APIs because it provides managed HTTPS, autoscaling, and simple environment-variable configuration.
+
+Use this pattern when you have a FastAPI, Flask, or similar HTTP service that wraps an agent or swarm.
+
+## Prerequisites
+
+- Google Cloud project with billing enabled
+- `gcloud` CLI installed and authenticated
+- Dockerfile for the Swarms service
+- Required model provider keys stored as environment variables
+
+## Minimal Dockerfile
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
+```
+
+Cloud Run injects the `PORT` environment variable, but `8080` is the default expected port and works for most deployments.
+
+## Deploy
+
+```bash
+gcloud run deploy swarms-agent-api \
+  --source . \
+  --region us-central1 \
+  --allow-unauthenticated \
+  --set-env-vars OPENAI_API_KEY="$OPENAI_API_KEY"
+```
+
+For private services, remove `--allow-unauthenticated` and configure IAM access for callers.
+
+## Operational Notes
+
+- Keep synchronous agent APIs bounded with low `max_loops` values.
+- Use Cloud Run minimum instances only when cold starts are a problem.
+- Store sensitive values in Secret Manager for production deployments.
+- Add a `/health` route so uptime checks can verify the service.
+- Log request IDs and high-level agent status, not raw secrets or long prompts.
+- Move long-running workflows to background jobs or queues instead of blocking an HTTP request.

--- a/docs/swarms_cloud/cloudflare_workers.md
+++ b/docs/swarms_cloud/cloudflare_workers.md
@@ -1,0 +1,56 @@
+# Deploy on Cloudflare Workers
+
+Cloudflare Workers are useful for lightweight edge workflows around Swarms systems, especially request routing, simple preprocessing, webhook intake, and calls to a hosted Swarms API.
+
+Workers are not a full Python runtime for running the Swarms Python package directly. Use a Worker as an edge adapter when your agent is hosted behind an HTTP API such as Cloud Run, a VM, or another container platform.
+
+## Good Fit
+
+- Routing requests to a hosted Swarms API
+- Validating lightweight payloads at the edge
+- Receiving webhooks and forwarding compact tasks
+- Adding simple authentication checks before traffic reaches the agent service
+
+## Worker Example
+
+```javascript
+export default {
+  async fetch(request, env) {
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    const payload = await request.json();
+    const response = await fetch(env.SWARMS_API_URL + "/run", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${env.SWARMS_API_TOKEN}`,
+      },
+      body: JSON.stringify({ task: payload.task }),
+    });
+
+    return new Response(await response.text(), {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+};
+```
+
+## Configuration
+
+Set the hosted Swarms service URL and token as Worker environment variables or secrets:
+
+```bash
+wrangler secret put SWARMS_API_TOKEN
+wrangler secret put SWARMS_API_URL
+```
+
+## Operational Notes
+
+- Keep the Worker focused on edge concerns and call the Swarms runtime over HTTP.
+- Validate payload size and required fields before forwarding.
+- Do not store provider keys in client-side code.
+- Add rate limiting or authentication before public endpoints.
+- Return compact errors so callers can retry safely.

--- a/docs/swarms_cloud/phala_deploy.md
+++ b/docs/swarms_cloud/phala_deploy.md
@@ -1,0 +1,42 @@
+# Deploy on Phala
+
+Phala can be used for trusted execution environment (TEE) deployments where a Swarms workload needs stronger isolation guarantees. This is useful for confidential agent workflows, private prompts, or workloads that process sensitive external inputs.
+
+Use this page as a deployment checklist and adapt the exact commands to the Phala environment and template you are using.
+
+## Good Fit
+
+- Confidential agent workflows
+- Private data processing
+- Services that need verifiable execution properties
+- Workloads where secrets should stay isolated from the host environment
+
+## Service Shape
+
+Package the Swarms application as a containerized HTTP service:
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+The service should expose a health check and one or more narrow endpoints that call the agent with validated inputs.
+
+## Deployment Checklist
+
+- Keep provider API keys and secrets out of source code.
+- Pass secrets through the deployment environment or secret manager.
+- Validate request payloads before invoking the agent.
+- Bound loops, retries, and tool calls to avoid unexpected cost.
+- Avoid logging private prompts, secrets, or raw confidential data.
+- Document what data enters and exits the trusted environment.
+
+## Runtime Notes
+
+For production workloads, prefer small explicit APIs over broad generic agent endpoints. This makes it easier to audit what the deployment is allowed to do and what data leaves the environment.


### PR DESCRIPTION
## Summary

- add the missing `docs/swarms_cloud/cloud_run.md` page referenced by the Deployment Solutions provider nav
- add the missing `docs/swarms_cloud/phala_deploy.md` page referenced by the provider nav
- add the missing `docs/swarms_cloud/cloudflare_workers.md` page referenced by the provider nav

## Validation

- `git diff --cached --check`
- confirmed the nav-target pages exist locally:
  - `docs/swarms_cloud/cloud_run.md`
  - `docs/swarms_cloud/phala_deploy.md`
  - `docs/swarms_cloud/cloudflare_workers.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
