### PR TITLE
[Bug] Revive the two validators pydantic.v1 silently disabled on v2 models (#1795)

### DIFF
--- a/swarms/artifacts/main_artifact.py
+++ b/swarms/artifacts/main_artifact.py
@@ -5,8 +5,7 @@ import time
 from datetime import datetime
 from typing import Any, Dict, List, Union
 
-from pydantic import BaseModel, Field
-from pydantic.v1 import validator
+from pydantic import BaseModel, Field, field_validator
 
 from swarms.utils.file_processing import create_file_in_folder
 from swarms.utils.loguru_logger import initialize_logger
@@ -54,8 +53,9 @@ class Artifact(BaseModel):
     )
     file_path: str = Field(..., description="The path to the file")
     file_type: str = Field(
-        ...,
-        description="The type of the file",
+        default="",
+        validate_default=True,
+        description="The type of the file, derived from file_path when omitted",
         # example=".txt",
     )
     contents: str = Field(
@@ -67,10 +67,11 @@ class Artifact(BaseModel):
         description="The number of times the file has been edited",
     )
 
-    @validator("file_type", pre=True, always=True)
-    def validate_file_type(cls, v, values):
+    @field_validator("file_type", mode="before")
+    @classmethod
+    def validate_file_type(cls, v, info):
         if not v:
-            file_path = values.get("file_path")
+            file_path = info.data.get("file_path")
             _, ext = os.path.splitext(file_path)
             if ext.lower() not in [
                 ".py",

--- a/swarms/prompts/prompt.py
+++ b/swarms/prompts/prompt.py
@@ -8,8 +8,8 @@ from pydantic import (
     BaseModel,
     Field,
     constr,
+    model_validator,
 )
-from pydantic.v1 import validator
 
 from swarms.tools.base_tool import BaseTool
 from swarms.utils.loguru_logger import initialize_logger
@@ -83,16 +83,14 @@ class Prompt(BaseModel):
     )
     llm: Any = None
 
-    @validator("edit_history", pre=True, always=True)
-    def initialize_history(cls, v, values):
+    @model_validator(mode="after")
+    def initialize_history(self):
         """
         Initializes the edit history by storing the first version of the prompt.
         """
-        if not v:
-            return [
-                values["content"]
-            ]  # Store initial version in history
-        return v
+        if not self.edit_history:
+            self.edit_history = [self.content]
+        return self
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/tests/artifacts/test_artifact_main.py
+++ b/tests/artifacts/test_artifact_main.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest.mock import mock_open, patch
 
 import pytest
+from pydantic import ValidationError
 
 from swarms.artifacts.main_artifact import Artifact, FileVersion
 
@@ -196,6 +197,21 @@ def test_export_import_json(saved_artifact):
 
     imported = Artifact(**data)
     assert imported.contents == content
+
+
+def test_file_type_validator_runs():
+    """The pydantic.v1 decorator was dead on this v2 model, so this never ran."""
+    base = dict(file_path="/tmp/x.py", contents="", edit_count=0)
+
+    # derived from the path when omitted
+    assert Artifact(**base).file_type == ".py"
+    # and the derived extension is checked against the allowlist
+    with pytest.raises(
+        ValidationError, match="Unsupported file type"
+    ):
+        Artifact(**{**base, "file_path": "/tmp/x.exe"})
+    # an explicit value is still passed through untouched
+    assert Artifact(**base, file_type=".py").file_type == ".py"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1795

## Problem

Two v2 `BaseModel` classes decorate a method with `validator` imported from `pydantic.v1`:

- `swarms/artifacts/main_artifact.py:9` and `:70` — `@validator("file_type", pre=True, always=True)`
- `swarms/prompts/prompt.py:12` and `:86` — `@validator("edit_history", pre=True, always=True)`

The v1 decorator registers into v1's machinery, which a v2 model never consults, so neither method runs. No error, no warning. Measured on master `829a6671` with pydantic 2.13.4:

```
Artifact(file_path="/tmp/x.exe", ...)     -> accepted, file_type is never derived or checked
Prompt(content="ORIGINAL").edit_history  -> []          (should be ["ORIGINAL"])
p.edit_prompt("SECOND"); p.edit_history  -> ["SECOND"]   (original is gone)
p.rollback(0)                            -> content == "SECOND"
```

That last line is the damaging one: `rollback(0)` is documented as "0 is the first version", and because the original content never entered the history, version 0 *is* the first edit. The original prompt is unrecoverable.

## Fix

**`prompt.py` — needs `model_validator`, not `field_validator`.** A straight decorator swap does not work here and it is worth being explicit about why: in v2 a `field_validator(..., mode="before")` is skipped for a field that was not supplied and has a default, and `edit_history` has `default_factory=list`. So the v1 `always=True` behaviour maps to a model validator, not a field one:

```python
    @model_validator(mode="after")
    def initialize_history(self):
        if not self.edit_history:
            self.edit_history = [self.content]
        return self
```

**`main_artifact.py` — `field_validator` plus a reachable default.** The validator body only acts when `file_type` is falsy, and the field was `Field(...)`, i.e. required, so under v2 the model errors on the missing field before any validator could derive it. Making the default explicit and validating it is what puts the original code path back in reach:

```python
    file_type: str = Field(
        default="",
        validate_default=True,
        description="The type of the file, derived from file_path when omitted",
    )

    @field_validator("file_type", mode="before")
    @classmethod
    def validate_file_type(cls, v, info):
        if not v:
            file_path = info.data.get("file_path")
```

`values` becomes `info.data`, which is the v2 equivalent for already-validated fields; `file_path` is declared above `file_type`, so it is present.

Two things I deliberately did not change:

- **`file_type` goes from required to optional.** That is the point of a validator that derives it from `file_path`, and it is backward compatible for every existing caller since passing the field still works. It does change the generated JSON schema, so if you would rather keep it required and only validate supplied values, drop the two `Field` lines and the derive path stays dead. Your call.
- **An explicitly passed `file_type` is still not allowlist-checked.** The original validator only checks the extension it derives itself and returns a supplied value untouched. I kept that as-is rather than widen the fix; `Artifact(file_type=".exe")` is accepted before and after.

## Test

One test appended to the existing `tests/artifacts/test_artifact_main.py`, no new file, 16 lines:

```python
def test_file_type_validator_runs():
    base = dict(file_path="/tmp/x.py", contents="", edit_count=0)

    assert Artifact(**base).file_type == ".py"
    with pytest.raises(ValidationError, match="Unsupported file type"):
        Artifact(**{**base, "file_path": "/tmp/x.exe"})
    assert Artifact(**base, file_type=".py").file_type == ".py"
```

With both source files reverted to master, the only difference is this test:

| `tests/artifacts/test_artifact_main.py` | failed | passed |
|---|---|---|
| master `829a6671` | 12 | 4 |
| this branch | 11 | 5 |

The other 11 failures are pre-existing on master and untouched by this change.

The `prompt.py` half has no test here because the repo has no test file for `swarms/prompts/prompt.py` and I did not want to add one uninvited. Verified by hand instead, on this branch:

```
history after construct: ['ORIGINAL']
history after edit:      ['ORIGINAL', 'SECOND']
rollback(0) -> 'ORIGINAL'                     (was 'SECOND')
explicit edit_history=["A","B"] -> ['A', 'B']  (still respected)
```

Say the word and I will add `tests/prompts/test_prompt.py` covering it.

`black --check` and `ruff check` clean at line-length 70. `grep -rn "pydantic.v1" swarms/` is now empty.

I use Claude Code to help me work through these and I check every claim against a real run before opening anything. If either behaviour was intentional, tell me and I will close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
