### PR TITLE
[Bug] tools_list_dictionary mutable default is shared by every Agent (#1789)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -382,7 +382,7 @@ class Agent:
         load_state_path: str = None,
         role: agent_roles = "worker",
         print_on: bool = True,
-        tools_list_dictionary: Optional[List[Dict[str, Any]]] = [],
+        tools_list_dictionary: Optional[List[Dict[str, Any]]] = None,
         mcp_url: Optional[Union[str, MCPConnection, Dict]] = None,
         mcp_urls: Optional[
             List[Union[str, MCPConnection, Dict]]
@@ -491,7 +491,14 @@ class Agent:
         self.load_state_path = load_state_path
         self.role = role
         self.print_on = print_on
-        self.tools_list_dictionary = tools_list_dictionary
+        # Own list per agent. The default used to be a literal [], so every
+        # agent that skipped this argument shared one object and inherited
+        # the tool schemas any other agent appended to it.
+        self.tools_list_dictionary = (
+            tools_list_dictionary
+            if tools_list_dictionary is not None
+            else []
+        )
         self.mcp_url = mcp_url
         self.mcp_urls = mcp_urls
         self.react_on = react_on

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2513,6 +2513,47 @@ class TestContextLength:
 
 
 # ============================================================================
+# TOOLS LIST ISOLATION
+# ============================================================================
+
+
+class TestToolsListIsolation:
+    """tools_list_dictionary must not be shared between Agent instances."""
+
+    @staticmethod
+    def _agent(name, **kwargs):
+        with patch("swarms.structs.agent.LiteLLM"):
+            return Agent(
+                agent_name=name,
+                model_name="gpt-5.4",
+                max_loops=1,
+                print_on=False,
+                verbose=False,
+                persistent_memory=False,
+                **kwargs,
+            )
+
+    def test_default_is_per_instance(self):
+        """One agent's tools must not reach another, or the next one."""
+        first = self._agent("First")
+        second = self._agent("Second")
+        first.tools_list_dictionary.append(
+            {"function": {"name": "x"}}
+        )
+
+        assert second.tools_list_dictionary == []
+        # a fresh agent too: the old pollution outlived agents on __defaults__
+        assert self._agent("Third").tools_list_dictionary == []
+        given = [{"function": {"name": "given"}}]
+        assert (
+            self._agent(
+                "Fourth", tools_list_dictionary=given
+            ).tools_list_dictionary
+            == given
+        )
+
+
+# ============================================================================
 # MAIN TEST RUNNER
 # ============================================================================
 


### PR DESCRIPTION
Fixes #1789

Rebased onto current master and the tests are down to one. Details at the bottom.

## Problem

`swarms/structs/agent.py:385`

```python
tools_list_dictionary: Optional[List[Dict[str, Any]]] = [],
```

A mutable default is evaluated once, at function definition, so every `Agent` built without this argument shares **one** list. The attribute is then mutated in place, `.extend()` in `__init__`, `.append()` in `tool_handling` and `_run_autonomous_loop`, writing straight through to the shared default.

So one agent registering a tool hands that tool to every other agent in the process, including ones constructed earlier. `LLMManager.build` forwards the list to LiteLLM as the model's tool list, so those agents can emit calls for tools they were never given. The list also grows for the lifetime of the process and the pollution survives on `Agent.__init__.__defaults__`, so a later `Agent()` starts pre-contaminated.

## Fix

```python
tools_list_dictionary: Optional[List[Dict[str, Any]]] = None,
...
self.tools_list_dictionary = (
    tools_list_dictionary if tools_list_dictionary is not None else []
)
```

Worth noting why the attribute is still normalised to `[]` rather than left as `None`. `exists()` is `val is not None`, and with the old `[]` default these were **true** for every default-constructed agent:

- `agent.py:1497` — `if exists(self.tools_list_dictionary):`
- `agent.py:3089` — `if self.tools_list_dictionary is not None:`

Flipping the stored value to `None` would silently turn both off, which is a separate behaviour change riding along on a bug fix. (The one at `:3089` emits a spurious "does not support function calling" warning for toolless agents, arguably worth fixing, but not here.) Normalising to a fresh `[]` keeps every downstream check identical and changes exactly one thing: the object is no longer shared.

## Test

One test appended to the existing `tests/structs/test_agent.py`, no new file. It covers all three things worth pinning in one sequence:

```python
    def test_default_is_per_instance(self):
        first = self._agent("First")
        second = self._agent("Second")
        first.tools_list_dictionary.append({"function": {"name": "x"}})

        assert second.tools_list_dictionary == []
        # a fresh agent too: the old pollution outlived agents on __defaults__
        assert self._agent("Third").tools_list_dictionary == []
        given = [{"function": {"name": "given"}}]
        assert self._agent("Fourth", tools_list_dictionary=given).tools_list_dictionary == given
```

On master, with only `agent.py` reverted:

```
E  AssertionError: assert [{'function': {'name': 'x'}}] == []
```

Full-file check, master `agent.py` vs this branch, the only difference is this test:

| | failed | passed | errors |
|---|---|---|---|
| master `829a6671` | 22 | 40 | 8 |
| this branch | 21 | 41 | 8 |

`black --check` and `ruff check` clean at line-length 70.

## What changed in this update

- **Rebased** onto `829a6671`. The conflict was self-inflicted: #1800 merged its `TestContextLength` class into the same spot at the end of `test_agent.py`. Both classes are kept, nothing from master was dropped.
- **Tests trimmed from three to one**, 20 fewer lines. The dropped assertion was `inspect.signature(...).default is None`, which pinned the implementation rather than the behaviour; a fix that kept a `[]` default but copied it in `__init__` would also be correct and that assertion would have failed it. The `self._agent("Third")` line covers the same leak behaviourally. Dropping it also let the `import inspect` go.

One thing I noticed while re-running the file, unrelated to this PR: `TestContextLength::test_unknown_model_falls_back` (from #1800) now fails on plain master. `eaacf5cc` routes an unmapped model into litellm, which raises `This model isn't mapped yet` instead of falling back to 16000. Happy to send a one-line follow-up for it, just say the word.

I use Claude Code to help me work through these and I check every claim against the source before opening anything. If I have read this wrong, tell me and I will close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
