### PR TITLE
docs: add swarms cloud api pages

### DIFF
--- a/docs/swarms_cloud/python_client.md
+++ b/docs/swarms_cloud/python_client.md
@@ -1,0 +1,45 @@
+# Swarms Cloud Python Client
+
+The Swarms Cloud Python client is the recommended interface for Python applications that need to call hosted Swarms infrastructure. The ecosystem overview links to this route as the Python SDK documentation entry point.
+
+Use this page as a starting point for client setup, environment configuration, and integration patterns.
+
+## Install
+
+```bash
+pip install -U swarms-sdk
+```
+
+## Configuration
+
+Store credentials in environment variables instead of source code:
+
+```bash
+export SWARMS_API_KEY="your-api-key"
+```
+
+For applications with multiple environments, keep development, staging, and production keys separate.
+
+## Integration Pattern
+
+Most Python client integrations follow this shape:
+
+1. Load the API key from the environment.
+2. Create a small wrapper around the hosted operation you need.
+3. Validate inputs before sending requests.
+4. Return compact results to the rest of your application.
+5. Log request status without logging secrets or sensitive payloads.
+
+## Production Checklist
+
+- Keep API keys out of notebooks, commits, and screenshots.
+- Add retries only for idempotent operations.
+- Set request timeouts in application code.
+- Preserve request IDs or trace IDs when debugging production issues.
+- Avoid sending unnecessary private data to hosted endpoints.
+
+## Related Docs
+
+- [Swarms Cloud API](swarms_api.md)
+- [Environment Setup](../swarms/install/env.md)
+- [Contributor Environment Setup](../contributors/environment_setup.md)

--- a/docs/swarms_cloud/swarms_api.md
+++ b/docs/swarms_cloud/swarms_api.md
@@ -1,0 +1,50 @@
+# Swarms Cloud API
+
+The Swarms Cloud API route is referenced by contributor documentation as the hosted API reference entry point. This page gives users a stable local documentation page for API setup, credentials, and integration guidance.
+
+For exact endpoint definitions, request and response schemas, and current hosted API behavior, use the official hosted API documentation for your Swarms Cloud environment.
+
+## Authentication
+
+Use an API key from the Swarms Cloud dashboard or your deployment environment. Keep it in an environment variable:
+
+```bash
+export SWARMS_API_KEY="your-api-key"
+```
+
+Applications should pass credentials through server-side configuration. Do not expose API keys in frontend code.
+
+## Request Pattern
+
+```python
+import os
+import requests
+
+
+def call_swarms_cloud(task: str) -> str:
+    api_key = os.getenv("SWARMS_API_KEY")
+    response = requests.post(
+        "https://api.swarms.world/v1/run",
+        headers={"Authorization": f"Bearer {api_key}"},
+        json={"task": task},
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.text
+```
+
+Adjust the URL and payload shape to the hosted API endpoint you are using.
+
+## Operational Notes
+
+- Validate request payloads before sending them to the API.
+- Set explicit timeouts for all network calls.
+- Keep retries bounded and avoid retrying non-idempotent operations blindly.
+- Log status codes and request IDs, not secrets.
+- Use server-side proxy routes when calling the API from a web application.
+
+## Related Docs
+
+- [Swarms Cloud Python Client](python_client.md)
+- [Environment Setup](../swarms/install/env.md)
+- [Contributor Environment Setup](../contributors/environment_setup.md)


### PR DESCRIPTION
## Summary

- add the missing `docs/swarms_cloud/python_client.md` page referenced by the ecosystem docs
- add the missing `docs/swarms_cloud/swarms_api.md` route referenced by contributor docs
- provide setup, credential, request-pattern, and production checklist guidance without hardcoding secrets

## Validation

- `git diff --cached --check`
- confirmed the new docs pages exist locally:
  - `docs/swarms_cloud/python_client.md`
  - `docs/swarms_cloud/swarms_api.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/install/env.md`
  - `docs/contributors/environment_setup.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
