### PR TITLE
[Bug] Cache remote image fetches in get_image_base64 (URL path, local/non-direct-URL models)

### DIFF
--- a/swarms/utils/image_file_b64.py
+++ b/swarms/utils/image_file_b64.py
@@ -10,6 +10,7 @@ import ipaddress
 import re
 import socket
 import uuid
+from functools import lru_cache
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -97,6 +98,25 @@ def _is_safe_url(url: str) -> bool:
         return False
 
 
+@lru_cache(maxsize=32)
+def _fetch_image_url(url: str) -> bytes:
+    """Fetch an image URL once per process; an agent re-sends the same img
+    every loop.
+
+    URLs only: file paths stay uncached so a mutated file is still re-read.
+    The guard sits inside the cache on purpose -- a hit makes no request, and
+    lru_cache does not memoize the raise, so a blocked URL fails every call.
+    Entries are bounded by count, not bytes: 32 images retained at most.
+    """
+    if not _is_safe_url(url):
+        raise ValueError(
+            f"Blocked URL '{url}': only external HTTP/HTTPS URLs are permitted."
+        )
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
 def is_base64_encoded(image_source: str) -> bool:
     """
     Check if a string is already base64 encoded (either as data URI or raw base64).
@@ -175,13 +195,7 @@ def get_image_base64(image_source: str) -> str:
 
     # Handle URLs
     if image_source.startswith(("http://", "https://")):
-        if not _is_safe_url(image_source):
-            raise ValueError(
-                f"Blocked URL '{image_source}': only external HTTP/HTTPS URLs are permitted."
-            )
-        response = requests.get(image_source, timeout=30)
-        response.raise_for_status()
-        image_data = response.content
+        image_data = _fetch_image_url(image_source)
     else:
         # Assume it's a file path
         with open(image_source, "rb") as file:

--- a/tests/utils/test_ssrf_url_guard.py
+++ b/tests/utils/test_ssrf_url_guard.py
@@ -19,6 +19,7 @@ import ipaddress
 
 import pytest
 
+from swarms.utils import image_file_b64
 from swarms.utils.image_file_b64 import _ip_is_blocked, _is_safe_url
 
 
@@ -122,3 +123,101 @@ def test_ip_is_blocked_false(ip):
 def test_malformed_is_unsafe(value):
     # None would raise inside urlparse; the guard must swallow and reject.
     assert _is_safe_url(value if value is not None else "") is False
+
+
+########################################################
+# URL fetches are cached; the guard still runs on every rejection
+########################################################
+
+
+@pytest.fixture(autouse=True)
+def _clear_image_url_cache():
+    """Stop the module-global fetch cache leaking fake bytes between tests."""
+    image_file_b64._fetch_image_url.cache_clear()
+    yield
+    image_file_b64._fetch_image_url.cache_clear()
+
+
+def _stub_fetch(monkeypatch, gets, safe=True):
+    """Patch the guard and requests.get, recording every GET."""
+
+    class _Resp:
+        content = b"\xff\xd8\xff\xe0fake-jpeg-bytes"
+
+        def raise_for_status(self):
+            return None
+
+    def _get(url, timeout=None):
+        gets.append(url)
+        return _Resp()
+
+    monkeypatch.setattr(
+        image_file_b64, "_is_safe_url", lambda url: safe
+    )
+    monkeypatch.setattr(image_file_b64.requests, "get", _get)
+
+
+def test_repeated_url_fetches_hit_the_network_once(monkeypatch):
+    """An agent re-sends the same img every loop -- fetch it once."""
+    gets = []
+    _stub_fetch(monkeypatch, gets)
+
+    url = "https://example.com/cat.jpg"
+    first = image_file_b64.get_image_base64(url)
+    for _ in range(4):
+        assert image_file_b64.get_image_base64(url) == first
+
+    assert len(gets) == 1, f"expected 1 network GET, got {len(gets)}"
+    assert first.startswith("data:image/jpeg;base64,")
+
+
+def test_blocked_url_is_rejected_every_call(monkeypatch):
+    """lru_cache must not memoize the rejection -- fail closed every call."""
+    checks = []
+
+    def _guard(url):
+        checks.append(url)
+        return False
+
+    monkeypatch.setattr(image_file_b64, "_is_safe_url", _guard)
+
+    url = "http://169.254.169.254/latest/meta-data/"
+    for _ in range(3):
+        with pytest.raises(ValueError, match="Blocked URL"):
+            image_file_b64.get_image_base64(url)
+
+    assert len(checks) == 3, "guard must re-run on every call"
+
+
+def test_cache_hit_skips_the_guard_but_new_urls_are_still_checked(
+    monkeypatch,
+):
+    """A hit makes no request, so it cannot re-run the guard.
+
+    Documents the deliberate consequence of caching behind the guard: a host
+    that later resolves to a private address cannot revoke an image already
+    fetched in this process. A hit issues no outbound request, so those bytes
+    already came through a passing guard.
+    """
+    gets = []
+    _stub_fetch(monkeypatch, gets)
+    url = "https://example.com/pinned.jpg"
+    warm = image_file_b64.get_image_base64(url)
+
+    guards = []
+
+    def _reject(u):
+        guards.append(u)
+        return False
+
+    monkeypatch.setattr(image_file_b64, "_is_safe_url", _reject)
+
+    assert image_file_b64.get_image_base64(url) == warm
+    assert not guards, "a cache hit must not re-run the guard"
+    assert len(gets) == 1, "a cache hit must not issue a request"
+
+    with pytest.raises(ValueError, match="Blocked URL"):
+        image_file_b64.get_image_base64(
+            "https://example.com/other.jpg"
+        )
+    assert len(gets) == 1


### PR DESCRIPTION
Addresses #1744 — the URL-fetch half. Please read the Scope section, which is narrower than the issue implies.

`get_image_base64` (`swarms/utils/image_file_b64.py`) had no caching, so when it is reached with a URL it performed a fresh network GET every call. An agent re-sends the same `img` into `call_llm` on every loop iteration and every retry (`agent.py:1479`, `:2140`, `:2379`), so the same image was downloaded once per loop.

This adds an `lru_cache` on a new private URL-fetch helper. Measured with a stubbed `requests.get`: **5 identical calls now issue 1 GET instead of 5.**

## Scope — narrower than #1744 implies

**A URL only reaches `get_image_base64` when direct-URL passing is off.** Both call sites (`litellm_wrapper.py:914`, `:992`) sit in the `else` of `if self._should_use_direct_url(image)`. For an `http(s)` URL on a vision-capable, non-local model that returns `True`, and the URL goes to the provider verbatim — nothing is downloaded locally at all. Verified:

```
gpt-4o              direct_url=True   -> get_image_base64 not called
claude-sonnet-4-5   direct_url=True   -> not called
gemini/2.5-pro      direct_url=True   -> not called
ollama/llava        direct_url=False  -> reaches get_image_base64
```

**That table is conditional on litellm having fetched its live model map.** `_should_use_direct_url` ends in `supports_vision(model=...)` and returns `False` on any exception, so the answer depends on which cost map is loaded. litellm is pinned at `1.76.1`, whose *bundled* map predates Claude 4.x and GPT-5:

| model | live map (default) | `LITELLM_LOCAL_MODEL_COST_MAP=True` |
|---|---|---|
| `claude-sonnet-4-5` | `True` -> cache unused | `False` -> **cache applies** |
| `gpt-5.4` | `True` -> unused | `False` -> **applies** |
| `gpt-4o` | `True` -> unused | `True` -> unused |

So anyone running offline, air-gapped, or with `LITELLM_LOCAL_MODEL_COST_MAP=True` set gets the caching benefit on hosted Claude and GPT-5 too. Worth knowing because that env var is the standard mitigation for litellm's import-time network fetch — setting it to avoid the fetch silently widens what this PR helps.

So this fixes repeated downloads for **local models** (`ollama`, `llama-cpp`, `localhost`/custom `base_url`) and any model litellm does not flag as vision-capable. **It is not a win for the default GPT/Claude/Gemini paths.** Neither the issue nor my original description of this PR mentioned that gate; correcting it here.

**Only the fetch is cached.** The base64 encode still runs on every call — a cache hit for a 2 MB image costs 2.03 ms, of which 2.00 ms is `b64encode`. #1744 also proposes encoding once before the loop; that is not done here.

**File-path inputs are not cached**, so the issue's file-path case is not covered either.

Happy to extend to the encode and file-path cases in a follow-up, or here if you prefer one change.

## Why a private helper rather than decorating `get_image_base64`

- The cache key is computed **before** the function body runs, so decorating the public entry point would hash every input — including data URIs, which short-circuit in ~0.06 µs and can be multiple megabytes. That multi-MB key would then be retained for the cache's lifetime.
- Placing the helper **below** the data-URI and raw-base64 short-circuits means only `http(s)` URLs become keys. Verified the data-URI path is still 0.06 µs/call and leaves `cache_info().currsize == 0`.

## Trade-offs, stated in both directions

File paths are deliberately uncached: local encode is ~2.4 ms for 2 MB, and caching a path means a mutated file returns stale content. Verified a mutation between calls is still observed.

URL entries have **no TTL**, so the same trade applies in reverse and deserves stating plainly: a stable URL serving changing content (a webcam snapshot, a rotating `latest.jpg`) is pinned to its first fetch for the lifetime of the process — indefinite for something like the AOP MCP server. Callers who need freshness should pass a data URI or a cache-busting query string.

## The SSRF guard moves inside the cached helper, on purpose

- A cache **hit issues no HTTP request at all**, so there is nothing left for the guard to protect. Caching can only reduce outbound requests.
- A blocked URL **raises**, and `lru_cache` does not memoize exceptions, so the guard re-runs and re-rejects on every call. Fail-closed is preserved.
- Keeping the guard *outside* the cache would re-resolve DNS on every hit (4–9 ms of `getaddrinfo`) for no security gain.

Keying on the **exact URL string** is deliberate — a normalising key would be the bug. Verified 10 near-miss variants of a cached URL (trailing dot, `:443`, userinfo, fragment, `/./`, percent-encoding, case differences) each miss the cache, re-run the guard, and are rejected when the guard says no:

```
blocked variants served from cache: []
gets: 1   guard runs: 11   cache: hits=0 misses=11 currsize=1
```

## Sizing

`maxsize=32` bounds entry count, not bytes. Simulated round-robin over 20 distinct images for 5 loops:

| maxsize | GETs | hits |
|---|---|---|
| 8 | 100 | 0 |
| 32 | 20 | 80 |

At the smaller size the cache retains memory while providing no benefit. Worst case is 32 retained images for the process lifetime, ~64 MB at a typical 2 MB each.

## Tests

Three added to `tests/utils/test_ssrf_url_guard.py` (**44 passed**, master 41):

- repeated fetches of one URL issue exactly one GET
- a blocked URL raises on every call
- a cache hit skips the guard, while a new URL is still checked and rejected

An autouse fixture clears the module-global cache around every test so a failing test cannot leak fake bytes into a later one.

`black 24.2.0 --check` clean; `ruff` matches the repo baseline.

## Known limitations, left alone deliberately

- Concurrent misses on the same cold key still fetch in parallel (16 threads with a latency-bearing stub measured 16 GETs, all returning one consistent result; with an instant stub the race does not appear). No worse than today, where every loop refetches.
- No byte cap on the response, so the retention ceiling above assumes well-behaved images. The fetch path has no size limit today either.
- `requests.get` still follows redirects and the redirect target is not re-guarded. Pre-existing on the same line, unchanged here.
- `get_audio_base64` (`litellm_wrapper.py:61`) has the identical refetch-per-loop shape and can reuse this helper; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

