### PR TITLE
[Bug] requirements.txt omits both opentelemetry deps, so a clean install cannot import swarms (#1792)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ requests
 litellm==1.76.1
 mcp>=1.28.1,<2.0.0
 schedule
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http


### PR DESCRIPTION
Fixes #1792

## Problem

`requirements.txt` is missing both OpenTelemetry packages that `pyproject.toml` lists as runtime dependencies:

```
opentelemetry-sdk = "*"
opentelemetry-exporter-otlp-proto-http = "*"
```

They are not optional at import time. `swarms/__init__.py:14` does `from swarms.telemetry import *`, `swarms/telemetry/__init__.py` does `from swarms.telemetry.otel import log_agent_data`, and `swarms/telemetry/otel.py:16-23` imports `opentelemetry` at module level with no guard. So `pip install -r requirements.txt` followed by `import swarms` fails.

That is exactly what the `Python package` workflow does: it installs from `requirements.txt` only, then runs `pytest`, so collection dies at import for all three of 3.10, 3.11 and 3.12.

## Reproducer

Making `opentelemetry` unimportable in an otherwise complete env, which is the state `requirements.txt` leaves you in:

```python
import sys, importlib
from importlib.abc import MetaPathFinder

class Block(MetaPathFinder):
    def find_spec(self, name, path=None, target=None):
        if name == "opentelemetry" or name.startswith("opentelemetry."):
            raise ModuleNotFoundError(f"No module named {name!r}", name=name)

sys.meta_path.insert(0, Block())
importlib.import_module("swarms")
```

On master:

```
ModuleNotFoundError: No module named 'opentelemetry'
```

## Fix

Add the two packages to `requirements.txt`, unpinned, matching how `pyproject.toml` already declares them.

No test in this one, following #1783, which was the same shape of fix (dependency metadata only, `pyproject.toml` plus `requirements.txt`).

Two notes while I was in here, both left alone since they are their own issues:

- `pyproject.toml` and `requirements.txt` have no mechanism keeping them in sync, which is how this drifted. Worth a parity check in CI at some point.
- The `Python package` job stays red after this change for the separate reasons in #1798 and #1797: bare `pytest` at the repo root collects the whole tree, and `tests/structs/test_agent_stream_token.py` makes a billed live LLM call at import. This fix clears the import failure, not those.

I use Claude Code to help me work through these, and I check each one against the source before opening anything. If I have read this wrong, tell me and I will close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
