### PR TITLE
[Bug] self.executor is never assigned in __init__, so run(imgs=[...]) raises AttributeError (#1793)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -563,6 +563,9 @@ class Agent:
         # Async subagent support
         self._subagent_registry = None
 
+        # Backs the lazy `executor` property below
+        self._executor = None
+
         # Owns fetching prompts from, and publishing prompts to, the Swarms Marketplace
         self.marketplace = AgentMarketplaceHandler(agent=self)
 
@@ -2138,6 +2141,20 @@ Subtask Breakdown:
             )
             raise error
 
+    @property
+    def executor(self) -> ContextThreadPoolExecutor:
+        """Thread pool backing the concurrent run paths.
+
+        Built on first use so agents that never run concurrently don't
+        allocate threads, and so it is always live — the pool used to be
+        created inside a ``with`` block, which shut it down on exit.
+        """
+        if self._executor is None:
+            self._executor = ContextThreadPoolExecutor(
+                max_workers=os.cpu_count()
+            )
+        return self._executor
+
     def run_concurrent_tasks(self, tasks: List[str], *args, **kwargs):
         """
         Run multiple tasks concurrently.
@@ -2480,12 +2497,9 @@ Subtask Breakdown:
                     rules=self.rules,
                 )
 
-            # Reinitialize executor if needed
-            # if not hasattr(self, "executor") or self.executor is None:
-            with ContextThreadPoolExecutor(
-                max_workers=os.cpu_count()
-            ) as executor:
-                self.executor = executor
+            # Drop any pool carried over from the saved state; the property
+            # below builds a fresh one on next use.
+            self._executor = None
 
         except Exception as e:
             logger.error(f"Error reinitializing components: {e}")

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2793,49 +2793,6 @@ class TestAutonomousAgentLoop:
 
 
 # ============================================================================
-# EXECUTOR LIFECYCLE
-# ============================================================================
-
-
-class TestExecutorLifecycle:
-    """The concurrent run paths need a live executor on a fresh agent."""
-
-    @staticmethod
-    def _agent():
-        with patch("swarms.structs.agent.LiteLLM"):
-            return Agent(
-                agent_name="exec_agent",
-                model_name="gpt-5.4",
-                max_loops=1,
-                print_on=False,
-                verbose=False,
-                persistent_memory=False,
-            )
-
-    def test_fresh_agent_has_a_usable_executor(self):
-        """run(imgs=[...]) used to raise AttributeError here."""
-        agent = self._agent()
-
-        assert agent.executor.submit(lambda: 21 * 2).result() == 42
-
-    def test_pool_is_lazy_and_reused(self):
-        """No threads for agents that never run concurrently."""
-        agent = self._agent()
-        assert agent._executor is None
-
-        first = agent.executor
-        assert agent._executor is not None
-        assert agent.executor is first
-
-    def test_executor_is_live_after_reload(self):
-        """The pool was built in a `with` block, so it arrived shut down."""
-        agent = self._agent()
-        agent._reinitialize_after_load()
-
-        assert agent.executor.submit(lambda: "ok").result() == "ok"
-
-
-# ============================================================================
 # MAIN TEST RUNNER
 # ============================================================================
 

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2793,6 +2793,49 @@ class TestAutonomousAgentLoop:
 
 
 # ============================================================================
+# EXECUTOR LIFECYCLE
+# ============================================================================
+
+
+class TestExecutorLifecycle:
+    """The concurrent run paths need a live executor on a fresh agent."""
+
+    @staticmethod
+    def _agent():
+        with patch("swarms.structs.agent.LiteLLM"):
+            return Agent(
+                agent_name="exec_agent",
+                model_name="gpt-5.4",
+                max_loops=1,
+                print_on=False,
+                verbose=False,
+                persistent_memory=False,
+            )
+
+    def test_fresh_agent_has_a_usable_executor(self):
+        """run(imgs=[...]) used to raise AttributeError here."""
+        agent = self._agent()
+
+        assert agent.executor.submit(lambda: 21 * 2).result() == 42
+
+    def test_pool_is_lazy_and_reused(self):
+        """No threads for agents that never run concurrently."""
+        agent = self._agent()
+        assert agent._executor is None
+
+        first = agent.executor
+        assert agent._executor is not None
+        assert agent.executor is first
+
+    def test_executor_is_live_after_reload(self):
+        """The pool was built in a `with` block, so it arrived shut down."""
+        agent = self._agent()
+        agent._reinitialize_after_load()
+
+        assert agent.executor.submit(lambda: "ok").result() == "ok"
+
+
+# ============================================================================
 # MAIN TEST RUNNER
 # ============================================================================
 


### PR DESCRIPTION
Fixes #1793

## Problem

`Agent.__init__` never assigns `self.executor`, but four methods submit to it:

| Method | Behaviour on a fresh agent |
|---|---|
| `run_multiple_images` (`:5393`) | `AttributeError` — reached from the public `run(imgs=[...])` |
| `talk_to_multiple_agents` (`:4442`) | `AttributeError` |
| `run_concurrent` (`:3005`) | swallows it, returns `None` |
| `run_concurrent_tasks` (`:3026`) | swallows it, returns `None` |

The two `run_concurrent*` paths are the worse case — the caller gets a silent `None` instead of an error.

The only assignment was inside a `with` block in `_reinitialize_after_load`:

```python
# if not hasattr(self, "executor") or self.executor is None:
with ContextThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
    self.executor = executor
```

`__exit__` calls `shutdown(wait=True)`, so even after `load()` the stored pool is already dead and the next submit raises `RuntimeError: cannot schedule new futures after shutdown`. The `hasattr` guard that would have made this conditional is commented out.

## Fix

Back it with a private field and build the pool on first access:

```python
@property
def executor(self) -> ContextThreadPoolExecutor:
    if self._executor is None:
        self._executor = ContextThreadPoolExecutor(max_workers=os.cpu_count())
    return self._executor
```

`__init__` sets `self._executor = None`, and `_reinitialize_after_load` now just clears the field instead of building-and-shutting-down a pool, so a reloaded agent gets a fresh live one.

Lazy rather than eager in `__init__` so agents that never run concurrently don't allocate `os.cpu_count()` threads — that would be a thread pool per Agent, and swarms build a lot of Agents.

Verified:

```
lazy before use: _executor=None
after access: ContextThreadPoolExecutor shutdown=False
stable across access: True
submit works: 42
after reload: _executor=None, new pool shutdown=False
```

I checked for external writers before converting the attribute to a read-only property — `grep -rn "\.executor" swarms/` outside `agent.py` only matches `advisor_swarm.py`'s unrelated `executor_agent` / `executor_model_name`.

## Tests

`tests/structs/test_agent.py::TestExecutorLifecycle` — 3 tests, all fail on master with the errors from the issue:

```
AttributeError: 'Agent' object has no attribute 'executor'
AttributeError: 'Agent' object has no attribute '_executor'
RuntimeError: cannot schedule new futures after shutdown
```

They cover a usable pool on a fresh agent, laziness plus reuse of the same object, and a live pool after `_reinitialize_after_load()`.

## Full-file results

| | failed | passed | errors |
|---|---|---|---|
| master `297ae6b7` | 20 | 38 | 8 |
| this branch | 19 | 42 | 8 |

Three of the four extra passes are the new tests. **The fourth I can't account for and am not claiming**: the pre-existing `TestAgentFeatures::test_agent_concurrent_execution` goes fail → pass. It's deterministic under pytest (master 6/6 fail, branch 6/6 pass, same test file both times, so the difference is the source change), but it makes live OpenAI calls and this machine has no `OPENAI_API_KEY`, and it passes standalone on master *and* this branch. I couldn't reproduce the mechanism outside pytest, so I'd treat that one as unexplained rather than as evidence this PR fixes it. Flagging it in case it means something to you.

No test goes pass → fail. `black --check` and `ruff check` clean.

Note: the red CI reproduces on `master` — `build` fails at `ModuleNotFoundError: No module named 'swarms'`, `test-main-features` at `poetry install --no-dev` (removed in Poetry 2.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update — test file dropped.** This is a small change to one function, so it ships without a test per the repo's preference for keeping diffs to the fix itself. The verification described above was run directly (reproduction before, same reproduction after); nothing about the fix or the evidence changed, only the absence of a committed test file.
