### PR TITLE
[improvement] Enable telemetry by default with explicit opt-out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 WORKSPACE_DIR="agent_workspace"
 SWARMS_VERBOSE_GLOBAL="False"
 SWARMS_API_KEY=""
-SWARMS_TELEMETRY_ON="false"
+# Telemetry is ON by default. Set to false/0/no/off to opt out.
+SWARMS_TELEMETRY_ON="true"
 
 
 

--- a/swarms/telemetry/otel.py
+++ b/swarms/telemetry/otel.py
@@ -38,6 +38,11 @@ MAX_CONFIG_CHARS = int(
 )
 
 
+TELEMETRY_OFF_VALUES = frozenset(
+    {"false", "0", "no", "off", "disable", "disabled"}
+)
+
+
 def telemetry_on() -> bool:
     """Return whether outbound telemetry is enabled.
 
@@ -45,11 +50,22 @@ def telemetry_on() -> bool:
     :func:`swarms.telemetry.main.log_agent_data`, so the whole framework has one
     on/off gate.
 
+    Telemetry is **on by default** — it must be switched off explicitly. Set
+    ``SWARMS_TELEMETRY_ON`` to any of ``"false"``, ``"0"``, ``"no"``, ``"off"``,
+    ``"disable"`` or ``"disabled"`` (case-insensitive) to opt out. An empty or
+    whitespace-only value also counts as off, so ``SWARMS_TELEMETRY_ON=`` in a
+    ``.env`` file disables it rather than silently enabling it.
+
     Returns:
-        bool: ``True`` only when ``SWARMS_TELEMETRY_ON`` is ``"True"``, ``"true"``
-        or ``"1"``; ``False`` otherwise.
+        bool: ``False`` only when the variable is set to a recognized off value;
+        ``True`` otherwise, including when the variable is unset.
     """
-    return os.getenv("SWARMS_TELEMETRY_ON") in ("True", "true", "1")
+    value = os.getenv("SWARMS_TELEMETRY_ON")
+
+    if value is None:
+        return True
+
+    return value.strip().lower() not in TELEMETRY_OFF_VALUES | {""}
 
 
 def _truncate(value: Any, limit: int = MAX_PAYLOAD_CHARS) -> str:
@@ -564,7 +580,8 @@ def capture_init(obj: Any, **extra_attributes: Any) -> None:
         from swarms.telemetry.otel import capture_init
         capture_init(self)
 
-    Completely safe and free when ``SWARMS_TELEMETRY_ON`` is off.
+    Completely safe and free when telemetry is switched off with
+    ``SWARMS_TELEMETRY_ON=false``.
 
     Args:
         obj (Any): The just-constructed component instance.
@@ -649,8 +666,8 @@ def log_agent_data(data: Any) -> None:
 
     Drop-in OpenTelemetry replacement for the legacy ``swarms.world`` telemetry
     POST. Accepts a component's ``to_dict()`` payload and emits it as a
-    ``swarms.state`` span. Gated on ``SWARMS_TELEMETRY_ON`` and fully fail-safe;
-    a no-op when telemetry is off.
+    ``swarms.state`` span. Gated on ``SWARMS_TELEMETRY_ON`` (on by default) and
+    fully fail-safe; a no-op when telemetry is switched off.
 
     Args:
         data (Any): The component state to record — typically ``self.to_dict()``.

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -108,18 +108,36 @@ def _agent(name="TelemetryTestAgent"):
 # ===========================================================================
 class TestHelpers:
     def test_telemetry_on_truthy(self, monkeypatch):
-        for val in ("true", "True", "1"):
+        # anything that is not a recognized off value means on
+        for val in ("true", "True", "1", "yes", "on", "anything"):
             monkeypatch.setenv("SWARMS_TELEMETRY_ON", val)
             assert telemetry_on() is True
 
     def test_telemetry_on_falsy(self, monkeypatch):
-        for val in ("false", "False", "0", "", "yes"):
+        for val in (
+            "false",
+            "False",
+            "FALSE",
+            "0",
+            "no",
+            "off",
+            "disable",
+            "disabled",
+            " false ",
+        ):
             monkeypatch.setenv("SWARMS_TELEMETRY_ON", val)
             assert telemetry_on() is False
 
-    def test_telemetry_on_unset(self, monkeypatch):
+    def test_telemetry_on_unset_defaults_to_on(self, monkeypatch):
+        """Telemetry is opt-out: unset means enabled."""
         monkeypatch.delenv("SWARMS_TELEMETRY_ON", raising=False)
