### PR TITLE
[FIX] [litellm_wrapper] omit empty text block for image-only vision calls

### DIFF
--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -864,6 +864,33 @@ class LiteLLM:
             )
             completion_params["extra_headers"] = headers
 
+    @staticmethod
+    def _vision_content(task: str, image_block: dict) -> list:
+        """
+        Build the content list for a vision user message.
+
+        The text block is included only when ``task`` is a non-empty string.
+        Anthropic rejects content blocks whose text is empty with
+        "text content blocks must be non-empty", so an image-only call
+        (empty or None task) must omit the text block rather than send
+        ``{"type": "text", "text": ""}``. This mirrors the empty-system-block
+        normalization already done in ``_prepare_messages``.
+
+        Args:
+            task (str): The text task/prompt. Omitted from the content when
+                empty, whitespace-only, or None.
+            image_block (dict): The image content block to include.
+
+        Returns:
+            list: ``[text_block, image_block]`` when task has text, else
+                ``[image_block]``.
+        """
+        content = []
+        if isinstance(task, str) and task.strip():
+            content.append({"type": "text", "text": task})
+        content.append(image_block)
+        return content
+
     def anthropic_vision_processing(
         self, task: str, image: str, messages: list
     ) -> list:
@@ -898,15 +925,15 @@ class LiteLLM:
             messages.append(
                 {
                     "role": "user",
-                    "content": [
-                        {"type": "text", "text": task},
+                    "content": self._vision_content(
+                        task,
                         {
                             "type": "image_url",
                             "image_url": {
                                 "url": image,
                             },
                         },
-                    ],
+                    ),
                 }
             )
         else:
@@ -936,8 +963,8 @@ class LiteLLM:
             messages.append(
                 {
                     "role": "user",
-                    "content": [
-                        {"type": "text", "text": task},
+                    "content": self._vision_content(
+                        task,
                         {
                             "type": "image_url",
                             "image_url": {
@@ -945,7 +972,7 @@ class LiteLLM:
                                 "format": mime_type,
                             },
                         },
-                    ],
+                    ),
                 }
             )
 
@@ -1033,10 +1060,7 @@ class LiteLLM:
         messages.append(
             {
                 "role": "user",
-                "content": [
-                    {"type": "text", "text": task},
-                    vision_message,
-                ],
+                "content": self._vision_content(task, vision_message),
             }
         )
 

