### PR TITLE
[Improvement] Expose the autonomous-loop iteration limits as Agent params (#1752)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -1919,15 +1919,15 @@ class Agent:
         - Creates a detailed plan using the `create_plan` tool
         - Breaks down the task into subtasks with dependencies, priorities, and step IDs
         - Supports handoff delegation during planning if handoffs are configured
-        - Maximum planning attempts are controlled by max_planning_attempts
+        - Maximum planning attempts are controlled by self.max_planning_attempts
 
         **Phase 2: Execution**
         - Executes each subtask in dependency order
         - For each subtask, runs a thinking -> tool actions -> observation loop
         - Supports both planning tools (think, subtask_done, complete_task) and user-defined tools
         - Prevents infinite thinking loops with max_consecutive_thinks limit
-        - Each subtask has a maximum iteration limit (max_subtask_loops)
-        - Overall execution has a maximum iteration limit (max_subtask_iterations)
+        - Each subtask has a maximum iteration limit (self.max_subtask_loops)
+        - Overall execution has a maximum iteration limit (self.max_subtask_iterations)
 
         **Phase 3: Summary**
         - Generates a comprehensive final summary when all subtasks are complete

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -167,6 +167,9 @@ class Agent:
         loop_interval (int): The loop interval
         retry_attempts (int): The number of retry attempts
         retry_interval (int): The retry interval
+        max_planning_attempts (int): max_loops="auto" — attempts allowed to produce a plan
+        max_subtask_iterations (int): max_loops="auto" — total iterations across all subtasks
+        max_subtask_loops (int): max_loops="auto" — iterations allowed per subtask
         stopping_token (str): The stopping token
         dynamic_loops (bool): Enable dynamic loops
         interactive (bool): Enable interactive mode
@@ -423,6 +426,9 @@ class Agent:
         selected_tools: Optional[Union[str, List[str]]] = "all",
         context_compression: bool = True,
         persistent_memory: bool = False,
+        max_planning_attempts: int = MAX_PLANNING_ATTEMPTS,
+        max_subtask_iterations: int = MAX_SUBTASK_ITERATIONS,
+        max_subtask_loops: int = MAX_SUBTASK_LOOPS,
         *args,
         **kwargs,
     ):
@@ -580,6 +586,9 @@ class Agent:
         self.max_consecutive_thinks = (
             2  # Maximum consecutive think calls
         )
+        self.max_planning_attempts = max_planning_attempts
+        self.max_subtask_iterations = max_subtask_iterations
+        self.max_subtask_loops = max_subtask_loops
 
         # Async subagent support
         self._subagent_registry = None
@@ -1910,15 +1919,15 @@ class Agent:
         - Creates a detailed plan using the `create_plan` tool
         - Breaks down the task into subtasks with dependencies, priorities, and step IDs
         - Supports handoff delegation during planning if handoffs are configured
-        - Maximum planning attempts are controlled by MAX_PLANNING_ATTEMPTS
+        - Maximum planning attempts are controlled by max_planning_attempts
 
         **Phase 2: Execution**
         - Executes each subtask in dependency order
         - For each subtask, runs a thinking -> tool actions -> observation loop
         - Supports both planning tools (think, subtask_done, complete_task) and user-defined tools
         - Prevents infinite thinking loops with max_consecutive_thinks limit
-        - Each subtask has a maximum iteration limit (MAX_SUBTASK_LOOPS)
-        - Overall execution has a maximum iteration limit (MAX_SUBTASK_ITERATIONS)
+        - Each subtask has a maximum iteration limit (max_subtask_loops)
+        - Overall execution has a maximum iteration limit (max_subtask_iterations)
 
         **Phase 3: Summary**
         - Generates a comprehensive final summary when all subtasks are complete
@@ -2124,7 +2133,7 @@ class Agent:
 
             plan_created = False
             planning_attempts = 0
-            max_planning_attempts = MAX_PLANNING_ATTEMPTS
+            max_planning_attempts = self.max_planning_attempts
 
             while (
                 not plan_created
@@ -2299,7 +2308,7 @@ class Agent:
                     title="Autonomous Loop: Execution Phase",
                 )
 
-            max_subtask_iterations = MAX_SUBTASK_ITERATIONS
+            max_subtask_iterations = self.max_subtask_iterations
             total_iterations = 0
 
             while not self._all_subtasks_complete():
@@ -2345,7 +2354,7 @@ class Agent:
 
                 # Subtask execution loop: thinking -> tool actions -> observation
                 subtask_iterations = 0
-                max_subtask_loops = MAX_SUBTASK_LOOPS
+                max_subtask_loops = self.max_subtask_loops
                 subtask_done = False
 
                 # Add the execution prompt ONCE before the inner loop so the model

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2508,7 +2508,9 @@ class TestAutonomousLoopLimits:
         with patch.object(
             agent, "call_llm", return_value="not a plan"
         ) as call_llm:
