### PR TITLE
[Bug] Replace deprecated asyncio.get_event_loop() with asyncio.to_thread in async helpers

### DIFF
--- a/swarms/structs/base_structure.py
+++ b/swarms/structs/base_structure.py
@@ -202,10 +202,7 @@ class BaseStructure:
 
     async def run_async(self, *args, **kwargs):
         """Run the structure asynchronously."""
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self.run, *args, **kwargs
-        )
+        return await asyncio.to_thread(self.run, *args, **kwargs)
 
     async def save_metadata_async(self, metadata: Dict[str, Any]):
         """Save metadata to file asynchronously.
@@ -213,10 +210,7 @@ class BaseStructure:
         Args:
             metadata (Dict[str, Any]): _description_
         """
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self.save_metadata, metadata
-        )
+        return await asyncio.to_thread(self.save_metadata, metadata)
 
     async def load_metadata_async(self) -> Dict[str, Any]:
         """Load metadata from file asynchronously.
@@ -224,8 +218,7 @@ class BaseStructure:
         Returns:
             Dict[str, Any]: _description_
         """
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(None, self.load_metadata)
+        return await asyncio.to_thread(self.load_metadata)
 
     async def log_error_async(self, error_message: str):
         """Log error to file asynchronously.
@@ -233,10 +226,7 @@ class BaseStructure:
         Args:
             error_message (str): _description_
         """
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self.log_error, error_message
-        )
+        return await asyncio.to_thread(self.log_error, error_message)
 
     async def save_artifact_async(
         self, artifact: Any, artifact_name: str
@@ -247,9 +237,8 @@ class BaseStructure:
             artifact (Any): _description_
             artifact_name (str): _description_
         """
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self.save_artifact, artifact, artifact_name
+        return await asyncio.to_thread(
+            self.save_artifact, artifact, artifact_name
         )
 
     async def load_artifact_async(self, artifact_name: str) -> Any:
@@ -261,9 +250,8 @@ class BaseStructure:
         Returns:
             Any: _description_
         """
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self.load_artifact, artifact_name
+        return await asyncio.to_thread(
+            self.load_artifact, artifact_name
         )
 
     async def log_event_async(
@@ -277,9 +265,8 @@ class BaseStructure:
             event (str): _description_
             event_type (str, optional): _description_. Defaults to "INFO".
         """
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None, self.log_event, event, event_type
+        return await asyncio.to_thread(
+            self.log_event, event, event_type
         )
 
     async def asave_to_file(

--- a/swarms/structs/base_swarm.py
+++ b/swarms/structs/base_swarm.py
@@ -371,9 +371,8 @@ class BaseSwarm(ABC):
         Args:
             task (Optional[str], optional): _description_. Defaults to None.
         """
-        loop = asyncio.get_event_loop()
-        result = await loop.run_in_executor(
-            None, self.run, task, *args, **kwargs
+        result = await asyncio.to_thread(
+            self.run, task, *args, **kwargs
         )
         return result
 
@@ -404,9 +403,8 @@ class BaseSwarm(ABC):
             task (Optional[str], optional): _description_. Defaults to None.
         """
         # Async Loop through the self.max_loops
-        loop = asyncio.get_event_loop()
-        result = await loop.run_in_executor(
-            None, self.loop, task, *args, **kwargs
+        result = await asyncio.to_thread(
+            self.loop, task, *args, **kwargs
         )
         return result
 

--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -2004,8 +2004,8 @@ class GraphWorkflow:
             logger.info("Starting async GraphWorkflow execution")
 
         try:
-            result = await asyncio.get_event_loop().run_in_executor(
-                None, self.run, task, *args, **kwargs
+            result = await asyncio.to_thread(
+                self.run, task, *args, **kwargs
             )
 
             if self.verbose:

--- a/swarms/structs/multi_agent_exec.py
+++ b/swarms/structs/multi_agent_exec.py
@@ -59,10 +59,7 @@ async def run_agent_async(agent: AgentType, task: str) -> Any:
         ...     result = await run_agent_async(agent, "Process data")
         ...     return result
     """
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(
-        None, run_single_agent, agent, task
-    )
+    return await asyncio.to_thread(run_single_agent, agent, task)
 
 
 async def run_agents_concurrently_async(

--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -605,9 +605,8 @@ class SocialAlgorithms:
         import asyncio
 
         async def async_execution():
-            loop = asyncio.get_event_loop()
-            return await loop.run_in_executor(
-                None, self.run, task, algorithm_args, **kwargs
+            return await asyncio.to_thread(
+                self.run, task, algorithm_args, **kwargs
             )
 
         return asyncio.run(async_execution())

--- a/tests/structs/test_base_structure.py
+++ b/tests/structs/test_base_structure.py
@@ -481,6 +481,33 @@ def test_run_async():
         raise
 
 
+def test_run_async_forwards_keyword_arguments():
+    """run_async must accept **kwargs.
+
+    loop.run_in_executor() takes no keyword arguments, so the previous
+    implementation raised TypeError for any keyword passed through.
+    """
+    try:
+        structure = TestStructure(name="TestAsyncKwargs")
+
+        async def run_test():
+            return await structure.run_async(task="kwarg_task")
+
+        result = asyncio.run(run_test())
+
+        assert (
+            result == "Processed: kwarg_task"
+        ), f"Expected keyword to reach run(), got {result!r}"
+
+        logger.info("✓ Run async kwargs test passed")
+
+    except Exception as e:
+        logger.error(
+            f"Error in test_run_async_forwards_keyword_arguments: {str(e)}"
+        )
+        raise
+
+
 def test_save_metadata_async():
     """Test async save metadata."""
     try:


### PR DESCRIPTION
Closes #1745.

The issue asks to swap the deprecated `asyncio.get_event_loop()` for `get_running_loop()` at 7 sites in `base_structure.py`. Every one of those sites has the same shape:

```python
loop = asyncio.get_event_loop()
return await loop.run_in_executor(None, fn, *args, **kwargs)
```

`asyncio.to_thread()` expresses that directly. It **removes** the deprecated call rather than renaming it, drops a line per site, and fixes a live bug. It is already the idiom in this repo — `base_structure.py:313` (`aload_from_file`) and `agent_rearrange.py:1080` both use it, and it already appears at 10 call sites across `swarms/`. Available since Python 3.9; this project requires `>=3.10`.

Net **−19 lines** across 5 files.

## It fixes a live TypeError at 5 sites

`loop.run_in_executor()` accepts no keyword arguments, so every helper forwarding `**kwargs` raises today:

```pycon
>>> asyncio.run(BaseStructure(name="t").run_async(foo="bar"))
TypeError: BaseEventLoop.run_in_executor() got an unexpected keyword argument 'foo'
```

Affected: `base_structure.run_async`, `base_swarm.arun`, `base_swarm.aloop`, `graph_workflow.arun`, `social_algorithms.run_async`. The other seven forward positionally and were fine. Regression test added.

One caveat, stated plainly: `social_algorithms.run_async` no longer raises `TypeError`, but it remains unusable for an unrelated pre-existing reason — `social_algorithms.py:298` installs a `SIGALRM` handler inside `run()`, which raises `signal only works in main thread of the main interpreter` whenever `run()` executes on a worker thread. True on master with either helper; not addressed here.

## Scope: 12 sites, not 7

The issue names one file, but the identical idiom appears at 12 sites across 5 files, all inside `async def`:

| file | lines |
|---|---|
| `base_structure.py` | 205, 216, 227, 236, 250, 264, 280 |
| `base_swarm.py` | 374 (`arun`), 407 (`aloop`) |
| `graph_workflow.py` | 2007 (`arun`) |
| `social_algorithms.py` | 608 (`async_execution`) |
| `multi_agent_exec.py` | 62 (`run_agent_async`) |

Fixing 7 of 12 would leave the codebase half-migrated and invite the same issue again next month.

## Eight occurrences deliberately left alone

- **`base_swarm.py:419, 431`** (417, 429 after this change) — sync `def`s calling `loop.run_until_complete()`. Not convertible: `to_thread` needs a running loop. They want `asyncio.run()`, which is a behaviour change. Worth noting these already raise `RuntimeError` today after any prior `asyncio.run()` in the process, so they are the genuinely broken pair and deserve their own fix.
- **`aop.py:1011-1099`** — three occurrences of `get_event_loop().time() if get_event_loop().is_running() else 0` (six `get_event_loop()` calls). These are *not* unsafe for lack of a loop: FastMCP invokes sync tool functions inline on the event-loop thread (`mcp/server/fastmcp/utilities/func_metadata.py:93-96`), so a loop is present and the `else 0` branch is dead. They are excluded because the whole expression is a hand-rolled stopwatch that should be `time.monotonic()` — a different change, and `time` is already imported there.

Happy to file follow-ups for both.

## Correction to the issue text

The issue states these sites "spam warnings under 3.12+". They do not. `get_event_loop()` emits **no** `DeprecationWarning` inside a coroutine on Python 3.12.13 — verified under both `-W error::DeprecationWarning` and `warnings.catch_warnings(record=True)`. Only the sync, no-running-loop case warns, which is exactly the set excluded above.

So the motivation is removing the deprecated API before it is deleted, plus the kwargs `TypeError` — not silencing warnings.

## Behaviour change worth flagging

`asyncio.to_thread` copies the current context into the worker thread; `run_in_executor(None, ...)` does not. This is an improvement rather than merely a difference. With a reused pool thread, `run_in_executor` lets a `ContextVar` set by one task stay visible to the *next* task on that thread, while the caller's own value is never visible:

```
run_in_executor  read: 'set-in-thread'   <- leaked from a previous task
run_in_executor  sees caller: 'set-in-thread'  <- caller's value invisible
to_thread        read: 'unset'           <- isolated
to_thread        sees caller: 'caller-value'
```

There are no `ContextVar` uses in `swarms/` itself; the consumer is OpenTelemetry, and the repo already propagates context into worker threads deliberately via `ContextThreadPoolExecutor` (`swarms/telemetry/otel.py`). Same default executor either way; cancellation and exception propagation verified identical.

## Verification

- `tests/structs/test_base_structure.py` — **28 passed** (27 existing + the new kwargs regression test, which fails on master with the `TypeError` above).
- `tests/structs/test_graph_workflow.py` — 47 passed, 11 skipped.
- Broader offline run: same 5 pre-existing failures as master, one extra pass. No regressions.
- `black 24.2.0 --check` clean; `ruff 0.2.1` output identical to master.
- Verified on a real Python 3.10 interpreter that `to_thread` behaves identically (kwargs, contextvars, cancellation).

Coverage is partial and worth stating: line tracing shows the existing suite executes `base_structure.py` 205, 216, 227, 250, 264 only. No test reaches `base_structure` 236/280, `base_swarm` 374/407, `graph_workflow` 2007 (that suite passes but never calls `arun`), `social_algorithms` 608, or `multi_agent_exec` 62. Those five were exercised manually, A/B against master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

