### PR TITLE
[Bug] Fix undefined name in aop client example (unblocks CI build/lint)

### DIFF
--- a/examples/guides/aop_examples/client/list_agents_and_call_them.py
+++ b/examples/guides/aop_examples/client/list_agents_and_call_them.py
@@ -46,7 +46,7 @@ def call_agent_tool(
 
         result = asyncio.run(
             MCPManager(mcp_url=server_path).aexecute_tool_calls(
-                tool_call_request,
+                call,
             )
         )
         return result


### PR DESCRIPTION
## Summary

`examples/guides/aop_examples/client/list_agents_and_call_them.py` builds a `call` dict (line 37) but passes an undefined `tool_call_request` to `aexecute_tool_calls` (line 49). The example raises `NameError` at runtime, and flake8 fails the repo-wide build:

```
list_agents_and_call_them.py:49:17: F821 undefined name 'tool_call_request'
list_agents_and_call_them.py:37:5:  F841 local variable 'call' is assigned to but never used
```

The two errors are the same mistake — `call` was built and then not passed. Fix is one word: pass `call`. That resolves F821 (no more undefined name) and F841 (`call` is now used) together.

## Why it matters

The build/lint jobs run flake8 across the whole repo on every PR, so this one broken example turns CI red for **every** open PR, not just anything touching this file. Fixing it here makes those jobs green.

## Verified

`ruff check --select F821,F841,E9` clean on the file; it parses; `tool_call_request` is gone and `call` is now referenced. `aexecute_tool_calls(response=...)` normalizes its argument via `_normalize_tool_calls`, and `call` is a single `{"function": {"name", "arguments"}}` tool-call in exactly that shape, so it is the value the example always meant to pass.