### PR TITLE
fix: roll back short_memory on a failed Agent._run retry attempt

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -1695,6 +1695,14 @@ class Agent:
                 attempt = 0
                 success = False
                 while attempt < self.retry_attempts and not success:
+                    # Checkpoint the conversation length before this attempt
+                    # so a failure partway through (e.g. a bad handoff/MCP
+                    # tool call) can roll back everything this attempt
+                    # added, instead of leaving it in place for the next
+                    # attempt to duplicate on top of.
+                    memory_length_before_attempt = len(
+                        self.short_memory.conversation_history
+                    )
                     try:
 
                         show_loading = (
@@ -1843,6 +1851,24 @@ class Agent:
                         AuthenticationError,
                         Exception,
                     ) as e:
+
+                        # Roll back any messages this failed attempt added
+                        # (the assistant response and any handoff/tool/MCP
+                        # follow-up messages added after it) so retrying
+                        # doesn't leave duplicate or orphaned turns in the
+                        # conversation history.
+                        while (
+                            len(
+                                self.short_memory.conversation_history
+                            )
+                            > memory_length_before_attempt
+                        ):
+                            self.short_memory.delete(
+                                len(
+                                    self.short_memory.conversation_history
+                                )
+                                - 1
+                            )
 
                         if self.autosave is True:
                             log_agent_data(self.to_dict())

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -1463,6 +1463,14 @@ class Agent:
                 attempt = 0
                 success = False
                 while attempt < self.retry_attempts and not success:
+                    # Checkpoint the conversation length before this attempt
+                    # so a failure partway through (e.g. a bad handoff/MCP
+                    # tool call) can roll back everything this attempt
+                    # added, instead of leaving it in place for the next
+                    # attempt to duplicate on top of.
+                    memory_length_before_attempt = len(
+                        self.short_memory.conversation_history
+                    )
                     try:
 
                         show_loading = (
@@ -1616,6 +1624,24 @@ class Agent:
                             name="Agent.llm_error",
                             loop=loop_count,
                         )
+
+                        # Roll back any messages this failed attempt added
+                        # (the assistant response and any handoff/tool/MCP
+                        # follow-up messages added after it) so retrying
+                        # doesn't leave duplicate or orphaned turns in the
+                        # conversation history.
+                        while (
+                            len(
+                                self.short_memory.conversation_history
+                            )
+                            > memory_length_before_attempt
+                        ):
+                            self.short_memory.delete(
+                                len(
+                                    self.short_memory.conversation_history
+                                )
+                                - 1
+                            )
 
                         if self.autosave is True:
                             log_agent_data(self.to_dict())

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2372,6 +2372,68 @@ class TestLLMArgsAndHandling:
         print("✓ LLM handling args and kwargs test passed")
 
 
+class TestAgentRetryMemoryRollback:
+    """Regression tests for issue #1718.
+
+    ``Agent._run`` adds the LLM response to ``short_memory`` before the
+    post-response steps (handoff parsing, tool execution, MCP handling)
+    have succeeded. If one of those steps raises, the broad ``except``
+    around the retry loop retries the whole attempt without undoing the
+    ``short_memory.add`` from the failed attempt, so a later successful
+    attempt leaves a duplicate/contradictory assistant turn in history.
+    """
+
+    def test_failed_handoff_parse_is_rolled_back_on_retry(self):
+        """A malformed handoff tool call must not leave a stray message
+        in short_memory once a later retry attempt succeeds."""
+        with patch("swarms.structs.agent.LiteLLM") as mock_llm:
+            mock_llm.return_value.run.return_value = "unused"
+            agent = Agent(
+                agent_name="rollback_test_agent",
+                max_loops=1,
+                retry_attempts=2,
+                verbose=False,
+                print_on=False,
+                persistent_memory=False,
+            )
+
+        bad_handoff_response = [
+            {
+                "function": {
+                    "name": "handoff_task",
+                    # Malformed JSON: raises inside the handoff-parsing
+                    # step, after the response has already been added
+                    # to short_memory.
+                    "arguments": "{not valid json",
+                }
+            }
+        ]
+        good_response = "final answer"
+        call_count = {"n": 0}
+
+        def fake_call_llm(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return bad_handoff_response
+            return good_response
+
+        agent.parse_llm_output = lambda response: response
+        agent.call_llm = fake_call_llm
+
+        result = agent._run(task="do something")
+
+        assert result == good_response
+        assert call_count["n"] == 2
+
+        assistant_messages = [
+            m
+            for m in agent.short_memory.conversation_history
+            if m.get("role") == agent.agent_name
+        ]
+        assert len(assistant_messages) == 1
+        assert assistant_messages[0]["content"] == good_response
+
+
 # ============================================================================
 # MAIN TEST RUNNER
 # ============================================================================

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2591,6 +2591,68 @@ class TestToolsListIsolation:
         )
 
 
