### PR TITLE
[Bug] Agent silently ignores llm_base_url and llm_api_key on the primary LLM path

### DIFF
--- a/swarms/agents/llm_manager.py
+++ b/swarms/agents/llm_manager.py
@@ -228,6 +228,11 @@ class LLMManager:
                 "agent_name": agent.agent_name,
                 "prompt_caching": agent.prompt_caching,
                 "cache_config": agent.cache_config,
+                # Omitting these sends custom-endpoint traffic to the default
+                # provider instead. temp_llm_instance_for_tool_summary
+                # already forwards both.
+                "base_url": agent.llm_base_url,
+                "api_key": agent.llm_api_key,
             }
 
             # Initialize tools_list_dictionary, if applicable

--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -1479,6 +1479,11 @@ class LiteLLM:
             if self.base_url is not None:
                 completion_params["base_url"] = self.base_url
 
+            # Only when present: litellm falls back to the provider env var
+            # on absence, and an explicit None would override that.
+            if self.api_key is not None:
+                completion_params["api_key"] = self.api_key
+
             if self.response_format is not None:
                 completion_params["response_format"] = (
                     self.response_format

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -5,6 +5,7 @@ import tempfile
 import time
 import unittest
 from statistics import mean, median, stdev, variance
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import psutil
@@ -14,6 +15,7 @@ from dotenv import load_dotenv
 from rich.console import Console
 from rich.table import Table
 
+import swarms.utils.litellm_wrapper as litellm_wrapper
 from swarms import (
     Agent,
     create_agents_from_yaml,
@@ -2370,6 +2372,99 @@ class TestLLMArgsAndHandling:
             raise
 
         print("✓ LLM handling args and kwargs test passed")
+
+    def _capture_completion_params(self, llm):
+        """Run llm with completion stubbed, returning the kwargs it got."""
+        captured = {}
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="ok", tool_calls=None
+                    )
+                )
+            ]
+        )
+
+        def fake_completion(**kwargs):
+            captured.update(kwargs)
+            return response
+
+        with patch.object(
+            litellm_wrapper, "completion", side_effect=fake_completion
+        ):
+            llm.run("hello")
+
+        return captured
+
+    def test_llm_base_url_and_api_key_reach_the_provider_call(self):
+        """A custom endpoint and key must survive Agent -> completion().
+
+        Both values cross two layers and each dropped them
+        independently, so requests silently went to the default
+        provider instead.
+        """
+        print("\nTesting llm_base_url / llm_api_key forwarding...")
+
+        base_url = "https://api.together.xyz/v1"
+        api_key = "sk-test-not-a-real-key"
+
+        agent = Agent(
+            agent_name="credential-forwarding-probe",
+            model_name="gpt-4o-mini",
+            llm_base_url=base_url,
+            llm_api_key=api_key,
+            max_loops=1,
+            persistent_memory=False,
+            print_on=False,
+        )
+
+        # Layer 1: Agent -> its LiteLLM instance
+        assert (
+            agent.llm.base_url == base_url
+        ), "llm_base_url did not reach the LiteLLM instance"
+        assert (
+            agent.llm.api_key == api_key
+        ), "llm_api_key did not reach the LiteLLM instance"
+        print("✓ Agent forwards both to its LiteLLM instance")
+
+        # Layer 2: LiteLLM -> litellm.completion
+        params = self._capture_completion_params(agent.llm)
+        assert (
+            params.get("base_url") == base_url
+        ), "base_url did not reach completion()"
+        assert (
+            params.get("api_key") == api_key
+        ), "api_key did not reach completion()"
+        print("✓ Both reach the provider call")
+
+    def test_unset_credentials_are_omitted_from_the_provider_call(
+        self,
+    ):
+        """An unset key must be absent, not passed as None.
+
+        litellm falls back to the provider env var only when the
+        kwarg is absent; an explicit None would override that and
+        break every caller not using a custom endpoint.
+        """
+        print("\nTesting that unset credentials stay absent...")
+
+        agent = Agent(
+            agent_name="credential-default-probe",
+            model_name="gpt-4o-mini",
+            max_loops=1,
+            persistent_memory=False,
+            print_on=False,
+        )
+
+        params = self._capture_completion_params(agent.llm)
+        assert (
+            "api_key" not in params
+        ), "api_key must be omitted so the env-var fallback applies"
+        assert (
+            "base_url" not in params
+        ), "base_url must be omitted when no endpoint is configured"
+        print("✓ Default path leaves both out")
 
 
 # ============================================================================