--- a/tests/utils/test_litellm_vision_empty_text.py
+++ b/tests/utils/test_litellm_vision_empty_text.py
@@ -1,0 +1,108 @@
+"""Regression tests for vision message construction in ``LiteLLM``.
+
+An image-only vision call (empty, whitespace-only, or ``None`` task) must not
+emit an empty text content block. Anthropic rejects such blocks with
+"text content blocks must be non-empty"; the wrapper already guards this for
+system blocks in ``_prepare_messages`` but historically emitted
+``{"type": "text", "text": ""}`` for the vision user message.
+
+These assertions are on the message structure the wrapper builds (they do not
+make a live provider call).
+"""
+
+import base64
+
+import pytest
+
+from swarms.utils.litellm_wrapper import LiteLLM
+
+# Smallest valid 1x1 PNG, enough for get_image_base64() to encode from a file
+# without any network access.
+_PNG_1x1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4"
+    "2mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture
+def png_path(tmp_path):
+    path = tmp_path / "pixel.png"
+    path.write_bytes(_PNG_1x1)
+    return str(path)
+
+
+def _user_content(messages):
+    user = next(m for m in messages if m["role"] == "user")
+    return user["content"]
+
+
+def _text_blocks(content):
+    return [
+        b
+        for b in content
+        if isinstance(b, dict) and b.get("type") == "text"
+    ]
+
+
+def _image_blocks(content):
+    return [
+        b
+        for b in content
+        if isinstance(b, dict) and b.get("type") == "image_url"
+    ]
+
+
+@pytest.mark.parametrize("task", ["", "   ", None])
+def test_anthropic_vision_omits_empty_text_block(task, png_path):
+    llm = LiteLLM(model_name="claude-3-5-sonnet-20241022")
+    messages = llm.anthropic_vision_processing(task, png_path, [])
+    content = _user_content(messages)
+    assert _text_blocks(content) == []
+    assert len(_image_blocks(content)) == 1
+
+
+@pytest.mark.parametrize("task", ["", "   ", None])
+def test_openai_vision_omits_empty_text_block(task, png_path):
+    llm = LiteLLM(model_name="gpt-4o")
+    messages = llm.openai_vision_processing(task, png_path, [])
+    content = _user_content(messages)
+    assert _text_blocks(content) == []
+    assert len(_image_blocks(content)) == 1
+
+
+def test_anthropic_direct_url_omits_empty_text_block(monkeypatch):
+    # Force the direct-URL branch so the URL is embedded, not fetched.
+    llm = LiteLLM(model_name="claude-3-5-sonnet-20241022")
+    monkeypatch.setattr(
+        llm, "_should_use_direct_url", lambda image: True
+    )
+    url = "https://example.com/pixel.png"
+    messages = llm.anthropic_vision_processing("", url, [])
+    content = _user_content(messages)
+    assert _text_blocks(content) == []
+    assert _image_blocks(content)[0]["image_url"]["url"] == url
+
+
+def test_anthropic_vision_keeps_nonempty_text_block(png_path):
+    # Over-deletion guard: a real task must still carry its text block.
+    llm = LiteLLM(model_name="claude-3-5-sonnet-20241022")
+    messages = llm.anthropic_vision_processing(
+        "Describe this image", png_path, []
+    )
+    content = _user_content(messages)
+    blocks = _text_blocks(content)
+    assert len(blocks) == 1
+    assert blocks[0]["text"] == "Describe this image"
+    assert len(_image_blocks(content)) == 1
+
+
+def test_openai_vision_keeps_nonempty_text_block(png_path):
+    llm = LiteLLM(model_name="gpt-4o")
+    messages = llm.openai_vision_processing(
+        "Describe this image", png_path, []
+    )
+    content = _user_content(messages)
+    blocks = _text_blocks(content)
+    assert len(blocks) == 1
+    assert blocks[0]["text"] == "Describe this image"
+    assert len(_image_blocks(content)) == 1


### PR DESCRIPTION
## What

`LiteLLM`'s vision message builders always prepended a text content block, even
when the task was empty or `None`. An image-only call such as `llm.run("", img=...)`
or `run(None, img=...)` therefore built a user message containing
`{"type": "text", "text": ""}` next to the image block.

## Root cause

`anthropic_vision_processing` (both the direct-URL and base64 branches) and
`openai_vision_processing` unconditionally start the content list with
`{"type": "text", "text": task}`. When `task` is empty or `None`, that block is
empty.

## Invariant

No content block in a vision message should carry empty text. The wrapper already
enforces this for system blocks in `_prepare_messages`, which drops empty system
blocks with the note that Anthropic rejects them ("system: text content blocks
must be non-empty"). The vision user-text block was the one spot in the same
family that was not guarded.

## Fix

Add a small `_vision_content(task, image_block)` helper that includes the text
block only when `task` is a non-empty (non-whitespace) string, then route all
three construction sites through it. With no task the message carries just the
image block; with a task, behavior is unchanged. This mirrors the existing
empty-system-block normalization.

## Verification

Ran in a clean Docker container (python:3.12-slim, litellm==1.76.1), offline
(`--network none`), against this branch and against master:

- New test `tests/utils/test_litellm_vision_empty_text.py`: the 7 image-only
  cases (empty / whitespace / None task, Anthropic and OpenAI paths, plus a
  forced direct-URL case) FAIL on master (the empty `{"type": "text", "text": ""}`
  block is present) and PASS on this branch.
- 2 over-deletion guards (a real task keeps its text block) pass on both sides,
  so the fix does not drop legitimate text.

```
docker run --rm --network none -e PYTHONPATH=/src -e WORKSPACE_DIR=/tmp \
  -v <clone>:/src -w /src <image> \
  python -m pytest tests/utils/test_litellm_vision_empty_text.py -v
```

The tests assert the message structure the wrapper builds. I did not make a live
Anthropic API call, so I have not personally observed the rejection; the premise
rests on Anthropic's documented "text content blocks must be non-empty"
constraint and on this repo's own existing system-block guard for it.

Black (24.2.0) and Ruff (0.2.1) are clean on both changed files.

Prepared with AI assistance; reproduced and verified as described above.
