### PR TITLE
docs: add agents route page

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,27 @@
+# Agents
+
+Agents are the core building block in Swarms. They combine a role, model configuration, prompts, tools, memory, and runtime settings into a reusable worker that can complete tasks on its own or inside a larger swarm.
+
+This page preserves the top-level `agents` route used by existing documentation links and points users to the maintained agent docs.
+
+## Start Here
+
+- [Agent Reference](swarms/structs/agent.md)
+- [Agents Index](swarms/agents/index.md)
+- [Create Agents from YAML](swarms/agents/create_agents_yaml.md)
+- [Agent Skills](swarms/agents/agent_skills.md)
+- [Structured Outputs](swarms/agents/structured_outputs.md)
+
+## Common Agent Workflows
+
+- Create a single agent for focused task execution.
+- Add tools when the agent needs external data or deterministic actions.
+- Use structured outputs when the result must follow a schema.
+- Move to a workflow or swarm when several agents need to collaborate.
+- Use YAML when you want version-controlled, repeatable agent definitions.
+
+## Related Examples
+
+- [Basic Agent](swarms/examples/basic_agent.md)
+- [Agent with Tools](swarms/examples/agent_with_tools.md)
+- [Model Providers](swarms/examples/model_providers.md)


### PR DESCRIPTION
## Summary

- add the missing top-level `docs/agents.md` route referenced by existing docs links
- provide a compact gateway to maintained agent reference, YAML, skills, and structured-output docs
- link to existing basic agent and tools examples

## Validation

- `git diff --check`
- confirmed the new route exists locally: `docs/agents.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/structs/agent.md`
  - `docs/swarms/agents/index.md`
  - `docs/swarms/agents/create_agents_yaml.md`
  - `docs/swarms/agents/agent_skills.md`
  - `docs/swarms/agents/structured_outputs.md`
  - `docs/swarms/examples/basic_agent.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
