### PR TITLE
docs: add tutorials route

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,0 +1,33 @@
+# Tutorials
+
+This page provides a stable top-level tutorials route for Swarms docs. Use it to find guided walkthroughs for agents, tools, workflows, MCP, deployment, and multi-agent orchestration.
+
+## Core Tutorials
+
+- [Basic Agent](swarms/examples/basic_agent.md)
+- [Agent with Tools](swarms/examples/agent_with_tools.md)
+- [Structured Outputs](swarms/agents/structured_outputs.md)
+- [Model Providers](swarms/examples/model_providers.md)
+- [CLI Quickstart](swarms/cli/cli_quickstart.md)
+
+## Multi-Agent Tutorials
+
+- [SequentialWorkflow](swarms/structs/sequential_workflow.md)
+- [ConcurrentWorkflow Examples](swarms/examples/concurrent_workflow.md)
+- [GraphWorkflow](swarms/structs/graph_workflow.md)
+- [Swarm Router](swarms/examples/swarm_router.md)
+- [LLM Council Examples](swarms/examples/llm_council_examples.md)
+
+## MCP and Deployment
+
+- [Agent MCP](swarms/structs/agent_mcp.md)
+- [MCP Client Utils](swarms/tools/mcp_client_call.md)
+- [AOP Reference](swarms/structs/aop.md)
+- [CronJob](swarms/structs/cron_job.md)
+
+## Learning Path
+
+1. Start with a single agent.
+2. Add tools or structured outputs.
+3. Move to a workflow when one agent is not enough.
+4. Add deployment, MCP, or AOP only after the local workflow is stable.


### PR DESCRIPTION
## Summary

- add the missing top-level `docs/tutorials.md` route referenced from Agent MCP docs
- provide a compact tutorial index for agents, tools, workflows, MCP, AOP, and deployment-adjacent docs
- include a short learning path for new users

## Validation

- `git diff --check`
- confirmed the new route exists locally: `docs/tutorials.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/examples/basic_agent.md`
  - `docs/swarms/examples/agent_with_tools.md`
  - `docs/swarms/agents/structured_outputs.md`
  - `docs/swarms/cli/cli_quickstart.md`
  - `docs/swarms/structs/agent_mcp.md`
  - `docs/swarms/tools/mcp_client_call.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