### PR DESCRIPTION
Found while working #1739. Unrelated to that issue's premise, so filing it on its own.

`Agent` accepts `llm_base_url` and `llm_api_key`, stores both, and then drops them. An agent pointed at an OpenAI-compatible endpoint that is not the default provider silently calls the **default provider** instead — against the wrong host, or billed to the wrong account, with nothing in the logs.

```python
agent = Agent(
    model_name="gpt-4o-mini",
    llm_base_url="https://api.together.xyz/v1",
    llm_api_key="sk-...",
)
```

Before this patch:

```
agent.llm_base_url = https://api.together.xyz/v1   # stored
agent.llm_api_key  = sk-test-12345                 # stored

agent.llm.base_url = None                          # never arrived
agent.llm.api_key  = None                          # never arrived
```

## Two layers, each broken on its own

**1. `LLMManager.llm_handling` never passed them on.** The `common_args` dict it builds its `LiteLLM` from (`swarms/agents/llm_manager.py:217-231`) carried neither `base_url` nor `api_key`.

What makes this look like an oversight rather than a decision: `Agent.__init__` stores both (`agent.py:508-509`), and `temp_llm_instance_for_tool_summary` **does** forward both (`agent.py:5071-5072`). So the tool-summary side path honoured the custom endpoint while the primary path silently ignored it — the same agent, two different destinations.

**2. `LiteLLM` accepted `api_key` and never used it.** `__init__` stores it at `litellm_wrapper.py:331` and no other line in the file reads it — it was never added to `completion_params`, so it never reached `litellm.completion()`. A directly constructed `LiteLLM(api_key=...)` ignored the key too, independent of `Agent`. `base_url` was already forwarded at `:1479`.

Fixing only layer 1 would not have worked: `base_url` would start flowing and `api_key` would still be dropped one layer deeper. Both are needed for the documented parameter to do anything.

## Change

Two additions, both guarded on presence:

- `common_args` gains `"base_url": agent.llm_base_url` and `"api_key": agent.llm_api_key`
- `LiteLLM.run` sets `completion_params["api_key"]` only when `self.api_key is not None`

The `is not None` guard on the key matters. litellm falls back to the provider env var only when the kwarg is **absent** — passing an explicit `api_key=None` would override that fallback and break the default path for everyone not using a custom endpoint. Two of the four tests cover exactly that.

After:

```
completion(base_url=) = https://api.together.xyz/v1
completion(api_key=)  = sk-test-12345
```

## Tests

Two tests added to `TestLLMArgsAndHandling` in `tests/structs/test_agent.py`, the existing home for this behaviour — no new file. Fully mocked, so no network and no API key:

- `test_llm_base_url_and_api_key_reach_the_provider_call` — asserts both layers: the values land on `agent.llm`, and then on the kwargs `litellm.completion()` actually receives.
- `test_unset_credentials_are_omitted_from_the_provider_call` — asserts both keys are **absent** (not `None`) when no endpoint is configured, so the env-var fallback still applies.

Cross-applied to `master`, the forwarding test fails and the omission test passes, which is the correct split — `master` already omits them:

```
FAILED TestLLMArgsAndHandling::test_llm_base_url_and_api_key_reach_the_provider_call
1 failed, 4 passed
```

```
AssertionError: llm_base_url did not reach the LiteLLM instance
```

On this branch: `5 passed` for that class, and the file still collects all 66 tests.

## Regression check

Ran the offline-safe suites on both `master` and this branch: **7 pre-existing failures on each** (`test_docstring_parser`, `test_extract_code_from_markdown`, `test_base_tool`), unrelated to these files and unchanged by this patch. `137 passed` on `master` vs `141 passed` here — the difference is exactly the 4 new tests. `black --check` (line-length 70) and `ruff check` clean.

## Scope

Deliberately not touched: the `mcp_api_key` / `mcp_authorization_token` family, which is a separate mechanism with its own resolution path, and `LiteLLM`'s `api_version`, which is already forwarded. This change only makes two already-public, already-documented `Agent` parameters take effect.

