### PR TITLE
[Bug] tool_execution_retry never retries and swallows tool failures (#1794)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -4073,20 +4073,26 @@ Summary: {summary}
             >>> agent.tool_execution_retry(None, loop_count=2)
             >>> # Logs warning but does not raise exception
         """
-        try:
-            if response is not None:
+        if response is None:
+            logger.warning(
+                f"Agent '{self.agent_name}' received None response from LLM in loop {loop_count}. "
+                f"This may indicate an issue with the model or prompt. Skipping tool execution."
+            )
+            return
+
+        attempts = max(1, self.tool_retry_attempts or 1)
+        for attempt in range(1, attempts + 1):
+            try:
                 self.execute_tools(
                     response=response,
                     loop_count=loop_count,
                 )
-            else:
-                logger.warning(
-                    f"Agent '{self.agent_name}' received None response from LLM in loop {loop_count}. "
-                    f"This may indicate an issue with the model or prompt. Skipping tool execution."
+                return
+            except AgentToolExecutionError as e:
+                logger.error(
+                    f"Agent '{self.agent_name}' encountered error during tool execution in loop {loop_count}: {str(e)}. "
+                    f"Full traceback: {traceback.format_exc()}. "
+                    f"Attempt {attempt} of {attempts}"
                 )
-        except AgentToolExecutionError as e:
-            logger.error(
-                f"Agent '{self.agent_name}' encountered error during tool execution in loop {loop_count}: {str(e)}. "
-                f"Full traceback: {traceback.format_exc()}. "
-                f"Attempting to retry tool execution with 3 attempts"
-            )
+                if attempt == attempts:
+                    raise

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -21,6 +21,7 @@ from swarms import (
     create_agents_from_yaml,
 )
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
+from swarms.schemas.agent_errors import AgentToolExecutionError
 
 # Load environment variables
 load_dotenv()
@@ -2157,6 +2158,39 @@ class TestAgentToolUsage:
         assert response is not None, "Calculus tool execution failed"
 
         print("✓ Tools with mathematical operations test passed")
+
+
+# ============================================================================
+# TOOL EXECUTION RETRY
+# ============================================================================
+
+
+class TestToolExecutionRetry:
+    """tool_execution_retry must actually retry, then surface the failure."""
+
+    def test_retries_then_raises(self):
+        with patch("swarms.structs.agent.LiteLLM"):
+            agent = Agent(
+                agent_name="retry_agent",
+                model_name="gpt-5.4",
+                max_loops=1,
+                print_on=False,
+                verbose=False,
+                persistent_memory=False,
+                tool_retry_attempts=3,
+            )
+
+        with patch.object(
+            agent,
+            "execute_tools",
+            side_effect=AgentToolExecutionError("tool blew up"),
+        ) as execute:
+            with pytest.raises(AgentToolExecutionError):
+                agent.tool_execution_retry(
+                    [{"function": {"name": "x"}}], loop_count=1
+                )
+
+        assert execute.call_count == 3
 
 
 # ============================================================================

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -21,7 +21,6 @@ from swarms import (
     create_agents_from_yaml,
 )
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
-from swarms.schemas.agent_errors import AgentToolExecutionError
 
 # Load environment variables
 load_dotenv()
@@ -2158,39 +2157,6 @@ class TestAgentToolUsage:
         assert response is not None, "Calculus tool execution failed"
 
         print("✓ Tools with mathematical operations test passed")
-
-
-# ============================================================================
-# TOOL EXECUTION RETRY
-# ============================================================================
-
-
-class TestToolExecutionRetry:
-    """tool_execution_retry must actually retry, then surface the failure."""
-
-    def test_retries_then_raises(self):
-        with patch("swarms.structs.agent.LiteLLM"):
-            agent = Agent(
-                agent_name="retry_agent",
-                model_name="gpt-5.4",
-                max_loops=1,
-                print_on=False,
-                verbose=False,
-                persistent_memory=False,
-                tool_retry_attempts=3,
-            )
-
-        with patch.object(
-            agent,
-            "execute_tools",
-            side_effect=AgentToolExecutionError("tool blew up"),
-        ) as execute:
-            with pytest.raises(AgentToolExecutionError):
-                agent.tool_execution_retry(
-                    [{"function": {"name": "x"}}], loop_count=1
-                )
-
-        assert execute.call_count == 3
 
 
 # ============================================================================


### PR DESCRIPTION
Fixes #1794

## Problem

`swarms/structs/agent.py:5535-5551`. The method named `tool_execution_retry` contains no retry:

```python
        except AgentToolExecutionError as e:
            logger.error(
                f"... Attempting to retry tool execution with 3 attempts"
            )
```

The `except` block logs and falls off the end. `execute_tools` is called exactly once, `self.tool_retry_attempts` (default 3) is never read, and the exception is swallowed, so the caller cannot tell a tool failed. The log line even claims a retry is about to happen.

Measured on master `829a6671`, patching `execute_tools` to raise:

```
tool_retry_attempts = 3
execute_tools calls  = 1        (expected 3)
propagated exception = None     (expected the error to surface)
```

Both halves contradict the docstring directly above it, which promises "Maximum retry attempts are controlled by self.tool_retry_attempts (default: 3)" and "After all retries are exhausted, the exception is re-raised".

## Fix

Same logic, restructured into the loop the docstring describes. Net **+18/-12 in one file**, and the early return for `None` removes a nesting level:

```python
        if response is None:
            logger.warning(...)
            return

        attempts = max(1, self.tool_retry_attempts or 1)
        for attempt in range(1, attempts + 1):
            try:
                self.execute_tools(response=response, loop_count=loop_count)
                return
            except AgentToolExecutionError as e:
                logger.error(f"... Attempt {attempt} of {attempts}")
                if attempt == attempts:
                    raise
```

`max(1, ... or 1)` keeps a caller-supplied `0` or `None` from turning tool execution off entirely, which is what a bare `range()` would do. The log now reports the real attempt number instead of a hardcoded 3.

**Behaviour change worth your call.** The re-raise is the "silently swallows" half of the issue and it is what the docstring specifies, but it does surface errors that master currently drops. Two of the three call sites, `agent.py:2600` and `:2693`, invoke this from inside their own `except Exception` handler as a fallback, so a tool that fails every attempt will now propagate out of the autonomous loop instead of being logged and stepped over. If you would rather keep it non-fatal, delete the two `if attempt == attempts: raise` lines and the retries still work. I can push that variant instead, just say which you prefer.

## Test

One test appended to the existing `tests/structs/test_agent.py`, no new file:

```python
        with patch.object(
            agent, "execute_tools",
            side_effect=AgentToolExecutionError("tool blew up"),
        ) as execute:
            with pytest.raises(AgentToolExecutionError):
                agent.tool_execution_retry([{"function": {"name": "x"}}], loop_count=1)

        assert execute.call_count == 3
```

It pins both halves at once, so either regression fails it: no retry gives `call_count == 1`, and swallowing gives `DID NOT RAISE AgentToolExecutionError`. With only `agent.py` reverted to master:

```
E  Failed: DID NOT RAISE AgentToolExecutionError
```

Full-file check, master `agent.py` vs this branch, the only difference is this test:

| | failed | passed | errors |
|---|---|---|---|
| master `829a6671` | 22 | 40 | 8 |
| this branch | 21 | 41 | 8 |

`black --check` and `ruff check` clean at line-length 70.

I use Claude Code to help me work through these and I verify every claim against the source first. If I have read the intent wrong here, tell me and I will close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update — test file dropped.** This is a small change to one function, so it ships without a test per the repo's preference for keeping diffs to the fix itself. The verification described above was run directly (reproduction before, same reproduction after); nothing about the fix or the evidence changed, only the absence of a committed test file.
