### PR TITLE
[Bug] context_length constructor argument is discarded and hardcoded to 16000 (#1790)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -27,6 +27,7 @@ from litellm.exceptions import (
 )
 from litellm.utils import (
     get_max_tokens,
+    get_model_info,
     supports_function_calling,
 )
 from loguru import logger
@@ -542,12 +543,8 @@ class Agent:
             retry_attempts=self.tool_retry_attempts,
         )
 
-        # self.context_length = (
-        #     get_single_model_max_tokens(model_name)
-        #     if model_name
-        #     else 16000
-        # )
-        self.context_length = 16000
+        if self.context_length is None:
+            self.context_length = self._default_context_length()
 
         if self.max_loops == "auto":
             self.system_prompt += (
@@ -3052,6 +3049,22 @@ Subtask Breakdown:
             return [self.run(**input_data) for input_data in inputs]
         except Exception as error:
             logger.info(f"Error running bulk run: {error}", "red")
+
+    def _default_context_length(self) -> int:
+        """The model's input window, or 16000 when it can't be determined.
+
+        ``get_max_tokens`` is the wrong source here — it reports max *output*
+        tokens (32768 for gpt-4.1, against a 1047576 input window).
+        """
+        try:
+            return (
+                get_model_info(self.model_name).get(
+                    "max_input_tokens"
+                )
+                or 16000
+            )
+        except Exception:
+            return 16000
 
     def reliability_check(self):
 

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2468,6 +2468,51 @@ class TestLLMArgsAndHandling:
 
 
 # ============================================================================
+# CONTEXT LENGTH
+# ============================================================================
+
+
+class TestContextLength:
+    """context_length must survive __init__ and reach the Conversation."""
+
+    @staticmethod
+    def _agent(**kwargs):
+        with patch("swarms.structs.agent.LiteLLM"):
+            return Agent(
+                agent_name="ctx_agent",
+                max_loops=1,
+                print_on=False,
+                verbose=False,
+                persistent_memory=False,
+                **kwargs,
+            )
+
+    def test_explicit_value_is_honoured(self):
+        """The constructor argument used to be overwritten with 16000."""
+        agent = self._agent(
+            model_name="gpt-4.1", context_length=200000
+        )
+
+        assert agent.context_length == 200000
+        assert agent.short_memory.context_length == 200000
+
+    def test_default_uses_the_model_input_window(self):
+        """Omitting it should size to the model, not a flat 16000."""
+        agent = self._agent(model_name="gpt-4o")
+
+        # gpt-4o's input window is far above the old hardcoded default;
+        # asserting the relation rather than the literal keeps this from
+        # breaking when litellm refreshes its model table.
+        assert agent.context_length > 16000
+
+    def test_unknown_model_falls_back(self):
+        """An unrecognised model must not raise out of __init__."""
+        agent = self._agent(model_name="totally-made-up-model-xyz")
+
+        assert agent.context_length == 16000
+
+
+# ============================================================================
 # MAIN TEST RUNNER
 # ============================================================================
 


### PR DESCRIPTION
Fixes #1790

## Problem

`Agent(context_length=...)` is a no-op. The value is assigned at `agent.py:447` and then unconditionally overwritten ~100 lines later in the same `__init__`:

```python
# self.context_length = (
#     get_single_model_max_tokens(model_name)
#     if model_name
#     else 16000
# )
self.context_length = 16000
```

So every agent runs a 16k window whatever the model or the caller asked for. Because `dynamic_context_window` defaults to `True`, `Conversation` (handed the same 16000 at `agent.py:1040`) truncates history against it on every read, and `ContextCompressor` divides by it — so compression fires far earlier than the configured threshold implies.

The loaders are hit too: `agent_loader.py` and `create_agents_from_yaml.py` default `context_length` to 200000 / 100000 and pass it into `Agent(...)`, where it's dropped.

The commented-out block above it calls `get_single_model_max_tokens`, which no longer exists anywhere in the repo.

## Fix

```python
if self.context_length is None:
    self.context_length = self._default_context_length()
```

```python
def _default_context_length(self) -> int:
    """The model's input window, or 16000 when it can't be determined."""
    try:
        return get_model_info(self.model_name).get("max_input_tokens") or 16000
    except Exception:
        return 16000
```

`get_model_info(...)["max_input_tokens"]` is the right source. The already-imported `get_max_tokens` is **max output tokens** — for `gpt-4.1` it returns 32768 against a 1047576 input window, so using it would have set the window ~32x too small. `get_model_info` is added to the existing `litellm.utils` import, so no new import.

Measured after the change:

```
explicit 200000 -> agent=200000 conv=200000
default gpt-4.1 -> 1047576
default gpt-4o  -> 128000
unknown model   -> 16000
```

This also restores the `reliability_check()` guard at `agent.py:3084` to a reachable state — it checks for a `None`/`0` context length and was dead, since line 550 always forced 16000 before it ran.

**Behaviour change worth calling out:** default-constructed agents on a recognised model now get the model's real window instead of 16000, so they truncate and compress much later. That is the point of the issue, but it is a real change for anyone who was relying on the 16k default, so it's your call whether you'd rather keep 16000 as the no-argument default and only honour an explicit value. That variant is a one-line edit to `_default_context_length`.

## Tests

`tests/structs/test_agent.py::TestContextLength` — 3 tests, 2 fail on master:

```
assert agent.context_length == 200000
E  assert 16000 == 200000

assert agent.context_length > 16000
E  assert 16000 > 16000
```

The first also asserts the value reaches `short_memory.context_length`, since propagating to `Conversation` is what actually matters. The third pins that an unrecognised model still falls back rather than raising out of `__init__`. It asserts a relation rather than a literal window size so it won't break when litellm refreshes its model table.

Full-file check — identical failures before and after, all pre-existing:

| | failed | passed | errors |
|---|---|---|---|
| master `297ae6b7` | 20 | 38 | 8 |
| this branch | 20 | 41 | 8 |

`black --check` and `ruff check` clean.

Note: the red CI reproduces on `master` — `build` fails at `ModuleNotFoundError: No module named 'swarms'`, `test-main-features` at `poetry install --no-dev` (removed in Poetry 2.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)