### PR TITLE
docs: add top-level examples route

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,34 @@
+# Examples
+
+This page provides a stable top-level route for Swarms examples. Use it when you want runnable patterns for agents, swarms, tools, model providers, streaming, RAG, AOP, and deployment workflows.
+
+## Start Here
+
+- [Basic Agent](swarms/examples/basic_agent.md)
+- [Agent with Tools](swarms/examples/agent_with_tools.md)
+- [Model Providers](swarms/examples/model_providers.md)
+- [Concurrent Workflow Examples](swarms/examples/concurrent_workflow.md)
+- [Swarm Router Examples](swarms/examples/swarm_router.md)
+- [AOP Server Example](swarms/examples/aop_server_example.md)
+
+## Source Tree
+
+The full examples source lives in the repository:
+
+<https://github.com/kyegomez/swarms/tree/master/examples>
+
+Useful source directories include:
+
+- `examples/single_agent/`
+- `examples/multi_agent/`
+- `examples/guides/`
+- `examples/tools/`
+- `examples/utils/`
+
+## How to Use Examples
+
+1. Pick the smallest example that matches your target workflow.
+2. Install the required packages.
+3. Set required API keys in environment variables.
+4. Run the example with a small test task.
+5. Copy the pattern into your application only after it works locally.


### PR DESCRIPTION
## Summary

- add the missing top-level `docs/examples.md` route referenced from support docs
- provide a compact examples gateway with links to existing local docs and the repository examples tree
- include a short checklist for adapting examples safely

## Validation

- `git diff --check`
- confirmed the new route exists locally: `docs/examples.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/examples/basic_agent.md`
  - `docs/swarms/examples/agent_with_tools.md`
  - `docs/swarms/examples/model_providers.md`
  - `docs/swarms/examples/concurrent_workflow.md`
  - `docs/swarms/examples/swarm_router.md`
  - `docs/swarms/examples/aop_server_example.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
