### PR TITLE
[Improvement] Memoize count_tokens (#1736)

### DIFF
--- a/swarms/utils/litellm_tokenizer.py
+++ b/swarms/utils/litellm_tokenizer.py
@@ -7,6 +7,11 @@ from functools import lru_cache
 DEFAULT_MODEL = "gpt-5.4"
 
 
+# Memoized because count_tokens is called from ~22 sites, several of them on
+# the same (large, unchanged) history string within a single turn. encode is
+# deterministic per model, so identical (text, model, encoder) always yields
+# the same count. maxsize bounds the retained strings; the values are ints.
+@lru_cache(maxsize=128)
 def count_tokens(
     text: str,
     model: str = DEFAULT_MODEL,


### PR DESCRIPTION
Closes #1736.

`count_tokens` (`swarms/utils/litellm_tokenizer.py`) has no memoization and is called from ~22 sites — per-turn budget checks (`check_available_tokens`, `tokens_checks`) and the transforms pipeline — several of which count the **same** large history string within one turn.

## Fix

`@lru_cache(maxsize=128)`. `encode` is deterministic per model, so identical `(text, model, encoder)` always yields the same count; repeated identical calls now return the cached value instead of re-tokenizing. `maxsize` bounds the retained key strings; the cached values are ints.

Verified against the real function with a stubbed encode: 5 identical calls issue **1** tokenization (4 cache hits), counts stay correct, empty/whitespace still returns 0 without tokenizing.

Scope: this removes redundant re-tokenizations of *identical* strings. The O(n²)-over-turns cost of re-counting the whole *changing* history each turn is the separate running-total change in #1735 — the two reinforce each other.

No test added: it's a one-line `lru_cache` on a pure function, so a test would exercise stdlib memoization rather than swarms logic. Happy to add one if preferred.