### PR TITLE
[perf][GraphWorkflow][native rustworkx algorithms, shared thread pool, single-pass compile]

### DIFF
--- a/example.py
+++ b/example.py
@@ -18,7 +18,7 @@ system_prompt = (
 
 # Initialize the agent
 agent = Agent(
-    agent_name="Quantitative-Trading-Agent--new",
+    agent_name="Quantitative-Trading-Agent",
     agent_description="Advanced quantitative trading and algorithmic analysis agent",
     system_prompt=system_prompt,
     model_name="gpt-5.4",

--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -154,6 +154,34 @@ class GraphBackend:
         """
         raise NotImplementedError
 
+    def is_dag(self) -> bool:
+        """
+        Report whether the graph is acyclic.
+
+        Cheap O(V+E) alternative to enumerating every simple cycle, which is
+        exponential in the number of cycles.
+
+        Returns:
+            bool: True when the graph contains no directed cycle.
+        """
+        raise NotImplementedError
+
+    def adjacency(
+        self,
+    ) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
+        """
+        Materialise successor and predecessor maps in a single pass.
+
+        Callers that need repeated neighbour lookups (validation, prompt
+        building) use this instead of paying per-node backend calls.
+
+        Returns:
+            Tuple[Dict[str, List[str]], Dict[str, List[str]]]: ``(successors,
+            predecessors)`` keyed by node ID. Every node is present, including
+            isolated ones.
+        """
+        raise NotImplementedError
+
 
 class NetworkXBackend(GraphBackend):
     """
@@ -241,9 +269,35 @@ class NetworkXBackend(GraphBackend):
         Get topological generations (layers) of the graph.
 
         Returns:
-            List[List[str]]: List of layers, where each layer is a list of node IDs.
+            List[List[str]]: List of layers, where each layer is a list of node
+            IDs. A cyclic remainder, if any, is appended as a final layer
+            rather than raising.
         """
-        return list(nx.topological_generations(self.graph))
+        try:
+            return list(nx.topological_generations(self.graph))
+        except nx.NetworkXUnfeasible:
+            # Cyclic graph: layer what we can with Kahn's algorithm and append
+            # the cyclic remainder so callers still get an execution order.
+            graph = self.graph
+            indegree = dict(graph.in_degree())
+            frontier = [n for n, d in indegree.items() if d == 0]
+            layers: List[List[str]] = []
+            placed = 0
+            while frontier:
+                layers.append(frontier)
+                placed += len(frontier)
+                nxt = []
+                for node_id in frontier:
+                    for succ_id in graph.successors(node_id):
+                        indegree[succ_id] -= 1
+                        if indegree[succ_id] == 0:
+                            nxt.append(succ_id)
+                frontier = nxt
+            if placed < graph.number_of_nodes():
+                layers.append(
+                    [n for n, d in indegree.items() if d > 0]
+                )
+            return layers
 
     def simple_cycles(self) -> List[List[str]]:
         """
@@ -252,6 +306,10 @@ class NetworkXBackend(GraphBackend):
         Returns:
             List[List[str]]: List of cycles, where each cycle is a list of node IDs.
         """
+        # Enumerating simple cycles is exponential in the number of cycles, so
+        # short-circuit on the overwhelmingly common acyclic case first.
+        if nx.is_directed_acyclic_graph(self.graph):
+            return []
         return list(nx.simple_cycles(self.graph))
 
     def descendants(self, node_id: str) -> Set[str]:
@@ -265,6 +323,33 @@ class NetworkXBackend(GraphBackend):
             Set[str]: Set of descendant node IDs.
         """
         return nx.descendants(self.graph, node_id)
+
+    def is_dag(self) -> bool:
+        """
+        Report whether the graph is acyclic.
+
+        Returns:
+            bool: True when the graph contains no directed cycle.
+        """
+        return nx.is_directed_acyclic_graph(self.graph)
+
+    def adjacency(
+        self,
+    ) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
+        """
+        Materialise successor and predecessor maps in a single pass.
+
+        Returns:
+            Tuple[Dict[str, List[str]], Dict[str, List[str]]]: ``(successors,
+            predecessors)`` keyed by node ID.
+        """
+        graph = self.graph
+        succ: Dict[str, List[str]] = {n: [] for n in graph}
+        pred: Dict[str, List[str]] = {n: [] for n in graph}
+        for source, target in graph.edges():
+            succ[source].append(target)
+            pred[target].append(source)
+        return succ, pred
 
 
 class RustworkxBackend(GraphBackend):
@@ -383,13 +468,17 @@ class RustworkxBackend(GraphBackend):
         if node_id not in self._node_id_to_index:
             return iter([])
         target_index = self._node_id_to_index[node_id]
-        # Use edge list to find predecessors (more reliable than predecessors() method)
-        result = []
-        for edge in self.graph.edge_list():
-            source_idx, target_idx = edge
-            if target_idx == target_index:
-                result.append(self._index_to_node_id[source_idx])
-        return iter(result)
+        index_to_id = self._index_to_node_id
+        # predecessor_indices is O(in-degree); scanning the full edge list
+        # would make this O(E) per node.
+        return iter(
+            [
+                index_to_id[idx]
+                for idx in self.graph.predecessor_indices(
+                    target_index
+                )
+            ]
+        )
 
     def reverse(self) -> "RustworkxBackend":
         """
@@ -419,82 +508,86 @@ class RustworkxBackend(GraphBackend):
         Returns:
             List[List[str]]: List of layers, where each layer is a list of node IDs.
         """
+        all_indices = list(self._node_id_to_index.values())
+        if not all_indices:
+            return []
+
+        index_to_id = self._index_to_node_id
+
         try:
-            # Get all node indices
-            all_indices = list(self._node_id_to_index.values())
-            if not all_indices:
-                return []
-
-            # Use layer-by-layer approach similar to NetworkX topological_generations
-            layers = []
-            remaining = set(all_indices)
-            processed = set()
-
-            while remaining:
-                # Find all nodes with in-degree 0 considering only edges from processed nodes
-                # In rustworkx, we need to check if all predecessors are in processed set
-                layer = []
-                # First pass: identify nodes that can be added to this layer
-                # (without modifying remaining/processed during iteration)
-                nodes_to_add = []
-                for idx in list(remaining):
-                    # Get all predecessors using edge list
-                    pred_indices = []
-                    for edge in self.graph.edge_list():
-                        source_idx, target_idx = edge
-                        if target_idx == idx:
-                            pred_indices.append(source_idx)
-                    # Check if all predecessors have been processed (or node has no predecessors)
-                    # A node can be added to the layer if:
-                    # 1. It has no predecessors (entry node), OR
-                    # 2. All its predecessors have already been processed (from previous layers)
-                    if not pred_indices:
-                        # No predecessors - this is an entry node
-                        nodes_to_add.append(idx)
-                    elif all(
-                        pred_idx in processed
-                        for pred_idx in pred_indices
-                    ):
-                        # All predecessors have been processed in previous layers
-                        nodes_to_add.append(idx)
-
-                # Second pass: add identified nodes to the layer and update sets
-                for idx in nodes_to_add:
-                    layer.append(self._index_to_node_id[idx])
-                    remaining.remove(idx)
-                    processed.add(idx)
-
-                if not layer:
-                    # Cycle detected or error, break
-                    break
-
-                layers.append(layer)
-
-            # If there are remaining nodes, they form a cycle - add them as a final layer
-            if remaining:
-                cycle_layer = [
-                    self._index_to_node_id[idx] for idx in remaining
-                ]
-                layers.append(cycle_layer)
-
-            return (
-                layers
-                if layers
-                else [
-                    [
-                        self._index_to_node_id[idx]
-                        for idx in all_indices
-                    ]
-                ]
-            )
-        except Exception as e:
-            logger.warning(
-                f"Error in rustworkx topological_generations: {e}, falling back to simple approach"
-            )
-            # Fallback: return all nodes in one layer
-            return [
-                [node_id for node_id in self._node_id_to_index.keys()]
+            # rustworkx computes generations natively in Rust — O(V+E).
+            layers = [
+                [index_to_id[idx] for idx in generation]
+                for generation in rx.topological_generations(
+                    self.graph
+                )
             ]
+        except Exception as e:
+            # Raised when the graph contains a cycle. Fall back to Kahn's
+            # algorithm so the cyclic remainder is still surfaced as a final
+            # layer, matching the previous behaviour.
+            logger.warning(
+                f"rustworkx topological_generations failed ({e}); "
+                "falling back to Kahn's algorithm"
+            )
+            return self._kahn_generations(all_indices)
+
+        placed = sum(len(layer) for layer in layers)
+        if placed < len(all_indices):
+            # Cyclic remainder: append the unplaced nodes as a final layer.
+            seen = {nid for layer in layers for nid in layer}
+            layers.append(
+                [
+                    index_to_id[idx]
+                    for idx in all_indices
+                    if index_to_id[idx] not in seen
+                ]
+            )
+
+        return layers or [[index_to_id[idx] for idx in all_indices]]
+
+    def _kahn_generations(
+        self, all_indices: List[int]
+    ) -> List[List[str]]:
+        """
+        Layer the graph with Kahn's algorithm, tolerating cycles.
+
+        Args:
+            all_indices (List[int]): Every node index in the graph.
+
+        Returns:
+            List[List[str]]: Layers of node IDs; any cyclic remainder is
+            appended as a final layer.
+        """
+        index_to_id = self._index_to_node_id
+        graph = self.graph
+
+        indegree = {idx: graph.in_degree(idx) for idx in all_indices}
+        frontier = [idx for idx in all_indices if indegree[idx] == 0]
+        layers: List[List[str]] = []
+        placed = 0
+
+        while frontier:
+            layers.append([index_to_id[idx] for idx in frontier])
+            placed += len(frontier)
+            nxt = []
+            for idx in frontier:
+                for succ_idx in graph.successor_indices(idx):
+                    indegree[succ_idx] -= 1
+                    if indegree[succ_idx] == 0:
+                        nxt.append(succ_idx)
+            frontier = nxt
+
+        if placed < len(all_indices):
+            layers.append(
+                [
+                    index_to_id[idx]
+                    for idx in all_indices
+                    if indegree[idx] > 0
+                ]
+            )
+
+        return layers or [[index_to_id[idx] for idx in all_indices]]
 
     def simple_cycles(self) -> List[List[str]]:
         """
@@ -504,22 +597,15 @@ class RustworkxBackend(GraphBackend):
             List[List[str]]: List of cycles, where each cycle is a list of node IDs.
         """
         try:
-            # Convert to NetworkX temporarily for cycle detection
-            # This is a limitation of rustworkx - it doesn't have simple_cycles
-            # We'll use a workaround by converting temporarily
-            import networkx as nx
-
-            nx_graph = nx.DiGraph()
-            for node_id in self._node_id_to_index.keys():
-                nx_graph.add_node(node_id)
-            for edge in self.graph.edge_list():
-                source_idx, target_idx = edge
-                source_id = self._index_to_node_id[source_idx]
-                target_id = self._index_to_node_id[target_idx]
-                nx_graph.add_edge(source_id, target_id)
-
-            cycles = list(nx.simple_cycles(nx_graph))
-            return cycles
+            # Enumerating cycles is exponential in their count; the acyclic
+            # check is O(V+E) and covers the common case.
+            if rx.is_directed_acyclic_graph(self.graph):
+                return []
+            index_to_id = self._index_to_node_id
+            return [
+                [index_to_id[idx] for idx in cycle]
+                for cycle in rx.simple_cycles(self.graph)
+            ]
         except Exception as e:
             logger.warning(
                 f"Error in rustworkx simple_cycles: {e}, returning empty list"
@@ -539,38 +625,46 @@ class RustworkxBackend(GraphBackend):
         if node_id not in self._node_id_to_index:
             return set()
         node_index = self._node_id_to_index[node_id]
-        # Use BFS to find all descendants
-        descendants = set()
-        queue = [node_index]
-        visited = {node_index}
+        index_to_id = self._index_to_node_id
+        # Native Rust traversal; the previous hand-rolled BFS also used
+        # list.pop(0), which is O(n) per dequeue.
+        return {
+            index_to_id[idx]
+            for idx in rx.descendants(self.graph, node_index)
+        }
 
-        while queue:
-            current_idx = queue.pop(0)
-            succ_data = self.graph.successors(current_idx)
-            for succ in succ_data:
-                # Handle both dict (node data) and int (index) returns
-                if isinstance(succ, dict):
-                    succ_node_id = succ.get("node_id")
-                    if (
-                        succ_node_id
-                        and succ_node_id in self._node_id_to_index
-                    ):
-                        succ_idx = self._node_id_to_index[
-                            succ_node_id
-                        ]
-                    else:
-                        continue
-                elif isinstance(succ, int):
-                    succ_idx = succ
-                else:
-                    continue
+    def is_dag(self) -> bool:
+        """
+        Report whether the graph is acyclic.
 
-                if succ_idx not in visited:
-                    visited.add(succ_idx)
-                    descendants.add(self._index_to_node_id[succ_idx])
-                    queue.append(succ_idx)
+        Returns:
+            bool: True when the graph contains no directed cycle.
+        """
+        return rx.is_directed_acyclic_graph(self.graph)
 
-        return descendants
+    def adjacency(
+        self,
+    ) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
+        """
+        Materialise successor and predecessor maps in a single pass.
+
+        Returns:
+            Tuple[Dict[str, List[str]], Dict[str, List[str]]]: ``(successors,
+            predecessors)`` keyed by node ID.
+        """
+        index_to_id = self._index_to_node_id
+        succ: Dict[str, List[str]] = {
+            nid: [] for nid in self._node_id_to_index
+        }
+        pred: Dict[str, List[str]] = {
+            nid: [] for nid in self._node_id_to_index
+        }
+        for source_idx, target_idx in self.graph.edge_list():
+            source_id = index_to_id[source_idx]
+            target_id = index_to_id[target_idx]
+            succ[source_id].append(target_id)
+            pred[target_id].append(source_id)
+        return succ, pred
 
 
 class NodeType(str, Enum):
@@ -825,6 +919,9 @@ class GraphWorkflow:
         # Private optimization attributes
         self._compiled = False
         self._sorted_layers = []
+        self._execution_plan = []
+        self._successors_map = {}
+        self._predecessors_cache = {}
         self.max_parallel_nodes = max_parallel_nodes
         self._max_workers = (
             max(1, max_parallel_nodes)
@@ -927,13 +1024,14 @@ class GraphWorkflow:
 
         self._compiled = False
         self._sorted_layers = []
+        self._execution_plan = []
+        self._successors_map = {}
         self._compilation_timestamp = None
 
         # Clear predecessors cache when graph structure changes
-        if hasattr(self, "_predecessors_cache"):
-            self._predecessors_cache = {}
-            if self.verbose:
-                logger.debug("Cleared predecessors cache")
+        self._predecessors_cache = {}
+        if self.verbose:
+            logger.debug("Cleared predecessors cache")
 
     def compile(self) -> None:
         """
@@ -969,28 +1067,6 @@ class GraphWorkflow:
                 logger.debug(f"Entry points: {self.entry_points}")
                 logger.debug(f"End points: {self.end_points}")
 
-            # Run structural validation so misconfiguration is surfaced at
-            # build time rather than mid-execution.  We never raise here so
-            # that compile() stays backward-compatible; callers that want
-            # strict enforcement should call validate(raise_on_error=True)
-            # explicitly.
-            if self.nodes:
-                _vr = self.validate(
-                    auto_fix=False, raise_on_error=False
-                )
-                if _vr["errors"]:
-                    logger.warning(
-                        f"GraphWorkflow compile: validation found "
-                        f"{len(_vr['errors'])} error(s) — "
-                        + "; ".join(_vr["errors"])
-                    )
-                if _vr["warnings"] and self.verbose:
-                    logger.warning(
-                        f"GraphWorkflow compile: validation found "
-                        f"{len(_vr['warnings'])} warning(s) — "
-                        + "; ".join(_vr["warnings"])
-                    )
-
             # Pre-compute topological layers for efficient execution
             if self.verbose:
                 logger.debug("Computing topological layers")
@@ -999,6 +1075,54 @@ class GraphWorkflow:
                 self.graph_backend.topological_generations()
             )
             self._sorted_layers = sorted_layers
+
+            # Build the adjacency maps once and reuse them for validation and
+            # for per-node predecessor lookups during execution.
+            succ, pred = self.graph_backend.adjacency()
+            self._successors_map = succ
+            self._predecessors_cache = {
+                node_id: tuple(parents)
+                for node_id, parents in pred.items()
+            }
+
+            # Structural validation, surfaced at build time rather than
+            # mid-execution.  We never raise here so that compile() stays
+            # backward-compatible; callers that want strict enforcement
+            # should call validate(raise_on_error=True) explicitly.
+            if self.nodes:
+                errors, warnings = self._fast_validate(succ, pred)
+                if errors:
+                    logger.warning(
+                        f"GraphWorkflow compile: validation found "
+                        f"{len(errors)} error(s) — "
+                        + "; ".join(errors)
+                    )
+                if warnings and self.verbose:
+                    logger.warning(
+                        f"GraphWorkflow compile: validation found "
+                        f"{len(warnings)} warning(s) — "
+                        + "; ".join(warnings)
+                    )
+
+            # Freeze the per-layer execution plan so run() does no dictionary
+            # lookups or attribute resolution in its hot loop.
+            self._execution_plan = [
+                [
+                    (
+                        node_id,
+                        self.nodes[node_id].agent,
+                        self.nodes[node_id].type,
+                        getattr(
+                            self.nodes[node_id].agent,
+                            "agent_name",
+                            node_id,
+                        ),
+                    )
+                    for node_id in layer
+                    if node_id in self.nodes
+                ]
+                for layer in sorted_layers
+            ]
 
             # Cache compilation timestamp for debugging
             self._compilation_timestamp = time.time()
@@ -1024,6 +1148,112 @@ class GraphWorkflow:
                 f"Error in GraphWorkflow compilation: {e}"
             )
             raise e
+
+    @staticmethod
+    def _multi_source_reachable(
+        sources: List[str], adjacency: Dict[str, List[str]]
+    ) -> Set[str]:
+        """
+        Nodes reachable from any of ``sources`` in one traversal.
+
+        A single multi-source BFS replaces one traversal per source, which is
+        what the per-entry-point/per-end-point loops used to cost.
+
+        Args:
+            sources (List[str]): Starting node IDs.
+            adjacency (Dict[str, List[str]]): Neighbour map to walk.
+
+        Returns:
+            Set[str]: All reachable node IDs, including the sources themselves.
+        """
+        seen = set(sources)
+        frontier = list(sources)
+        while frontier:
+            node_id = frontier.pop()
+            for neighbour in adjacency.get(node_id, ()):
+                if neighbour not in seen:
+                    seen.add(neighbour)
+                    frontier.append(neighbour)
+        return seen
+
+    def _fast_validate(
+        self,
+        succ: Dict[str, List[str]],
+        pred: Dict[str, List[str]],
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Structural checks driven off pre-built adjacency maps.
+
+        Equivalent in coverage to the checks :meth:`validate` performs at
+        compile time, but computed from the maps already materialised by
+        :meth:`compile` — no per-node backend calls, no reversed graph copy,
+        and no cycle enumeration.
+
+        Args:
+            succ (Dict[str, List[str]]): Successor map from ``adjacency()``.
+            pred (Dict[str, List[str]]): Predecessor map from ``adjacency()``.
+
+        Returns:
+            Tuple[List[str], List[str]]: ``(errors, warnings)``.
+        """
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        invalid_agents = [
+            node_id
+            for node_id, node in self.nodes.items()
+            if node.agent is None
+        ]
+        if invalid_agents:
+            errors.append(
+                f"Found {len(invalid_agents)} nodes with invalid agent "
+                f"instances: {invalid_agents}"
+            )
+
+        if not self.edges:
+            warnings.append("Workflow has no edges between nodes")
+
+        isolated = [
+            node_id
+            for node_id in self.nodes
+            if not succ.get(node_id) and not pred.get(node_id)
+        ]
+        if isolated:
+            warnings.append(
+                f"Found {len(isolated)} isolated nodes: {isolated}"
+            )
+
+        # O(V+E) acyclicity test instead of enumerating every simple cycle,
+        # which is exponential in the number of cycles.
+        try:
+            if not self.graph_backend.is_dag():
+                warnings.append("Found cycles in workflow")
+        except Exception as e:
+            warnings.append(f"Could not check for cycles: {e}")
+
+        all_ids = set(self.nodes.keys())
+
+        if self.entry_points:
+            unreachable = all_ids - self._multi_source_reachable(
+                self.entry_points, succ
+            )
+            if unreachable:
+                warnings.append(
+                    f"Found {len(unreachable)} nodes unreachable from "
+                    f"entry points: {unreachable}"
+                )
+
+        if self.end_points:
+            dead_ends = all_ids - self._multi_source_reachable(
+                self.end_points, pred
+            )
+            if dead_ends:
+                warnings.append(
+                    f"Found {len(dead_ends)} nodes that cannot reach any "
+                    f"exit point: {dead_ends}"
+                )
+
+        return errors, warnings
 
     def add_node(
         self,
@@ -1652,16 +1882,15 @@ class GraphWorkflow:
         Returns:
             Tuple[str, ...]: Tuple of predecessor node IDs.
         """
-        # Use instance-level caching instead of @lru_cache to avoid hashing issues
-        if not hasattr(self, "_predecessors_cache"):
-            self._predecessors_cache = {}
-
-        if node_id not in self._predecessors_cache:
-            self._predecessors_cache[node_id] = tuple(
-                self.graph_backend.predecessors(node_id)
-            )
-
-        return self._predecessors_cache[node_id]
+        # Instance-level caching instead of @lru_cache to avoid hashing issues.
+        # compile() populates this map wholesale from a single adjacency pass;
+        # this path only fills gaps for nodes queried before compilation.
+        cache = self._predecessors_cache
+        preds = cache.get(node_id)
+        if preds is None:
+            preds = tuple(self.graph_backend.predecessors(node_id))
+            cache[node_id] = preds
+        return preds
 
     def _build_prompt(
         self,
@@ -1865,6 +2094,31 @@ class GraphWorkflow:
                 f"Using cached compilation for {self.max_loops} loops (compiled at {getattr(self, '_compilation_timestamp', 'unknown time')})"
             )
 
+        # One executor for the whole run instead of one per layer per loop.
+        # Thread creation and pool shutdown dominated execution time on graphs
+        # with many layers.  Sized to the widest layer, capped at _max_workers,
+        # and created lazily so purely sequential graphs spawn no threads.
+        widest_layer = max(
+            (len(layer) for layer in self._execution_plan), default=1
+        )
+        executor: Optional[ContextThreadPoolExecutor] = None
+
+        def _get_executor() -> ContextThreadPoolExecutor:
+            nonlocal executor
+            if executor is None:
+                executor = ContextThreadPoolExecutor(
+                    max_workers=max(
+                        1, min(self._max_workers, widest_layer)
+                    ),
+                    thread_name_prefix=f"graph-{self.name}",
+                )
+                if self.verbose:
+                    logger.debug(
+                        f"Created shared thread pool with "
+                        f"{max(1, min(self._max_workers, widest_layer))} workers"
+                    )
+            return executor
+
         try:
             loop = 0
             # Accumulated results across all loops
@@ -1890,10 +2144,14 @@ class GraphWorkflow:
 
                 # Derive a deterministic key for this task so checkpoints
                 # survive process restarts (Python's hash() is salted and
-                # is NOT stable across runs).
-                task_key = hashlib.sha256(
-                    task.encode("utf-8")
-                ).hexdigest()[:16]
+                # is NOT stable across runs).  Only needed when checkpointing.
+                task_key = (
+                    hashlib.sha256(task.encode("utf-8")).hexdigest()[
+                        :16
+                    ]
+                    if self.checkpoint_dir
+                    else None
+                )
 
                 # Seed entry-point nodes with end-point outputs from the
                 # previous loop so agents can refine iteratively.
@@ -1901,7 +2159,7 @@ class GraphWorkflow:
                     prev_outputs.update(prior_loop_end_outputs)
 
                 for layer_idx, layer in enumerate(
-                    self._sorted_layers
+                    self._execution_plan
                 ):
                     layer_start_time = time.time()
 
@@ -1955,12 +2213,18 @@ class GraphWorkflow:
 
                     if self.verbose:
                         logger.info(
-                            f"Executing layer {layer_idx + 1}/{len(self._sorted_layers)} with {len(layer)} nodes: {layer}"
+                            f"Executing layer {layer_idx + 1}/{len(self._execution_plan)} "
+                            f"with {len(layer)} nodes: {[n[0] for n in layer]}"
                         )
 
                     # Pre-build all prompts for this layer
                     layer_data = []
-                    for node_id in layer:
+                    for (
+                        node_id,
+                        agent,
+                        node_type,
+                        agent_name,
+                    ) in layer:
                         try:
                             prompt = self._build_prompt(
                                 node_id,
@@ -1969,198 +2233,206 @@ class GraphWorkflow:
                                 layer_idx,
                                 loop,
                             )
-                            layer_data.append(
-                                (
-                                    node_id,
-                                    self.nodes[node_id].agent,
-                                    prompt,
-                                )
-                            )
                         except Exception as e:
                             logger.exception(
                                 f"Error building prompt for node {node_id}: {e}"
                             )
-                            # Continue with empty prompt as fallback
-                            layer_data.append(
-                                (
-                                    node_id,
-                                    self.nodes[node_id].agent,
-                                    f"Error building prompt: {e}",
+                            # Continue with an error prompt as fallback
+                            prompt = f"Error building prompt: {e}"
+                        layer_data.append(
+                            (
+                                node_id,
+                                agent,
+                                node_type,
+                                agent_name,
+                                prompt,
+                            )
+                        )
+
+                    def _make_call(node_id, agent, node_type, prompt):
+                        """Bind one node's invocation into a zero-arg callable."""
+                        if node_type == NodeType.SUBGRAPH:
+                            # Subgraphs receive the prompt as their task and
+                            # run in isolation.  Checkpoint state is stored
+                            # under a sub-directory keyed by the parent node.
+                            inner: GraphWorkflow = agent
+                            _prev_cp = inner.checkpoint_dir
+                            if (
+                                self.checkpoint_dir
+                                and not inner.checkpoint_dir
+                            ):
+                                inner.checkpoint_dir = str(
+                                    Path(self.checkpoint_dir)
+                                    / node_id
                                 )
-                            )
 
-                    # Execute all agents in this layer in parallel
-                    with ContextThreadPoolExecutor(
-                        max_workers=min(self._max_workers, len(layer))
-                    ) as executor:
-
-                        if self.verbose:
-                            logger.debug(
-                                f"Created thread pool with {min(self._max_workers, len(layer))} workers for layer {layer_idx + 1}"
-                            )
-
-                        future_to_data = {}
-
-                        # Submit all tasks
-                        for node_id, agent, prompt in layer_data:
-                            try:
-                                node = self.nodes[node_id]
-                                if node.type == NodeType.SUBGRAPH:
-                                    # Subgraphs receive the prompt as their
-                                    # task and run in isolation.  Checkpoint
-                                    # state is stored under a sub-directory
-                                    # keyed by the parent node ID.
-                                    inner: GraphWorkflow = agent
-                                    _prev_cp = inner.checkpoint_dir
-                                    if (
-                                        self.checkpoint_dir
-                                        and not inner.checkpoint_dir
-                                    ):
-                                        inner.checkpoint_dir = str(
-                                            Path(self.checkpoint_dir)
-                                            / node_id
-                                        )
-
-                                    def _run_inner(
-                                        _inner=inner,
-                                        _prompt=prompt,
-                                        _prev=_prev_cp,
-                                        _img=img,
-                                        _args=args,
-                                        _kwargs=kwargs,
-                                    ):
-                                        try:
-                                            return _inner.run(
-                                                _prompt,
-                                                img=_img,
-                                                *_args,
-                                                **_kwargs,
-                                            )
-                                        finally:
-                                            _inner.checkpoint_dir = (
-                                                _prev
-                                            )
-
-                                    future = executor.submit(
-                                        _run_inner
-                                    )
-                                else:
-                                    # Build per-agent kwargs, injecting
-                                    # streaming_callback if provided.
-                                    submit_kwargs = dict(kwargs)
-                                    if (
-                                        _streaming_callback
-                                        is not None
-                                    ):
-                                        _nid = node_id
-                                        submit_kwargs[
-                                            "streaming_callback"
-                                        ] = lambda token, _nid=_nid: _streaming_callback(
-                                            _nid, token
-                                        )
-
-                                    future = executor.submit(
-                                        agent.run,
-                                        prompt,
-                                        img,
+                            def _run_inner(
+                                _inner=inner,
+                                _prompt=prompt,
+                                _prev=_prev_cp,
+                            ):
+                                try:
+                                    return _inner.run(
+                                        _prompt,
+                                        img=img,
                                         *args,
-                                        **submit_kwargs,
+                                        **kwargs,
                                     )
-                                future_to_data[future] = (
-                                    node_id,
-                                    agent,
+                                finally:
+                                    _inner.checkpoint_dir = _prev
+
+                            return _run_inner
+
+                        if _streaming_callback is None:
+                            # Common path: no per-node kwargs copy needed.
+                            def _run_agent(
+                                _agent=agent, _prompt=prompt
+                            ):
+                                return _agent.run(
+                                    _prompt, img, *args, **kwargs
                                 )
 
-                                if self.verbose:
-                                    logger.debug(
-                                        f"Submitted execution task for agent: {getattr(agent, 'agent_name', node_id)}"
-                                    )
+                            return _run_agent
 
+                        def _run_agent_streaming(
+                            _agent=agent,
+                            _prompt=prompt,
+                            _nid=node_id,
+                        ):
+                            call_kwargs = dict(kwargs)
+                            call_kwargs["streaming_callback"] = (
+                                lambda token: _streaming_callback(
+                                    _nid, token
+                                )
+                            )
+                            return _agent.run(
+                                _prompt, img, *args, **call_kwargs
+                            )
+
+                        return _run_agent_streaming
+
+                    def _record(
+                        node_id, agent_name, node_type, output
+                    ):
+                        """Persist one node's output into the run's state."""
+                        # Subgraph nodes return a dict; flatten to a readable
+                        # string for downstream agents.  Only applied to
+                        # SUBGRAPH nodes so that agent nodes returning
+                        # structured dicts are not silently coerced.
+                        if (
+                            node_type == NodeType.SUBGRAPH
+                            and isinstance(output, dict)
+                        ):
+                            output = "\n\n".join(
+                                f"[{k}]: {v}"
+                                for k, v in output.items()
+                                if v is not None
+                            )
+
+                        prev_outputs[node_id] = output
+                        execution_results[node_id] = output
+
+                        try:
+                            self.conversation.add(
+                                role=agent_name, content=output
+                            )
+                        except Exception as e:
+                            logger.exception(
+                                f"Error adding output to conversation for agent {agent_name}: {e}"
+                            )
+
+                        if _on_node_complete is not None:
+                            try:
+                                _on_node_complete(node_id, output)
                             except Exception as e:
                                 logger.exception(
-                                    f"Error submitting task for agent {getattr(agent, 'agent_name', node_id)}: {e}"
+                                    f"Error in on_node_complete callback for {agent_name}: {e}"
                                 )
-                                # Add error result directly
+
+                    if len(layer_data) == 1:
+                        # Single-node layer: run inline. Dispatching to a
+                        # worker thread would only add handoff latency.
+                        (
+                            node_id,
+                            agent,
+                            node_type,
+                            agent_name,
+                            prompt,
+                        ) = layer_data[0]
+                        try:
+                            output = _make_call(
+                                node_id, agent, node_type, prompt
+                            )()
+                        except Exception as e:
+                            output = f"[ERROR] Agent {agent_name} failed: {e}"
+                            logger.exception(
+                                f"Error in GraphWorkflow agent execution for {agent_name}: {e}"
+                            )
+                        _record(
+                            node_id, agent_name, node_type, output
+                        )
+                    else:
+                        # Parallel layer: dispatch onto the run-wide pool.
+                        pool = _get_executor()
+                        future_to_data = {}
+
+                        for (
+                            node_id,
+                            agent,
+                            node_type,
+                            agent_name,
+                            prompt,
+                        ) in layer_data:
+                            try:
+                                future = pool.submit(
+                                    _make_call(
+                                        node_id,
+                                        agent,
+                                        node_type,
+                                        prompt,
+                                    )
+                                )
+                                future_to_data[future] = (
+                                    node_id,
+                                    agent_name,
+                                    node_type,
+                                )
+                            except Exception as e:
+                                logger.exception(
+                                    f"Error submitting task for agent {agent_name}: {e}"
+                                )
                                 error_output = f"[ERROR] Failed to submit task: {e}"
                                 prev_outputs[node_id] = error_output
                                 execution_results[node_id] = (
                                     error_output
                                 )
 
-                        # Collect results as they complete
                         completed_count = 0
                         for future in concurrent.futures.as_completed(
                             future_to_data
                         ):
-                            node_id, agent = future_to_data[future]
-                            agent_name = getattr(
-                                agent, "agent_name", node_id
-                            )
-
+                            (
+                                node_id,
+                                agent_name,
+                                node_type,
+                            ) = future_to_data[future]
                             try:
-                                agent_start_time = time.time()
                                 output = future.result()
-                                agent_execution_time = (
-                                    time.time() - agent_start_time
-                                )
-
-                                # Subgraph nodes return a dict; flatten to
-                                # a readable string for downstream agents.
-                                # Only apply to SUBGRAPH nodes so that agent
-                                # nodes returning structured dicts are not
-                                # silently coerced.
-                                if (
-                                    isinstance(output, dict)
-                                    and self.nodes[node_id].type
-                                    == NodeType.SUBGRAPH
-                                ):
-                                    output = "\n\n".join(
-                                        f"[{k}]: {v}"
-                                        for k, v in output.items()
-                                        if v is not None
-                                    )
-
                                 completed_count += 1
-
                                 if self.verbose:
                                     logger.success(
-                                        f"Agent {agent_name} completed successfully ({completed_count}/{len(layer_data)}) in {agent_execution_time:.3f}s"
+                                        f"Agent {agent_name} completed successfully "
+                                        f"({completed_count}/{len(layer_data)})"
                                     )
-
                             except Exception as e:
                                 output = f"[ERROR] Agent {agent_name} failed: {e}"
                                 logger.exception(
                                     f"Error in GraphWorkflow agent execution for {agent_name}: {e}"
                                 )
 
-                            prev_outputs[node_id] = output
-                            execution_results[node_id] = output
-
-                            # Add to conversation (this could be optimized further by batching)
-                            try:
-                                self.conversation.add(
-                                    role=agent_name,
-                                    content=output,
-                                )
-
-                                if self.verbose:
-                                    logger.debug(
-                                        f"Added output to conversation for agent: {agent_name}"
-                                    )
-
-                            except Exception as e:
-                                logger.exception(
-                                    f"Error adding output to conversation for agent {agent_name}: {e}"
-                                )
-
-                            # Fire the on_node_complete callback
-                            if _on_node_complete is not None:
-                                try:
-                                    _on_node_complete(node_id, output)
-                                except Exception as e:
-                                    logger.exception(
-                                        f"Error in on_node_complete callback for {agent_name}: {e}"
-                                    )
+                            _record(
+                                node_id, agent_name, node_type, output
+                            )
 
                     layer_execution_time = (
                         time.time() - layer_start_time
@@ -2179,9 +2451,9 @@ class GraphWorkflow:
                                 / f"{task_key}_layer_{layer_idx}.json"
                             )
                             layer_outputs = {
-                                nid: prev_outputs[nid]
-                                for nid in layer
-                                if nid in prev_outputs
+                                entry[0]: prev_outputs[entry[0]]
+                                for entry in layer
+                                if entry[0] in prev_outputs
                             }
                             checkpoint_path.write_text(
                                 json.dumps(
@@ -2254,6 +2526,10 @@ class GraphWorkflow:
                 f"Error in GraphWorkflow.run after {total_time:.3f}s: {e}"
             )
             raise e
+
+        finally:
+            if executor is not None:
+                executor.shutdown(wait=True)
 
     def visualize(
         self,
@@ -3501,12 +3777,16 @@ class GraphWorkflow:
                 )
                 result["is_valid"] = False
 
+            # One adjacency pass feeds the isolation and reachability checks
+            # below, replacing per-node backend calls and a reversed copy of
+            # the whole graph.
+            succ, pred = self.graph_backend.adjacency()
+
             # Check for isolated nodes (no incoming or outgoing edges)
             isolated = [
                 n
                 for n in self.nodes
-                if self.graph_backend.in_degree(n) == 0
-                and self.graph_backend.out_degree(n) == 0
+                if not succ.get(n) and not pred.get(n)
             ]
             if isolated:
                 result["warnings"].append(
@@ -3542,13 +3822,9 @@ class GraphWorkflow:
 
             # Check for unreachable nodes (not reachable from entry points)
             if self.entry_points:
-                reachable = set()
-                for entry in self.entry_points:
-                    reachable.update(
-                        self.graph_backend.descendants(entry)
-                    )
-                    reachable.add(entry)
-
+                reachable = self._multi_source_reachable(
+                    self.entry_points, succ
+                )
                 unreachable = set(self.nodes.keys()) - reachable
                 if unreachable:
                     result["warnings"].append(
@@ -3566,14 +3842,9 @@ class GraphWorkflow:
 
             # Check for dead-end nodes (cannot reach any exit point)
             if self.end_points:
-                reverse_graph = self.graph_backend.reverse()
-                reachable_to_exit = set()
-                for exit_point in self.end_points:
-                    reachable_to_exit.update(
-                        reverse_graph.descendants(exit_point)
-                    )
-                    reachable_to_exit.add(exit_point)
-
+                reachable_to_exit = self._multi_source_reachable(
+                    self.end_points, pred
+                )
                 dead_ends = set(self.nodes.keys()) - reachable_to_exit
                 if dead_ends:
                     result["warnings"].append(

--- a/tests/benchmarks/graph_workflow_benchmarks/README.md
+++ b/tests/benchmarks/graph_workflow_benchmarks/README.md
@@ -1,0 +1,111 @@
+# GraphWorkflow benchmarks
+
+Measures `swarms.GraphWorkflow` orchestration overhead against LangGraph's
+`StateGraph`, and tracks the effect of optimizations over time.
+
+All nodes are **no-ops**. Every number here is framework overhead — none of it
+is LLM latency. That is deliberate: a real agent call is 500–5000 ms, so
+orchestration differences only matter in aggregate, at scale, or at startup.
+
+## Running
+
+```bash
+# full suite → tests/benchmarks/graph_workflow_benchmarks/results/latest.json + latest.md
+python3 tests/benchmarks/graph_workflow_benchmarks/graph_workflow_bench.py
+
+# a quick pass
+python3 tests/benchmarks/graph_workflow_benchmarks/graph_workflow_bench.py --sizes 10,50 --repeats 3 --topologies diamond
+
+# record a baseline, change code, compare
+python3 tests/benchmarks/graph_workflow_benchmarks/graph_workflow_bench.py --out tests/benchmarks/graph_workflow_benchmarks/results/before.json
+#   ...edit swarms/structs/graph_workflow.py...
+python3 tests/benchmarks/graph_workflow_benchmarks/graph_workflow_bench.py --out tests/benchmarks/graph_workflow_benchmarks/results/after.json
+python3 tests/benchmarks/graph_workflow_benchmarks/plot_results.py tests/benchmarks/graph_workflow_benchmarks/results/after.json \
+    --baseline tests/benchmarks/graph_workflow_benchmarks/results/before.json
+```
+
+Figures land in `tests/benchmarks/graph_workflow_benchmarks/results/figures/`, in light and dark variants.
+
+## What is measured
+
+| Phase | Meaning |
+|---|---|
+| `import` | Cold interpreter, `from X import Y`, in a subprocess, minus bare interpreter start |
+| `build` | Adding N nodes and M edges to an uncompiled graph |
+| `compile` | Topological pre-computation and structural validation |
+| `first_run` | Cold path: build + compile + one execution |
+| `steady_run` | One execution of an already-compiled graph |
+
+Two derived metrics are computed from those:
+
+- **`total_cold_start_ms`** — `import + first_run`. What a one-shot script pays.
+- **`breakeven_runs`** — how many executions it takes a slower-to-import
+  framework to repay its startup deficit through a lower per-run cost.
+
+## Topologies
+
+| Name | Shape | Stresses |
+|---|---|---|
+| `chain` | `n0 → n1 → … → nN` | depth — N layers of one node each |
+| `wide` | one root → N−1 leaves | width — two layers, maximum fan-out |
+| `diamond` | fan-out then fan-in | the common map/reduce shape |
+| `layered` | stacks of 4, fully connected between | depth *and* width together |
+| `tree` | binary tree | log-depth fan-out |
+
+`chain` and `layered` are the discriminating cases: they have many layers, which
+is where per-layer overhead compounds.
+
+## Methodology
+
+- **Working tree, not site-packages.** The harness pins the repo root onto
+  `sys.path` and prints the resolved `swarms` module path. Running the script
+  puts `tests/benchmarks/graph_workflow_benchmarks/` on the path rather than the repo root, so an installed
+  `swarms` would otherwise win silently and the numbers would describe the
+  wrong code.
+- **Warmup then sample.** Default 2 discarded warmup iterations, then 9 timed
+  samples. Median is the headline; min/mean/p95/stdev and every raw sample are
+  written to the JSON.
+- **GC controlled.** Collection is forced between samples and disabled inside
+  each timed region, so a collection triggered by one sample is never billed to
+  a later one.
+- **Logging silenced.** swarms installs a loguru sink with `enqueue=True` at
+  import; left on, its pickle-and-queue cost lands inside the measurement.
+- **Provenance recorded.** Platform, core count, Python version, library
+  versions, git rev, and whether `swarms/` was dirty all go into the JSON.
+
+### Fairness to LangGraph
+
+- Both frameworks execute the identical topology, node-for-node and
+  edge-for-edge.
+- LangGraph's default 25-superstep recursion cap is raised, so deep graphs run
+  in full rather than erroring out.
+- **State reducer.** Fan-in nodes need a reducer to write concurrently.
+  `--lg-reducer list` accumulates every node's output, which is what swarms'
+  `prev_outputs` and conversation do inherently; `--lg-reducer counter` keeps
+  state O(1) per superstep. Both were measured to check whether the reducer
+  was inflating LangGraph's results — **it was not**: steady-run differences
+  are 1–12%, against a 5–13x gap. The gap is orchestration cost, not state
+  accumulation. Raw numbers in `results/langgraph_counter_reducer.json`.
+
+## Known limits of this benchmark
+
+State them before quoting the numbers:
+
+- **Not feature-equivalent.** LangGraph's per-superstep cost buys checkpointing,
+  channel-based state reduction, conditional edges, cycles with control flow,
+  and interrupts. `GraphWorkflow.run()` is a topological layer sweep and does
+  none of that. Some of LangGraph's overhead is machinery swarms lacks.
+- **Sync path only.** `arun` / `ainvoke` are not covered.
+- **No real I/O.** With no-op nodes there is no concurrency to exploit, which is
+  the case that actually matters for agents.
+- **One machine.** No cross-platform or cross-CPU data.
+- **No checkpointer configured** for LangGraph (its default), and no swarms
+  `max_loops > 1`.
+
+## Charts
+
+`plot_results.py` follows the repo's data-viz conventions: a CVD-validated
+three-slot categorical palette (validated with the palette checker in both light
+and dark modes), log scales where the data spans decades, direct labels on every
+series with collision avoidance, recessive grid and axes, and no dual axes.
+Series identity never rests on color alone — every line and bar is labelled.

--- a/tests/benchmarks/graph_workflow_benchmarks/graph_workflow_bench.py
+++ b/tests/benchmarks/graph_workflow_benchmarks/graph_workflow_bench.py
@@ -1,0 +1,757 @@
+"""
+GraphWorkflow performance benchmark — swarms vs LangGraph.
+
+Measures the framework overhead that is *not* LLM latency:
+
+  1. import      — cold interpreter, `from X import Y` (subprocess, baselined)
+  2. build       — add N nodes + M edges to an uncompiled graph
+  3. compile     — topological pre-computation / validation
+  4. first_run   — cold: build + compile + one execution
+  5. steady_run  — repeated execution of an already-compiled graph
+
+Nodes are no-ops, so every measured microsecond is orchestration overhead.
+Derived metrics (total cold start, break-even run count) are computed from
+those five and written alongside them.
+
+Usage
+-----
+    python3 tests/benchmarks/graph_workflow_benchmarks/graph_workflow_bench.py
+    python3 tests/benchmarks/graph_workflow_benchmarks/graph_workflow_bench.py --sizes 10,50,200 --repeats 9
+    python3 tests/benchmarks/graph_workflow_benchmarks/graph_workflow_bench.py --out tests/benchmarks/graph_workflow_benchmarks/results/after.json
+
+Then visualise:
+
+    python3 tests/benchmarks/graph_workflow_benchmarks/plot_results.py tests/benchmarks/graph_workflow_benchmarks/results/after.json \\
+        --baseline tests/benchmarks/graph_workflow_benchmarks/results/before.json
+
+Fairness notes
+--------------
+* Both frameworks execute the identical topology, node-for-node and edge-for-edge.
+* LangGraph's default 25-superstep cap is raised so deep graphs are not truncated.
+* LangGraph state accumulation is measured under BOTH reducers (see ``--lg-reducer``):
+  ``counter`` keeps state O(1) per superstep, ``list`` accumulates every node's
+  output the way swarms' ``prev_outputs``/conversation inherently does. Reporting
+  both isolates reducer cost from orchestration cost.
+"""
+
+import argparse
+import gc
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from typing import Any, Callable, Dict, List, Tuple
+
+os.environ.setdefault("SWARMS_TELEMETRY_ON", "false")
+
+def _find_repo_root() -> str:
+    """
+    Walk up from this file until the directory containing the `swarms` package.
+
+    Always measure the working tree, never a `pip install`ed copy: running this
+    script puts its own directory on `sys.path`, not the repo root, so an
+    installed swarms would silently win and the numbers would describe the
+    wrong code. Searching for the package rather than counting parent
+    directories keeps this correct if the benchmark is ever moved again.
+
+    Returns:
+        str: Absolute path to the repo root, or this file's directory if no
+        `swarms/` package was found above it.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    current = here
+    while True:
+        if os.path.isfile(
+            os.path.join(current, "swarms", "__init__.py")
+        ):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return here
+        current = parent
+
+
+_REPO_ROOT = _find_repo_root()
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+os.environ["PYTHONPATH"] = os.pathsep.join(
+    p for p in [_REPO_ROOT, os.environ.get("PYTHONPATH", "")] if p
+)
+
+# Results live beside this script, not at the repo root.
+_RESULTS_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "results"
+)
+
+PHASES = ["build", "compile", "first_run", "steady_run"]
+
+
+# ----------------------------------------------------------------------------
+# environment capture — a benchmark without provenance is an anecdote
+# ----------------------------------------------------------------------------
+def environment() -> Dict[str, Any]:
+    """Record the machine and library versions the numbers were produced on."""
+
+    def version(module_name: str) -> str:
+        try:
+            import importlib.metadata as md
+
+            return md.version(module_name)
+        except Exception:
+            return "not-installed"
+
+    try:
+        git_rev = (
+            subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                capture_output=True,
+                text=True,
+                cwd=_REPO_ROOT,
+            ).stdout.strip()
+            or "unknown"
+        )
+        git_dirty = bool(
+            subprocess.run(
+                ["git", "status", "--porcelain", "swarms/"],
+                capture_output=True,
+                text=True,
+                cwd=_REPO_ROOT,
+            ).stdout.strip()
+        )
+    except Exception:
+        git_rev, git_dirty = "unknown", False
+
+    return {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "platform": platform.platform(),
+        "processor": platform.processor() or platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "python": sys.version.split()[0],
+        "git_rev": git_rev,
+        "git_dirty_swarms": git_dirty,
+        "versions": {
+            name: version(name)
+            for name in (
+                "swarms",
+                "langgraph",
+                "networkx",
+                "rustworkx",
+            )
+        },
+    }
+
+
+# ----------------------------------------------------------------------------
+# timing
+# ----------------------------------------------------------------------------
+def bench(
+    fn: Callable[[], object],
+    repeats: int,
+    warmup: int,
+    setup: Callable[[], None] = None,
+) -> Dict[str, Any]:
+    """
+    Time ``fn`` and summarise the distribution.
+
+    Garbage collection is disabled inside each timed region and forced between
+    samples, so a collection triggered by an earlier sample is never billed to a
+    later one.
+
+    Args:
+        fn (Callable[[], object]): The zero-argument callable to time.
+        repeats (int): Number of timed samples to collect.
+        warmup (int): Untimed iterations run first and discarded.
+        setup (Callable[[], None]): Optional per-sample setup, run untimed.
+
+    Returns:
+        Dict[str, Any]: ``min_ms``/``median_ms``/``mean_ms``/``p95_ms``/
+        ``stdev_ms``/``n`` plus the raw ``samples_ms`` list.
+    """
+    for _ in range(warmup):
+        if setup:
+            setup()
+        fn()
+
+    samples: List[float] = []
+    for _ in range(repeats):
+        if setup:
+            setup()
+        gc.collect()
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            start = time.perf_counter()
+            fn()
+            samples.append((time.perf_counter() - start) * 1000.0)
+        finally:
+            if gc_was_enabled:
+                gc.enable()
+
+    ordered = sorted(samples)
+    p95_idx = min(
+        len(ordered) - 1, int(round(0.95 * (len(ordered) - 1)))
+    )
+    return {
+        "min_ms": ordered[0],
+        "median_ms": statistics.median(samples),
+        "mean_ms": statistics.fmean(samples),
+        "p95_ms": ordered[p95_idx],
+        "stdev_ms": (
+            statistics.stdev(samples) if len(samples) > 1 else 0.0
+        ),
+        "n": len(samples),
+        "samples_ms": samples,
+    }
+
+
+def cold_import_ms(statement: str, repeats: int) -> Dict[str, Any]:
+    """
+    Median cost of ``statement`` in a fresh interpreter, minus interpreter start.
+
+    Args:
+        statement (str): Import statement to time.
+        repeats (int): Subprocess launches to median over.
+
+    Returns:
+        Dict[str, Any]: ``median_ms`` (baseline-subtracted) and raw samples.
+    """
+    baseline = _subprocess_samples("pass", repeats)
+    loaded = _subprocess_samples(statement, repeats)
+    base_median = statistics.median(baseline)
+    return {
+        "median_ms": max(
+            0.0, statistics.median(loaded) - base_median
+        ),
+        "raw_median_ms": statistics.median(loaded),
+        "interpreter_baseline_ms": base_median,
+        "samples_ms": loaded,
+        "n": len(loaded),
+    }
+
+
+def _subprocess_samples(statement: str, repeats: int) -> List[float]:
+    code = (
+        "import time;_t=time.perf_counter()\n"
+        f"{statement}\n"
+        "print((time.perf_counter()-_t)*1000)"
+    )
+    env = dict(os.environ, SWARMS_TELEMETRY_ON="false")
+    samples = []
+    for _ in range(repeats):
+        out = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if out.returncode != 0:
+            raise RuntimeError(
+                f"import probe failed for {statement!r}:\n{out.stderr}"
+            )
+        samples.append(float(out.stdout.strip().splitlines()[-1]))
+    return samples
+
+
+# ----------------------------------------------------------------------------
+# topologies — identical shape for both frameworks
+# ----------------------------------------------------------------------------
+def chain_edges(n: int) -> List[Tuple[str, str]]:
+    """Pure depth: n0 -> n1 -> ... -> n(n-1). One node per layer."""
+    return [(f"n{i}", f"n{i + 1}") for i in range(n - 1)]
+
+
+def wide_edges(n: int) -> List[Tuple[str, str]]:
+    """Pure width: one root fanning out to n-1 leaves. Two layers."""
+    return [("n0", f"n{i}") for i in range(1, n)]
+
+
+def diamond_edges(n: int) -> List[Tuple[str, str]]:
+    """Fan-out then fan-in: n0 -> n1..n(n-2) -> n(n-1). Three layers."""
+    if n < 3:
+        return chain_edges(n)
+    edges = [("n0", f"n{i}") for i in range(1, n - 1)]
+    edges += [(f"n{i}", f"n{n - 1}") for i in range(1, n - 1)]
+    return edges
+
+
+def layered_edges(n: int, width: int = 4) -> List[Tuple[str, str]]:
+    """Stacked layers of ``width`` nodes, fully connected between layers."""
+    edges = []
+    layers = [
+        [f"n{i}" for i in range(s, min(s + width, n))]
+        for s in range(0, n, width)
+    ]
+    for a, b in zip(layers, layers[1:]):
+        for src in a:
+            for dst in b:
+                edges.append((src, dst))
+    return edges
+
+
+def tree_edges(n: int) -> List[Tuple[str, str]]:
+    """Binary tree: node i has children 2i+1 and 2i+2. Log-depth fan-out."""
+    edges = []
+    for i in range(n):
+        for child in (2 * i + 1, 2 * i + 2):
+            if child < n:
+                edges.append((f"n{i}", f"n{child}"))
+    return edges
+
+
+TOPOLOGIES = {
+    "chain": chain_edges,
+    "wide": wide_edges,
+    "diamond": diamond_edges,
+    "layered": layered_edges,
+    "tree": tree_edges,
+}
+
+
+# ----------------------------------------------------------------------------
+# swarms harness
+# ----------------------------------------------------------------------------
+class NoOpAgent:
+    """Minimal stand-in for `Agent` — isolates graph overhead from LLM latency."""
+
+    __slots__ = ("agent_name",)
+
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+
+    def run(self, task=None, img=None, *args, **kwargs):
+        return "ok"
+
+
+def swarms_build(n: int, edges, backend: str, auto_compile: bool):
+    """Construct a GraphWorkflow with ``n`` no-op agents and the given edges."""
+    from swarms.structs.graph_workflow import GraphWorkflow
+
+    wf = GraphWorkflow(auto_compile=auto_compile, backend=backend)
+    for i in range(n):
+        wf.add_node(NoOpAgent(f"n{i}"))
+    for src, dst in edges:
+        wf.add_edge(src, dst)
+    return wf
+
+
+def swarms_suite(
+    n: int, edges, backend: str, repeats: int, warmup: int
+) -> Dict[str, Any]:
+    """Run every phase against swarms' GraphWorkflow."""
+    res: Dict[str, Any] = {}
+
+    res["build"] = bench(
+        lambda: swarms_build(n, edges, backend, auto_compile=False),
+        repeats,
+        warmup,
+    )
+
+    # compile() is idempotent, so each sample needs a fresh uncompiled graph;
+    # building it is done in untimed setup.
+    holder: Dict[str, Any] = {}
+
+    res["compile"] = bench(
+        lambda: holder["wf"].compile(),
+        repeats,
+        warmup,
+        setup=lambda: holder.__setitem__(
+            "wf", swarms_build(n, edges, backend, auto_compile=False)
+        ),
+    )
+
+    def _cold():
+        wf = swarms_build(n, edges, backend, auto_compile=True)
+        wf.run("benchmark task")
+
+    res["first_run"] = bench(_cold, repeats, warmup)
+
+    warm = swarms_build(n, edges, backend, auto_compile=True)
+    warm.run("warmup")
+    res["steady_run"] = bench(
+        lambda: warm.run("benchmark task"), repeats, warmup
+    )
+    return res
+
+
+# ----------------------------------------------------------------------------
+# langgraph harness
+# ----------------------------------------------------------------------------
+def _lg_state(reducer: str):
+    """
+    Build the state schema.
+
+    Args:
+        reducer (str): ``"counter"`` keeps accumulated state O(1) per superstep;
+            ``"list"`` accumulates every node's output, matching what swarms'
+            ``prev_outputs`` and conversation do inherently. Measuring both
+            separates reducer cost from orchestration cost.
+
+    Returns:
+        type: A TypedDict subclass usable as a StateGraph schema.
+    """
+    import operator
+    from typing import Annotated, List
+
+    from typing_extensions import TypedDict
+
+    if reducer == "counter":
+
+        class State(TypedDict):
+            task: str
+            out: Annotated[int, operator.add]
+
+    else:
+
+        class State(TypedDict):
+            task: str
+            out: Annotated[List[str], operator.add]
+
+    return State
+
+
+def langgraph_build(n: int, edges, compile_it: bool, reducer: str):
+    """Construct the equivalent LangGraph StateGraph with no-op nodes."""
+    from langgraph.graph import END, START, StateGraph
+
+    if reducer == "counter":
+
+        def make(_name):
+            def node(state):
+                return {"out": 1}
+
+            return node
+
+    else:
+
+        def make(name):
+            def node(state):
+                return {"out": [f"{name}:ok"]}
+
+            return node
+
+    g = StateGraph(_lg_state(reducer))
+    for i in range(n):
+        g.add_node(f"n{i}", make(f"n{i}"))
+
+    targets = {dst for _, dst in edges}
+    sources = {src for src, _ in edges}
+    for i in range(n):
+        name = f"n{i}"
+        if name not in targets:
+            g.add_edge(START, name)
+        if name not in sources:
+            g.add_edge(name, END)
+    for src, dst in edges:
+        g.add_edge(src, dst)
+
+    return g.compile() if compile_it else g
+
+
+def langgraph_suite(
+    n: int, edges, repeats: int, warmup: int, reducer: str
+) -> Dict[str, Any]:
+    """Run every phase against LangGraph."""
+    res: Dict[str, Any] = {}
+
+    res["build"] = bench(
+        lambda: langgraph_build(n, edges, False, reducer),
+        repeats,
+        warmup,
+    )
+
+    holder: Dict[str, Any] = {}
+    res["compile"] = bench(
+        lambda: holder["g"].compile(),
+        repeats,
+        warmup,
+        setup=lambda: holder.__setitem__(
+            "g", langgraph_build(n, edges, False, reducer)
+        ),
+    )
+
+    seed = {
+        "task": "benchmark task",
+        "out": 0 if reducer == "counter" else [],
+    }
+    # Deep graphs exceed LangGraph's default 25-superstep cap; raise it so both
+    # frameworks execute the identical topology rather than a truncated one.
+    cfg = {"recursion_limit": 100_000}
+
+    def _cold():
+        app = langgraph_build(n, edges, True, reducer)
+        app.invoke(dict(seed), config=cfg)
+
+    res["first_run"] = bench(_cold, repeats, warmup)
+
+    warm = langgraph_build(n, edges, True, reducer)
+    warm.invoke(dict(seed), config=cfg)
+    res["steady_run"] = bench(
+        lambda: warm.invoke(dict(seed), config=cfg), repeats, warmup
+    )
+    return res
+
+
+# ----------------------------------------------------------------------------
+# derived metrics
+# ----------------------------------------------------------------------------
+def derive(results: Dict[str, Any]) -> None:
+    """
+    Add total-cold-start and break-even figures in place.
+
+    ``total_cold_start_ms`` is import + first_run: what a one-shot script pays.
+    ``breakeven_runs`` is how many executions it takes for a slower-to-import
+    framework to repay its startup deficit against the fastest importer.
+    """
+    imports = results.get("imports", {})
+    if not imports:
+        return
+
+    import_for = {
+        "swarms-networkx": imports.get(
+            "swarms.GraphWorkflow", {}
+        ).get("median_ms"),
+        "swarms-rustworkx": imports.get(
+            "swarms.GraphWorkflow", {}
+        ).get("median_ms"),
+        "langgraph": imports.get("langgraph.StateGraph", {}).get(
+            "median_ms"
+        ),
+    }
+
+    for topo, sizes in results["topologies"].items():
+        for size, per_impl in sizes.items():
+            cold = {}
+            for impl, phases in per_impl.items():
+                imp = import_for.get(impl)
+                if imp is None:
+                    continue
+                cold[impl] = imp + phases["first_run"]["median_ms"]
+                phases["total_cold_start_ms"] = cold[impl]
+
+            if not cold:
+                continue
+
+            fastest_cold = min(cold, key=cold.get)
+            for impl, phases in per_impl.items():
+                if impl not in cold:
+                    continue
+                deficit = cold[impl] - cold[fastest_cold]
+                gain = (
+                    per_impl[fastest_cold]["steady_run"]["median_ms"]
+                    - phases["steady_run"]["median_ms"]
+                )
+                phases["breakeven_runs"] = (
+                    None
+                    if gain <= 0
+                    else (0 if deficit <= 0 else deficit / gain)
+                )
+                phases["breakeven_vs"] = fastest_cold
+
+
+# ----------------------------------------------------------------------------
+# reporting
+# ----------------------------------------------------------------------------
+def report(results: Dict[str, Any]) -> str:
+    """Render the results as a Markdown report (also printed to stdout)."""
+    env = results["env"]
+    lines = [
+        "# GraphWorkflow benchmark — swarms vs LangGraph",
+        "",
+        f"*{env['timestamp']} · {env['platform']} · "
+        f"{env['cpu_count']} cores · Python {env['python']} · "
+        f"swarms @ {env['git_rev']}"
+        f"{' (dirty)' if env['git_dirty_swarms'] else ''}*",
+        "",
+        "Versions: "
+        + ", ".join(f"{k} {v}" for k, v in env["versions"].items()),
+        "",
+        f"Timing: median of {results['config']['repeats']} samples after "
+        f"{results['config']['warmup']} warmup iterations, GC disabled inside "
+        f"each timed region. LangGraph reducer: "
+        f"`{results['config']['lg_reducer']}`.",
+        "",
+        "All nodes are no-ops — every number is orchestration overhead, not "
+        "LLM latency.",
+        "",
+    ]
+
+    if results.get("imports"):
+        lines += [
+            "## Import (cold interpreter, baseline-subtracted)",
+            "",
+            "| target | median ms |",
+            "| --- | ---: |",
+        ]
+        for name, stats in results["imports"].items():
+            lines.append(f"| `{name}` | {stats['median_ms']:.1f} |")
+        lines.append("")
+
+    impls = results["impls"]
+    for topo, sizes in results["topologies"].items():
+        lines += [f"## Topology: {topo}", ""]
+        header = "| nodes | phase | " + " | ".join(impls) + " |"
+        lines.append(header)
+        lines.append(
+            "| ---: | --- | "
+            + " | ".join("---:" for _ in impls)
+            + " |"
+        )
+        for size in sorted(sizes, key=int):
+            per_impl = sizes[size]
+            for phase in PHASES:
+                cells = []
+                for impl in impls:
+                    stats = per_impl.get(impl, {}).get(phase)
+                    cells.append(
+                        f"{stats['median_ms']:.3f}" if stats else "—"
+                    )
+                lines.append(
+                    f"| {size} | {phase} | "
+                    + " | ".join(cells)
+                    + " |"
+                )
+        lines.append("")
+
+    md = "\n".join(lines)
+    print(md)
+    return md
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--sizes", default="10,50,200")
+    ap.add_argument("--repeats", type=int, default=9)
+    ap.add_argument("--warmup", type=int, default=2)
+    ap.add_argument("--import-repeats", type=int, default=5)
+    ap.add_argument(
+        "--topologies", default="chain,wide,diamond,layered,tree"
+    )
+    ap.add_argument(
+        "--impls",
+        default="swarms-networkx,swarms-rustworkx,langgraph",
+    )
+    ap.add_argument(
+        "--lg-reducer",
+        default="list",
+        choices=["counter", "list"],
+        help=(
+            "LangGraph state reducer. 'list' accumulates every node's output "
+            "(comparable to swarms' prev_outputs); 'counter' keeps state O(1) "
+            "to isolate reducer cost from orchestration cost."
+        ),
+    )
+    ap.add_argument("--skip-imports", action="store_true")
+    ap.add_argument(
+        "--out",
+        default=os.path.join(
+            _RESULTS_DIR, "latest.json"
+        ),
+        help="where to write raw results JSON (a .md report goes beside it)",
+    )
+    args = ap.parse_args()
+
+    sizes = [int(s) for s in args.sizes.split(",")]
+    impls = [s.strip() for s in args.impls.split(",")]
+    topologies = [t.strip() for t in args.topologies.split(",")]
+
+    # Import both frameworks up front, then silence their loggers, so neither
+    # one-off import cost nor log I/O leaks into the phase timings.
+    if any(i.startswith("swarms") for i in impls):
+        import swarms.structs.graph_workflow as _gw
+
+        print(f"swarms module: {_gw.__file__}", file=sys.stderr)
+    if "langgraph" in impls:
+        import langgraph.graph  # noqa: F401
+
+    import logging
+
+    logging.disable(logging.CRITICAL)
+    try:
+        from loguru import logger as _loguru
+
+        _loguru.remove()
+    except Exception:
+        pass
+
+    results: Dict[str, Any] = {
+        "env": environment(),
+        "config": {
+            "sizes": sizes,
+            "repeats": args.repeats,
+            "warmup": args.warmup,
+            "topologies": topologies,
+            "lg_reducer": args.lg_reducer,
+        },
+        "impls": impls,
+        "imports": {},
+        "topologies": {},
+    }
+
+    if not args.skip_imports:
+        print("Measuring cold import times...", file=sys.stderr)
+        probes = {}
+        if any(i.startswith("swarms") for i in impls):
+            probes["swarms (top-level)"] = "import swarms"
+            probes["swarms.GraphWorkflow"] = (
+                "from swarms.structs.graph_workflow import GraphWorkflow"
+            )
+        if "langgraph" in impls:
+            probes["langgraph.StateGraph"] = (
+                "from langgraph.graph import StateGraph"
+            )
+        for name, stmt in probes.items():
+            results["imports"][name] = cold_import_ms(
+                stmt, args.import_repeats
+            )
+
+    for topo in topologies:
+        edge_fn = TOPOLOGIES[topo]
+        results["topologies"][topo] = {}
+        for n in sizes:
+            edges = edge_fn(n)
+            print(
+                f"  {topo} n={n} ({len(edges)} edges)...",
+                file=sys.stderr,
+            )
+            per_impl = {}
+            if "swarms-networkx" in impls:
+                per_impl["swarms-networkx"] = swarms_suite(
+                    n, edges, "networkx", args.repeats, args.warmup
+                )
+            if "swarms-rustworkx" in impls:
+                per_impl["swarms-rustworkx"] = swarms_suite(
+                    n, edges, "rustworkx", args.repeats, args.warmup
+                )
+            if "langgraph" in impls:
+                per_impl["langgraph"] = langgraph_suite(
+                    n,
+                    edges,
+                    args.repeats,
+                    args.warmup,
+                    args.lg_reducer,
+                )
+            results["topologies"][topo][str(n)] = per_impl
+
+    derive(results)
+    md = report(results)
+
+    os.makedirs(
+        os.path.dirname(os.path.abspath(args.out)), exist_ok=True
+    )
+    with open(args.out, "w") as fh:
+        json.dump(results, fh, indent=2)
+    md_path = os.path.splitext(args.out)[0] + ".md"
+    with open(md_path, "w") as fh:
+        fh.write(md)
+    print(f"\nRaw results → {args.out}", file=sys.stderr)
+    print(f"Report      → {md_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/graph_workflow_benchmarks/plot_results.py
+++ b/tests/benchmarks/graph_workflow_benchmarks/plot_results.py
@@ -1,0 +1,641 @@
+"""
+Render benchmark results from ``graph_workflow_bench.py`` as PNG figures.
+
+    python3 tests/benchmarks/graph_workflow_benchmarks/plot_results.py tests/benchmarks/graph_workflow_benchmarks/results/latest.json
+    python3 tests/benchmarks/graph_workflow_benchmarks/plot_results.py tests/benchmarks/graph_workflow_benchmarks/results/after.json \\
+        --baseline tests/benchmarks/graph_workflow_benchmarks/results/before.json
+
+Figures are written to ``tests/benchmarks/graph_workflow_benchmarks/results/figures/`` in both light and dark
+variants. Every figure is direct-labelled: three of the palette slots sit below
+3:1 contrast on a light surface, so identity never rests on color alone.
+"""
+
+import argparse
+import json
+import os
+from typing import Any, Dict, List
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.ticker import FuncFormatter  # noqa: E402
+
+PHASES = ["build", "compile", "first_run", "steady_run"]
+PHASE_TITLES = {
+    "build": "Build (add nodes + edges)",
+    "compile": "Compile (topological pre-computation)",
+    "first_run": "First run (build + compile + execute)",
+    "steady_run": "Steady run (execute, already compiled)",
+}
+
+# Categorical slots 1-3 from the validated reference palette. The order is the
+# CVD-safety mechanism, not cosmetic — do not reassign or cycle.
+THEMES = {
+    "light": {
+        "surface": "#fcfcfb",
+        "text": "#0b0b0b",
+        "text_secondary": "#52514e",
+        "muted": "#898781",
+        "grid": "#e1e0d9",
+        "axis": "#c3c2b7",
+        "series": {
+            "swarms-networkx": "#2a78d6",
+            "swarms-rustworkx": "#eb6834",
+            "langgraph": "#1baf7a",
+        },
+    },
+    "dark": {
+        "surface": "#1a1a19",
+        "text": "#ffffff",
+        "text_secondary": "#c3c2b7",
+        "muted": "#898781",
+        "grid": "#2c2c2a",
+        "axis": "#383835",
+        "series": {
+            "swarms-networkx": "#3987e5",
+            "swarms-rustworkx": "#d95926",
+            "langgraph": "#199e70",
+        },
+    },
+}
+
+LABELS = {
+    "swarms-networkx": "swarms (networkx)",
+    "swarms-rustworkx": "swarms (rustworkx)",
+    "langgraph": "LangGraph",
+}
+
+
+def ms_fmt(value: float, _pos: int = 0) -> str:
+    """Axis tick formatter: drop trailing zeros, keep sub-millisecond legible."""
+    if value >= 100:
+        return f"{value:.0f}"
+    if value >= 10:
+        return f"{value:.0f}"
+    if value >= 1:
+        return f"{value:.1f}"
+    return f"{value:.2f}"
+
+
+def style(theme: Dict[str, Any]) -> None:
+    """Apply recessive chrome: hairline grid, muted ticks, no top/right spines."""
+    plt.rcParams.update(
+        {
+            "figure.facecolor": theme["surface"],
+            "axes.facecolor": theme["surface"],
+            "savefig.facecolor": theme["surface"],
+            "text.color": theme["text"],
+            "axes.labelcolor": theme["text_secondary"],
+            "axes.edgecolor": theme["axis"],
+            "xtick.color": theme["muted"],
+            "ytick.color": theme["muted"],
+            "grid.color": theme["grid"],
+            "font.family": "sans-serif",
+            "font.sans-serif": [
+                "Helvetica Neue",
+                "Helvetica",
+                "Arial",
+                "DejaVu Sans",
+            ],
+            "font.size": 9,
+            "axes.titlesize": 10,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "figure.dpi": 160,
+        }
+    )
+
+
+def _finish_axis(ax, theme: Dict[str, Any]) -> None:
+    ax.grid(True, axis="y", linewidth=0.6, alpha=0.9, zorder=0)
+    ax.set_axisbelow(True)
+    for spine in ("left", "bottom"):
+        ax.spines[spine].set_linewidth(0.8)
+
+
+def _direct_labels(ax, entries, min_gap: float = 0.055) -> None:
+    """
+    Place end-of-line labels, nudged apart so converging series stay readable.
+
+    Labels are the accessibility channel here — three palette slots fall below
+    3:1 on the light surface — so they must never collide into illegibility.
+    Positions are converted to axes fraction, separated by ``min_gap``, and
+    re-anchored there, which keeps the nudge independent of the data scale.
+
+    Args:
+        ax: The axes to annotate.
+        entries: Iterable of ``(x, y, text, color)`` in data coordinates.
+        min_gap (float): Minimum vertical separation, in axes fraction.
+    """
+    if not entries:
+        return
+
+    to_axes = ax.transAxes.inverted()
+    points = []
+    for x, y, text, color in entries:
+        ax_x, ax_y = to_axes.transform(ax.transData.transform((x, y)))
+        points.append([ax_x, ax_y, text, color])
+
+    points.sort(key=lambda p: p[1])
+    for i in range(1, len(points)):
+        if points[i][1] - points[i - 1][1] < min_gap:
+            points[i][1] = points[i - 1][1] + min_gap
+
+    for ax_x, ax_y, text, color in points:
+        ax.annotate(
+            text,
+            xy=(ax_x, ax_y),
+            xycoords="axes fraction",
+            xytext=(5, 0),
+            textcoords="offset points",
+            color=color,
+            fontsize=7.5,
+            va="center",
+            zorder=4,
+        )
+
+
+# ----------------------------------------------------------------------------
+# figure: scaling — how each phase grows with graph size
+# ----------------------------------------------------------------------------
+def fig_scaling(
+    results: Dict[str, Any], topo: str, theme_name: str, out_dir: str
+) -> str:
+    """Four panels (one per phase) of median time vs node count, log-log."""
+    theme = THEMES[theme_name]
+    style(theme)
+
+    sizes_map = results["topologies"][topo]
+    sizes = sorted(sizes_map, key=int)
+    impls = results["impls"]
+
+    fig, axes = plt.subplots(2, 2, figsize=(9.5, 7.0))
+    for ax, phase in zip(axes.flat, PHASES):
+        label_entries = []
+        for impl in impls:
+            xs, ys = [], []
+            for size in sizes:
+                stats = sizes_map[size].get(impl, {}).get(phase)
+                if stats:
+                    xs.append(int(size))
+                    ys.append(stats["median_ms"])
+            if not xs:
+                continue
+            color = theme["series"][impl]
+            ax.plot(
+                xs,
+                ys,
+                color=color,
+                linewidth=2.0,
+                marker="o",
+                markersize=5,
+                markeredgecolor=theme["surface"],
+                markeredgewidth=1.2,
+                zorder=3,
+            )
+            label_entries.append(
+                (xs[-1], ys[-1], LABELS[impl], color)
+            )
+
+        ax.set_xscale("log")
+        ax.set_yscale("log")
+        ax.set_title(PHASE_TITLES[phase], color=theme["text"], pad=8)
+        ax.set_xlabel("nodes")
+        ax.set_ylabel("median ms")
+        ax.set_xticks([int(s) for s in sizes])
+        ax.set_xticks([], minor=True)
+        ax.get_xaxis().set_major_formatter(
+            FuncFormatter(lambda v, p: f"{v:.0f}")
+        )
+        ax.get_yaxis().set_major_formatter(FuncFormatter(ms_fmt))
+        ax.margins(x=0.30)
+        _finish_axis(ax, theme)
+        # Placed last: axes limits must be final before data→axes conversion.
+        _direct_labels(ax, label_entries)
+
+    fig.suptitle(
+        f"GraphWorkflow orchestration overhead — {topo} topology",
+        color=theme["text"],
+        fontsize=12,
+        y=0.985,
+    )
+    fig.text(
+        0.5,
+        0.005,
+        "No-op nodes; lower is better. Log-log axes.",
+        ha="center",
+        color=theme["muted"],
+        fontsize=7.5,
+    )
+    fig.tight_layout(rect=(0, 0.02, 1, 0.96))
+    return _save(fig, out_dir, f"scaling_{topo}", theme_name)
+
+
+# ----------------------------------------------------------------------------
+# figure: per-phase comparison at one size
+# ----------------------------------------------------------------------------
+def fig_phases(
+    results: Dict[str, Any],
+    topo: str,
+    size: str,
+    theme_name: str,
+    out_dir: str,
+) -> str:
+    """Horizontal grouped bars: every phase at a single graph size."""
+    theme = THEMES[theme_name]
+    style(theme)
+
+    per_impl = results["topologies"][topo][size]
+    impls = [i for i in results["impls"] if i in per_impl]
+
+    fig, ax = plt.subplots(figsize=(8.2, 4.4))
+    bar_h = 0.24
+    for row, phase in enumerate(PHASES):
+        for k, impl in enumerate(impls):
+            stats = per_impl[impl].get(phase)
+            if not stats:
+                continue
+            y = row + (k - (len(impls) - 1) / 2) * (bar_h + 0.02)
+            value = stats["median_ms"]
+            ax.barh(
+                y,
+                value,
+                height=bar_h,
+                color=theme["series"][impl],
+                zorder=3,
+                label=LABELS[impl] if row == 0 else None,
+            )
+            ax.annotate(
+                f"{value:.2f} ms",
+                xy=(value, y),
+                xytext=(5, 0),
+                textcoords="offset points",
+                va="center",
+                fontsize=7.5,
+                color=theme["text_secondary"],
+                zorder=4,
+            )
+
+    ax.set_yticks(range(len(PHASES)))
+    ax.set_yticklabels(
+        [PHASE_TITLES[p].split(" (")[0] for p in PHASES],
+        color=theme["text"],
+    )
+    ax.invert_yaxis()
+    ax.set_xscale("log")
+    ax.set_xlabel("median ms (log scale) — lower is better")
+    ax.get_xaxis().set_major_formatter(FuncFormatter(ms_fmt))
+    ax.grid(True, axis="x", linewidth=0.6, alpha=0.9, zorder=0)
+    ax.set_axisbelow(True)
+    ax.margins(x=0.30)
+
+    legend = ax.legend(
+        frameon=False, loc="lower right", fontsize=8, ncol=1
+    )
+    for text in legend.get_texts():
+        text.set_color(theme["text_secondary"])
+
+    ax.set_title(
+        f"{topo} topology · {size} nodes",
+        color=theme["text"],
+        pad=10,
+        loc="left",
+    )
+    fig.tight_layout()
+    return _save(fig, out_dir, f"phases_{topo}_n{size}", theme_name)
+
+
+# ----------------------------------------------------------------------------
+# figure: the total story — cold start vs steady state, and break-even
+# ----------------------------------------------------------------------------
+def fig_total(
+    results: Dict[str, Any],
+    topo: str,
+    size: str,
+    theme_name: str,
+    out_dir: str,
+) -> str:
+    """
+    Two panels: what a cold start costs, and how many runs repay it.
+
+    The left panel splits total cold start into import vs first execution — the
+    split is the whole point, since import dominates. The right panel plots
+    cumulative wall clock against run count so the crossover is readable.
+    """
+    theme = THEMES[theme_name]
+    style(theme)
+
+    per_impl = results["topologies"][topo][size]
+    impls = [i for i in results["impls"] if i in per_impl]
+    imports = results.get("imports", {})
+    import_ms = {
+        "swarms-networkx": imports.get(
+            "swarms.GraphWorkflow", {}
+        ).get("median_ms", 0.0),
+        "swarms-rustworkx": imports.get(
+            "swarms.GraphWorkflow", {}
+        ).get("median_ms", 0.0),
+        "langgraph": imports.get("langgraph.StateGraph", {}).get(
+            "median_ms", 0.0
+        ),
+    }
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11.0, 4.4))
+
+    # --- left: cold start composition -------------------------------------
+    xs = range(len(impls))
+    for i, impl in enumerate(impls):
+        imp = import_ms.get(impl, 0.0)
+        first = per_impl[impl]["first_run"]["median_ms"]
+        color = theme["series"][impl]
+        # Import leg in the series hue; execution leg hatched, separated by a
+        # 2px surface gap so the two segments never touch.
+        ax1.bar(i, imp, color=color, zorder=3, width=0.5)
+        ax1.bar(
+            i,
+            first,
+            bottom=imp * 1.02,
+            color=color,
+            alpha=0.45,
+            hatch="///",
+            edgecolor=theme["surface"],
+            linewidth=1.4,
+            zorder=3,
+            width=0.5,
+        )
+        ax1.annotate(
+            f"{imp + first:,.0f} ms",
+            xy=(i, imp + first),
+            xytext=(0, 5),
+            textcoords="offset points",
+            ha="center",
+            fontsize=8.5,
+            color=theme["text"],
+            zorder=4,
+        )
+        ax1.annotate(
+            f"import {imp:,.0f}",
+            xy=(i, imp / 2),
+            ha="center",
+            va="center",
+            fontsize=7,
+            color=theme["surface"],
+            zorder=4,
+        )
+
+    ax1.set_xticks(list(xs))
+    ax1.set_xticklabels(
+        [LABELS[i].replace(" (", "\n(") for i in impls],
+        color=theme["text"],
+        fontsize=8,
+    )
+    ax1.set_ylabel("ms")
+    ax1.set_title(
+        "Total cold start: import + first execution",
+        color=theme["text"],
+        pad=10,
+        loc="left",
+    )
+    _finish_axis(ax1, theme)
+
+    # --- right: cumulative cost vs run count -------------------------------
+    max_runs = 120
+    runs = list(range(0, max_runs + 1))
+    crossings = []
+    label_entries = []
+    for impl in impls:
+        imp = import_ms.get(impl, 0.0)
+        steady = per_impl[impl]["steady_run"]["median_ms"]
+        ys = [imp + steady * r for r in runs]
+        color = theme["series"][impl]
+        ax2.plot(runs, ys, color=color, linewidth=2.0, zorder=3)
+        label_entries.append((runs[-1], ys[-1], LABELS[impl], color))
+        crossings.append((impl, imp, steady))
+
+    ax2.set_xlabel("executions")
+    ax2.set_ylabel("cumulative ms")
+    ax2.set_title(
+        "Cumulative wall clock, including import",
+        color=theme["text"],
+        pad=10,
+        loc="left",
+    )
+    ax2.margins(x=0.22)
+    ax2.set_xlim(left=0)  # negative execution counts are meaningless
+    _finish_axis(ax2, theme)
+
+    # Mark where the slower-importing framework repays its deficit. The label
+    # is pinned near the top of the axes so it never lands on a series line.
+    if len(crossings) >= 2:
+        fastest = min(crossings, key=lambda c: c[1])
+        for impl, imp, steady in crossings:
+            if impl == fastest[0]:
+                continue
+            gain = fastest[2] - steady
+            if gain <= 0:
+                continue
+            n_runs = (imp - fastest[1]) / gain
+            if 0 < n_runs <= max_runs:
+                ax2.axvline(
+                    n_runs,
+                    color=theme["muted"],
+                    linewidth=1.0,
+                    linestyle=(0, (4, 3)),
+                    zorder=2,
+                )
+                ax2.annotate(
+                    f"break-even: {n_runs:.0f} runs",
+                    xy=(n_runs, 0.965),
+                    xycoords=ax2.get_xaxis_transform(),
+                    xytext=(6, 0),
+                    textcoords="offset points",
+                    fontsize=7.5,
+                    color=theme["text_secondary"],
+                    va="top",
+                    zorder=4,
+                )
+                break
+
+    _direct_labels(ax2, label_entries)
+
+    fig.suptitle(
+        f"{topo} topology · {size} nodes — startup cost vs per-run cost",
+        color=theme["text"],
+        fontsize=12,
+        y=0.99,
+    )
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
+    return _save(fig, out_dir, f"total_{topo}_n{size}", theme_name)
+
+
+# ----------------------------------------------------------------------------
+# figure: optimization gains (before vs after)
+# ----------------------------------------------------------------------------
+def fig_gains(
+    after: Dict[str, Any],
+    before: Dict[str, Any],
+    theme_name: str,
+    out_dir: str,
+) -> str:
+    """Speedup factor per phase for the swarms implementations, before → after."""
+    theme = THEMES[theme_name]
+    style(theme)
+
+    impls = [i for i in after["impls"] if i.startswith("swarms")]
+    rows: List[tuple] = []
+    for topo, sizes in after["topologies"].items():
+        if topo not in before["topologies"]:
+            continue
+        for size in sorted(sizes, key=int):
+            if size not in before["topologies"][topo]:
+                continue
+            for phase in PHASES:
+                for impl in impls:
+                    a = (
+                        after["topologies"][topo][size]
+                        .get(impl, {})
+                        .get(phase)
+                    )
+                    b = (
+                        before["topologies"][topo][size]
+                        .get(impl, {})
+                        .get(phase)
+                    )
+                    if not a or not b or a["median_ms"] <= 0:
+                        continue
+                    # Backend goes in the row label too: two impls can produce
+                    # the same topo/size/phase row, and color alone must not
+                    # be what tells them apart.
+                    backend = impl.split("-", 1)[-1]
+                    rows.append(
+                        (
+                            f"{topo} n={size} · {phase} · {backend}",
+                            impl,
+                            b["median_ms"] / a["median_ms"],
+                        )
+                    )
+
+    rows = [r for r in rows if r[2] >= 1.15]
+    rows.sort(key=lambda r: r[2])
+    rows = rows[-22:]
+    if not rows:
+        return ""
+
+    fig, ax = plt.subplots(figsize=(8.6, max(4.0, 0.30 * len(rows))))
+    for i, (label, impl, speedup) in enumerate(rows):
+        color = theme["series"][impl]
+        ax.barh(i, speedup, height=0.62, color=color, zorder=3)
+        ax.annotate(
+            f"{speedup:.1f}x",
+            xy=(speedup, i),
+            xytext=(5, 0),
+            textcoords="offset points",
+            va="center",
+            fontsize=7.5,
+            color=theme["text_secondary"],
+            zorder=4,
+        )
+
+    ax.axvline(1.0, color=theme["axis"], linewidth=1.0, zorder=2)
+    ax.set_yticks(range(len(rows)))
+    ax.set_yticklabels(
+        [r[0] for r in rows], fontsize=7.5, color=theme["text"]
+    )
+    ax.set_xscale("log")
+    ax.set_xlabel("speedup factor (before ÷ after, log scale)")
+    ax.get_xaxis().set_major_formatter(
+        FuncFormatter(lambda v, p: f"{v:g}x")
+    )
+    ax.grid(True, axis="x", linewidth=0.6, alpha=0.9, zorder=0)
+    ax.set_axisbelow(True)
+    ax.margins(x=0.18)
+
+    handles = [
+        plt.Rectangle((0, 0), 1, 1, color=theme["series"][i])
+        for i in impls
+    ]
+    legend = ax.legend(
+        handles,
+        [LABELS[i] for i in impls],
+        frameon=False,
+        loc="lower right",
+        fontsize=8,
+    )
+    for text in legend.get_texts():
+        text.set_color(theme["text_secondary"])
+
+    ax.set_title(
+        "Optimization gains — swarms GraphWorkflow, before vs after",
+        color=theme["text"],
+        pad=10,
+        loc="left",
+    )
+    fig.tight_layout()
+    return _save(fig, out_dir, "optimization_gains", theme_name)
+
+
+def _save(fig, out_dir: str, name: str, theme_name: str) -> str:
+    os.makedirs(out_dir, exist_ok=True)
+    path = os.path.join(out_dir, f"{name}.{theme_name}.png")
+    fig.savefig(path, bbox_inches="tight")
+    plt.close(fig)
+    return path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "results", help="results JSON from graph_workflow_bench.py"
+    )
+    ap.add_argument(
+        "--baseline",
+        default=None,
+        help="optional earlier results JSON to compute before/after gains",
+    )
+    ap.add_argument("--out-dir", default=None)
+    ap.add_argument(
+        "--themes", default="light,dark", help="comma separated"
+    )
+    args = ap.parse_args()
+
+    with open(args.results) as fh:
+        after = json.load(fh)
+    before = None
+    if args.baseline:
+        with open(args.baseline) as fh:
+            before = json.load(fh)
+
+    out_dir = args.out_dir or os.path.join(
+        os.path.dirname(os.path.abspath(args.results)), "figures"
+    )
+
+    written: List[str] = []
+    for theme_name in args.themes.split(","):
+        theme_name = theme_name.strip()
+        for topo in after["topologies"]:
+            written.append(
+                fig_scaling(after, topo, theme_name, out_dir)
+            )
+            largest = max(after["topologies"][topo], key=int)
+            written.append(
+                fig_phases(after, topo, largest, theme_name, out_dir)
+            )
+            if after.get("imports"):
+                written.append(
+                    fig_total(
+                        after, topo, largest, theme_name, out_dir
+                    )
+                )
+        if before:
+            path = fig_gains(after, before, theme_name, out_dir)
+            if path:
+                written.append(path)
+
+    for path in written:
+        print(path)
+    print(f"\n{len(written)} figures → {out_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Three independent performance fixes in `GraphWorkflow`, plus a benchmark suite to keep them honest. Behavior is unchanged — all 58 existing tests pass, and pass identically on the pre-change code.

## 1. `RustworkxBackend` reimplemented rustworkx in Python

The backend users select **for speed** was slower than the pure-Python one at scale, because almost none of its methods called rustworkx.

| method | before | after |
| --- | --- | --- |
| `topological_generations` | rescanned the **entire edge list** for every node in every layer — O(layers × V × E) | `rx.topological_generations()` |
| `predecessors` | scanned all edges to find one node's parents — O(E) per call | `graph.predecessor_indices(idx)` |
| `simple_cycles` | rebuilt the graph as a **networkx** graph, then called `nx.simple_cycles` | `rx.is_directed_acyclic_graph()` fast path, then `rx.simple_cycles` |
| `descendants` | hand-rolled BFS using `list.pop(0)` — O(n) per dequeue | `rx.descendants()` |

`rx.topological_generations` raises on cyclic input where the old code returned a cyclic remainder layer, so `_kahn_generations` preserves that behavior. `NetworkXBackend.topological_generations` got the same cycle tolerance, so the two backends now agree on cyclic input.

## 2. `run()` created a thread pool per layer, per loop

Profiling a 50-layer graph showed **91% of execution time** in thread pool creation and shutdown — 2000 thread starts across 20 runs.

- One executor per run, sized to the widest layer, capped at `_max_workers`, created lazily and shut down in a `finally`.
- **Single-node layers execute inline** — dispatching one call to a worker thread only adds handoff latency. A purely sequential graph now spawns **zero threads**.
- Node invocation and result recording are factored into `_make_call` / `_record`, so the inline and pooled paths share one implementation.
- `dict(kwargs)` is no longer copied per node when there is no streaming callback.
- `hashlib.sha256(task)` is computed only when `checkpoint_dir` is set; it previously ran every loop regardless.

## 3. `compile()` cost six traversals plus a full graph copy

`compile()` called `validate()`, which did per-node `in_degree`/`out_degree`, full `simple_cycles()` enumeration, `descendants()` **per entry point**, a complete reversed copy of the graph, and `descendants()` **per exit point**.

Now one `adjacency()` pass builds successor/predecessor maps, reused for:

- `_fast_validate()` — reachability via one multi-source BFS per direction, replacing one traversal per entry/exit point and removing the graph copy entirely
- `_predecessors_cache` — populated wholesale instead of lazily per node
- `_execution_plan` — a frozen per-layer list of `(node_id, agent, node_type, agent_name)`, so `run()` does no dict lookups or `getattr` in its hot loop

Cycle detection uses a new `is_dag()` (O(V+E)) instead of enumerating every simple cycle, which is exponential in the number of cycles. `validate()` itself got the same adjacency-driven treatment.

## Measured impact

Median of 9 samples, no-op agents, 200 nodes, macOS arm64 / Python 3.12:

| case | before | after | speedup |
| --- | ---: | ---: | ---: |
| `chain` compile (rustworkx) | 151.18 ms | **0.25 ms** | **615x** |
| `layered` compile (rustworkx) | 141.25 ms | **0.30 ms** | **470x** |
| `chain` first_run (rustworkx) | 163.79 ms | **1.04 ms** | **157x** |
| `chain` steady_run (networkx) | 11.33 ms | **0.31 ms** | **37x** |
| `layered` first_run (rustworkx) | 155.09 ms | **4.05 ms** | **38x** |
| `diamond` compile (rustworkx) | 6.81 ms | **0.22 ms** | **31x** |

Deep graphs gain most — that is where per-layer overhead compounds. A 200-node chain is 200 single-node layers, which previously meant 200 thread pools created and destroyed per run.

## Benchmark suite

`tests/benchmarks/graph_workflow_benchmarks/` — harness, plotting, and methodology docs.

- Five topologies: `chain`, `wide`, `diamond`, `layered`, `tree`
- Phases: import, build, compile, first_run, steady_run, plus derived total-cold-start and break-even
- Warmup iterations, GC controlled inside timed regions, median/p95/stdev and every raw sample retained
- Environment and git provenance recorded in the output JSON
- Before/after comparison and chart generation (matplotlib, light and dark)

Against LangGraph 1.0.4 the suite compares 120 cells (5 topologies × 3 sizes × 2 backends × 4 phases). Post-change, swarms is ahead in all 120, from 1.8x to 61x. Import time is the exception and is **not** addressed here — see #1755.

The harness locates the repo root by walking up to the `swarms` package rather than counting parent directories, because running the script puts its own directory on `sys.path` and an installed `swarms` would otherwise win silently and the numbers would describe the wrong code. It prints the resolved module path on every run.

## Testing

All 58 tests in `tests/structs/test_graph_workflow.py` pass, and pass identically on the pre-change code, confirming the suite is a valid regression check rather than vacuous.

**Caveat worth flagging:** those tests construct real `Agent`s with `model_name="gpt-5.4"` and call `.run()`, so the suite requires live network — an unstubbed run hangs past 600s. I ran them with `Agent.run` stubbed via a local pytest plugin, which exercises every orchestration path (layer sweep, executor, checkpoints, subgraphs, callbacks) without leaving the machine. That stub is **not** included here; making the suite runnable offline is worth doing separately.

## Behavior notes

One deliberate difference: cyclic graphs no longer raise from `nx.topological_generations` on the networkx backend — they flatten into a single layer, matching what rustworkx always did. That silent flattening is itself a bug, filed separately as #1757.

## Related issues

- #1755 — import time (the remaining gap vs LangGraph; not addressed here)
- #1757 — cycles silently flatten
- #1763 — wire this suite into CI

## Unrelated change included

`example.py` carries a one-line `agent_name` rename that was already in the working tree before this work. Happy to drop it if you would rather keep this PR clean.
