### PR TITLE
docs: add swarms tools nav pages

### DIFF
--- a/docs/swarms_tools/finance.md
+++ b/docs/swarms_tools/finance.md
@@ -1,0 +1,52 @@
+# Finance Tools
+
+Finance tools let Swarms agents retrieve market data, portfolio context, filings, risk signals, or other financial inputs before producing an analysis. They are useful when an agent needs live or structured data instead of relying on model memory.
+
+For a working example that uses `swarms-tools`, see the [Yahoo Finance example](../swarms/examples/yahoo_finance.md).
+
+## Common Use Cases
+
+- Looking up public market data for a ticker
+- Summarizing portfolio or watchlist metrics
+- Fetching macroeconomic indicators from a provider API
+- Comparing assets against a fixed scoring rubric
+- Pulling price, volume, or fundamentals data before an agent writes a report
+
+## Example
+
+```python
+import os
+import requests
+
+
+def get_market_snapshot(symbol: str) -> str:
+    """Return a compact market snapshot for a ticker symbol."""
+    api_key = os.getenv("MARKET_DATA_API_KEY")
+    response = requests.get(
+        "https://api.example.com/markets/snapshot",
+        params={"symbol": symbol, "api_key": api_key},
+        timeout=20,
+    )
+    response.raise_for_status()
+    return response.text
+```
+
+```python
+from swarms import Agent
+
+finance_agent = Agent(
+    agent_name="Finance-Agent",
+    model_name="gpt-4.1",
+    tools=[get_market_snapshot],
+)
+
+finance_agent.run("Analyze the current risk profile for NVDA.")
+```
+
+## Notes
+
+- Document the required provider and environment variables.
+- Return the raw provider payload only when the downstream agent needs all fields.
+- Prefer compact JSON for repeatable analysis workflows.
+- Include provider timestamps when the freshness of the data matters.
+- Avoid hardcoding API keys, account identifiers, or private portfolio values.

--- a/docs/swarms_tools/overview.md
+++ b/docs/swarms_tools/overview.md
@@ -1,0 +1,62 @@
+# Swarms Tools
+
+Swarms tools are callable functions that agents can use to reach outside the model, fetch data, call APIs, run deterministic logic, or hand off work to external systems. A tool can be a plain Python function, a Pydantic schema-backed callable, or an integration exposed through MCP.
+
+Use this section when you need domain-specific tool patterns. For the core agent tool interface, start with the [tool system guide](../swarms/tools/main.md), [BaseTool reference](../swarms/tools/base_tool.md), and [MCP client utilities](../swarms/tools/mcp_client_call.md).
+
+## When to Use a Tool
+
+Add a tool when an agent needs a capability that should not be guessed by the language model:
+
+- Fetching current or private data from an API
+- Running a calculation with deterministic output
+- Looking up documents, market data, search results, or social posts
+- Sending data to another service with explicit inputs
+- Wrapping an internal workflow behind a stable function call
+
+Keep tools narrow. A tool should do one job, accept typed inputs, and return a predictable string or serialized result that the agent can reason over.
+
+## Basic Pattern
+
+```python
+import os
+import requests
+
+
+def fetch_public_data(query: str) -> str:
+    """Fetch public data for an agent workflow."""
+    api_key = os.getenv("PUBLIC_DATA_API_KEY")
+    response = requests.get(
+        "https://api.example.com/search",
+        params={"q": query, "api_key": api_key},
+        timeout=20,
+    )
+    response.raise_for_status()
+    return response.text
+```
+
+Then pass the callable to an agent:
+
+```python
+from swarms import Agent
+
+agent = Agent(
+    agent_name="Research-Agent",
+    model_name="gpt-4.1",
+    tools=[fetch_public_data],
+)
+
+agent.run("Find recent public data about battery supply chains.")
+```
+
+## Implementation Checklist
+
+- Use clear function names that describe the external action.
+- Add type hints for every parameter.
+- Read secrets from environment variables with `os.getenv`.
+- Set request timeouts for network calls.
+- Return strings, JSON strings, or concise serialized results.
+- Include enough error handling for the agent to understand failures.
+- Keep side effects explicit in the function name and docstring.
+
+For contribution standards, see [Contributing Tools and Plugins](../contributors/tools.md).

