### PR TITLE
[Bug] AOP persistence: reset the restart count after a successful start so max_restart_attempts can fire (#1796)

### DIFF
--- a/swarms/structs/aop.py
+++ b/swarms/structs/aop.py
@@ -2445,9 +2445,13 @@ class AOP:
                     # Wait before restarting
                     time.sleep(self.restart_delay)
 
-                # Reset restart count on successful start
-                self._restart_count = 0
                 self.start_server()
+
+                # Reset restart count on successful start. This has to
+                # happen after start_server() returns, otherwise a failed
+                # attempt clears the count it just incremented and the
+                # max_restart_attempts failsafe below can never fire.
+                self._restart_count = 0
 
             except KeyboardInterrupt:
                 if (

--- a/tests/structs/test_aop.py
+++ b/tests/structs/test_aop.py
@@ -1360,3 +1360,59 @@ def test_get_queue_stats_all_agents_comprehensive(
         assert "second_agent" in result["stats"]
         assert result["stats"]["test_agent"]["total_tasks"] == 10
         assert result["stats"]["second_agent"]["total_tasks"] == 5
+
+
+def test_persistence_stops_after_max_restart_attempts():
+    """A deterministically failing server must hit the restart failsafe.
+
+    Bad bind address, port in use, missing credentials: whatever the cause,
+    the loop has to give up after max_restart_attempts instead of retrying
+    forever.
+    """
+    aop = AOP(
+        persistence=True, max_restart_attempts=3, restart_delay=0
+    )
+    attempts = []
+
+    def always_fail(*args, **kwargs):
+        attempts.append(1)
+        if len(attempts) > 10:
+            # Bounds the loop so a regression fails the test instead of
+            # hanging it. SystemExit is a BaseException, so run()'s
+            # `except Exception` handler cannot swallow it.
+            raise SystemExit("restart loop never terminated")
+        raise RuntimeError("bad bind address")
+
+    with patch.object(aop, "start_server", side_effect=always_fail):
+        aop.run()
+
+    # One initial attempt plus three restarts, then the failsafe fires.
+    assert len(attempts) == 4
+    assert aop._restart_count == 4
+    assert aop.get_persistence_status()["remaining_restarts"] == 0
+
+
+def test_persistence_restart_count_resets_after_a_clean_run():
+    """A server that ran and stopped on its own is not a failed attempt."""
+    aop = AOP(
+        persistence=True, max_restart_attempts=2, restart_delay=0
+    )
+    attempts = []
+
+    def clean_then_fail(*args, **kwargs):
+        attempts.append(1)
+        if len(attempts) == 1:
+            return None
+        if len(attempts) > 10:
+            raise SystemExit("restart loop never terminated")
+        raise RuntimeError("bad bind address")
+
+    with patch.object(
+        aop, "start_server", side_effect=clean_then_fail
+    ):
+        aop.run()
+
+    # The clean run zeroes the count, so the three failures after it get
+    # the full budget: 1 clean + 3 failing attempts.
+    assert len(attempts) == 4
+    assert aop._restart_count == 3


### PR DESCRIPTION
Fixes #1796

## Problem

`AOP.run()` with `persistence=True` advertises a failsafe bounded by `max_restart_attempts`, and that failsafe cannot fire for any value `>= 1`, including the default of 10. A server that fails deterministically (bad bind address, port already in use, missing credentials) is retried forever. The process never exits, never surfaces a terminal error, and the "Maximum restart attempts exceeded" log line is dead code.

The counter is zeroed at the top of every iteration, before the call that may fail, at `swarms/structs/aop.py:2448-2450`:

```python
                # Reset restart count on successful start
                self._restart_count = 0
                self.start_server()
```

The comment says the intent is to reset on a successful start, but the line runs on every attempt, including right after a failure incremented the counter. So `_restart_count` is only ever 0 or 1, `1 > max_restart_attempts` is false, the `break` at `:2500` is unreachable, the `while` guard at `:2438` always holds, and the post-loop branch at `:2542` can never be taken. `get_persistence_status()` reports `restart_count` and `remaining_restarts` off the same field, so both always read 0 and `max_restart_attempts`.

Only `max_restart_attempts=0` terminated, since `1 > 0` holds.

## Fix

Move the reset below `start_server()`, which is where "successful start" actually is, since `start_server()` blocks until the server stops:

```python
                self.start_server()

                # Reset restart count on successful start. This has to
                # happen after start_server() returns, otherwise a failed
                # attempt clears the count it just incremented and the
                # max_restart_attempts failsafe below can never fire.
                self._restart_count = 0
```

Failures now accumulate, so the `break` at `:2500` fires, the `while` guard bounds the network-error path at `:2478` too, and the permanent-failure log at `:2542` becomes reachable. A server that starts and stops on its own still clears the streak, so an occasional clean stop does not eat the restart budget.

## Tests

`tests/structs/test_aop.py`, 2 new tests, both fail on master:

```
FAILED test_persistence_stops_after_max_restart_attempts
FAILED test_persistence_restart_count_resets_after_a_clean_run
tests/structs/test_aop.py:1407: SystemExit: restart loop never terminated
```

Each patches `start_server` to fail and caps itself with a `SystemExit` after 10 attempts, so a regression fails the test instead of hanging it forever. `SystemExit` is a `BaseException`, so `run()`'s `except Exception` handler cannot swallow it. On this branch both pass, with `max_restart_attempts=3` giving exactly 4 start attempts (1 initial plus 3 restarts).

Rest of the file, same `-k "persistence or restart or shutdown or status or queue"` selection, master vs this branch, byte-identical progress output:

```
F..FF..FF.F.F.F.FF...F.F.
```

13 pass, 12 fail, same set both ways, all pre-existing.

`black --check` and `ruff check` clean at the repo's line-length 70.

## Separate defect I did not touch

I could not run the whole file either way. It gets SIGKILLed at `test_run_with_persistence_success` on master and on this branch alike, for a different bug in the same function: that test patches `start_server` to return normally and asserts `mock_start.assert_called_once()`, but the clean-return path restarts immediately with no delay (the `time.sleep(restart_delay)` at `:2446` is behind `if self._restart_count > 0`), so `run()` spins on the mock until the process is killed.

So the existing test in your repo already asserts that `run()` should return after one successful start, while the code loops forever. Fixing that is a semantics call I did not want to bundle into this one: either persistence means restart-on-crash-only, or a clean stop should at least sleep `restart_delay` first. Say which you want and I will send it as a follow-up.

I use Claude Code to help me work through these and I verify everything against the source before opening anything. If I have misread the intent here, tell me and I will close it.

---

Edit after merge: I briefly replaced the description above with a one-test version. What actually merged here is the two tests described above. The one-test consolidation is #1807 instead, so this body matches the merged diff again. Sorry for the churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
