### PR TITLE
docs: add dynamic conversational swarm route

### DIFF
--- a/docs/swarms/structs/dynamic_conversational_swarm.md
+++ b/docs/swarms/structs/dynamic_conversational_swarm.md
@@ -1,0 +1,41 @@
+# Dynamic Conversational Swarm
+
+Dynamic Conversational Swarm is a multi-agent conversation pattern where agents participate in a flexible discussion rather than following a fixed linear route. The architecture docs link to this route for users exploring adaptive conversation-based coordination.
+
+Use this page as a pattern reference. Current examples show this style through experimental conversation workflows and structured-output demonstrations.
+
+## When to Use
+
+- Open-ended multi-agent discussion
+- Adaptive speaker selection
+- Exploratory reasoning across several agent perspectives
+- Group review before a final answer
+- Conversation workflows where the next speaker depends on prior context
+
+## Pattern Shape
+
+A dynamic conversational swarm usually includes:
+
+- A set of agents with distinct roles
+- Shared conversation state
+- A speaker-selection or routing policy
+- A completion rule
+- A final summarizer or judge
+
+## Design Tips
+
+- Give each agent a clear role and decision boundary.
+- Keep the number of agents small until the conversation quality is stable.
+- Use structured outputs when the final response must be machine-readable.
+- Add a maximum turn count to avoid open-ended loops.
+- Capture the final decision separately from intermediate discussion.
+
+## Related Docs
+
+- [GroupChat](group_chat.md)
+- [AgentRearrange](agent_rearrange.md)
+- [Swarm Architectures](../concept/swarm_architectures.md)
+
+## Source Example
+
+- `examples/single_agent/tools/structured_outputs/example_meaning_of_life_agents.py`


### PR DESCRIPTION
## Summary

- add the missing `docs/swarms/structs/dynamic_conversational_swarm.md` route linked from architecture docs
- document the dynamic conversational swarm pattern and when to use it
- link to existing GroupChat, AgentRearrange, architecture docs, and a structured-output example

## Validation

- `git diff --check`
- confirmed the new route exists locally: `docs/swarms/structs/dynamic_conversational_swarm.md`
- confirmed linked/reference files exist:
  - `docs/swarms/structs/group_chat.md`
  - `docs/swarms/structs/agent_rearrange.md`
  - `docs/swarms/concept/swarm_architectures.md`
  - `examples/single_agent/tools/structured_outputs/example_meaning_of_life_agents.py`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
