### PR TITLE
fix(security): expand run_bash_tool denylist to block credential theft and SSRF

### DIFF
--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -968,18 +968,28 @@ _BASH_BLOCKLIST = [
     ("/etc/passwd",),
     ("/etc/shadow",),
     ("/etc/sudoers",),
-    # Network exfiltration primitives
-    ("curl", "-d"),
-    ("wget", "--post"),
+    # Network exfiltration primitives — block all curl/wget network calls,
+    # not just data-posting variants; GET requests can reach internal services
+    # and cloud metadata endpoints just as effectively as POST.
+    ("curl ",),
+    ("wget ",),
     ("nc ", "-e"),
     ("ncat", "-e"),
-    # Environment/credential exposure
+    # Environment/credential exposure — bare env/set leak all env vars too
     ("printenv",),
-    ("env |",),
-    ("set |",),
+    ("env",),
+    ("set",),
     # History manipulation
     ("history -c",),
     ("unset histfile",),
+    # Arbitrary interpreter invocation with inline code execution.
+    # Pipe-to-interpreter was already blocked; direct -c/-e invocations were not.
+    ("python3", "-c"),
+    ("python", "-c"),
+    ("perl", "-e"),
+    ("ruby", "-e"),
+    ("node", "-e"),
+    ("php", "-r"),
 ]
 
 _BASH_BLOCKLIST_REGEX = [
@@ -992,6 +1002,18 @@ _BASH_BLOCKLIST_REGEX = [
     _re.compile(r">\s*/bin/"),
     _re.compile(r">\s*/usr/"),
     _re.compile(r">\s*/root/"),
+    # Credential file paths — cloud credentials, SSH keys, gcloud, kubeconfig
+    _re.compile(r"~/?\.aws/"),
+    _re.compile(r"~/?\.ssh/"),
+    _re.compile(r"~/?\.config/gcloud"),
+    _re.compile(r"~/?\.kube/config"),
+    _re.compile(r"~/?\.docker/config"),
+    # /proc/self/environ leaks all process environment variables
+    _re.compile(r"/proc/self/environ"),
+    # Cloud instance metadata endpoints (AWS IMDSv1/v2, GCP, Azure, DO, Oracle)
+    _re.compile(r"169\.254\.169\.254"),
+    _re.compile(r"metadata\.google\.internal"),
+    _re.compile(r"169\.254\.170\.2"),
 ]
 
 _BASH_MAX_LENGTH = 512


### PR DESCRIPTION
## Problem

The `_BASH_BLOCKLIST` and `_BASH_BLOCKLIST_REGEX` guards in `run_bash_tool` (`swarms/structs/autonomous_loop_utils.py`) have critical coverage gaps that allow prompt-injection attacks to run dangerous shell commands through the autonomous agent's `run_bash` tool.

**Confirmed bypass payloads** (all pass `_check_bash_command()` unblocked):

| Command | Impact |
|---|---|
| `cat ~/.aws/credentials` | AWS credential theft |
| `cat ~/.ssh/id_rsa` | SSH key exfiltration |
| `cat /proc/self/environ` | Environment variable leakage |
| `env` (bare, no pipe) | All env vars exposed |
| `curl http://169.254.169.254/` | Cloud IMDS SSRF |
| `wget http://internal-service/` | Internal SSRF |
| `python3 -c "import os; print(os.environ)"` | Arbitrary Python execution |

**Attack chain:** User message / document / MCP tool output → LLM generates `{"name": "run_bash", "arguments": {"command": "cat ~/.aws/credentials"}}` → incomplete denylist passes command → `subprocess.run(command, shell=True)`.

**Root causes:**
- `("curl", "-d")` blocks curl only with `-d` flag; plain `curl http://...` GET is not blocked
- `("wget", "--post")` blocks wget only with `--post`; GET is not blocked  
- `("env |",)` requires a pipe; bare `env` is not blocked
- `("| python3",)` blocks pipe-to-python only; `python3 -c "..."` direct invocation is not blocked
- No patterns cover credential paths (`~/.aws/`, `~/.ssh/`, `~/.kube/config`, etc.)
- No patterns cover cloud metadata endpoints (`169.254.169.254`)

## Fix

Expands `_BASH_BLOCKLIST` and `_BASH_BLOCKLIST_REGEX`:
- Blocks all `curl` and `wget` invocations (not just `-d`/`--post`)
- Blocks bare `env` and `set` (not only `env |` / `set |`)
- Blocks `python3 -c`, `python -c`, `perl -e`, `ruby -e`, `node -e`, `php -r`
- Adds regex patterns for credential paths (`~/.aws/`, `~/.ssh/`, `~/.kube/config`, `~/.config/gcloud`, `~/.docker/config`, `/proc/self/environ`)
- Adds cloud metadata endpoint regexes (`169.254.169.254`, `metadata.google.internal`, `169.254.170.2`)

Benign commands remain unaffected: `ls`, `git log`, `cat README.md`, `python3 script.py`, `python3 -m pytest`.

## Test Plan
- [ ] `cat ~/.aws/credentials` → blocked (was: allowed)
- [ ] `cat ~/.ssh/id_rsa` → blocked (was: allowed)
- [ ] `env` → blocked (was: allowed)
- [ ] `curl http://169.254.169.254/` → blocked (was: allowed)
- [ ] `python3 -c "import os; print(os.environ)"` → blocked (was: allowed)
- [ ] `ls -la` → still allowed
- [ ] `python3 script.py` → still allowed
- [ ] `git log --oneline` → still allowed
- [ ] `python3 -m pytest tests/` → still allowed

## Security Note

**Severity:** High. The `run_bash` tool is exposed to the LLM agent in autonomous mode (`max_loops="auto"`, `selected_tools="all"` — the framework defaults). An attacker who can inject content into the agent's context (via documents, URLs, or user messages) can cause the agent to run credential-stealing commands.

Private vulnerability reporting is enabled on this repository. Filed as a GitHub Security Advisory to allow coordinated disclosure.

<!-- failsafe-scan-id: tob-fallback-2026-06-15 -->