-            with pytest.raises(Exception):
+            with pytest.raises(
+                Exception, match="Failed to create plan"
+            ):
                 agent.run("task")
 
         assert call_llm.call_count == 2

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -20,6 +20,11 @@ from swarms import (
     Agent,
     create_agents_from_yaml,
 )
+from swarms.structs.autonomous_loop_utils import (
+    MAX_PLANNING_ATTEMPTS,
+    MAX_SUBTASK_ITERATIONS,
+    MAX_SUBTASK_LOOPS,
+)
 
 # Load environment variables
 load_dotenv()
@@ -2465,6 +2470,48 @@ class TestLLMArgsAndHandling:
             "base_url" not in params
         ), "base_url must be omitted when no endpoint is configured"
         print("✓ Default path leaves both out")
+
+
+# ============================================================================
+# AUTONOMOUS LOOP LIMITS
+# ============================================================================
+
+
+class TestAutonomousLoopLimits:
+    """The max_loops="auto" iteration caps are per-agent, not module-wide."""
+
+    @staticmethod
+    def _agent(**kwargs):
+        with patch("swarms.structs.agent.LiteLLM"):
+            return Agent(
+                agent_name="limits_agent",
+                model_name="gpt-5.4",
+                max_loops="auto",
+                print_on=False,
+                verbose=False,
+                persistent_memory=False,
+                **kwargs,
+            )
+
+    def test_defaults_match_the_module_constants(self):
+        """Omitting the params must not change existing behaviour."""
+        agent = self._agent()
+
+        assert agent.max_planning_attempts == MAX_PLANNING_ATTEMPTS
+        assert agent.max_subtask_iterations == MAX_SUBTASK_ITERATIONS
+        assert agent.max_subtask_loops == MAX_SUBTASK_LOOPS
+
+    def test_planning_stops_at_the_configured_attempt_count(self):
+        """A lowered cap must actually shorten the planning retry loop."""
+        agent = self._agent(max_planning_attempts=2)
+
+        with patch.object(
+            agent, "call_llm", return_value="not a plan"
+        ) as call_llm:
+            with pytest.raises(Exception):
+                agent.run("task")
+
+        assert call_llm.call_count == 2
 
 
 # ============================================================================


### PR DESCRIPTION
Fixes #1752

## Problem

The `max_loops="auto"` iteration caps are module-level constants in `autonomous_loop_utils.py`, read directly inside `_run_autonomous_loop`:

```python
max_planning_attempts  = MAX_PLANNING_ATTEMPTS    # 5
max_subtask_iterations = MAX_SUBTASK_ITERATIONS   # 100
max_subtask_loops      = MAX_SUBTASK_LOOPS        # 20
```

`MAX_SUBTASK_ITERATIONS = 100` on a loop that re-sends the whole transcript every call is a large budget for a cheap task and possibly too small for a big one. Today the only way to change it is to monkey-patch the module — which is process-global, so it also hits every other agent in the same process.

## Fix

Three new `Agent.__init__` params, defaulting to the existing constants:

```python
max_planning_attempts: int = MAX_PLANNING_ATTEMPTS,
max_subtask_iterations: int = MAX_SUBTASK_ITERATIONS,
max_subtask_loops: int = MAX_SUBTASK_LOOPS,
```

The three read sites now use `self.` instead of the module constant. Defaults are the constants themselves, so omitting the params leaves behaviour byte-identical and the constants stay as the single source of truth for the defaults.

```python
agent = Agent(
    agent_name="Bounded",
    model_name="gpt-5.4",
    max_loops="auto",
    max_subtask_iterations=20,   # cap the run
    max_subtask_loops=5,
)
```

The issue also suggests removing `MAX_CONSECUTIVE_THINKS` along with the `think` tool. That is a behaviour change in a different area, so I left it for its own PR and touched only the three limits named in the title.

## Tests

`tests/structs/test_agent.py::TestAutonomousLoopLimits` — 2 tests, both fail on master:

- defaults equal the module constants → `AttributeError: 'Agent' object has no attribute 'max_planning_attempts'`
- `max_planning_attempts=2` with a model that never emits `create_plan` stops after 2 calls → on master `assert 5 == 2`, since the value lands in `**kwargs` and is silently ignored

The second one is the important one: it asserts the param actually reaches the loop rather than just being stored on the instance.

Full-file check for regressions — identical failures before and after (all pre-existing on master):

| | failed | passed | errors |
|---|---|---|---|
| master | 20 | 38 | 8 |
| this branch | 20 | 40 | 8 |

`black --check` and `ruff check` clean.

Note: the unrelated CI failures on this PR reproduce on `master` — the `Python package` workflow never installs `swarms` itself, so every job fails at `ModuleNotFoundError: swarms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)