+class TestAgentRetryMemoryRollback:
+    """Regression tests for issue #1718.
+
+    ``Agent._run`` adds the LLM response to ``short_memory`` before the
+    post-response steps (handoff parsing, tool execution, MCP handling)
+    have succeeded. If one of those steps raises, the broad ``except``
+    around the retry loop retries the whole attempt without undoing the
+    ``short_memory.add`` from the failed attempt, so a later successful
+    attempt leaves a duplicate/contradictory assistant turn in history.
+    """
+
+    def test_failed_handoff_parse_is_rolled_back_on_retry(self):
+        """A malformed handoff tool call must not leave a stray message
+        in short_memory once a later retry attempt succeeds."""
+        with patch("swarms.structs.agent.LiteLLM") as mock_llm:
+            mock_llm.return_value.run.return_value = "unused"
+            agent = Agent(
+                agent_name="rollback_test_agent",
+                max_loops=1,
+                retry_attempts=2,
+                verbose=False,
+                print_on=False,
+                persistent_memory=False,
+            )
+
+        bad_handoff_response = [
+            {
+                "function": {
+                    "name": "handoff_task",
+                    # Malformed JSON: raises inside the handoff-parsing
+                    # step, after the response has already been added
+                    # to short_memory.
+                    "arguments": "{not valid json",
+                }
+            }
+        ]
+        good_response = "final answer"
+        call_count = {"n": 0}
+
+        def fake_call_llm(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return bad_handoff_response
+            return good_response
+
+        agent.parse_llm_output = lambda response: response
+        agent.call_llm = fake_call_llm
+
+        result = agent._run(task="do something")
+
+        assert result == good_response
+        assert call_count["n"] == 2
+
+        assistant_messages = [
+            m
+            for m in agent.short_memory.conversation_history
+            if m.get("role") == agent.agent_name
+        ]
+        assert len(assistant_messages) == 1
+        assert assistant_messages[0]["content"] == good_response
+
+
 # ============================================================================
 # MAIN TEST RUNNER
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes #1718.

In `Agent._run`'s retry loop, the LLM response is added to `short_memory` **before** several post-processing steps that can raise (handoff `json.loads` of tool-call arguments, MCP tool handling). If the model call on an attempt succeeds (so `short_memory.add` runs) but a later, unwrapped post-add step then raises, the broad `except (..., Exception)` retries the **entire** attempt — calling the model again and appending a **second** assistant message for what should be a single reasoning step. The failed attempt's message is never rolled back, so the conversation ends up with duplicate/contradictory assistant turns (context corruption + extra token cost, and potential duplicated tool side effects if a tool call happened before the unwrapped failure).

## Fix

Checkpoint `len(self.short_memory.conversation_history)` at the start of each retry attempt. On failure, before incrementing `attempt` and retrying, pop every entry added since that checkpoint (the assistant response and any handoff/tool/MCP follow-up messages added after it).

I considered the alternative of just moving `short_memory.add(...)` to run after all post-processing succeeds, but that would change the *success* path: `mcp_tool_handling` calls `self.short_memory.get_str()` mid-step to build context for its follow-up summarization call, and expects the current turn's response to already be in history at that point. Moving the add would silently degrade MCP tool-response summaries. The rollback approach only changes the *failure* path, so the success path (including MCP handling) is untouched.

## Test plan

- Added `TestAgentRetryMemoryRollback::test_failed_handoff_parse_is_rolled_back_on_retry` in `tests/structs/test_agent.py`: forces a malformed `handoff_task` tool call on the first attempt (raises during `json.loads`, after the response was already added to memory) and a normal response on the second attempt, then asserts `short_memory` ends up with exactly one assistant message.
- Verified red→green: reverting the `agent.py` change reproduces the bug (2 duplicate assistant messages instead of 1) with this same test.
- Full `tests/structs/test_agent.py` run before/after the change: identical set of pre-existing failures (need real `OPENAI_API_KEY` / an unrelated missing `mocked_llm` fixture) in both runs; this change adds one new passing test with no regressions.
- `black`/`ruff` clean on both changed files (using the versions pinned in `pyproject.toml`'s allowed ranges).