### PR TITLE
[BUGF] Fix SSRF bypass in remote image fetch and world-readable OAuth token cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,52 +847,7 @@ Swarms seamlessly integrates with industry-standard protocols and open specifica
 
 ## Examples
 
-Explore comprehensive examples and tutorials to learn how to use Swarms effectively.
-
-| Category | Example | Description | Link |
-|----------|---------|-------------|------|
-| **Basic Examples** | Basic Agent | Simple agent setup and usage | [Basic Agent](https://docs.swarms.world/examples/basic-agent) |
-| **Basic Examples** | Agent with Tools | Using agents with various tools | [Agent with Tools](https://docs.swarms.world/examples/agent-with-tools) |
-| **Basic Examples** | Agent with Structured Outputs | Working with structured data outputs | [Structured Outputs](https://docs.swarms.world/agents/structured-outputs) |
-| **Basic Examples** | Agent with MCP Integration | Model Context Protocol integration | [MCP Integration](https://docs.swarms.world/integrations/mcp) |
-| **Basic Examples** | Vision Processing | Agents with image processing capabilities | [Vision Processing](https://docs.swarms.world/examples/vision-agent) |
-| **Basic Examples** | Multiple Images | Working with multiple images | [Multiple Images](https://docs.swarms.world/examples/vision-agent) |
-| **Basic Examples** | Vision and Tools | Combining vision with tool usage | [Vision and Tools](https://docs.swarms.world/examples/vision-agent) |
-| **Basic Examples** | Agent Streaming | Real-time agent output streaming | [Agent Streaming](https://docs.swarms.world/examples/agents/agent-streaming) |
-| **Basic Examples** | Agent Output Types | Different output formats and types | [Output Types](https://docs.swarms.world/agents/structured-outputs) |
-| **Basic Examples** | Gradio Chat Interface | Building interactive chat interfaces | [Gradio UI](https://docs.swarms.world/examples/basic-agent) |
-| **Model Providers** | Model Providers Overview | Complete guide to supported models | [Model Providers](https://docs.swarms.world/integrations/model-providers) |
-| **Model Providers** | OpenAI | OpenAI model integration | [OpenAI Examples](https://docs.swarms.world/integrations/model-providers) |
-| **Model Providers** | Anthropic | Claude model integration | [Anthropic Examples](https://docs.swarms.world/integrations/model-providers) |
-| **Model Providers** | Groq | Groq model integration | [Groq Examples](https://docs.swarms.world/integrations/model-providers) |
-| **Model Providers** | Cohere | Cohere model integration | [Cohere Examples](https://docs.swarms.world/integrations/model-providers) |
-| **Model Providers** | DeepSeek | DeepSeek model integration | [DeepSeek Examples](https://docs.swarms.world/integrations/model-providers) |
-| **Model Providers** | Ollama | Local Ollama model integration | [Ollama Examples](https://docs.swarms.world/integrations/model-providers) |
-| **Model Providers** | OpenRouter | OpenRouter model integration | [OpenRouter Examples](https://docs.swarms.world/integrations/model-providers) |
-| **Model Providers** | XAI | XAI model integration | [XAI Examples](https://docs.swarms.world/integrations/model-providers) |
-| **Model Providers** | Llama4 | Llama4 model integration | [Llama4 Examples](https://docs.swarms.world/integrations/model-providers) |
-| **Multi-Agent Architecture** | HierarchicalSwarm | Hierarchical agent orchestration | [HierarchicalSwarm Examples](https://docs.swarms.world/examples/hierarchical-swarm-example) |
-| **Multi-Agent Architecture** | Hybrid Hierarchical-Cluster Swarm | Advanced hierarchical patterns | [HHCS Examples](https://docs.swarms.world/api/hhcs) |
-| **Multi-Agent Architecture** | GroupChat | Multi-agent conversations | [GroupChat Examples](https://docs.swarms.world/examples/group-chat-example) |
-| **Multi-Agent Architecture** | Sequential Workflow | Step-by-step agent workflows | [Sequential Examples](https://docs.swarms.world/examples/sequential-workflow-example) |
-| **Multi-Agent Architecture** | SwarmRouter | Universal swarm orchestration | [SwarmRouter Examples](https://docs.swarms.world/architectures/swarm-router) |
-| **Multi-Agent Architecture** | MultiAgentRouter | Minimal router example | [MultiAgentRouter Examples](https://docs.swarms.world/api/multi-agent-router) |
-| **Multi-Agent Architecture** | ConcurrentWorkflow | Parallel agent execution | [Concurrent Examples](https://docs.swarms.world/examples/concurrent-workflow-example) |
-| **Multi-Agent Architecture** | Mixture of Agents | Expert agent collaboration | [MoA Examples](https://docs.swarms.world/examples/mixture-of-agents-example) |
-| **Multi-Agent Architecture** | Unique Swarms | Specialized swarm patterns | [Unique Swarms](https://docs.swarms.world/architectures/overview) |
-| **Multi-Agent Architecture** | Agents as Tools | Using agents as tools in workflows | [Agents as Tools](https://docs.swarms.world/architectures/overview) |
-| **Multi-Agent Architecture** | Aggregate Responses | Combining multiple agent outputs | [Aggregate Examples](https://docs.swarms.world/architectures/mixture-of-agents) |
-| **Multi-Agent Architecture** | Interactive GroupChat | Real-time agent interactions | [Interactive GroupChat](https://docs.swarms.world/examples/group-chat-example) |
-| **Deployment Solutions** | Agent Orchestration Protocol (AOP) | Deploy agents as distributed services with discovery and management | [AOP Reference](https://docs.swarms.world/api/aop) |
-| **Applications** | Advanced Research System | Multi-agent research system inspired by Anthropic's research methodology | [AdvancedResearch](https://github.com/The-Swarm-Corporation/AdvancedResearch) |
-| **Applications** | Hospital Simulation | Healthcare simulation system using multi-agent architecture | [HospitalSim](https://github.com/The-Swarm-Corporation/HospitalSim) |
-| **Applications** | Browser Agents | Web automation with agents | [Browser Agents](https://docs.swarms.world/examples/integrations/browser-use) |
-| **Applications** | Medical Analysis | Healthcare applications | [Medical Examples](https://docs.swarms.world/examples/multi-agent/aop-medical) |
-| **Applications** | Finance Analysis | Financial applications | [Finance Examples](https://docs.swarms.world/examples/use-cases/financial-analysis) |
-| **Cookbook & Templates** | Examples Overview | Complete examples directory | [Examples Index](https://docs.swarms.world/examples/) |
-| **Cookbook & Templates** | Cookbook Index | Curated example collection | [Cookbook](https://docs.swarms.world/examples/overviews/cookbook) |
-| **Cookbook & Templates** | Paper Implementations | Research paper implementations | [Paper Implementations](https://docs.swarms.world/examples/overviews/paper-implementations) |
-| **Cookbook & Templates** | Templates & Applications | Reusable templates | [Templates](https://docs.swarms.world/examples/overviews/templates) |
+Explore comprehensive examples and tutorials to learn how to use Swarms effectively [HERE](examples/README.md)
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -441,6 +441,56 @@ This directory contains comprehensive examples demonstrating various capabilitie
 | [Research Agent](cli/research_agent_example.sh) | Research agent example |
 | [Run All Examples](cli/run_all_examples.sh) | Run all CLI examples |
 
+
+# MISC
+
+
+| Category | Example | Description | Link |
+|----------|---------|-------------|------|
+| **Basic Examples** | Basic Agent | Simple agent setup and usage | [Basic Agent](https://docs.swarms.world/examples/basic-agent) |
+| **Basic Examples** | Agent with Tools | Using agents with various tools | [Agent with Tools](https://docs.swarms.world/examples/agent-with-tools) |
+| **Basic Examples** | Agent with Structured Outputs | Working with structured data outputs | [Structured Outputs](https://docs.swarms.world/agents/structured-outputs) |
+| **Basic Examples** | Agent with MCP Integration | Model Context Protocol integration | [MCP Integration](https://docs.swarms.world/integrations/mcp) |
+| **Basic Examples** | Vision Processing | Agents with image processing capabilities | [Vision Processing](https://docs.swarms.world/examples/vision-agent) |
+| **Basic Examples** | Multiple Images | Working with multiple images | [Multiple Images](https://docs.swarms.world/examples/vision-agent) |
+| **Basic Examples** | Vision and Tools | Combining vision with tool usage | [Vision and Tools](https://docs.swarms.world/examples/vision-agent) |
+| **Basic Examples** | Agent Streaming | Real-time agent output streaming | [Agent Streaming](https://docs.swarms.world/examples/agents/agent-streaming) |
+| **Basic Examples** | Agent Output Types | Different output formats and types | [Output Types](https://docs.swarms.world/agents/structured-outputs) |
+| **Basic Examples** | Gradio Chat Interface | Building interactive chat interfaces | [Gradio UI](https://docs.swarms.world/examples/basic-agent) |
+| **Model Providers** | Model Providers Overview | Complete guide to supported models | [Model Providers](https://docs.swarms.world/integrations/model-providers) |
+| **Model Providers** | OpenAI | OpenAI model integration | [OpenAI Examples](https://docs.swarms.world/integrations/model-providers) |
+| **Model Providers** | Anthropic | Claude model integration | [Anthropic Examples](https://docs.swarms.world/integrations/model-providers) |
+| **Model Providers** | Groq | Groq model integration | [Groq Examples](https://docs.swarms.world/integrations/model-providers) |
+| **Model Providers** | Cohere | Cohere model integration | [Cohere Examples](https://docs.swarms.world/integrations/model-providers) |
+| **Model Providers** | DeepSeek | DeepSeek model integration | [DeepSeek Examples](https://docs.swarms.world/integrations/model-providers) |
+| **Model Providers** | Ollama | Local Ollama model integration | [Ollama Examples](https://docs.swarms.world/integrations/model-providers) |
+| **Model Providers** | OpenRouter | OpenRouter model integration | [OpenRouter Examples](https://docs.swarms.world/integrations/model-providers) |
+| **Model Providers** | XAI | XAI model integration | [XAI Examples](https://docs.swarms.world/integrations/model-providers) |
+| **Model Providers** | Llama4 | Llama4 model integration | [Llama4 Examples](https://docs.swarms.world/integrations/model-providers) |
+| **Multi-Agent Architecture** | HierarchicalSwarm | Hierarchical agent orchestration | [HierarchicalSwarm Examples](https://docs.swarms.world/examples/hierarchical-swarm-example) |
+| **Multi-Agent Architecture** | Hybrid Hierarchical-Cluster Swarm | Advanced hierarchical patterns | [HHCS Examples](https://docs.swarms.world/api/hhcs) |
+| **Multi-Agent Architecture** | GroupChat | Multi-agent conversations | [GroupChat Examples](https://docs.swarms.world/examples/group-chat-example) |
+| **Multi-Agent Architecture** | Sequential Workflow | Step-by-step agent workflows | [Sequential Examples](https://docs.swarms.world/examples/sequential-workflow-example) |
+| **Multi-Agent Architecture** | SwarmRouter | Universal swarm orchestration | [SwarmRouter Examples](https://docs.swarms.world/architectures/swarm-router) |
+| **Multi-Agent Architecture** | MultiAgentRouter | Minimal router example | [MultiAgentRouter Examples](https://docs.swarms.world/api/multi-agent-router) |
+| **Multi-Agent Architecture** | ConcurrentWorkflow | Parallel agent execution | [Concurrent Examples](https://docs.swarms.world/examples/concurrent-workflow-example) |
+| **Multi-Agent Architecture** | Mixture of Agents | Expert agent collaboration | [MoA Examples](https://docs.swarms.world/examples/mixture-of-agents-example) |
+| **Multi-Agent Architecture** | Unique Swarms | Specialized swarm patterns | [Unique Swarms](https://docs.swarms.world/architectures/overview) |
+| **Multi-Agent Architecture** | Agents as Tools | Using agents as tools in workflows | [Agents as Tools](https://docs.swarms.world/architectures/overview) |
+| **Multi-Agent Architecture** | Aggregate Responses | Combining multiple agent outputs | [Aggregate Examples](https://docs.swarms.world/architectures/mixture-of-agents) |
+| **Multi-Agent Architecture** | Interactive GroupChat | Real-time agent interactions | [Interactive GroupChat](https://docs.swarms.world/examples/group-chat-example) |
+| **Deployment Solutions** | Agent Orchestration Protocol (AOP) | Deploy agents as distributed services with discovery and management | [AOP Reference](https://docs.swarms.world/api/aop) |
+| **Applications** | Advanced Research System | Multi-agent research system inspired by Anthropic's research methodology | [AdvancedResearch](https://github.com/The-Swarm-Corporation/AdvancedResearch) |
+| **Applications** | Hospital Simulation | Healthcare simulation system using multi-agent architecture | [HospitalSim](https://github.com/The-Swarm-Corporation/HospitalSim) |
+| **Applications** | Browser Agents | Web automation with agents | [Browser Agents](https://docs.swarms.world/examples/integrations/browser-use) |
+| **Applications** | Medical Analysis | Healthcare applications | [Medical Examples](https://docs.swarms.world/examples/multi-agent/aop-medical) |
+| **Applications** | Finance Analysis | Financial applications | [Finance Examples](https://docs.swarms.world/examples/use-cases/financial-analysis) |
+| **Cookbook & Templates** | Examples Overview | Complete examples directory | [Examples Index](https://docs.swarms.world/examples/) |
+| **Cookbook & Templates** | Cookbook Index | Curated example collection | [Cookbook](https://docs.swarms.world/examples/overviews/cookbook) |
+| **Cookbook & Templates** | Paper Implementations | Research paper implementations | [Paper Implementations](https://docs.swarms.world/examples/overviews/paper-implementations) |
+| **Cookbook & Templates** | Templates & Applications | Reusable templates | [Templates](https://docs.swarms.world/examples/overviews/templates) |
+
+
 ## Documentation
 
 Each subdirectory contains its own README.md file with detailed descriptions and links to all available examples. Click on any folder above to explore its specific examples and use cases.
@@ -458,3 +508,5 @@ Found an interesting example or want to add your own? Check out our [contributin
 ---
 
 *This examples directory is continuously updated with new patterns, integrations, and use cases. Check back regularly for the latest examples!*
+
+

--- a/swarms/tools/mcp_manager.py
+++ b/swarms/tools/mcp_manager.py
@@ -193,8 +193,24 @@ class MCPFileTokenStorage:
     def _write(self, data: Dict[str, Any]) -> None:
         with self._lock:
             try:
-                self.path.parent.mkdir(parents=True, exist_ok=True)
-                self.path.write_text(json.dumps(data, indent=2))
+                self.path.parent.mkdir(
+                    parents=True, exist_ok=True, mode=0o700
+                )
+                # Create the file 0600 from the start. write_text() creates it
+                # honoring the umask (typically 0644), leaving a window in which
+                # another local user could read the OAuth token before a later
+                # chmod lands. os.open with an explicit mode closes that window.
+                fd = os.open(
+                    self.path,
+                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                    0o600,
+                )
+                try:
+                    os.write(fd, json.dumps(data, indent=2).encode())
+                finally:
+                    os.close(fd)
+                # os.open's mode only applies on creation; tighten a file that
+                # already existed with looser permissions.
                 os.chmod(self.path, 0o600)
             except Exception as e:
                 logger.warning(

--- a/swarms/utils/image_file_b64.py
+++ b/swarms/utils/image_file_b64.py
@@ -8,6 +8,7 @@ converting them to base64-encoded data URIs suitable for use with LLM APIs.
 import base64
 import ipaddress
 import re
+import socket
 import uuid
 from pathlib import Path
 from urllib.parse import urlparse
@@ -16,30 +17,81 @@ import requests
 from loguru import logger
 
 
+def _ip_is_blocked(addr: ipaddress._BaseAddress) -> bool:
+    """Return True for any address that must never be reached over the network.
+
+    Covers loopback, private (RFC 1918), link-local (incl. the 169.254.169.254
+    cloud-metadata range), reserved, unspecified, and multicast space. IPv4
+    addresses embedded in IPv6 (``::ffff:a.b.c.d`` and 6to4) are unwrapped and
+    re-checked, so a mapped metadata address cannot slip through.
+    """
+    # Unwrap IPv4-in-IPv6 so ::ffff:169.254.169.254 is judged as the v4 address.
+    mapped = getattr(addr, "ipv4_mapped", None)
+    if mapped is not None:
+        addr = mapped
+    sixtofour = getattr(addr, "sixtofour", None)
+    if sixtofour is not None:
+        addr = sixtofour
+
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_unspecified
+        or addr.is_multicast
+    )
+
+
 def _is_safe_url(url: str) -> bool:
     """
     Reject URLs that target private/link-local networks (SSRF prevention).
-    Only http:// and https:// schemes are permitted.
+
+    Only ``http``/``https`` are permitted, and the host is **resolved** before
+    the verdict: a hostname that maps to a private or cloud-metadata address is
+    blocked, and *every* address it resolves to must be public (so a name with
+    one public and one internal A-record cannot be used to pivot). Numeric host
+    forms (decimal, hex, octal) and IPv4-in-IPv6 are normalized rather than
+    trusted as opaque strings.
+
+    Note: this checks the addresses known at call time. A determined attacker
+    controlling DNS can still rebind between this check and the subsequent
+    request (TOCTOU); eliminating that requires pinning the resolved IP for the
+    actual connection, which the calling HTTP client does not currently do.
     """
     try:
         parsed = urlparse(url)
         if parsed.scheme not in ("http", "https"):
             return False
-        host = parsed.hostname or ""
-        # Block localhost variants
-        if host in ("localhost", ""):
+
+        host = (parsed.hostname or "").strip()
+        if not host or host.lower() == "localhost":
             return False
+
+        # If the host is already a literal IP (in any notation ipaddress
+        # accepts — decimal, hex, dotted), judge it directly.
         try:
-            addr = ipaddress.ip_address(host)
-            if (
-                addr.is_private
-                or addr.is_loopback
-                or addr.is_link_local
-                or addr.is_reserved
-            ):
-                return False
+            return not _ip_is_blocked(ipaddress.ip_address(host))
         except ValueError:
-            pass  # hostname, not a raw IP — allow it
+            pass  # a hostname — resolve it below.
+
+        # Resolve the hostname and require EVERY answer to be public.
+        try:
+            infos = socket.getaddrinfo(host, None)
+        except socket.gaierror:
+            return False  # cannot resolve — do not fetch.
+
+        resolved = {info[4][0] for info in infos}
+        if not resolved:
+            return False
+
+        for ip in resolved:
+            try:
+                if _ip_is_blocked(ipaddress.ip_address(ip)):
+                    return False
+            except ValueError:
+                return False
+
         return True
     except Exception:
         return False

--- a/tests/utils/test_ssrf_url_guard.py
+++ b/tests/utils/test_ssrf_url_guard.py
@@ -1,0 +1,124 @@
+"""
+Regression tests for the SSRF guard on remote image/audio fetching.
+
+``_is_safe_url`` gates every URL that ``get_image_base64`` (and the audio path
+in ``litellm_wrapper``) will fetch. Those fetchers are reachable from
+``agent.run(img=<url>)`` with an end-user-supplied value, so a weak guard is a
+server-side request forgery hole into cloud metadata and internal services.
+
+The original guard only inspected *literal* IPs and passed every hostname
+straight through, and it never resolved names — so ``2130706433`` (decimal
+127.0.0.1), ``metadata.google.internal``, and wildcard-DNS names like
+``127.0.0.1.nip.io`` all sailed past. These tests lock the closures shut.
+
+Run:
+    pytest tests/utils/test_ssrf_url_guard.py -v
+"""
+
+import ipaddress
+
+import pytest
+
+from swarms.utils.image_file_b64 import _ip_is_blocked, _is_safe_url
+
+
+########################################################
+# Must be blocked
+########################################################
+
+BLOCKED = [
+    # Cloud metadata endpoints — the crown jewels of SSRF.
+    "http://169.254.169.254/latest/meta-data/",
+    "http://[fd00:ec2::254]/latest/meta-data/",
+    # Loopback in every notation.
+    "http://127.0.0.1:8000/admin",
+    "http://localhost/",
+    "http://LocalHost/",
+    "http://2130706433/",  # decimal 127.0.0.1
+    "http://0x7f000001/",  # hex 127.0.0.1
+    "http://[::1]/",  # IPv6 loopback
+    # IPv4 embedded in IPv6.
+    "http://[::ffff:169.254.169.254]/",
+    "http://[::ffff:127.0.0.1]/",
+    # Private ranges.
+    "http://10.0.0.5/",
+    "http://192.168.1.1/",
+    "http://172.16.0.1/",
+    # Link-local and unspecified.
+    "http://169.254.1.1/",
+    "http://0.0.0.0/",
+    # Wildcard-DNS names that resolve into blocked space.
+    "http://127.0.0.1.nip.io/",
+    # Non-HTTP schemes must never be fetched.
+    "file:///etc/passwd",
+    "ftp://internal/secret",
+    "gopher://127.0.0.1:6379/_INFO",
+    "http:///nohost",
+]
+
+
+@pytest.mark.parametrize("url", BLOCKED)
+def test_blocked_urls_are_rejected(url):
+    assert _is_safe_url(url) is False, f"SSRF guard allowed {url!r}"
+
+
+########################################################
+# Must be allowed
+########################################################
+
+ALLOWED = [
+    "http://example.com/image.png",
+    "https://example.com/image.png",
+    "https://raw.githubusercontent.com/org/repo/main/x.png",
+    "https://upload.wikimedia.org/wikipedia/commons/x.jpg",
+]
+
+
+@pytest.mark.parametrize("url", ALLOWED)
+def test_public_urls_are_allowed(url):
+    assert (
+        _is_safe_url(url) is True
+    ), f"SSRF guard blocked public {url!r}"
+
+
+########################################################
+# The address classifier
+########################################################
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "127.0.0.1",
+        "169.254.169.254",
+        "10.1.2.3",
+        "192.168.0.1",
+        "172.31.255.255",
+        "0.0.0.0",
+        "::1",
+        "fe80::1",
+        "::ffff:127.0.0.1",  # IPv4-mapped loopback
+    ],
+)
+def test_ip_is_blocked_true(ip):
+    assert _ip_is_blocked(ipaddress.ip_address(ip)) is True
+
+
+@pytest.mark.parametrize(
+    "ip", ["8.8.8.8", "1.1.1.1", "93.184.216.34"]
+)
+def test_ip_is_blocked_false(ip):
+    assert _ip_is_blocked(ipaddress.ip_address(ip)) is False
+
+
+########################################################
+# Malformed input degrades to "unsafe", never raises
+########################################################
+
+
+@pytest.mark.parametrize(
+    "value", ["", "not a url", "http://", "://x", None]
+)
+def test_malformed_is_unsafe(value):
+    # None would raise inside urlparse; the guard must swallow and reject.
+    assert _is_safe_url(value if value is not None else "") is False


### PR DESCRIPTION
## Summary

Two security fixes found in a review of remote-fetch and secret-handling paths, plus a docs move.

## 🔴 SSRF bypass in remote image/audio fetch

`swarms/utils/image_file_b64.py:_is_safe_url` gates every URL that `get_image_base64` fetches, and the same guard covers the audio path in `litellm_wrapper`. Both are reachable from **`agent.run(img=<url>)`** — an end-user-supplied value in any hosted agent.

The guard only inspected **literal** IP addresses. A hostname hit `except ValueError: pass` and was allowed **without ever being resolved**, so the private/loopback/metadata checks were skipped entirely for names and for non-dotted numeric forms.

Confirmed bypasses, all of which connect to blocked targets:

| Payload | Reaches |
|---|---|
| `http://metadata.google.internal/…` | GCP metadata (credentials) |
| `http://2130706433/` (decimal) | `127.0.0.1` |
| `http://0x7f000001/` (hex) | `127.0.0.1` |
| `http://127.0.0.1.nip.io/` | `127.0.0.1` via wildcard DNS |
| any hostname with an internal A-record | any internal IP |

Combined with the raw-IP block that already worked, this is a full SSRF into cloud metadata (`169.254.169.254`) and internal services.

**Fix:** the host is now resolved and **every** address it resolves to must be public (so a name with one public and one internal A-record cannot be used to pivot); numeric IP notations are normalized through `ipaddress` rather than trusted as opaque strings; and IPv4-in-IPv6 (`::ffff:a.b.c.d`, 6to4) is unwrapped before the check. The blocked set now also covers unspecified (`0.0.0.0`) and multicast.

A 41-case regression suite (`tests/utils/test_ssrf_url_guard.py`) locks each closure shut and confirms legitimate public URLs still pass.

**Residual risk, documented in the code:** this validates the addresses known at call time. An attacker who controls DNS can still rebind between the check and the request (TOCTOU). Eliminating that requires pinning the resolved IP for the actual connection, which the HTTP client does not currently do — a larger change, called out in the docstring rather than silently left open.

## 🟠 OAuth token cache world-readable at creation

`swarms/tools/mcp_manager.py:MCPFileTokenStorage._write` wrote the token cache with `Path.write_text` (which honors the umask, typically `0644`) and only then `chmod 0o600`. On a shared host, another local user could read the OAuth token in the window between the write and the chmod.

**Fix:** the file is created with `os.open(..., 0o600)` so it is never group/other-readable, the parent directory is created `0o700`, and the trailing `chmod` is kept to tighten any pre-existing looser file.

## Docs

`README.md` carried a large duplicated examples table; moved it into `examples/README.md` where the examples live.

## Testing

`tests/utils/test_ssrf_url_guard.py` — 41 passing, covering metadata endpoints, every loopback/private notation, IPv4-in-IPv6, wildcard-DNS names, non-HTTP schemes, the address classifier, and malformed input. Full MCP manager suite (85) still green; the token-perm change verified to produce a `0600` file and `0700` parent.

## Note on disclosure

The SSRF is remotely triggerable in a deployed agent. If a private advisory is preferred over a public PR, I can move it — flagging so the maintainers can decide.
