### PR TITLE
docs: add swarms overview route

### DIFF
--- a/docs/swarms/overview.md
+++ b/docs/swarms/overview.md
@@ -1,0 +1,25 @@
+# Swarms Overview
+
+Swarms is a framework for building production-oriented single-agent and multi-agent systems. It provides agent primitives, workflows, routing, tools, memory, structured outputs, and deployment-oriented utilities.
+
+This page preserves the `swarms/overview` route used by existing documentation links and points users to the maintained overview pages.
+
+## Core Areas
+
+- **Agents**: configurable workers with prompts, tools, model settings, and memory.
+- **Structs**: reusable orchestration patterns such as sequential, concurrent, graph, group chat, and router workflows.
+- **Tools**: callable functions, schemas, and MCP utilities that extend agent capabilities.
+- **Examples**: runnable patterns for single-agent, multi-agent, tool, RAG, and deployment workflows.
+- **Contributors**: setup, docs, test, and contribution guides.
+
+## Recommended Starting Points
+
+- [Installation](install/install.md)
+- [Agents Index](agents/index.md)
+- [Structs Overview](structs/overview.md)
+- [Tool System](tools/main.md)
+- [Basic Agent Example](examples/basic_agent.md)
+
+## Choosing a Pattern
+
+Start with a single `Agent` for focused tasks. Move to `SequentialWorkflow` when the work has ordered steps, `ConcurrentWorkflow` when work can happen in parallel, and `GraphWorkflow` when you need explicit dependencies between nodes. Use `SwarmRouter` when the architecture should be selected at runtime.


### PR DESCRIPTION
## Summary

- add the missing `docs/swarms/overview.md` route referenced by existing docs links
- provide a compact framework overview with pointers to maintained installation, agents, structs, tools, and examples docs
- include a short guide for choosing between common orchestration patterns

## Validation

- `git diff --check`
- confirmed the new route exists locally: `docs/swarms/overview.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/install/install.md`
  - `docs/swarms/agents/index.md`
  - `docs/swarms/structs/overview.md`
  - `docs/swarms/tools/main.md`
  - `docs/swarms/examples/basic_agent.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
