### PR TITLE
[feat] Kimi K3 and GraphWorkflow example scripts

### DIFF
--- a/examples/models/moonshot/kimi_k3_local.py
+++ b/examples/models/moonshot/kimi_k3_local.py
@@ -1,0 +1,36 @@
+from dotenv import load_dotenv
+
+from swarms import Agent
+
+load_dotenv()
+
+# Define an expanded system prompt tailored for customer support
+system_prompt = (
+    "You are Customer-Support-Agent, a highly skilled and empathetic virtual assistant dedicated to helping customers with a wide range of inquiries. "
+    "Your primary goal is to resolve customer issues efficiently and courteously, providing clear, accurate, and friendly support at all times. "
+    "Greet users warmly, actively listen to their concerns, and guide them through step-by-step solutions. "
+    "If you need more information, politely request clarification. Summarize actions and offer next steps if needed. "
+    "Always maintain a positive, professional tone, show patience, and reassure the user when appropriate. "
+    "If a problem falls outside your scope, kindly recommend escalation or suggest alternative resources. "
+    "Ensure all responses are easy to understand, avoid jargon, and prioritize customer satisfaction in every interaction."
+)
+
+# Initialize the agent for customer support
+agent = Agent(
+    agent_name="Customer-Support-Agent",
+    agent_description="Empathetic and efficient AI agent for providing customer support across a variety of issues",
+    system_prompt=system_prompt,
+    model_name="ollama/kimi-k3:cloud",
+    max_loops=1,
+    top_p=None,
+    temperature=None,
+    reasoning_effort="low",
+    max_tokens=16000,
+    tools_list_dictionary=None,
+)
+
+out = agent.run(
+    task="A customer writes in: 'I'm having trouble logging into my account. Can you help me get back in?'",
+)
+
+print(out)

--- a/examples/models/moonshot/kimi_k3_or.py
+++ b/examples/models/moonshot/kimi_k3_or.py
@@ -1,0 +1,36 @@
+from dotenv import load_dotenv
+
+from swarms import Agent
+
+load_dotenv()
+
+# Define an expanded system prompt tailored for customer support
+system_prompt = (
+    "You are Customer-Support-Agent, a highly skilled and empathetic virtual assistant dedicated to helping customers with a wide range of inquiries. "
+    "Your primary goal is to resolve customer issues efficiently and courteously, providing clear, accurate, and friendly support at all times. "
+    "Greet users warmly, actively listen to their concerns, and guide them through step-by-step solutions. "
+    "If you need more information, politely request clarification. Summarize actions and offer next steps if needed. "
+    "Always maintain a positive, professional tone, show patience, and reassure the user when appropriate. "
+    "If a problem falls outside your scope, kindly recommend escalation or suggest alternative resources. "
+    "Ensure all responses are easy to understand, avoid jargon, and prioritize customer satisfaction in every interaction."
+)
+
+# Initialize the agent for customer support
+agent = Agent(
+    agent_name="Customer-Support-Agent",
+    agent_description="Empathetic and efficient AI agent for providing customer support across a variety of issues",
+    system_prompt=system_prompt,
+    model_name="openrouter/moonshotai/kimi-k3",
+    max_loops=1,
+    top_p=None,
+    temperature=None,
+    reasoning_effort="low",
+    max_tokens=16000,
+    tools_list_dictionary=None,
+)
+
+out = agent.run(
+    task="A customer writes in: 'I'm having trouble logging into my account. Can you help me get back in?'",
+)
+
+print(out)

