### PR TITLE
[Improvement] ConcurrentWorkflow: add max_workers so the pool is not capped at CPU cores

### DIFF
--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -48,6 +48,8 @@ class ConcurrentWorkflow:
         agent_statuses (dict): Dictionary tracking status and output of each agent
         metadata_output_path (str): Path for saving workflow metadata
         conversation (Conversation): Conversation object for storing agent interactions
+        max_workers (Optional[int]): Thread pool size for concurrent agent
+            execution. Defaults to a CPU-core heuristic when not set.
 
     Methods:
         run: Execute all agents concurrently on a given task
@@ -90,6 +92,7 @@ class ConcurrentWorkflow:
         autosave: bool = True,
         verbose: bool = False,
         on_error: str = "store",
+        max_workers: Optional[int] = None,
     ):
         self.id = id or generate_id("concurrent-workflow")
         self.name = name
@@ -103,6 +106,7 @@ class ConcurrentWorkflow:
         self.autosave = autosave
         self.verbose = verbose
         self.on_error = on_error
+        self.max_workers = max_workers
         self.swarm_workspace_dir = None
         self.metadata_output_path = (
             f"concurrent_workflow_name_{name}_id_{self.id}.json"
@@ -147,6 +151,18 @@ class ConcurrentWorkflow:
                 agent.print_on = False
         return self.agents
 
+    def _resolve_max_workers(self) -> int:
+        """Determine the thread pool size for concurrent agent execution.
+
+        Agent calls are I/O-bound (network calls to LLM providers), so CPU core
+        count is rarely the right sizing signal. Uses ``self.max_workers`` when
+        explicitly configured; otherwise falls back to the prior default of
+        ``0.95 * cpu_count()``.
+        """
+        if self.max_workers is not None:
+            return max(1, int(self.max_workers))
+        return max(1, int((get_cpu_cores() or 1) * 0.95))
+
     def reliability_check(self):
         """
         Validate workflow configuration.
@@ -155,9 +171,11 @@ class ConcurrentWorkflow:
         - Checks that agents are provided
         - Validates that agents list is not empty
         - Warns if only one agent is provided (concurrent execution not beneficial)
+        - Validates max_workers is positive when provided
 
         Raises:
-            ValueError: If no agents are provided or agents list is empty.
+            ValueError: If no agents are provided, agents list is empty, or
+                max_workers is not positive.
             Exception: If any other validation error occurs.
         """
         try:
@@ -169,6 +187,11 @@ class ConcurrentWorkflow:
             if len(self.agents) == 0:
                 raise ValueError(
                     "ConcurrentWorkflow: No agents provided"
+                )
+
+            if self.max_workers is not None and self.max_workers <= 0:
+                raise ValueError(
+                    "ConcurrentWorkflow: max_workers must be greater than 0 when provided."
                 )
 
             if len(self.agents) == 1:
@@ -261,7 +284,7 @@ class ConcurrentWorkflow:
             if self.show_dashboard:
                 self.display_agent_dashboard()
 
-            max_workers = int(get_cpu_cores() * 0.95)
+            max_workers = self._resolve_max_workers()
             futures = []
             results = []
 
@@ -409,7 +432,7 @@ class ConcurrentWorkflow:
         """
         self.conversation.add(role="User", content=task)
 
-        max_workers = int(get_cpu_cores() * 0.95)
+        max_workers = self._resolve_max_workers()
 
         with ContextThreadPoolExecutor(
             max_workers=max_workers

--- a/tests/structs/test_concurrent_workflow.py
+++ b/tests/structs/test_concurrent_workflow.py
@@ -490,5 +490,40 @@ def test_concurrent_workflow_autosave_saves_conversation_after_run(
     get_workspace_dir.cache_clear()
 
 
+def _worker_stub(name: str) -> Agent:
+    return Agent(
+        agent_name=name,
+        agent_description=f"{name} test agent",
+        model_name="gpt-5.4",
+        max_loops=1,
+        verbose=False,
+        print_on=False,
+    )
+
+
+def test_max_workers_defaults_to_cpu_heuristic():
+    workflow = ConcurrentWorkflow(agents=[_worker_stub("A")])
+
+    assert workflow.max_workers is None
+    assert workflow._resolve_max_workers() == max(
+        1, int((os.cpu_count() or 1) * 0.95)
+    )
+
+
+def test_max_workers_override_is_used():
+    """Agent calls are network-bound, so the pool must be sizeable above cores."""
+    workflow = ConcurrentWorkflow(
+        agents=[_worker_stub("A")],
+        max_workers=64,
+    )
+
+    assert workflow._resolve_max_workers() == 64
+
+
+def test_non_positive_max_workers_is_rejected():
+    with pytest.raises(ValueError, match="max_workers"):
+        ConcurrentWorkflow(agents=[_worker_stub("A")], max_workers=0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #1737.

`ConcurrentWorkflow` hardcoded its thread pool size in two places, with no way for a caller to override it:

```python
# concurrent_workflow.py, in run() and in the streaming run path
max_workers = int(get_cpu_cores() * 0.95)
```

Agent runs are network calls to an LLM provider, so they are I/O-bound. Core count is not a useful sizing signal for them. On an 8-core machine a workflow of 50 agents executes 7 at a time, and the only way around it was to stop using `ConcurrentWorkflow`.

## Approach

`HierarchicalSwarm` already fixed exactly this, in `_resolve_max_workers()`:

```python
def _resolve_max_workers(self) -> int:
    """...Worker calls are I/O-bound (network calls to LLM providers), so CPU
    core count is rarely the right sizing signal..."""
    if self.max_workers is not None:
        return max(1, int(self.max_workers))
    return max(1, int((os.cpu_count() or 1) * 0.75))
```

So this mirrors that method for `ConcurrentWorkflow` rather than introducing a second pattern for the same problem:

- optional `max_workers` constructor argument, defaulting to `None`
- `_resolve_max_workers()` falling back to the **previous** `0.95 * cpu_count()` default
- validation in `reliability_check()`, worded to match the message `HierarchicalSwarm` uses
- both call sites now use the resolver

The default is deliberately unchanged, so this is not a behaviour change for existing callers. It only removes the ceiling for those who want to lift it. Whether the *default* should also be raised is a separate judgement call for maintainers, and is not made here.

## Incidental fix

`get_cpu_cores()` returns `os.cpu_count()`, and its own docstring notes this may be `None`. The previous `int(get_cpu_cores() * 0.95)` would raise `TypeError` on such a platform. The resolver uses `(get_cpu_cores() or 1)`, matching how `HierarchicalSwarm` guards it.

## Tests

Three tests added to `tests/structs/test_concurrent_workflow.py`, mirroring the shape of the existing `HierarchicalSwarm` max_workers tests:

- `test_max_workers_defaults_to_cpu_heuristic` — default is unchanged
- `test_max_workers_override_is_used` — an override above core count is honoured
- `test_non_positive_max_workers_is_rejected` — `max_workers=0` raises

All three were confirmed to fail against unpatched `concurrent_workflow.py` (`TypeError: __init__() got an unexpected keyword argument 'max_workers'`) and to pass with the patch.

Also verified end to end against `claude-haiku-4-5`: `ConcurrentWorkflow(agents=..., max_workers=32)` resolves to 32 and runs; with no argument it resolves to 9 on a 10-core machine, as before.

## Unrelated observation, not addressed here

While smoke-testing, a 3-agent `ConcurrentWorkflow` returned output for only 2 agents, and `agent_statuses` remained `pending` for all three after a completed run. This reproduces identically on unpatched `master`, so it is pre-existing and independent of this change. Flagging it here rather than folding it into this diff; happy to open it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
