### PR TITLE
[BUG] SequentialWorkflow drift detection reruns the pipeline forever on persistent low scores

### DIFF
--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -95,6 +95,7 @@ class SequentialWorkflow:
         drift_detection: bool = False,
         drift_threshold: float = 0.75,
         drift_model: str = "claude-sonnet-4-5",
+        drift_max_retries: int = 3,
         *args,
         **kwargs,
     ):
@@ -118,6 +119,10 @@ class SequentialWorkflow:
                 A warning is logged when the score falls below this value. Defaults to 0.75.
             drift_model (str, optional): Model used by the drift detection judge agent.
                 Defaults to "claude-sonnet-4-5".
+            drift_max_retries (int, optional): Maximum number of pipeline reruns when the
+                drift score stays below drift_threshold. Once exhausted the last output is
+                returned with a warning instead of rerunning forever. 0 disables reruns, so
+                the output is scored and reported but never regenerated. Defaults to 3.
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
@@ -136,6 +141,7 @@ class SequentialWorkflow:
         self.autosave = autosave
         self.verbose = verbose
         self.drift_threshold = drift_threshold
+        self.drift_max_retries = drift_max_retries
         self.drift_agent = (
             Agent(
                 agent_name="DriftDetector",
@@ -183,6 +189,11 @@ class SequentialWorkflow:
 
         if self.max_loops == 0:
             raise ValueError("max_loops cannot be 0")
+
+        if self.drift_max_retries < 0:
+            raise ValueError(
+                "drift_max_retries must be greater than or equal to 0"
+            )
 
         if self.multi_agent_collab_prompt is True:
             for agent in self.agents:
@@ -239,7 +250,15 @@ class SequentialWorkflow:
     def _run_drift_detection(
         self, task: str, result: str, run_kwargs: dict
     ) -> str:
-        while True:
+        """Score the final output and rerun the pipeline while it drifts.
+
+        Bounded by ``drift_max_retries``. An output that never reaches
+        ``drift_threshold`` -- an impossible task, a threshold set too high, a
+        judge that always scores low -- would otherwise rerun every agent
+        forever, so the last attempt is returned with a warning once the retry
+        budget is spent.
+        """
+        for attempt in range(self.drift_max_retries + 1):
             try:
                 raw = self.drift_agent.run(
                     f"Original task: {task}\n\nFinal output: {result}"
@@ -254,10 +273,18 @@ class SequentialWorkflow:
                 logger.warning(
                     f"Drift detection failed ({e}); skipping"
                 )
-                break
+                return result
             if score >= self.drift_threshold:
                 logger.info(f"Drift check passed: score={score:.2f}")
-                break
+                return result
+            if attempt == self.drift_max_retries:
+                logger.warning(
+                    f"Drift detected: score={score:.2f} below threshold="
+                    f"{self.drift_threshold}, but drift_max_retries="
+                    f"{self.drift_max_retries} is exhausted; returning the "
+                    "last output as-is"
+                )
+                return result
             logger.warning(
                 f"Drift detected: score={score:.2f} below threshold={self.drift_threshold}, rerunning pipeline"
             )
@@ -280,9 +307,9 @@ class SequentialWorkflow:
 
         If drift_detection is configured, a judge agent scores the final output's semantic
         alignment with the original task after the pipeline completes. If the score falls
-        below drift_threshold, the pipeline reruns and the cycle repeats until the score
-        meets the threshold. If the judge output cannot be parsed, drift checking is skipped
-        and the last result is returned as-is.
+        below drift_threshold, the pipeline reruns, for at most drift_max_retries attempts,
+        after which the last output is returned with a warning. If the judge output cannot
+        be parsed, drift checking is skipped and the last result is returned as-is.
 
         Args:
             task (str): The task for the agents to execute.

--- a/tests/structs/test_sequential_workflow.py
+++ b/tests/structs/test_sequential_workflow.py
@@ -557,3 +557,58 @@ def test_workflow_run_drift_retries_until_threshold_met():
     assert result == "good output"
     assert pipeline_call_count == 3
     assert drift_call_count == 3
+
+
+def test_workflow_run_drift_stops_at_max_retries():
+    """A score that never clears the threshold must not rerun forever.
+
+    Without a retry cap this test does not fail, it hangs: the judge always
+    scores below threshold, so the pipeline is rerun in an unbounded loop.
+    """
+    wf = _make_workflow(
+        drift_detection=True,
+        drift_threshold=0.75,
+        drift_max_retries=2,
+    )
+
+    pipeline_call_count = 0
+
+    def pipeline_side_effect(**kwargs):
+        nonlocal pipeline_call_count
+        pipeline_call_count += 1
+        return f"output {pipeline_call_count}"
+
+    with patch.object(
+        wf.agent_rearrange, "run", side_effect=pipeline_side_effect
+    ), patch.object(
+        wf.drift_agent, "run", return_value=_tool_call_response(0.1)
+    ):
+        result = wf.run("task")
+
+    # one initial run plus drift_max_retries reruns
+    assert pipeline_call_count == 3
+    assert result == "output 3"
+
+
+def test_workflow_drift_max_retries_zero_never_reruns():
+    """drift_max_retries=0 scores the output but never regenerates it."""
+    wf = _make_workflow(
+        drift_detection=True,
+        drift_threshold=0.75,
+        drift_max_retries=0,
+    )
+
+    with patch.object(
+        wf.agent_rearrange, "run", return_value="only output"
+    ) as pipeline, patch.object(
+        wf.drift_agent, "run", return_value=_tool_call_response(0.1)
+    ):
+        result = wf.run("task")
+
+    assert pipeline.call_count == 1
+    assert result == "only output"
+
+
+def test_negative_drift_max_retries_is_rejected():
+    with pytest.raises(ValueError, match="drift_max_retries"):
+        _make_workflow(drift_detection=True, drift_max_retries=-1)


### PR DESCRIPTION
Closes #1536.

`SequentialWorkflow._run_drift_detection()` is a `while True:` loop with only two exits: the judge output failing to parse, or the score reaching `drift_threshold`.

```python
def _run_drift_detection(self, task, result, run_kwargs) -> str:
    while True:
        try:
            ...
            score = float(...)
        except Exception as e:
            logger.warning(f"Drift detection failed ({e}); skipping")
            break
        if score >= self.drift_threshold:
            break
        logger.warning("Drift detected ... rerunning pipeline")
        result = self.agent_rearrange.run(**run_kwargs)   # <-- reruns every agent
    return result
```

Neither exit is guaranteed. If the score persistently stays below the threshold — a task the pipeline cannot satisfy, a `drift_threshold` set too high, or a judge that just scores low — every agent in the workflow is rerun forever. Each iteration is a full pipeline of LLM calls, so this burns tokens without a ceiling, and there is no parameter a caller can set to stop it.

## Reproduction

This test hangs indefinitely against current `master`:

```python
wf = _make_workflow(drift_detection=True, drift_threshold=0.75)
with patch.object(wf.agent_rearrange, "run", return_value="output"), \
     patch.object(wf.drift_agent, "run", return_value=_tool_call_response(0.1)):
    wf.run("task")   # never returns
```

Confirmed by running it under a 20s subprocess timeout on unpatched source: `TIMED OUT after 20s`. With the patch the same test completes in ~1.6s.

## Change

Adds `drift_max_retries` (default `3`) and converts the loop to a bounded `for`. When the budget is spent the last output is returned with a warning that names the exhausted setting:

```
Drift detected: score=0.10 below threshold=0.75, but drift_max_retries=2
is exhausted; returning the last output as-is
```

`drift_max_retries=0` disables reruns entirely, so the output is still scored and reported but never regenerated — useful if you want drift *observability* without paying for retries. Validated as `>= 0` in `reliability_check()`, matching how `HierarchicalSwarm` validates `max_agent_retries`.

Two deliberate choices:

- **Returns the last attempt, not the best-scoring one.** Tracking the best score is a few more lines and arguably nicer output, but it would change the returned value on paths that already terminated today. Keeping it to a bounding change means every previously-terminating call returns exactly what it returned before. Happy to add best-score selection if you would prefer it.
- **Warns rather than raises.** Raising would break callers who currently do get a passing result eventually. A best-effort return with a loud warning preserves existing behaviour where it worked.

The `run()` docstring promised the cycle "repeats until the score meets the threshold" — an accurate description of the bug. It now describes the bounded behaviour.

## Tests

Three tests added to `tests/structs/test_sequential_workflow.py`, reusing the existing `_make_workflow` and `_tool_call_response` helpers:

- `test_workflow_run_drift_stops_at_max_retries` — an always-low judge terminates after `1 + drift_max_retries` pipeline runs. **Hangs** on unpatched source rather than failing, which is the point.
- `test_workflow_drift_max_retries_zero_never_reruns` — `0` scores without regenerating.
- `test_negative_drift_max_retries_is_rejected` — negative values raise.

The 11 pre-existing drift tests still pass, including `test_workflow_run_drift_retries_until_threshold_met`, which exercises two reruns before passing and is unaffected by the default cap of 3. 25 offline tests in that file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