--- a/examples/models/ollama/kimi_k3_local_agent.py
+++ b/examples/models/ollama/kimi_k3_local_agent.py
@@ -1,0 +1,34 @@
+"""
+Run Kimi K3 locally with Ollama.
+
+The same single-agent example as the OpenRouter version, but served by a local
+Ollama model — the only change is the ``model_name`` string. This is the "run
+locally with Ollama" step from the "Getting Started with Kimi K3 in Swarms"
+tutorial.
+
+Pull and serve the model first:
+    ollama run kimi-k3:cloud
+
+Then run:
+    uv run examples/models/ollama/kimi_k3_local_agent.py
+"""
+
+from swarms import Agent
+
+agent = Agent(
+    agent_name="Research-Agent",
+    agent_description="A concise research and analysis assistant",
+    system_prompt=(
+        "You are a sharp research analyst. Answer clearly, cite the key "
+        "trade-offs, and state any assumptions you make."
+    ),
+    model_name="ollama/kimi-k3:cloud",  # local via Ollama; no API key needed
+    max_loops=1,
+    reasoning_effort="low",
+)
+
+result = agent.run(
+    task="Explain the trade-offs between vector databases and keyword search for RAG."
+)
+
+print(result)

--- a/examples/models/openrouter/kimi_k3_single_agent.py
+++ b/examples/models/openrouter/kimi_k3_single_agent.py
@@ -1,0 +1,36 @@
+"""
+Single-agent example using OpenRouter Moonshotai Kimi K3.
+
+A concise research/analysis assistant — the "single agent" step from the
+"Getting Started with Kimi K3 in Swarms" tutorial.
+
+Set your OpenRouter API key before running:
+    export OPENROUTER_API_KEY="your-api-key"
+
+Run:
+    uv run examples/models/openrouter/kimi_k3_single_agent.py
+"""
+
+from dotenv import load_dotenv
+
+from swarms import Agent
+
+load_dotenv()
+
+agent = Agent(
+    agent_name="Research-Agent",
+    agent_description="A concise research and analysis assistant",
+    system_prompt=(
+        "You are a sharp research analyst. Answer clearly, cite the key "
+        "trade-offs, and state any assumptions you make."
+    ),
+    model_name="openrouter/moonshotai/kimi-k3",
+    max_loops=1,
+    reasoning_effort="low",
+)
+
+result = agent.run(
+    task="Explain the trade-offs between vector databases and keyword search for RAG."
+)
+
+print(result)

--- a/examples/multi_agent/graphworkflow_examples/graph_workflow_fanout_fanin.py
+++ b/examples/multi_agent/graphworkflow_examples/graph_workflow_fanout_fanin.py
@@ -1,0 +1,60 @@
+"""
+GraphWorkflow fan-out / fan-in.
+
+A research node fans out to a summarizer and a critic that run in parallel, and
+both feed a final editor. Fan-out/fan-in is the most common non-linear pattern
+in agentic systems, and GraphWorkflow runs the independent branches (summarize
+and critique) concurrently by default — no configuration required.
+
+Graph:
+    Research ─┬─> Summarize ─┐
+              └─> Critique  ─┴─> Final
+
+Agents are passed straight into ``add_node`` / ``add_edge`` (no Node/Edge
+wrappers, no stringly-typed names), ``auto_compile=True`` prepares the graph,
+and ``run()`` returns a dict keyed by agent name.
+
+Set your model provider key before running, e.g.:
+    export OPENAI_API_KEY="your-api-key"
+
+Run:
+    uv run examples/multi_agent/graphworkflow_examples/graph_workflow_fanout_fanin.py
+"""
+
+from swarms import Agent, GraphWorkflow
+
+
+def node(name: str, prompt: str) -> Agent:
+    return Agent(
+        agent_name=name,
+        system_prompt=prompt,
+        model_name="gpt-4o-mini",
+        max_loops=1,
+    )
+
+
+research = node("Research", "Research the given topic thoroughly.")
+summarize = node(
+    "Summarize", "Summarize the research into key points."
+)
+critique = node(
+    "Critique", "Critique the research and flag weak claims."
+)
+final = node(
+    "Final", "Write the final brief from the summary and critique."
+)
+
+wf = GraphWorkflow(name="Analysis", auto_compile=True)
+
+for agent in (research, summarize, critique, final):
+    wf.add_node(agent)
+
+wf.add_edge(research, summarize)
+wf.add_edge(research, critique)
+wf.add_edge(summarize, final)
+wf.add_edge(critique, final)
+
+result = wf.run(task="Assess the EV battery market")
+
+# result is a dict keyed by agent name; every intermediate is available too.
+print(result["Final"])