--- a/docs/swarms_tools/search.md
+++ b/docs/swarms_tools/search.md
@@ -1,0 +1,52 @@
+# Search Tools
+
+Search tools give Swarms agents a controlled way to retrieve external documents, web results, internal knowledge base entries, or indexed records. They are best used when the agent needs fresh context, citations, or a narrow set of retrieved passages before answering.
+
+## Common Use Cases
+
+- Retrieving web search results for a research agent
+- Querying an internal document index
+- Looking up product, policy, or support articles
+- Fetching recent news or public reports
+- Combining search results with a summarization or review agent
+
+## Example
+
+```python
+import os
+import requests
+
+
+def web_search(query: str, limit: int = 5) -> str:
+    """Search a provider API and return serialized results."""
+    api_key = os.getenv("SEARCH_API_KEY")
+    response = requests.get(
+        "https://api.example.com/search",
+        params={"q": query, "limit": limit, "api_key": api_key},
+        timeout=20,
+    )
+    response.raise_for_status()
+    return response.text
+```
+
+```python
+from swarms import Agent
+
+research_agent = Agent(
+    agent_name="Search-Agent",
+    model_name="gpt-4.1",
+    tools=[web_search],
+)
+
+research_agent.run("Find recent sources about multimodal agent evaluation.")
+```
+
+## Retrieval Guidelines
+
+- Keep result counts small enough for the agent to inspect.
+- Return titles, URLs, snippets, and timestamps when available.
+- Preserve source URLs so the agent can cite or compare evidence.
+- Handle empty results with a clear message instead of raising opaque errors.
+- Use provider filters for domain, date range, or document type when possible.
+
+For lower-level tool registration patterns, see the [tool system guide](../swarms/tools/main.md).

--- a/docs/swarms_tools/twitter.md
+++ b/docs/swarms_tools/twitter.md
@@ -1,0 +1,53 @@
+# Twitter Tools
+
+Twitter tools help Swarms agents retrieve posts, profile context, engagement signals, or social conversation data from an approved provider API. They are useful for brand monitoring, market research, creator analytics, and incident response workflows.
+
+Use the patterns in this page with the general [Swarms tool system](../swarms/tools/main.md). Always follow the API provider's terms and privacy requirements.
+
+## Common Use Cases
+
+- Monitoring recent posts for a keyword or account
+- Summarizing public conversation around a launch
+- Tracking engagement changes for a campaign
+- Routing social mentions to a support or research agent
+- Comparing public sentiment across topics
+
+## Example
+
+```python
+import os
+import requests
+
+
+def search_recent_posts(query: str, limit: int = 10) -> str:
+    """Return recent public posts matching a query."""
+    bearer_token = os.getenv("TWITTER_BEARER_TOKEN")
+    response = requests.get(
+        "https://api.example.com/twitter/search",
+        params={"query": query, "limit": limit},
+        headers={"Authorization": f"Bearer {bearer_token}"},
+        timeout=20,
+    )
+    response.raise_for_status()
+    return response.text
+```
+
+```python
+from swarms import Agent
+
+social_agent = Agent(
+    agent_name="Social-Research-Agent",
+    model_name="gpt-4.1",
+    tools=[search_recent_posts],
+)
+
+social_agent.run("Summarize recent public posts about our product launch.")
+```
+
+## Safety and Compliance
+
+- Use official or approved provider APIs.
+- Do not store access tokens in code or documentation examples.
+- Return only the fields needed for the agent's task.
+- Respect rate limits and provider policies.
+- Avoid collecting private, sensitive, or unnecessary personal data.


### PR DESCRIPTION
## Summary

- add the missing `docs/swarms_tools/overview.md` page referenced by the Tools nav
- add finance, search, and Twitter vertical tool pages referenced by the Tools nav
- link the new pages back to the existing Swarms tool system, Yahoo Finance example, and tool contribution guide

## Validation

- `git diff --check`
- confirmed the nav-target pages exist locally:
  - `docs/swarms_tools/overview.md`
  - `docs/swarms_tools/finance.md`
  - `docs/swarms_tools/search.md`
  - `docs/swarms_tools/twitter.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/tools/main.md`
  - `docs/swarms/tools/base_tool.md`
  - `docs/swarms/tools/mcp_client_call.md`
  - `docs/swarms/examples/yahoo_finance.md`
  - `docs/contributors/tools.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