-        assert telemetry_on() is False
+        assert telemetry_on() is True
+
+    def test_telemetry_on_empty_value_is_off(self, monkeypatch):
+        """`SWARMS_TELEMETRY_ON=` in a .env disables rather than enables."""
+        for val in ("", "   "):
+            monkeypatch.setenv("SWARMS_TELEMETRY_ON", val)
+            assert telemetry_on() is False
 
     def test_truncate_short_passthrough(self):
         assert _truncate("hello") == "hello"

--- a/tests/telemetry/test_telemetry_invariants.py
+++ b/tests/telemetry/test_telemetry_invariants.py
@@ -103,10 +103,9 @@ def toggle_telemetry(_exporter):
     @contextmanager
     def _toggle(on: bool):
         prev = os.environ.get("SWARMS_TELEMETRY_ON")
-        if on:
-            os.environ["SWARMS_TELEMETRY_ON"] = "true"
-        else:
-            os.environ.pop("SWARMS_TELEMETRY_ON", None)
+        # Telemetry is opt-out, so "off" must be set explicitly — unsetting the
+        # variable would enable it.
+        os.environ["SWARMS_TELEMETRY_ON"] = "true" if on else "false"
         otel.swarm_telemetry.cache_clear()
         telem = otel.swarm_telemetry()
         if on:


### PR DESCRIPTION
## Summary

Flips telemetry from **opt-in** to **opt-out**. Leaving `SWARMS_TELEMETRY_ON` unset now enables tracing; disabling requires setting it explicitly.

```python
TELEMETRY_OFF_VALUES = frozenset({"false", "0", "no", "off", "disable", "disabled"})

def telemetry_on() -> bool:
    value = os.getenv("SWARMS_TELEMETRY_ON")
    if value is None:
        return True
    return value.strip().lower() not in TELEMETRY_OFF_VALUES | {""}
```

## Behavior

| `SWARMS_TELEMETRY_ON` | Result |
|---|---|
| unset | **on** |
| `true`, `1`, `yes`, `on`, any unrecognized string | **on** |
| `false`, `False`, `FALSE`, `0`, `no`, `off`, `disable`, `disabled` | **off** |
| `""` or whitespace-only | **off** |

Two deliberate choices:

1. **Case-insensitive and whitespace-tolerant** — `" False "` disables, so a stray space in a `.env` file does not silently re-enable tracing.
2. **An empty value counts as off.** `SWARMS_TELEMETRY_ON=` in a `.env` reads as an attempt to disable; treating it as on would be the wrong failure mode.

Opting out:

```bash
export SWARMS_TELEMETRY_ON=false
```

## Changes

- `swarms/telemetry/otel.py` — the gate itself, plus docstrings that described the old opt-in default
- `.env.example` — now `"true"` with a comment on how to opt out
- `tests/telemetry/test_telemetry.py` — `test_telemetry_on_unset` asserted `False`; replaced with `test_telemetry_on_unset_defaults_to_on`, added a case for empty/whitespace values, and expanded the truthy/falsy vocabularies
- `tests/telemetry/test_telemetry_invariants.py` — its `_toggle(False)` helper **popped** the variable to disable telemetry, which under opt-out enables it. Now sets `"false"` explicitly

## Tests

`test_telemetry.py` 74 passed · `test_telemetry_multi_agent_core.py` 28 passed · `test_telemetry_multi_agent_advanced.py` 18 passed · `test_user_utils.py` 5 passed. `tests/agents/` plus the MCP manager suite: 351 passed, unaffected.

`test_telemetry_invariants.py` reports 7 failed / 29 passed — **the identical 7 fail on `master` without this change**, verified against a stashed baseline, so nothing here caused them. Two separate pre-existing issues, worth their own fix:

1. `test_two_agent_sequential_workflow_is_eight_flat_root_spans` asserts `Agent.run` has no parent. The span-nesting fix in #1731 intentionally made spans nest, so this test now asserts the old bug.
2. Six `init_config` tests expect payload sanitization that `otel.py` does not implement — configs currently leak memory addresses (`<swarms.structs.agent.Agent object at 0x117c51220>`) and raise on circular references.

## Note for the release

This turns tracing on for every user who upgrades. Spans carry task text, agent outputs, and full constructor configuration — **including system prompts**. The opt-out is documented in the gate's docstring, `.env.example`, and the telemetry docs page, but it is worth calling out in the release notes as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
