### PR TITLE
[FEAT][AgentRearrange] Per-node retry and fallback flow annotations (!N, >X, ?X)

### DIFF
--- a/docs/swarms/structs/agent_rearrange.md
+++ b/docs/swarms/structs/agent_rearrange.md
@@ -348,6 +348,57 @@ output = agent_system.run("Some task")`
 
 This will raise a `ValueError` with the message `"Agent 'Worker3' is not registered."`.
 
+## Per-Node Retry and Fallback Annotations
+---------------------------------------
+
+Individual nodes in the flow can declare their own error-handling
+policy inline, instead of wrapping the entire run in `try/except`:
+
+| Syntax | Behavior |
+|--------|----------|
+| `"A -> B!3 -> C"` | `B` retries up to 3 extra times on failure |
+| `"A -> B!3>D -> C"` | `B` retries 3 times, then falls back to agent `D` |
+| `"A -> B?D -> C"` | `B` routes to `D` on the first failure |
+| `"A -> B>D -> C"` | Same as `?` — immediate fallback |
+
+**Rules:**
+
+- `!`, `>`, and `?` are reserved characters and cannot appear in agent names used inside a flow.
+
+- Fallback agents must be registered in `agents`. Unknown fallback names fail in `validate_flow()` / `set_custom_flow()` rather than mid-run.
+
+- The fallback agent runs once. If it also fails, the error propagates exactly like an unannotated node's error.
+
+- Annotations also work inside parallel groups: `"A -> B!2>D, C -> E"`.
+
+- Retries never duplicate conversation history — an attempt is only recorded after it succeeds.
+
+- In `output_type="dict"` results, the output is recorded under the agent that actually produced it (the fallback's name when the fallback ran).
+
+```python
+from swarms import Agent, AgentRearrange
+
+pipeline = AgentRearrange(
+    agents=[researcher, analyst, backup_analyst, writer],
+    flow="Researcher -> Analyst!2>Backup_Analyst -> Writer",
+)
+result = pipeline.run("Quarterly market analysis")
+```
+
+Programmatic access to the parser is available via
+`parse_flow_node`, which returns a `NodeSpec` dataclass:
+
+```python
+from swarms import parse_flow_node
+
+node = parse_flow_node("Analyst!2>Backup_Analyst")
+# NodeSpec(name='Analyst', retries=2, fallback='Backup_Analyst')
+```
+
+Note: retry/fallback policies are not yet enforced in streaming mode
+(`run_stream` / `arun_stream`) — annotated nodes resolve to their
+base agent there.
+
 ## Parallel and Sequential Processing
 ----------------------------------
 

--- a/examples/multi_agent/agent_rearrange_examples/06_retry_fallback_annotations.py
+++ b/examples/multi_agent/agent_rearrange_examples/06_retry_fallback_annotations.py
@@ -1,0 +1,78 @@
+r"""
+Per-node retry & fallback annotations
+=====================================
+
+AgentRearrange flows can declare error handling directly on a node
+instead of wrapping the whole run in try/except:
+
+    "A -> B!3 -> C"      B retries up to 3 extra times on failure
+    "A -> B!3>D -> C"    B retries 3 times, then falls back to D
+    "A -> B?D -> C"      B routes to D on the first failure
+
+Rules:
+- `!`, `>`, and `?` are reserved characters — they cannot appear in
+  agent names used inside a flow.
+- Fallback agents must be registered in `agents`; unknown names fail
+  in validate_flow / set_custom_flow instead of mid-run.
+- The fallback agent runs once. If it also fails, the error
+  propagates exactly like an unannotated node's error.
+- Annotations work in parallel groups too: "A -> B!2>D, C -> E".
+
+This example builds a research pipeline where the primary analyst is
+backed by a cheaper fallback model, so a provider outage on the
+primary does not kill the run.
+"""
+
+from swarms import Agent, AgentRearrange
+
+MODEL = "gpt-4o-mini"
+
+
+def _agent(name: str, prompt: str, model: str = MODEL) -> Agent:
+    return Agent(
+        agent_name=name,
+        system_prompt=prompt,
+        model_name=model,
+        max_loops=1,
+        verbose=False,
+        persistent_memory=False,
+    )
+
+
+researcher = _agent(
+    "Researcher",
+    "Collect the key facts on the given topic in 5 bullet points.",
+)
+analyst = _agent(
+    "Analyst",
+    "Analyze the research bullets and extract the 3 most important "
+    "implications. Be concise.",
+)
+backup_analyst = _agent(
+    "Backup_Analyst",
+    "You are the backup analyst. Analyze the research bullets and "
+    "extract the 3 most important implications. Be concise.",
+    model="gpt-4o-mini",
+)
+writer = _agent(
+    "Writer",
+    "Turn the analysis into a short executive summary (<=120 words).",
+)
+
+# Analyst retries twice on transient failures, then hands the exact
+# same context to Backup_Analyst. Writer never knows the difference.
+pipeline = AgentRearrange(
+    agents=[researcher, analyst, backup_analyst, writer],
+    flow="Researcher -> Analyst!2>Backup_Analyst -> Writer",
+    max_loops=1,
+    output_type="final",
+)
+
+# Inspect the resolved plan without spending tokens.
+pipeline.explain()
+
+if __name__ == "__main__":
+    result = pipeline.run(
+        "The impact of on-device LLMs on cloud inference demand."
+    )
+    print(result)

--- a/swarms/structs/__init__.py
+++ b/swarms/structs/__init__.py
@@ -1,7 +1,12 @@
 from swarms.structs.advisor_swarm import AdvisorSwarm
 from swarms.structs.agent import Agent
 from swarms.structs.agent_loader import AgentLoader
-from swarms.structs.agent_rearrange import AgentRearrange, rearrange
+from swarms.structs.agent_rearrange import (
+    AgentRearrange,
+    NodeSpec,
+    parse_flow_node,
+    rearrange,
+)
 from swarms.structs.aop import AOP
 from swarms.structs.async_subagent import (
     SubagentRegistry,
@@ -91,6 +96,8 @@ __all__ = [
     "GroupChat",
     "MajorityVoting",
     "AgentRearrange",
+    "NodeSpec",
+    "parse_flow_node",
     "rearrange",
     "RoundRobinSwarm",
     "SequentialWorkflow",

--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -1,12 +1,15 @@
 import copy
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
     Dict,
     List,
     Optional,
+    Tuple,
     Union,
     get_args,
 )
@@ -31,6 +34,114 @@ logger = initialize_logger(log_folder="rearrange")
 # sync if HistoryOutputType ever gains/loses members.
 _VALID_OUTPUT_TYPES = set(get_args(OutputType))
 
+# One flow-node token with optional retry/fallback annotations.
+# Grammar (whitespace tolerated around every part):
+#   name            plain node
+#   name!N          retry up to N extra times on failure
+#   name!N>other    retry N times, then fall back to `other`
+#   name?other      on failure, immediately fall back to `other`
+#   name>other      same as `?` (immediate fallback)
+# `!`, `>`, and `?` are reserved and cannot appear in agent names.
+_NODE_TOKEN_RE = re.compile(
+    r"^(?P<name>[^!>?]+?)\s*"
+    r"(?:!\s*(?P<retries>\d+))?\s*"
+    r"(?:[>?]\s*(?P<fallback>[^!>?]+))?$"
+)
+
+
+@dataclass(frozen=True)
+class NodeSpec:
+    """A single node in an AgentRearrange flow.
+
+    Carries the per-node error-handling policy parsed from flow
+    annotations (see ``parse_flow_node``).
+
+    Attributes:
+        name (str): The agent name this node executes.
+        retries (int): Extra attempts after the first failure
+            (``0`` means fail on the first error).
+        fallback (Optional[str]): Agent to route to once all
+            attempts on ``name`` are exhausted. ``None`` means
+            the error propagates.
+    """
+
+    name: str
+    retries: int = 0
+    fallback: Optional[str] = None
+
+    @property
+    def annotated(self) -> bool:
+        """True when this node declares any retry/fallback policy."""
+        return self.retries > 0 or self.fallback is not None
+
+    def __str__(self) -> str:
+        out = self.name
+        if self.retries:
+            out += f"!{self.retries}"
+        if self.fallback:
+            out += f">{self.fallback}"
+        return out
+
+
+def parse_flow_node(token: str) -> NodeSpec:
+    """Parse one flow-node token into a ``NodeSpec``.
+
+    Supported forms::
+
+        "B"       plain node
+        "B!3"     B retries up to 3 extra times on failure
+        "B!3>D"   B retries 3 times, then falls back to D
+        "B?D"     B routes to D on the first failure
+        "B>D"     same as "B?D"
+
+    Args:
+        token (str): A single node token from a flow string
+            (i.e. the text between ``->`` / ``,`` separators).
+
+    Returns:
+        NodeSpec: The parsed node with its retry/fallback policy.
+
+    Raises:
+        ValueError: If the token is empty, malformed (e.g. a
+            non-numeric retry count, a dangling ``>``), or the
+            fallback names the node itself.
+    """
+    stripped = token.strip()
+    if not stripped:
+        raise ValueError("Empty agent name in flow")
+
+    match = _NODE_TOKEN_RE.match(stripped)
+    if match is None:
+        raise ValueError(
+            f"Malformed flow node {stripped!r}. Expected 'name', "
+            "'name!N', 'name!N>fallback', or 'name?fallback'."
+        )
+
+    name = match.group("name").strip()
+    retries = int(match.group("retries") or 0)
+    fallback = match.group("fallback")
+    if fallback is not None:
+        fallback = fallback.strip()
+        if fallback == name:
+            raise ValueError(
+                f"Node {name!r} cannot fall back to itself"
+            )
+
+    return NodeSpec(name=name, retries=retries, fallback=fallback)
+
+
+def _node_display_name(token: str) -> str:
+    """Best-effort base agent name for display/awareness contexts.
+
+    Falls back to the stripped raw token when the token does not
+    parse (e.g. custom-task text injected into the flow), so
+    non-critical paths never raise.
+    """
+    try:
+        return parse_flow_node(token).name
+    except ValueError:
+        return token.strip()
+
 
 class AgentRearrange(SerializableMixin):
     """
@@ -44,6 +155,7 @@ class AgentRearrange(SerializableMixin):
     Key Features:
     - Sequential and concurrent agent execution
     - Custom flow patterns with arrow (->) and comma (,) syntax
+    - Per-node retry and fallback annotations (!N, >X, ?X)
     - Team awareness and sequential flow information
     - Memory system support
     - Batch and concurrent processing capabilities
@@ -53,6 +165,15 @@ class AgentRearrange(SerializableMixin):
     - Use '->' to define sequential execution: "agent1 -> agent2 -> agent3"
     - Use ',' to define concurrent execution: "agent1, agent2 -> agent3"
     - Combine both: "agent1 -> agent2, agent3 -> agent4"
+
+    Per-Node Retry & Fallback:
+    - "A -> B!3 -> C"    B retries up to 3 extra times on failure
+    - "A -> B!3>D -> C"  B retries 3 times, then falls back to D
+    - "A -> B?D -> C"    B routes to D on the first failure
+    - Fallback agents must be registered in ``agents``; unknown
+      names fail in ``validate_flow`` rather than mid-run.
+    - The fallback agent runs once; if it also fails, the error
+      propagates as usual.
 
     Attributes:
         id (str): Unique identifier for the agent rearrange system
@@ -282,13 +403,15 @@ class AgentRearrange(SerializableMixin):
         total_invocations = 0
         rows: List[tuple] = []
         for i, step in enumerate(steps, start=1):
-            agent_names = [name.strip() for name in step.split(",")]
-            total_invocations += len(agent_names)
-            label = ", ".join(agent_names)
-            if len(agent_names) == 1:
+            nodes = [
+                parse_flow_node(token) for token in step.split(",")
+            ]
+            total_invocations += len(nodes)
+            label = ", ".join(str(node) for node in nodes)
+            if len(nodes) == 1:
                 kind = "[sequential]"
             else:
-                kind = f"[parallel, {len(agent_names)} agents]"
+                kind = f"[parallel, {len(nodes)} agents]"
             rows.append((i, label, kind))
 
         width = max((len(label) for _, label, _ in rows), default=0)
@@ -345,9 +468,14 @@ class AgentRearrange(SerializableMixin):
         Pure-concurrent flows (e.g. ``"a, b, c"``) and pure-sequential
         flows (e.g. ``"a -> b -> c"``) are both valid.
 
+        Nodes may carry retry/fallback annotations (``B!3``,
+        ``B!3>D``, ``B?D``). Both the node's agent and its fallback
+        agent must be registered.
+
         Raises:
-            ValueError: If the flow is empty or references an agent name
-                that is not registered.
+            ValueError: If the flow is empty, a node token is
+                malformed, or a node (or its fallback) references an
+                agent name that is not registered.
 
         Returns:
             bool: True if the flow pattern is valid.
@@ -359,19 +487,24 @@ class AgentRearrange(SerializableMixin):
         steps = self.flow.split("->")
 
         for step in steps:
-            agent_names = [name.strip() for name in step.split(",")]
-            for agent_name in agent_names:
-                if not agent_name:
+            tokens = [token.strip() for token in step.split(",")]
+            for token in tokens:
+                if not token:
                     raise ValueError(
                         f"Empty agent name in flow segment {step!r}"
                     )
-                try:
-                    find_agent_by_name(self.agents, agent_name)
-                except (TypeError, ValueError):
-                    raise ValueError(
-                        f"Agent '{agent_name}' is not registered."
-                    )
-                agents_in_flow.append(agent_name)
+                node = parse_flow_node(token)
+                referenced = [node.name]
+                if node.fallback is not None:
+                    referenced.append(node.fallback)
+                for ref in referenced:
+                    try:
+                        find_agent_by_name(self.agents, ref)
+                    except (TypeError, ValueError):
+                        raise ValueError(
+                            f"Agent '{ref}' is not registered."
+                        )
+                agents_in_flow.append(node.name)
 
         logger.info(f"Flow: {self.flow} is valid.")
         return True
@@ -403,7 +536,8 @@ class AgentRearrange(SerializableMixin):
             agent_position = None
             for i, task in enumerate(tasks):
                 agent_names = [
-                    name.strip() for name in task.split(",")
+                    _node_display_name(token)
+                    for token in task.split(",")
                 ]
                 if agent_name in agent_names:
                     agent_position = i
@@ -418,7 +552,8 @@ class AgentRearrange(SerializableMixin):
         if agent_position > 0:
             prev_task = tasks[agent_position - 1]
             prev_agents = [
-                name.strip() for name in prev_task.split(",")
+                _node_display_name(token)
+                for token in prev_task.split(",")
             ]
             if prev_agents:
                 awareness_info.append(
@@ -429,7 +564,8 @@ class AgentRearrange(SerializableMixin):
         if agent_position < len(tasks) - 1:
             next_task = tasks[agent_position + 1]
             next_agents = [
-                name.strip() for name in next_task.split(",")
+                _node_display_name(token)
+                for token in next_task.split(",")
             ]
             if next_agents:
                 awareness_info.append(
@@ -456,7 +592,9 @@ class AgentRearrange(SerializableMixin):
         flow_info = []
 
         for i, task in enumerate(tasks):
-            agent_names = [name.strip() for name in task.split(",")]
+            agent_names = [
+                _node_display_name(token) for token in task.split(",")
+            ]
             if agent_names:
                 position_info = (
                     f"Step {i+1}: {', '.join(agent_names)}"
@@ -464,7 +602,8 @@ class AgentRearrange(SerializableMixin):
                 if i > 0:
                     prev_task = tasks[i - 1]
                     prev_agents = [
-                        name.strip() for name in prev_task.split(",")
+                        _node_display_name(token)
+                        for token in prev_task.split(",")
                     ]
                     if prev_agents:
                         position_info += (
@@ -473,7 +612,8 @@ class AgentRearrange(SerializableMixin):
                 if i < len(tasks) - 1:
                     next_task = tasks[i + 1]
                     next_agents = [
-                        name.strip() for name in next_task.split(",")
+                        _node_display_name(token)
+                        for token in next_task.split(",")
                     ]
                     if next_agents:
                         position_info += (
@@ -527,8 +667,9 @@ class AgentRearrange(SerializableMixin):
         simultaneously and their results are collected and returned.
 
         Args:
-            agent_names (List[str]): List of agent names to run concurrently.
-                These agents will execute in parallel.
+            agent_names (List[str]): List of agent node tokens to run
+                concurrently. Tokens may carry retry/fallback
+                annotations (``B!3``, ``B!3>D``, ``B?D``).
             img (str, optional): Image input for agents that support it.
                 Defaults to None.
             *args: Additional positional arguments passed to agent execution.
@@ -536,46 +677,168 @@ class AgentRearrange(SerializableMixin):
 
         Returns:
             Dict[str, str]: Dictionary mapping agent names to their execution results.
-                Keys are agent names, values are their respective outputs.
+                Keys are agent names (the fallback agent's name when a
+                fallback executed), values are their respective outputs.
 
         Note:
-            This method uses the run_agents_concurrently utility function
-            to handle the actual parallel execution and result collection.
+            Unannotated groups use the run_agents_concurrently utility
+            for parallel execution. Groups containing annotated nodes
+            run each node under its retry/fallback policy in its own
+            worker thread instead.
         """
-        logger.info(f"Running agents in parallel: {agent_names}")
+        specs = [parse_flow_node(token) for token in agent_names]
 
-        agents_to_run = []
-        missing = []
-        for name in agent_names:
-            try:
-                agents_to_run.append(
-                    find_agent_by_name(self.agents, name)
-                )
-            except (TypeError, ValueError):
-                missing.append(name)
-        if missing:
-            raise ValueError(
-                f"Agent(s) {missing} not registered in this AgentRearrange instance."
-            )
-
-        # Run agents concurrently
-        results = run_agents_concurrently(
-            agents=agents_to_run,
-            task=self.conversation.get_str(),
+        logger.info(
+            f"Running agents in parallel: "
+            f"{[spec.name for spec in specs]}"
         )
 
-        # Process results and update conversation
+        if not any(spec.annotated for spec in specs):
+            agents_to_run = []
+            missing = []
+            for spec in specs:
+                try:
+                    agents_to_run.append(
+                        find_agent_by_name(self.agents, spec.name)
+                    )
+                except (TypeError, ValueError):
+                    missing.append(spec.name)
+            if missing:
+                raise ValueError(
+                    f"Agent(s) {missing} not registered in this AgentRearrange instance."
+                )
+
+            # Run agents concurrently
+            results = run_agents_concurrently(
+                agents=agents_to_run,
+                task=self.conversation.get_str(),
+            )
+
+            # Process results and update conversation
+            response_dict = {}
+            for i, spec in enumerate(specs):
+                result = results[i]
+
+                self.conversation.add(spec.name, result)
+                response_dict[spec.name] = result
+                logger.debug(f"Agent {spec.name} output: {result}")
+
+            return response_dict
+
+        # Annotated path: each node runs under its retry/fallback
+        # policy in its own worker thread. The shared conversation is
+        # only written after every worker returns, from this thread,
+        # so history stays consistent regardless of completion order.
+        base_task = self.conversation.get_str()
+        with ThreadPoolExecutor(max_workers=len(specs)) as executor:
+            futures = [
+                executor.submit(
+                    self._run_node_with_policy,
+                    spec,
+                    base_task,
+                    img,
+                    *args,
+                    **kwargs,
+                )
+                for spec in specs
+            ]
+            outcomes = [future.result() for future in futures]
+
         response_dict = {}
-        for i, agent_name in enumerate(agent_names):
-            result = results[i]
-
-            # print(f"Result: {result}")
-
-            self.conversation.add(agent_name, result)
-            response_dict[agent_name] = result
-            logger.debug(f"Agent {agent_name} output: {result}")
+        for executed_name, output in outcomes:
+            self.conversation.add(executed_name, output)
+            response_dict[executed_name] = output
+            logger.debug(f"Agent {executed_name} output: {output}")
 
         return response_dict
+
+    def _apply_node_policy(
+        self,
+        node: NodeSpec,
+        attempt: Callable[[str], str],
+    ) -> Tuple[str, str]:
+        """Drive ``attempt`` under a node's retry/fallback policy.
+
+        Calls ``attempt(node.name)`` up to ``node.retries + 1``
+        times. If every attempt raises and the node declares a
+        fallback, runs ``attempt(node.fallback)`` once. Errors from
+        the fallback (or from a node without one) propagate.
+
+        Args:
+            node (NodeSpec): The node whose policy to enforce.
+            attempt (Callable[[str], str]): Executes one attempt for
+                the given agent name and returns its output.
+
+        Returns:
+            Tuple[str, str]: ``(executed_agent_name, output)`` where
+                the name is ``node.fallback`` when the fallback ran.
+
+        Raises:
+            Exception: The last error from the primary agent when all
+                attempts fail and no fallback is declared, or any
+                error raised by the fallback attempt.
+        """
+        attempts = node.retries + 1
+        last_error: Optional[Exception] = None
+        for attempt_no in range(1, attempts + 1):
+            try:
+                return node.name, attempt(node.name)
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                logger.warning(
+                    f"Node '{node.name}' attempt "
+                    f"{attempt_no}/{attempts} failed: {e}"
+                )
+        if node.fallback is not None:
+            logger.warning(
+                f"Node '{node.name}' exhausted {attempts} "
+                f"attempt(s); falling back to '{node.fallback}'"
+            )
+            return node.fallback, attempt(node.fallback)
+        raise last_error
+
+    def _run_node_with_policy(
+        self,
+        node: NodeSpec,
+        task: str,
+        img: str = None,
+        *args,
+        **kwargs,
+    ) -> Tuple[str, str]:
+        """Execute one node directly against ``task`` under its policy.
+
+        Runs the agent's ``run()`` without touching the shared
+        conversation — callers add the returned output themselves,
+        which keeps this method safe to call from worker threads.
+
+        Args:
+            node (NodeSpec): The node to execute.
+            task (str): The task/context string passed to the agent.
+            img (str, optional): Image input for agents that support
+                it. Defaults to None.
+            *args: Additional positional arguments for ``agent.run``.
+            **kwargs: Additional keyword arguments for ``agent.run``.
+
+        Returns:
+            Tuple[str, str]: ``(executed_agent_name, output)``.
+
+        Raises:
+            Exception: Propagated per ``_apply_node_policy``.
+        """
+
+        def _attempt(agent_name: str) -> str:
+            agent = find_agent_by_name(self.agents, agent_name)
+            output = agent.run(
+                task=task,
+                img=img,
+                *args,
+                **kwargs,
+            )
+            if not isinstance(output, str):
+                output = any_to_str(output)
+            return output
+
+        return self._apply_node_policy(node, _attempt)
 
     def _run_sequential_workflow(
         self,
@@ -662,6 +925,53 @@ class AgentRearrange(SerializableMixin):
 
         return current_task
 
+    def _execute_sequential_node(
+        self,
+        node: NodeSpec,
+        tasks: List[str],
+        task_idx: int = None,
+        img: str = None,
+        *args,
+        **kwargs,
+    ) -> Tuple[str, str]:
+        """Run one sequential flow node under its retry/fallback policy.
+
+        Each attempt goes through ``_run_sequential_workflow`` so
+        sequential awareness injection and conversation updates behave
+        exactly as they do for unannotated nodes. Failed attempts do
+        not write to the conversation (the write happens after a
+        successful ``agent.run``), so retries never duplicate history.
+
+        Args:
+            node (NodeSpec): The node to execute.
+            tasks (List[str]): All flow steps, for awareness context.
+            task_idx (int, optional): Position of this node in the
+                flow. Defaults to None.
+            img (str, optional): Image input for agents that support
+                it. Defaults to None.
+            *args: Additional positional arguments for execution.
+            **kwargs: Additional keyword arguments for execution.
+
+        Returns:
+            Tuple[str, str]: ``(executed_agent_name, output)`` where
+                the name is the fallback agent's when it ran.
+
+        Raises:
+            Exception: Propagated per ``_apply_node_policy``.
+        """
+
+        def _attempt(agent_name: str) -> str:
+            return self._run_sequential_workflow(
+                agent_name=agent_name,
+                tasks=tasks,
+                task_idx=task_idx,
+                img=img,
+                *args,
+                **kwargs,
+            )
+
+        return self._apply_node_policy(node, _attempt)
+
     def _run(
         self,
         task: str = None,
@@ -734,15 +1044,15 @@ class AgentRearrange(SerializableMixin):
             )
 
             for task_idx, task in enumerate(tasks):
-                agent_names = [
-                    name.strip() for name in task.split(",")
+                node_tokens = [
+                    token.strip() for token in task.split(",")
                 ]
 
-                if len(agent_names) > 1:
+                if len(node_tokens) > 1:
                     # Concurrent processing - comma detected
                     concurrent_results = (
                         self._run_concurrent_workflow(
-                            agent_names=agent_names,
+                            agent_names=node_tokens,
                             img=img,
                             *args,
                             **kwargs,
@@ -751,25 +1061,28 @@ class AgentRearrange(SerializableMixin):
                     response_dict.update(concurrent_results)
 
                 else:
-                    # Sequential processing
-                    agent_name = agent_names[0]
-                    result = self._run_sequential_workflow(
-                        agent_name=agent_name,
-                        tasks=tasks,
-                        task_idx=task_idx,
-                        img=img,
-                        *args,
-                        **kwargs,
+                    # Sequential processing. The node may carry
+                    # retry/fallback annotations (B!3, B!3>D, B?D).
+                    node = parse_flow_node(node_tokens[0])
+                    executed_name, result = (
+                        self._execute_sequential_node(
+                            node=node,
+                            tasks=tasks,
+                            task_idx=task_idx,
+                            img=img,
+                            *args,
+                            **kwargs,
+                        )
                     )
 
                     # Use indexed key to preserve all outputs
                     # from repeated agents (e.g., "Writer_0", "Writer_2")
-                    if agent_name in response_dict:
-                        response_dict[f"{agent_name}_{task_idx}"] = (
-                            result
-                        )
+                    if executed_name in response_dict:
+                        response_dict[
+                            f"{executed_name}_{task_idx}"
+                        ] = result
                     else:
-                        response_dict[agent_name] = result
+                        response_dict[executed_name] = result
 
             loop_count += 1
 
@@ -1236,7 +1549,10 @@ class AgentRearrange(SerializableMixin):
                 ``{"type": "agent_end", "agent": ..., "output": ...}``.
 
         Not yet supported in streaming mode: ``max_loops > 1``,
-        ``custom_tasks``. Use ``run()`` for those.
+        ``custom_tasks``, and retry/fallback annotations (``!N``,
+        ``>X``, ``?X``) — annotated nodes resolve to their base
+        agent, but the retry/fallback policy is not enforced. Use
+        ``run()`` for those.
         """
         self.conversation.add("User", task)
 
@@ -1246,7 +1562,8 @@ class AgentRearrange(SerializableMixin):
 
         for task_idx, task_segment in enumerate(tasks_list):
             agent_names = [
-                name.strip() for name in task_segment.split(",")
+                parse_flow_node(token).name
+                for token in task_segment.split(",")
             ]
 
             if len(agent_names) > 1:

--- a/tests/structs/test_agent_rearrange.py
+++ b/tests/structs/test_agent_rearrange.py
@@ -8,6 +8,8 @@ Covers:
 - Error propagation through run/__call__/batch_run
 - batch_run concurrency, ordering, conversation isolation, image forwarding,
   and batch_size validation (mock-based unit tests)
+- Per-node retry/fallback flow annotations (!N, >X, ?X): parsing,
+  validation, sequential and concurrent execution behavior
 """
 
 import threading
@@ -17,7 +19,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from swarms import Agent, AgentRearrange
+from swarms import (
+    Agent,
+    AgentRearrange,
+    NodeSpec,
+    parse_flow_node,
+)
 
 
 # ============================================================================
@@ -1214,6 +1221,331 @@ class TestBatchSizeBoundaries:
             pipeline.batch_run(
                 tasks=["t1", "t2"], img=["img1.png"], batch_size=5
             )
+
+
+# ============================================================================
+# Per-node retry/fallback annotations (!N, >X, ?X)
+# ============================================================================
+
+
+def _make_flaky_agent(name: str, fail_times: int = 0):
+    """Mock agent whose run() raises for the first *fail_times* calls.
+
+    The call counter is exposed as ``agent.calls["count"]`` so tests
+    can assert exactly how many attempts were made.
+    """
+    agent = MagicMock()
+    agent.agent_name = name
+    agent.system_prompt = f"I am {name}."
+    calls = {"count": 0}
+
+    def _run(task=None, *a, **kw):
+        calls["count"] += 1
+        if calls["count"] <= fail_times:
+            raise RuntimeError(f"{name} failure #{calls['count']}")
+        return f"{name}-ok"
+
+    agent.run = _run
+    agent.calls = calls
+    return agent
+
+
+class TestParseFlowNode:
+    """Unit tests for the flow-node annotation parser."""
+
+    def test_plain_node(self):
+        node = parse_flow_node("AgentA")
+        assert node == NodeSpec("AgentA", 0, None)
+        assert not node.annotated
+
+    def test_retry_annotation(self):
+        node = parse_flow_node("AgentA!3")
+        assert node == NodeSpec("AgentA", 3, None)
+        assert node.annotated
+
+    def test_retry_with_fallback(self):
+        node = parse_flow_node("AgentA!3>AgentB")
+        assert node == NodeSpec("AgentA", 3, "AgentB")
+
+    def test_immediate_fallback_question_mark(self):
+        node = parse_flow_node("AgentA?AgentB")
+        assert node == NodeSpec("AgentA", 0, "AgentB")
+
+    def test_immediate_fallback_angle_bracket(self):
+        node = parse_flow_node("AgentA>AgentB")
+        assert node == NodeSpec("AgentA", 0, "AgentB")
+
+    def test_whitespace_tolerated(self):
+        node = parse_flow_node("  AgentA ! 2 > AgentB  ")
+        assert node == NodeSpec("AgentA", 2, "AgentB")
+
+    def test_str_round_trip(self):
+        assert str(parse_flow_node("A!2>B")) == "A!2>B"
+        assert str(parse_flow_node("A")) == "A"
+
+    @pytest.mark.parametrize(
+        "token",
+        ["", "   ", "A!", "A!x", "A>", "A?", "A>B>C", "!3", "A!!2"],
+    )
+    def test_malformed_tokens_raise(self, token):
+        with pytest.raises(ValueError):
+            parse_flow_node(token)
+
+    def test_self_fallback_raises(self):
+        with pytest.raises(ValueError, match="itself"):
+            parse_flow_node("AgentA?AgentA")
+
+
+class TestFlowAnnotationValidation:
+    """validate_flow must catch bad annotations at parse time."""
+
+    def test_valid_annotated_flow(self):
+        a = _make_agent("A")
+        b = _make_agent("B")
+        d = _make_agent("D")
+        wf = AgentRearrange(
+            agents=[a, b, d],
+            flow="A -> B!2>D",
+            autosave=False,
+        )
+        assert wf.validate_flow() is True
+
+    def test_unknown_fallback_rejected(self):
+        a = _make_agent("A")
+        b = _make_agent("B")
+        wf = AgentRearrange(
+            agents=[a, b],
+            flow="A -> B",
+            autosave=False,
+        )
+        with pytest.raises(ValueError, match="Ghost"):
+            wf.set_custom_flow("A -> B!2>Ghost")
+        # previous flow restored on failure
+        assert wf.flow == "A -> B"
+
+    def test_malformed_annotation_rejected(self):
+        a = _make_agent("A")
+        b = _make_agent("B")
+        wf = AgentRearrange(
+            agents=[a, b],
+            flow="A -> B",
+            autosave=False,
+        )
+        with pytest.raises(ValueError, match="Malformed"):
+            wf.set_custom_flow("A -> B!x")
+
+    def test_explain_renders_annotations(self):
+        a = _make_agent("A")
+        b = _make_agent("B")
+        d = _make_agent("D")
+        wf = AgentRearrange(
+            agents=[a, b, d],
+            flow="A -> B!2>D",
+            autosave=False,
+        )
+        plan = wf.explain(return_str=True)
+        assert "B!2>D" in plan
+
+
+class TestSequentialRetryFallback:
+    """Retry/fallback behavior for sequential (->) nodes."""
+
+    def test_retry_recovers_after_transient_failures(self):
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B", fail_times=2)
+        c = _make_flaky_agent("C")
+        wf = AgentRearrange(
+            agents=[a, b, c],
+            flow="A -> B!2 -> C",
+            autosave=False,
+            output_type="final",
+        )
+        result = wf.run("task")
+        # initial attempt + 2 retries
+        assert b.calls["count"] == 3
+        assert "C-ok" in str(result)
+
+    def test_retries_exhausted_without_fallback_raises(self):
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B", fail_times=99)
+        wf = AgentRearrange(
+            agents=[a, b],
+            flow="A -> B!1",
+            autosave=False,
+            output_type="final",
+        )
+        with pytest.raises(RuntimeError, match="B failure"):
+            wf.run("task")
+        assert b.calls["count"] == 2
+
+    def test_fallback_runs_after_retries_exhausted(self):
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B", fail_times=99)
+        d = _make_flaky_agent("D")
+        c = _make_flaky_agent("C")
+        wf = AgentRearrange(
+            agents=[a, b, c, d],
+            flow="A -> B!1>D -> C",
+            autosave=False,
+            output_type="final",
+        )
+        result = wf.run("task")
+        assert b.calls["count"] == 2
+        assert d.calls["count"] == 1
+        assert "C-ok" in str(result)
+
+    def test_immediate_fallback_on_first_failure(self):
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B", fail_times=99)
+        d = _make_flaky_agent("D")
+        wf = AgentRearrange(
+            agents=[a, b, d],
+            flow="A -> B?D",
+            autosave=False,
+            output_type="final",
+        )
+        result = wf.run("task")
+        assert b.calls["count"] == 1
+        assert d.calls["count"] == 1
+        assert "D-ok" in str(result)
+
+    def test_fallback_failure_propagates(self):
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B", fail_times=99)
+        d = _make_flaky_agent("D", fail_times=99)
+        wf = AgentRearrange(
+            agents=[a, b, d],
+            flow="A -> B?D",
+            autosave=False,
+            output_type="final",
+        )
+        with pytest.raises(RuntimeError, match="D failure"):
+            wf.run("task")
+
+    def test_fallback_output_recorded_under_fallback_name(self):
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B", fail_times=99)
+        d = _make_flaky_agent("D")
+        wf = AgentRearrange(
+            agents=[a, b, d],
+            flow="A -> B?D",
+            autosave=False,
+            output_type="dict",
+        )
+        wf.run("task")
+        history = wf.conversation.return_history_as_string()
+        assert "D-ok" in history
+
+    def test_retries_do_not_duplicate_conversation_entries(self):
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B", fail_times=2)
+        wf = AgentRearrange(
+            agents=[a, b],
+            flow="A -> B!2",
+            autosave=False,
+            output_type="final",
+        )
+        wf.run("task")
+        history = wf.conversation.return_history_as_string()
+        assert history.count("B-ok") == 1
+
+    def test_plain_flow_behavior_unchanged(self):
+        """Unannotated flows run exactly one attempt per node."""
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B")
+        wf = AgentRearrange(
+            agents=[a, b],
+            flow="A -> B",
+            autosave=False,
+            output_type="final",
+        )
+        result = wf.run("task")
+        assert a.calls["count"] == 1
+        assert b.calls["count"] == 1
+        assert "B-ok" in str(result)
+
+
+class TestConcurrentRetryFallback:
+    """Retry/fallback behavior inside parallel (,) groups."""
+
+    def test_annotated_node_in_parallel_group_retries(self):
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B", fail_times=1)
+        c = _make_flaky_agent("C")
+        d = _make_flaky_agent("D")
+        wf = AgentRearrange(
+            agents=[a, b, c, d],
+            flow="A -> B!1, C -> D",
+            autosave=False,
+            output_type="final",
+        )
+        result = wf.run("task")
+        assert b.calls["count"] == 2
+        assert c.calls["count"] == 1
+        assert "D-ok" in str(result)
+
+    def test_parallel_fallback_routes_to_backup(self):
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B", fail_times=99)
+        c = _make_flaky_agent("C")
+        d = _make_flaky_agent("D")
+        wf = AgentRearrange(
+            agents=[a, b, c, d],
+            flow="A -> B?D, C",
+            autosave=False,
+            output_type="final",
+        )
+        wf.run("task")
+        assert b.calls["count"] == 1
+        assert d.calls["count"] == 1
+        assert c.calls["count"] == 1
+        history = wf.conversation.return_history_as_string()
+        assert "D-ok" in history
+        assert "C-ok" in history
+
+    def test_parallel_group_without_annotations_unchanged(self):
+        """Plain parallel groups keep using the fast path."""
+        a = _make_flaky_agent("A")
+        b = _make_flaky_agent("B")
+        c = _make_flaky_agent("C")
+        wf = AgentRearrange(
+            agents=[a, b, c],
+            flow="A -> B, C",
+            autosave=False,
+            output_type="final",
+        )
+        wf.run("task")
+        assert b.calls["count"] == 1
+        assert c.calls["count"] == 1
+
+
+class TestAnnotationAwareness:
+    """Awareness strings must show base names, not annotations."""
+
+    def test_flow_info_strips_annotations(self):
+        a = _make_agent("A")
+        b = _make_agent("B")
+        d = _make_agent("D")
+        wf = AgentRearrange(
+            agents=[a, b, d],
+            flow="A -> B!2>D",
+            autosave=False,
+        )
+        info = wf.get_sequential_flow_structure()
+        assert "B!2" not in info
+        assert "B" in info
+
+    def test_sequential_awareness_strips_annotations(self):
+        a = _make_agent("A")
+        b = _make_agent("B")
+        d = _make_agent("D")
+        wf = AgentRearrange(
+            agents=[a, b, d],
+            flow="A -> B!2>D",
+            autosave=False,
+        )
+        awareness = wf.get_agent_sequential_awareness("A")
+        assert "B!2" not in awareness
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Implements #1556 — per-node retry and fallback annotations in the `AgentRearrange` flow DSL, so error handling lives next to the node that can fail instead of in every caller's `try/except`:

```
"A -> B!3 -> C"      # B retries up to 3 extra times on failure
"A -> B!3>D -> C"    # B retries 3 times, then falls back to D
"A -> B?D -> C"      # B routes to D on the first failure
```

## Implementation

- **`NodeSpec` dataclass + `parse_flow_node()`** — a single canonical node parser (regex-based) used by every code path that reads the flow (`validate_flow`, `explain`, awareness helpers, `_run`, streaming). Both are exported from `swarms.structs` for programmatic use.
- **Parse-time validation** — `validate_flow()` rejects malformed tokens (`B!x`, `B>`, `B>D>E`), unknown fallback agents, and self-fallbacks (`B?B`), so bad flows fail at `set_custom_flow()` / `validate_flow()` rather than mid-run. `!`, `>`, `?` are reserved characters in agent names.
- **Sequential nodes** run through a small `_apply_node_policy` state machine: attempt → retry → fallback → raise. Each attempt goes through the existing `_run_sequential_workflow`, so sequential-awareness injection behaves exactly as before, and conversation writes only happen after a successful attempt — **retries never duplicate history**.
- **Parallel groups** keep the existing `run_agents_concurrently` fast path when unannotated (zero behavior change). Annotated groups run each node under its policy in its own worker thread; conversation writes are deferred to the coordinating thread so history stays consistent regardless of completion order.
- **Fallback semantics**: the fallback agent runs once; if it also fails the error propagates like any unannotated node's error. Outputs are recorded under the agent that actually produced them.
- **Display/awareness paths** (`explain()`, team-awareness strings) strip annotations to base agent names. Streaming (`arun_stream`/`run_stream`) resolves annotated nodes to their base agent; policy enforcement in streaming mode is documented as not yet supported.

## Tests

34 new unit tests in `tests/structs/test_agent_rearrange.py` (mock-based, no API calls), covering:

- Parser: all annotation forms, whitespace tolerance, round-trips, 9 malformed-token cases, self-fallback rejection
- Validation: unknown fallback rejected with previous flow restored, malformed annotations rejected, `explain()` rendering
- Sequential: retry recovery, exhaustion raising, fallback routing, immediate `?` fallback, fallback-failure propagation, no duplicated conversation entries, **plain flows unchanged (single attempt)**
- Concurrent groups: retry inside `,` groups, fallback routing, plain groups keep the fast path
- Awareness strings show base names, not annotations

```
34 passed  (the 8 pre-existing failures in this file also fail on clean master — dict-style `agents["name"]` indexing from an older API — and are unrelated)
```

`black --check` (24.2.0) and `ruff check` (0.2.1) pass on all changed files.

## Docs & Example

- New "Per-Node Retry and Fallback Annotations" section in `docs/swarms/structs/agent_rearrange.md`
- Runnable example: `examples/multi_agent/agent_rearrange_examples/06_retry_fallback_annotations.py`

Fixes #1556

🤖 Generated with [Claude Code](https://claude.com/claude-code)