### PR TITLE
docs: add examples footer pages

### DIFF
--- a/docs/examples/aop_medical.md
+++ b/docs/examples/aop_medical.md
@@ -1,0 +1,25 @@
+# Medical AOP Example
+
+The examples tree includes medical Agent Orchestration Protocol (AOP) workflows that show how to expose domain-specific agents through an AOP server and call them from client scripts.
+
+These examples are for engineering demonstrations only. They are not medical advice and should not be used for clinical decision-making without appropriate review, validation, and compliance controls.
+
+## What the Example Demonstrates
+
+- Creating medical-domain agents
+- Registering agents behind an AOP server
+- Discovering available agents from a client
+- Sending a task to a specific tool or agent
+- Returning structured text results to the caller
+
+## Source Examples
+
+- Medical AOP examples: <https://github.com/kyegomez/swarms/tree/master/examples/guides/aop_examples/medical_aop>
+- AOP examples overview: <https://github.com/kyegomez/swarms/tree/master/examples/guides/aop_examples>
+- AOP client examples: <https://github.com/kyegomez/swarms/tree/master/examples/guides/aop_examples/client>
+
+## Related Docs
+
+- [AOP Reference](../swarms/structs/aop.md)
+- [AOP Server Setup](../swarms/examples/aop_server_example.md)
+- [AOP Cluster Example](../swarms/examples/aop_cluster_example.md)

--- a/docs/examples/gold_etf_research.md
+++ b/docs/examples/gold_etf_research.md
@@ -1,0 +1,34 @@
+# Gold ETF Research Example
+
+The Swarms examples include finance-oriented workflows that can research exchange-traded funds, compare market instruments, and produce structured investment notes.
+
+Use this page as a starting point for adapting Swarms to financial research tasks. This is documentation for building agent workflows, not financial advice.
+
+## Example Pattern
+
+A typical ETF research swarm has:
+
+- A research agent for gathering fund context
+- A risk agent for volatility, liquidity, and concentration concerns
+- A comparison agent for ranking candidate ETFs
+- A final writer or judge agent that produces a concise report
+
+## Prompt Shape
+
+```text
+Compare the top gold ETFs for a long-term portfolio.
+Include ticker, expense ratio, liquidity considerations,
+tracking approach, and key risks. Return a markdown table.
+```
+
+## Related Examples
+
+- Heavy swarm examples: <https://github.com/kyegomez/swarms/tree/master/examples/multi_agent/heavy_swarm_examples>
+- RAG examples with gold ETF sample data: <https://github.com/kyegomez/swarms/tree/master/examples/single_agent/rag>
+- LLM Council ETF examples: <https://github.com/kyegomez/swarms/tree/master/examples/multi_agent/llm_council_examples>
+
+## Related Docs
+
+- [LLM Council Examples](../swarms/examples/llm_council_examples.md)
+- [HeavySwarm](../swarms/structs/heavy_swarm.md)
+- [Agent with Tools](../swarms/examples/agent_with_tools.md)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,23 @@
+# Examples
+
+The Swarms repository includes examples for single agents, multi-agent systems, tools, Agent Orchestration Protocol (AOP), Retrieval Augmented Generation (RAG), streaming, simulations, and deployment workflows.
+
+Use this page as a documentation entry point for the examples linked from the site footer.
+
+## Main Example Areas
+
+- **Single agents**: basic agents, autonomous agents, RAG, model providers, tools, streaming, and MCP integrations.
+- **Multi-agent systems**: graph workflows, hierarchical swarms, councils, debates, majority voting, forest swarms, and orchestration examples.
+- **AOP examples**: server, client, discovery, queue, cluster, and medical AOP examples.
+- **Tools**: browser automation, stagehand, agent-as-tool workflows, and external API integrations.
+- **Guides and workshops**: release-specific tutorials, demos, and workshop material.
+
+## Starting Points
+
+- [Basic Agent](../swarms/examples/basic_agent.md)
+- [Agent with Tools](../swarms/examples/agent_with_tools.md)
+- [LLM Council Examples](../swarms/examples/llm_council_examples.md)
+- [AOP Reference](../swarms/structs/aop.md)
+- [GraphWorkflow](../swarms/structs/graph_workflow.md)
+
+For the full source tree, see the repository examples directory: <https://github.com/kyegomez/swarms/tree/master/examples>.

--- a/docs/examples/templates.md
+++ b/docs/examples/templates.md
@@ -1,0 +1,31 @@
+# Templates and Applications
+
+Swarms examples include reusable templates for common agent and swarm application shapes. These examples are useful when you want a starting point rather than a blank file.
+
+## Template Categories
+
+| Category | Use for |
+| --- | --- |
+| Single agent templates | Basic task execution, model-provider setup, RAG, and tools |
+| Multi-agent templates | Councils, hierarchical teams, majority voting, and graph workflows |
+| AOP templates | Distributed agent services, client scripts, and discovery examples |
+| Domain examples | Finance, medical, legal, product, growth, and research workflows |
+| Deployment examples | API services, scheduled jobs, and cloud-oriented patterns |
+
+## Recommended Flow
+
+1. Start from the smallest example that matches your workflow.
+2. Replace the prompt, model name, and API keys.
+3. Run the example locally with a small task.
+4. Add tests or smoke checks around your own inputs.
+5. Move the workflow into a service or scheduled job only after it is stable.
+
+## Useful Docs
+
+- [Basic Agent](../swarms/examples/basic_agent.md)
+- [Agent with Tools](../swarms/examples/agent_with_tools.md)
+- [SequentialWorkflow](../swarms/structs/sequential_workflow.md)
+- [GraphWorkflow](../swarms/structs/graph_workflow.md)
+- [AOP Reference](../swarms/structs/aop.md)
+
+Full examples source: <https://github.com/kyegomez/swarms/tree/master/examples>.


### PR DESCRIPTION
## Summary

- add the missing `docs/examples/index.md` route linked from the footer examples overview
- add missing footer-linked pages for templates, gold ETF research, and medical AOP examples
- connect the pages to existing Swarms examples/source trees and related local docs

## Validation

- `git diff --cached --check`
- confirmed the new docs pages exist locally:
  - `docs/examples/index.md`
  - `docs/examples/templates.md`
  - `docs/examples/gold_etf_research.md`
  - `docs/examples/aop_medical.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/examples/basic_agent.md`
  - `docs/swarms/examples/agent_with_tools.md`
  - `docs/swarms/examples/llm_council_examples.md`
  - `docs/swarms/structs/aop.md`
  - `docs/swarms/examples/aop_server_example.md`
  - `docs/swarms/examples/aop_cluster_example.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
