### PR TITLE
[Bug] 11 examples fail at import on the non-existent swarm_models package (#1739 findings a+b)

### DIFF
--- a/examples/guides/demos/crypto/ethchain_agent.py
+++ b/examples/guides/demos/crypto/ethchain_agent.py
@@ -1,6 +1,5 @@
 import os
 from swarms import Agent
-from swarm_models import OpenAIChat
 from web3 import Web3
 from typing import Dict, Optional, Any
 from datetime import datetime
@@ -75,16 +74,11 @@ class EthereumAnalyzer:
                 "OpenAI API key not found in environment variables"
             )
 
-        model = OpenAIChat(
-            openai_api_key=api_key,
-            model_name="gpt-4",
-            temperature=0.1,
-        )
-
         self.agent = Agent(
             agent_name="Ethereum-Analysis-Agent",
             system_prompt=BLOCKCHAIN_AGENT_PROMPT,
-            llm=model,
+            model_name="gpt-4",
+            temperature=0.1,
             max_loops=1,
             autosave=True,
             dashboard=False,

--- a/examples/guides/demos/medical/health_privacy_swarm.py
+++ b/examples/guides/demos/medical/health_privacy_swarm.py
@@ -1,14 +1,6 @@
-import os
 from swarms import Agent, AgentRearrange
-from swarm_models import OpenAIChat
 
-# Get the OpenAI API key from the environment variable
-api_key = os.getenv("OPENAI_API_KEY")
-
-# Create an instance of the OpenAIChat class
-model = OpenAIChat(
-    api_key=api_key, model_name="gpt-5.4", temperature=0.1
-)
+MODEL_NAME = "gpt-5.4"
 
 # Initialize the gatekeeper agent
 gatekeeper_agent = Agent(
@@ -61,7 +53,8 @@ gatekeeper_agent = Agent(
         </audit_trail>
     </compliance>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -105,7 +98,8 @@ boss_agent = Agent(
         </communication>
     </interaction_protocols>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -150,7 +144,8 @@ worker1 = Agent(
         </reporting>
     </protocols>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -195,7 +190,8 @@ worker2 = Agent(
         </report_generation>
     </protocols>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,

--- a/examples/guides/demos/medical/health_privacy_swarm_two.py
+++ b/examples/guides/demos/medical/health_privacy_swarm_two.py
@@ -1,16 +1,6 @@
-import os
 from swarms import Agent, AgentRearrange
-from swarm_models import OpenAIChat
 
-# Initialize OpenAI model
-api_key = os.getenv(
-    "OPENAI_API_KEY"
-)  # ANTHROPIC_API_KEY, COHERE_API_KEY
-model = OpenAIChat(
-    api_key=api_key,
-    model_name="gpt-5.4",
-    temperature=0.7,  # Higher temperature for more creative responses
-)
+MODEL_NAME = "gpt-5.4"
 
 # Patient Agent - Holds and protects private information
 patient_agent = Agent(
@@ -63,7 +53,8 @@ patient_agent = Agent(
         </responses>
     </interaction_protocols>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.7,
     max_loops=1,
     verbose=True,
     stopping_token="<DONE>",
@@ -118,7 +109,8 @@ doctor_agent = Agent(
         </patient_interaction>
     </protocols>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.7,
     max_loops=1,
     verbose=True,
     stopping_token="<DONE>",
@@ -171,7 +163,8 @@ nurse_agent = Agent(
         </assistance>
     </protocols>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.7,
     max_loops=1,
     verbose=True,
     stopping_token="<DONE>",
@@ -217,7 +210,8 @@ records_agent = Agent(
         </data_handling>
     </protocols>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.7,
     max_loops=1,
     verbose=True,
     stopping_token="<DONE>",

--- a/examples/guides/demos/privacy_building.py
+++ b/examples/guides/demos/privacy_building.py
@@ -1,14 +1,6 @@
-import os
 from swarms import Agent, AgentRearrange
-from swarm_models import OpenAIChat
 
-# Get the OpenAI API key from the environment variable
-api_key = os.getenv("OPENAI_API_KEY")
-
-# Create an instance of the OpenAIChat class
-model = OpenAIChat(
-    api_key=api_key, model_name="gpt-5.4", temperature=0.1
-)
+MODEL_NAME = "gpt-5.4"
 
 # Initialize the matchmaker agent (Director)
 matchmaker_agent = Agent(
@@ -72,7 +64,8 @@ matchmaker_agent = Agent(
         <description>Be clear about what information is being shared and why</description>
     </ethical_guidelines>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -138,7 +131,8 @@ profile_analyzer = Agent(
         </privacy_filters>
     </output_guidelines>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -208,7 +202,8 @@ connection_facilitator = Agent(
         </improvement_loop>
     </feedback_system>
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,

--- a/examples/guides/demos/real_estate/real_estate_agent.py
+++ b/examples/guides/demos/real_estate/real_estate_agent.py
@@ -11,7 +11,6 @@ import json
 import requests
 from loguru import logger
 from swarms import Agent
-from swarm_models import OpenAIChat
 from dotenv import load_dotenv
 from enum import Enum
 
@@ -189,18 +188,13 @@ class CommercialRealEstateAgent:
         """
         self.property_api = PropertyRadarAPI(propertyradar_api_key)
 
-        # Initialize OpenAI model
-        self.model = OpenAIChat(
-            openai_api_key=openai_api_key,
-            model_name=model_name,
-            temperature=temperature,
-        )
-
         # Initialize the agent
         self.agent = Agent(
             agent_name="Commercial-Real-Estate-Agent",
             system_prompt=self._get_system_prompt(),
-            llm=self.model,
+            model_name=model_name,
+            temperature=temperature,
+            llm_api_key=openai_api_key,
             max_loops=1,
             autosave=True,
             dashboard=False,

--- a/examples/multi_agent/hscf_examples/simple_hscf.py
+++ b/examples/multi_agent/hscf_examples/simple_hscf.py
@@ -1,36 +1,31 @@
-import os
 from dotenv import load_dotenv
 from swarms import Agent, HierarchicalSwarm
-from swarm_models import OpenAIChat
 
 load_dotenv()
 
-api_key = os.getenv("OPENAI_API_KEY")
-
-llm = OpenAIChat(
-    openai_api_key=api_key,
-    model_name="gpt-4o",
-    temperature=0.1,
-)
+MODEL_NAME = "gpt-4o"
 
 director = Agent(
     agent_name="Director",
     system_prompt="You are the director. You break down tasks and coordinate your team.",
-    llm=llm,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
 )
 
 researcher = Agent(
     agent_name="Researcher",
     system_prompt="You are an expert researcher. You gather and analyze information.",
-    llm=llm,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
 )
 
 writer = Agent(
     agent_name="Writer",
     system_prompt="You are an expert writer. You synthesize information into clear reports.",
-    llm=llm,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
 )
 

--- a/examples/multi_agent/swarm_rearrange_examples/swarm_rearrange_demo.py
+++ b/examples/multi_agent/swarm_rearrange_examples/swarm_rearrange_demo.py
@@ -1,21 +1,10 @@
-import os
-
-from swarm_models import OpenAIChat
-
 from swarms import Agent, AgentRearrange, SwarmRearrange
 
 company = "NVDA"
 
-# Get the OpenAI API key from the environment variable
-api_key = os.getenv("GROQ_API_KEY")
-
-# Model
-model = OpenAIChat(
-    openai_api_base="https://api.groq.com/openai/v1",
-    openai_api_key=api_key,
-    model_name="llama-3.1-70b-versatile",
-    temperature=0.1,
-)
+# LiteLLM routes on the "groq/" prefix and reads GROQ_API_KEY from the
+# environment, so no client object or base_url is needed.
+MODEL_NAME = "groq/llama-3.3-70b-versatile"
 
 
 # Initialize the Managing Director agent
@@ -31,7 +20,8 @@ managing_director = Agent(
     
     For the current potential acquisition of {company}, direct the tasks for the team to thoroughly analyze all aspects of the company, including its financials, industry position, technology, market potential, and regulatory compliance. Provide guidance and feedback as needed to ensure a rigorous and unbiased assessment.
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -55,7 +45,8 @@ vp_finance = Agent(
 
     Be sure to consider factors such as the sustainability of {company}' business model, the strength of its customer base, and its ability to generate consistent cash flows. Your analysis should be data-driven, objective, and aligned with Blackstone's investment criteria.
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -79,7 +70,8 @@ industry_analyst = Agent(
     
     Your analysis should provide a clear and objective assessment of the attractiveness and future potential of the industrial robotics industry, as well as {company}' positioning within it. Consider both short-term and long-term factors, and provide evidence-based insights to inform the investment decision.
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -103,7 +95,8 @@ tech_expert = Agent(
     
     Your analysis should provide a comprehensive assessment of {company}' technological strengths and weaknesses, as well as the sustainability of its competitive advantages. Consider both the current state of its technology and its future potential in light of industry trends and advancements.
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -127,7 +120,8 @@ market_researcher = Agent(
     
     Your analysis should provide a data-driven assessment of the market opportunity for {company} and the feasibility of achieving our investment return targets. Consider both bottom-up and top-down market perspectives, and identify any key sensitivities or assumptions in your projections.
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,
@@ -151,7 +145,8 @@ regulatory_specialist = Agent(
     
     Your analysis should provide a comprehensive assessment of the regulatory and legal landscape surrounding {company}, and identify any material risks or potential deal-breakers. Consider both the current state and future outlook, and provide practical recommendations to mitigate identified risks.
     """,
-    llm=model,
+    model_name=MODEL_NAME,
+    temperature=0.1,
     max_loops=1,
     dashboard=False,
     streaming_on=True,

--- a/examples/single_agent/capabilities/tools/multi_tool_usage_agent.py
+++ b/examples/single_agent/capabilities/tools/multi_tool_usage_agent.py
@@ -7,7 +7,6 @@ import inspect
 import typing
 from typing import Union
 from swarms import Agent
-from swarm_models import OpenAIChat
 
 
 @dataclass
@@ -129,17 +128,13 @@ class ToolAgent:
         self.functions = {func.__name__: func for func in functions}
         self.function_specs = self._analyze_functions(functions)
 
-        self.model = OpenAIChat(
-            openai_api_key=openai_api_key,
-            model_name=model_name,
-            temperature=temperature,
-        )
-
         self.system_prompt = self._create_system_prompt()
         self.agent = Agent(
             agent_name="Tool-Agent",
             system_prompt=self.system_prompt,
-            llm=self.model,
+            model_name=model_name,
+            temperature=temperature,
+            llm_api_key=openai_api_key,
             max_loops=1,
             verbose=True,
         )

--- a/examples/single_agent/demos/persistent_legal_agent.py
+++ b/examples/single_agent/demos/persistent_legal_agent.py
@@ -1,6 +1,4 @@
-import os
 from swarms import Agent
-from swarm_models import OpenAIChat
 from dotenv import load_dotenv
 
 # Custom system prompt for VC legal document generation
@@ -19,25 +17,14 @@ Remember: All output should be marked as 'DRAFT' and require professional legal 
 
 def create_vc_legal_agent():
     load_dotenv()
-    api_key = os.getenv("OPENAI_API_KEY")
-
-    # Configure the model with appropriate parameters for legal work
-    # Get the OpenAI API key from the environment variable
-    api_key = os.getenv("GROQ_API_KEY")
-
-    # Model
-    model = OpenAIChat(
-        openai_api_base="https://api.groq.com/openai/v1",
-        openai_api_key=api_key,
-        model_name="llama-3.1-70b-versatile",
-        temperature=0.1,
-    )
 
     # Initialize the persistent agent
     agent = Agent(
         agent_name="VC-Legal-Document-Agent",
         system_prompt=VC_LEGAL_AGENT_PROMPT,
-        llm=model,
+        # The "groq/" prefix routes to Groq and picks up GROQ_API_KEY.
+        model_name="groq/llama-3.3-70b-versatile",
+        temperature=0.1,
         max_loops="auto",  # Allows multiple iterations until completion
         stopping_token="<DONE>",  # Agent will continue until this token is output
         autosave=True,

--- a/examples/single_agent/getting_started/onboarding/onboard-basic.py
+++ b/examples/single_agent/getting_started/onboarding/onboard-basic.py
@@ -1,33 +1,19 @@
-import os
-
 from dotenv import load_dotenv
 from loguru import logger
-from swarm_models import OpenAIChat
 
-from swarms.agents.create_agents_from_yaml import (
-    create_agents_from_yaml,
-)
+from swarms import create_agents_from_yaml
 
 # Load environment variables
 load_dotenv()
 
-# Path to your YAML file
+# Path to your YAML file. Each agent's model is chosen by the model_name
+# field inside the YAML, so no model object is built here.
 yaml_file = "agents.yaml"
 
-# Get the OpenAI API key from the environment variable
-api_key = os.getenv("OPENAI_API_KEY")
-
-# Create an instance of the OpenAIChat class
-model = OpenAIChat(
-    openai_api_key=api_key, model_name="gpt-5.4", temperature=0.1
-)
-
-print(model)
-
 try:
-    # Create agents and run tasks (using 'both' to return agents and task results)
+    # Create agents and return them without running any task
     task_results = create_agents_from_yaml(
-        model=model, yaml_file=yaml_file, return_type="agents"
+        yaml_file=yaml_file, return_type="agents"
     )
 
     print(task_results)

--- a/examples/single_agent/reasoning/reasoning_duo.py
+++ b/examples/single_agent/reasoning/reasoning_duo.py
@@ -1,17 +1,8 @@
-import os
 from swarms import Agent
 from dotenv import load_dotenv
 
-from swarm_models import OpenAIChat
-
 load_dotenv()
 
-
-model = OpenAIChat(
-    model_name="deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free",
-    openai_api_key=os.getenv("TOGETHER_API_KEY"),
-    base_url="https://api.together.xyz/v1",
-)
 
 # Define system prompts for reasoning agents
 THINKING_AGENT_PROMPT = """You are a sophisticated analytical and strategic thinking agent focused on deep problem analysis and solution design.
@@ -126,7 +117,9 @@ thinking_agent = Agent(
     agent_description="Deep analysis and strategic planning agent",
     system_prompt=THINKING_AGENT_PROMPT,
     max_loops=1,
-    llm=model,
+    # The "together_ai/" prefix routes to Together and picks up
+    # TOGETHER_API_KEY.
+    model_name="together_ai/deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free",
     dynamic_temperature_enabled=True,
 )
 

--- a/examples/single_agent/utils/async_agent.py
+++ b/examples/single_agent/utils/async_agent.py
@@ -3,7 +3,7 @@ from swarms.prompts.finance_agent_sys_prompt import (
     FINANCIAL_AGENT_SYS_PROMPT,
 )
 
-# Initialize the agent (no swarm_models import needed)
+# Initialize the agent
 agent = Agent(
     agent_name="Financial-Analysis-Agent",
     agent_description="Personal finance advisor agent",

--- a/swarms/prompts/autoswarm.py
+++ b/swarms/prompts/autoswarm.py
@@ -17,15 +17,15 @@ The script should be well-structured and production-ready. DO NOT use placeholde
 copy/paste to vscode and run it without issue. Here are some tips to consider:
 
 1. **Import Statements**:
-   - Begin with necessary Python imports. Import the 'Agent' class from the 'swarms.structs' module.
-   - Import the language or vision model from 'swarms.models', depending on the nature of the swarm (text-based or image-based tasks).
+   - Begin with necessary Python imports. Import the 'Agent' class from the 'swarms' package.
+   - Select the model with the 'model_name' argument on each Agent, e.g. model_name="gpt-4o" for text or a vision-capable model for image tasks. There is no separate model class to import.
    - Import the SOPs for each agent type from swarms.prompts.(insert swarm team name here). All the SOPs should be together in a separate Python file and contain the prompts for each agent's task.
-   - Use os.getenv for the OpenAI API key.
+   - Read the provider API key from the environment; the model layer picks it up automatically.
 
-2. **Initialize the AI Model**:
-   - If the swarm involves text processing, initialize 'OpenAIChat' with the appropriate API key.
-   - For image processing tasks, initialize 'GPT4VisionAPI' similarly.
-   - Ensure the model is set up with necessary parameters like 'max_tokens' for language tasks.
+2. **Select the AI Model**:
+   - For text processing, pass a text model name to each Agent, e.g. model_name="gpt-4o".
+   - For image processing tasks, pass a vision-capable model name the same way.
+   - Set any generation parameters directly on the Agent, e.g. max_tokens and temperature.
 
 3. **Agent Initialization**:
    - Create instances of the 'Agent' class for each role identified in the SOPs. Pass the corresponding SOP and the initialized AI model to each agent.
@@ -47,25 +47,23 @@ copy/paste to vscode and run it without issue. Here are some tips to consider:
 
 Output Format: A complete Python script that is ready for copy/paste to GitHub and demo execution. It should be formatted with complete logic, proper indentation, clear variable names, and comments.
 Here is an example of a a working swarm script that you can use as a rough template for the logic:
-import os
 from dotenv import load_dotenv
-from swarm_models import OpenAIChat
-from swarms.structs import Agent
+from swarms import Agent
 import swarms.prompts.swarm_daddy as sdsp
 
-# Load environment variables and initialize the OpenAI Chat model
+# Load environment variables so the model layer can read the provider API key
 load_dotenv()
-api_key = os.getenv("OPENAI_API_KEY")
-llm = OpenAIChat(model_name = "gpt-4", openai_api_key=api_key)
+
+MODEL_NAME = "gpt-4o"
 
 user_idea = "screenplay writing"
 
 
-#idea_analysis_agent = Agent(llm=llm, sop=sdsp.IDEA_ANALYSIS_AGENT_PROMPT, max_loops=1)
-role_identification_agent = Agent(llm=llm, sop=sdsp.AGENT_ROLE_IDENTIFICATION_AGENT_PROMPT, max_loops=1)
-agent_configuration_agent = Agent(llm=llm, sop=sdsp.AGENT_CONFIGURATION_AGENT_PROMPT, max_loops=1)
-swarm_assembly_agent = Agent(llm=llm, sop=sdsp.SWARM_ASSEMBLY_AGENT_PROMPT, max_loops=1)
-testing_optimization_agent = Agent(llm=llm, sop=sdsp.TESTING_OPTIMIZATION_AGENT_PROMPT, max_loops=1)
+#idea_analysis_agent = Agent(model_name=MODEL_NAME, sop=sdsp.IDEA_ANALYSIS_AGENT_PROMPT, max_loops=1)
+role_identification_agent = Agent(model_name=MODEL_NAME, sop=sdsp.AGENT_ROLE_IDENTIFICATION_AGENT_PROMPT, max_loops=1)
+agent_configuration_agent = Agent(model_name=MODEL_NAME, sop=sdsp.AGENT_CONFIGURATION_AGENT_PROMPT, max_loops=1)
+swarm_assembly_agent = Agent(model_name=MODEL_NAME, sop=sdsp.SWARM_ASSEMBLY_AGENT_PROMPT, max_loops=1)
+testing_optimization_agent = Agent(model_name=MODEL_NAME, sop=sdsp.TESTING_OPTIMIZATION_AGENT_PROMPT, max_loops=1)
 
 # Process the user idea through each agent
 # idea_analysis_output = idea_analysis_agent.run(user_idea)


### PR DESCRIPTION
Closes #1739 — this fixes findings (a) and (b) from my comment there, the two real defects behind that issue. They share one root cause, so they are one change. (Finding (c), the import-time side effects, is #1773.)

To be clear about that issue: **#1739's own premise is a false positive** — the lines it cites are inside a string literal, and I still suggest closing it as invalid. This PR fixes the two real problems I found while checking it.

`swarm_models` is not a dependency of this project. It is absent from `pyproject.toml`, and there is no `[tool.poetry.extras]` section that would make it optional. So every file importing it fails at import:

```
$ python examples/single_agent/reasoning/reasoning_duo.py
ModuleNotFoundError: No module named 'swarm_models'
```

Eleven runnable example files did that. Net **−68 lines** across 13 files.

## What each one was doing

All eleven built a provider client and handed it to `Agent(llm=...)`:

```python
model = OpenAIChat(api_key=api_key, model_name="gpt-5.4", temperature=0.1)
agent = Agent(..., llm=model)
```

`Agent` takes `model_name` directly and LiteLLM resolves the provider from the name, so the client object is not needed at all:

```python
agent = Agent(..., model_name="gpt-5.4", temperature=0.1)
```

## Custom endpoints use provider prefixes, not base_url

Three examples pointed at a non-default endpoint via `openai_api_base` / `base_url`. Rather than port that to `Agent(llm_base_url=...)`, they now use LiteLLM's own provider routing, which reads the standard env var and needs no base URL:

| example | was | now |
|---|---|---|
| `reasoning_duo.py` | `base_url=https://api.together.xyz/v1` | `together_ai/deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free` |
| `swarm_rearrange_demo.py` | `openai_api_base=https://api.groq.com/openai/v1` | `groq/llama-3.3-70b-versatile` |
| `persistent_legal_agent.py` | same Groq base URL | `groq/llama-3.3-70b-versatile` |

This is deliberate: it keeps these examples independent of #1769, which fixes `Agent`'s `llm_base_url` / `llm_api_key` being silently ignored. Using the prefix form means they work on `master` today.

Groq's `llama-3.1-70b-versatile` is decommissioned, so those two move to `llama-3.3-70b-versatile` — the id already used in `CLAUDE.md:157`.

## Two examples keep an explicit key

`real_estate_agent.py` and `multi_tool_usage_agent.py` accept `openai_api_key` as a constructor argument rather than reading the environment, so the key is forwarded as `llm_api_key=openai_api_key`. **That parameter is currently a no-op** — it is what #1769 fixes. Until #1769 lands these two fall back to `OPENAI_API_KEY` from the environment, which is what they would have used anyway; after it lands they work as written. Flagging it rather than leaving it implicit.

## onboard-basic.py was broken twice

Beyond the import, it passed `model=model` to `create_agents_from_yaml`, whose signature is `(yaml_file, yaml_string, return_type)` — no `model` parameter, so this was a `TypeError` waiting behind the `ModuleNotFoundError`. Each agent's model comes from the YAML's own `model_name` field, so the argument is simply dropped. Its comment also claimed `'both'` while passing `'agents'`; corrected while I was on the line.

## prompts/autoswarm.py — finding (a)

This is the file #1739 is about, though not for the reason given. Its prompt text instructs the model to write the same broken import:

- `:52` — `from swarm_models import OpenAIChat`
- `:21` — "Import the language or vision model from `swarms.models`", which also does not exist (`import swarms.models` raises `ModuleNotFoundError`)
- `:26` — "initialize `OpenAIChat` with the appropriate API key"

So every script generated from this prompt failed on its first line. The embedded template now uses `model_name` and the top-level `swarms` import.

The module remains free of import-time side effects, which was #1739's actual concern — verified after the change:

```
top-level nodes: ['Assign', 'Assign', 'Assign', 'Assign']
Import nodes: 0 | Call nodes: 0
all values Constant: True
```

## Verification

Parsed each file and executed its top-level import block only — the reported failure was at import, and full execution would need live keys and network:

```
11 importable, 1 failing
```

The one failure is `ethchain_agent.py`, on `web3`. That is a genuine third-party dependency of that example and not in `pyproject.toml` or `requirements.txt`. On `master` the same file fails on **both**:

```
line 3: swarm_models -> ModuleNotFoundError
line 4: web3        -> ModuleNotFoundError
```

This PR removes the `swarm_models` blocker; `web3` remains a legitimate `pip install web3` away and is untouched here.

`black --check` (line-length 70) and `ruff check` clean on all 13 files.

## Deliberately left alone

`swarms/structs/agent_router.py:277` still mentions `swarm_models`, inside a commented-out example block that runs ~167 lines to end of file. Deleting dead code that large is its own change with its own justification, so it is not bundled here. Happy to do it separately if you want it gone.

I did remove one stale one-liner: `examples/single_agent/utils/async_agent.py:6` read `# Initialize the agent (no swarm_models import needed)`. That comment is what made my first count on #1739 say twelve files instead of eleven, so it seemed worth not leaving for the next person's grep.

