### PR TITLE
docs: add swarms conversation route

### DIFF
--- a/docs/swarms/conversation.md
+++ b/docs/swarms/conversation.md
@@ -1,0 +1,24 @@
+# Conversation
+
+Conversation is the message-history and memory container used by Swarms agents and workflows. It helps store turns, serialize context, save state, and support longer-running agent interactions.
+
+This page preserves the `swarms/conversation` route used by existing documentation links and points users to the maintained reference docs.
+
+## What Conversation Handles
+
+- Agent and user message history
+- System prompts and context
+- Serialization to files or structured formats
+- Persistent memory patterns
+- Conversation inspection during debugging
+
+## Start Here
+
+- [Conversation Reference](structs/conversation.md)
+- [Agent Memory](agents/agent_memory.md)
+- [Agent Reference](structs/agent.md)
+- [Custom Swarm](structs/custom_swarm.md)
+
+## Usage Notes
+
+Use conversation persistence when an agent needs continuity across turns or process restarts. Keep sensitive data handling in mind when saving conversation history, and avoid storing secrets in prompts, tool outputs, or serialized logs.


### PR DESCRIPTION
## Summary

- add the missing `docs/swarms/conversation.md` route referenced by existing docs links
- explain the conversation/history role at a high level
- link to maintained Conversation, Agent Memory, Agent, and Custom Swarm docs

## Validation

- `git diff --check`
- confirmed the new route exists locally: `docs/swarms/conversation.md`
- confirmed linked local docs pages exist:
  - `docs/swarms/structs/conversation.md`
  - `docs/swarms/agents/agent_memory.md`
  - `docs/swarms/structs/agent.md`
  - `docs/swarms/structs/custom_swarm.md`

## Bounty

This is a documentation contribution under the Swarms documentation bounty program. If accepted/merged, PayPal payout destination:

https://paypal.me/ShaimaaElkadi