--- a/examples/multi_agent/groupchat/kimi_k3_groupchat.py
+++ b/examples/multi_agent/groupchat/kimi_k3_groupchat.py
@@ -1,0 +1,63 @@
+"""
+GroupChat of Kimi K3 agents.
+
+Three agents with distinct personas (optimist, skeptic, realist) discuss a
+question and reach a conclusion. This is the "multi-agent GroupChat" step from
+the "Getting Started with Kimi K3 in Swarms" tutorial.
+
+Each agent listens to the others and decides on its own whether to chime in.
+``GroupChat`` handles speaker selection, message passing, and the stopping
+condition — ``auto_equip`` (on by default) injects the RESPOND_TOOL into every
+agent, so there is no extra tooling to attach.
+
+Set your OpenRouter API key before running:
+    export OPENROUTER_API_KEY="your-api-key"
+
+Run:
+    uv run examples/multi_agent/groupchat/kimi_k3_groupchat.py
+"""
+
+from dotenv import load_dotenv
+
+from swarms import Agent
+from swarms.structs.groupchat import GroupChat
+
+load_dotenv()
+
+MODEL = "openrouter/moonshotai/kimi-k3"
+
+optimist = Agent(
+    agent_name="Optimist",
+    system_prompt="You argue for the opportunities and upside.",
+    model_name=MODEL,
+    max_loops=1,
+    persistent_memory=False,
+)
+
+skeptic = Agent(
+    agent_name="Skeptic",
+    system_prompt="You stress-test claims and surface the risks.",
+    model_name=MODEL,
+    max_loops=1,
+    persistent_memory=False,
+)
+
+realist = Agent(
+    agent_name="Realist",
+    system_prompt="You weigh both sides and push for a decision.",
+    model_name=MODEL,
+    max_loops=1,
+    persistent_memory=False,
+)
+
+chat = GroupChat(
+    name="Kimi Roundtable",
+    agents=[optimist, skeptic, realist],
+    max_loops=6,
+)
+
+result = chat.run(
+    "Should an early-stage startup build its own agents or buy a platform?"
+)
+
+print(result)


### PR DESCRIPTION
## Summary

Adds runnable example scripts that back two blog posts — the Kimi K3 getting-started tutorial and the Swarms `GraphWorkflow` vs LangGraph comparison. Each file is placed in its conventional folder so a reader who copies code from the blog lands on a runnable script.

## Files

**Kimi K3 (Moonshot) agents**

| File | Shows |
|---|---|
| `examples/models/openrouter/kimi_k3_single_agent.py` | Single Kimi K3 agent via OpenRouter |
| `examples/models/ollama/kimi_k3_local_agent.py` | The same agent served locally with Ollama — a one-line `model_name` swap |
| `examples/models/moonshot/kimi_k3_or.py` | Kimi K3 support agent (OpenRouter) |
| `examples/models/moonshot/kimi_k3_local.py` | Kimi K3 support agent (Ollama) |
| `examples/multi_agent/groupchat/kimi_k3_groupchat.py` | Three Kimi agents debating in a `GroupChat` |

**GraphWorkflow**

| File | Shows |
|---|---|
| `examples/multi_agent/graphworkflow_examples/graph_workflow_fanout_fanin.py` | Parallel fan-out/fan-in DAG — research fans out to summarize + critique, both feed a final editor |

## Notes

- The Ollama examples use `model_name="ollama/kimi-k3:cloud"`; the OpenRouter ones use `openrouter/moonshotai/kimi-k3` — both verified against the existing model examples in the repo.
- The GraphWorkflow example uses the ergonomic API (`add_node(agent)` / `add_edge(agent_a, agent_b)` with `auto_compile=True`), demonstrating that independent branches run concurrently by default.

## Verification

Every file compiles. The GraphWorkflow and GroupChat examples were run end to end against a stubbed model (no API cost) and execute correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
