### PR TITLE
docs: add interactive groupchat route

### DIFF
--- a/docs/swarms/structs/interactive_groupchat.md
+++ b/docs/swarms/structs/interactive_groupchat.md
@@ -1,0 +1,37 @@
+# Interactive Group Chat
+
+Interactive Group Chat is a collaboration pattern for multi-agent discussions where speaker selection, moderation, and turn-taking matter. The architecture docs link to this route for users who want a deeper explanation of the pattern.
+
+Use this page as a route and pattern reference. For runnable source examples, see the group chat examples in the repository.
+
+## When to Use
+
+- Multi-agent brainstorming
+- Panel discussions
+- Review workflows where agents respond to each other
+- Moderated debates or expert conversations
+- Human-in-the-loop group coordination
+
+## Pattern Shape
+
+An interactive group chat usually includes:
+
+- A moderator or coordinator
+- Two or more specialized agents
+- A turn-selection policy
+- A shared task or discussion goal
+- A stopping condition or final-summary step
+
+## Related Docs
+
+- [GroupChat](group_chat.md)
+- [Swarm Architectures](../concept/swarm_architectures.md)
+- [AgentRearrange](agent_rearrange.md)
+- [Multi-Agent Collaboration](../concept/swarm_architectures.md)
+
+## Source Examples
+
+- `examples/multi_agent/groupchat/enhanced_collaboration_example.py`
+- `examples/multi_agent/groupchat/random_dynamic_speaker_example.py`
+- `examples/multi_agent/groupchat/speaker_function_examples.py`
+- `examples/multi_agent/groupchat/README.md`


### PR DESCRIPTION
## Summary

- add the missing `docs/swarms/structs/interactive_groupchat.md` route linked from architecture docs
- document the interactive group chat pattern and when to use it
- link to existing GroupChat docs, architecture docs, and runnable groupchat examples

## Validation

- `git diff --check`
- confirmed the new route exists locally: `docs/swarms/structs/interactive_groupchat.md`
- confirmed linked/reference files exist:
  - `docs/swarms/structs/group_chat.md`
  - `docs/swarms/concept/swarm_architectures.md`
  - `docs/swarms/structs/agent_rearrange.md`
  - `examples/multi_agent/groupchat/enhanced_collaboration_example.py`
  - `examples/multi_agent/groupchat/random_dynamic_speaker_example.py`
  - `examples/multi_agent/groupchat/speaker_function_examples.py`
  - `examples/multi_agent/groupchat/README.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
