### PR TITLE
docs: add v10 changelog page

### DIFF
--- a/docs/changelogs/v10.md
+++ b/docs/changelogs/v10.md
@@ -1,0 +1,45 @@
+# Swarms v10 Changelog
+
+This page preserves the v10 changelog route used by the documentation navigation and gives users a compact place to check upgrade notes before moving older projects forward.
+
+For exact package releases, tags, and commit-level history, use the [Swarms GitHub releases](https://github.com/kyegomez/swarms/releases) and PyPI package history. The notes below focus on documentation and migration checks that are useful when maintaining existing Swarms projects.
+
+## Upgrade Checklist
+
+- Upgrade Swarms in a clean environment:
+
+```bash
+pip install -U swarms
+```
+
+- Confirm Python compatibility with the environment setup guide.
+- Re-run smoke tests for agents, swarms, tool calls, and structured outputs.
+- Check API keys and model provider environment variables.
+- Review any custom tools for typed parameters and serializable return values.
+- Pin versions for production deployments before rolling changes out broadly.
+
+## Areas to Review
+
+### Agents and Swarms
+
+Review agent construction, loop limits, model names, and tool configuration. If an existing workflow depends on older defaults, make those settings explicit in code before upgrading.
+
+### Tools and MCP
+
+Tool definitions should use clear type hints, stable input names, and predictable string or JSON-string outputs. For MCP workflows, verify server configuration and connection settings in the deployment environment.
+
+### Structured Outputs
+
+Structured-output workflows should validate their Pydantic schemas and include fallback handling for malformed model responses. Re-run examples that parse model output before moving production traffic.
+
+### Deployment
+
+Deployment scripts should read secrets from environment variables, expose a health check where possible, and keep synchronous agent runs bounded with explicit loop and timeout settings.
+
+## Related Docs
+
+- [Installation](../swarms/install/install.md)
+- [Environment Setup](../swarms/install/env.md)
+- [Agent Reference](../swarms/structs/agent.md)
+- [Tool System](../swarms/tools/main.md)
+- [Testing Guide](../swarms/framework/test.md)


### PR DESCRIPTION
## Summary

- add the missing `docs/changelogs/v10.md` page referenced by the docs navigation
- provide a compact v10 route page with upgrade checks and links to existing install, environment, agent, tool, and testing docs
- avoid inventing release-specific claims by pointing exact release history to GitHub releases and PyPI

## Validation

- `git diff --cached --check`
- confirmed the nav-target page exists locally: `docs/changelogs/v10.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/install/install.md`
  - `docs/swarms/install/env.md`
  - `docs/swarms/structs/agent.md`
  - `docs/swarms/tools/main.md`
  - `docs/swarms/framework/test.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
