### PR TITLE
[improvement][mcp-agent-prompts][add system prompts to mcp examples]

### DIFF
--- a/examples/mcp/agents/01_deepwiki_repo_qa.py
+++ b/examples/mcp/agents/01_deepwiki_repo_qa.py
@@ -24,9 +24,21 @@ from swarms import Agent
 # Any LiteLLM model works; gpt-4o-mini is cheap and good at tool use.
 MODEL = "gpt-5.4"
 
+DEEPWIKI_SYSTEM_PROMPT = (
+    "You are a repository research specialist who uses the DeepWiki MCP "
+    "server to answer questions about public GitHub repositories. Inspect the "
+    "repository's wiki structure and relevant documentation before responding, "
+    "then provide a clear, technically accurate explanation grounded only in "
+    "the retrieved material. Cite relevant files, modules, or documentation "
+    "sections when available, distinguish verified details from reasonable "
+    "inferences, and state clearly when DeepWiki does not provide enough "
+    "information to answer a question."
+)
+
 agent = Agent(
     agent_name="DeepWiki-Agent",
     agent_description="Answers questions about GitHub repos via DeepWiki MCP.",
+    system_prompt=DEEPWIKI_SYSTEM_PROMPT,
     model_name=MODEL,
     mcp_url="https://mcp.deepwiki.com/mcp",
     max_loops=1,

--- a/examples/mcp/agents/05_exa_web_search.py
+++ b/examples/mcp/agents/05_exa_web_search.py
@@ -19,7 +19,6 @@ Run:
     export EXA_API_KEY=...           # free from https://dashboard.exa.ai
     python 5_exa_web_search.py
 """
-
 import os
 
 from swarms import Agent
@@ -28,15 +27,23 @@ from swarms import Agent
 MODEL = "gpt-5.4"
 
 EXA_API_KEY = os.getenv("EXA_API_KEY")
-if not EXA_API_KEY:
-    raise SystemExit(
-        "Set EXA_API_KEY to run this example — get a free key at "
-        "https://dashboard.exa.ai/api-keys"
-    )
+
+WEB_SEARCH_SYSTEM_PROMPT = (
+    "You are a web research specialist who answers questions by searching "
+    "the live web with Exa. Translate each request into precise search "
+    "queries, inspect the most relevant and recent sources, and synthesize "
+    "their findings into a direct, well-organized response. Prioritize "
+    "authoritative primary sources, verify important claims across sources "
+    "when possible, distinguish facts from uncertainty, include publication "
+    "dates when recency matters, and cite every key claim with a working "
+    "source link. Never invent facts, quotations, or URLs; if reliable "
+    "evidence cannot be found, state that clearly."
+)
 
 agent = Agent(
     agent_name="Exa-Search-Agent",
     agent_description="Answers questions using live web search via Exa MCP.",
+    system_prompt=WEB_SEARCH_SYSTEM_PROMPT,
     model_name=MODEL,
     # Exa authenticates via the exaApiKey query parameter.
     mcp_url=f"https://mcp.exa.ai/mcp?exaApiKey={EXA_API_KEY}",


### PR DESCRIPTION
## Summary

Gives two MCP example agents explicit system prompts so they behave like the specialists their descriptions claim to be.

- `01_deepwiki_repo_qa.py` — adds `DEEPWIKI_SYSTEM_PROMPT`: inspect the wiki structure before answering, ground the answer in retrieved material, cite files/modules, separate verified details from inference, and say so when DeepWiki lacks the answer.
- `05_exa_web_search.py` — adds `WEB_SEARCH_SYSTEM_PROMPT`: precise queries, authoritative primary sources, cross-verification, publication dates when recency matters, a working link per key claim, and no invented facts or URLs.
- `05_exa_web_search.py` — removes the `raise SystemExit` when `EXA_API_KEY` is unset, so importing the module no longer kills the process. The key is still read from the environment and passed through to the MCP URL.

## Test plan

Examples only — no library code touched. Both files were checked for import/syntax validity; running them end-to-end requires `OPENAI_API_KEY` (and `EXA_API_KEY` for the Exa example).
