### PR TITLE
[Bug] Agent.__init__ raises on any model id litellm does not know

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -3096,10 +3096,19 @@ Subtask Breakdown:
         Returns:
             int: The maximum number of output tokens for the model. Returns 16000 if undetermined.
         """
-        return (
-            get_model_info(self.model_name).get("max_output_tokens")
-            or 16000
-        )
+        # get_model_info raises for an unmapped model id rather than
+        # returning an empty mapping, so an unknown, custom or self-hosted
+        # model would otherwise take down Agent.__init__. The sibling
+        # _default_context_length guards the same call the same way.
+        try:
+            return (
+                get_model_info(self.model_name).get(
+                    "max_output_tokens"
+                )
+                or 16000
+            )
+        except Exception:
+            return 16000
 
     def reliability_check(self):
 


### PR DESCRIPTION
## Problem

On current master, constructing an `Agent` with any model id litellm does not know raises out of `__init__`:

```python
Agent(agent_name="t", model_name="totally-made-up-model-xyz", max_loops=1)
```

```
Exception: This model isn't mapped yet. model=totally-made-up-model-xyz,
custom_llm_provider=None. Add it here - https://github.com/BerriAI/litellm/...
  File "swarms/structs/agent.py", line 556, in __init__
    self.max_tokens = self._default_max_tokens() or 16000
  File "swarms/structs/agent.py", line 3100, in _default_max_tokens
    get_model_info(self.model_name).get("max_output_tokens")
```

That closes the door on custom, self-hosted and newly released model ids, and on anyone passing their own `llm` object while leaving `model_name` as a label. It is a regression from `eaacf5cc`, which added `_default_max_tokens`.

The docstring right above the call already promises the safe behaviour:

> Returns 16000 as default if the property does not exist or can't be determined.

`get_model_info` does not return an empty mapping for an unknown model, it raises, so "can't be determined" was never handled.

## Fix

Guard the call exactly the way its sibling `_default_context_length` (added in #1800, 40 lines above) already guards the same function:

```python
        try:
            return (
                get_model_info(self.model_name).get("max_output_tokens")
                or 16000
            )
        except Exception:
            return 16000
```

One file, and the two methods now behave consistently. Measured after the change:

```
totally-made-up-model-xyz: max_tokens=16000  context_length=16000
gpt-4o:                    max_tokens=16384  context_length=128000
```

Known models are unaffected; unknown ones fall back and `reliability_check` still emits its "may not be supported" warning, which is the right place for that signal.

## Test

**No new test.** The repo already has one for exactly this, and it is currently red on master:

```
tests/structs/test_agent.py::TestContextLength::test_unknown_model_falls_back
  Exception: This model isn't mapped yet. model=totally-made-up-model-xyz
```

It was green when it was added and `eaacf5cc` broke it. This PR turns it back green, which seemed better than adding a second test asserting the same thing.

Full `tests/structs/test_agent.py`, master vs this branch:

| | failed | passed | errors |
|---|---|---|---|
| master `06413ebc` | 21 | 41 | 8 |
| this branch | 20 | 42 | 8 |

The single difference is that test flipping to passing. Nothing else in the file changes. `black --check` and `ruff check` clean at line-length 70.

I use Claude Code to help me work through these and I reproduce everything against a real run first. If raising on an unknown model was intentional, tell me and I will close this and send a PR deleting the stale test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
