### PR TITLE
[Chore] Unblock the Lint job: one blank line black wants in an examples file

### DIFF
--- a/examples/mcp/agents/05_exa_web_search.py
+++ b/examples/mcp/agents/05_exa_web_search.py
@@ -19,6 +19,7 @@ Run:
     export EXA_API_KEY=...           # free from https://dashboard.exa.ai
     python 5_exa_web_search.py
 """
+
 import os
 
 from swarms import Agent


### PR DESCRIPTION
## Problem

The `Lint` workflow fails on master at its first step, `black . --check --diff`, for one file:

```
would reformat /home/runner/work/swarms/swarms/examples/mcp/agents/05_exa_web_search.py
##[error]Process completed with exit code 1.
```

The file came in with #1808 and is missing the blank line black wants after a module docstring. Because the job stops there, the `ruff check .` step never runs on any PR.

## Fix

```diff
     python 5_exa_web_search.py
 """
+
 import os
```

One file, one blank line, no code change.

Verified with the exact versions the workflow pins (`black==24.2.0`, `ruff==0.2.1`), not my local ones:

| | black | ruff |
|---|---|---|
| master `06413ebc` | 1 file would be reformatted | 25 errors |
| this branch | **967 files unchanged** | 25 errors |

## What this does not fix

**The `Lint` job will still fail**, one step later, on `ruff check .`. Those 25 findings are pre-existing and identical before and after this change:

| rule | count |
|---|---|
| E722 bare `except` | 10 |
| F401 unused import | 7 |
| E402 import not at top | 6 |
| F402 import shadowed by loop var | 1 |
| E721 type comparison | 1 |

They sit in `examples/` (17), `tests/` (7) and `scripts/` (1). **None are in `swarms/`.** Most are idiomatic for the files they are in: the F401s are availability probes inside `try:` blocks, and the E402s follow `load_dotenv()` calls.

I did not bundle that sweep in here, because clearing it means touching about 20 files and rewriting 10 bare `except:` clauses in example scripts, which is a semantic change dressed as a lint fix, not something to slip into a one-line PR.

Two ways to finish it, whichever you prefer:

1. I send a follow-up that fixes all 25 properly (`except Exception`, `importlib.util.find_spec` for the probes, `# noqa: E402` after the dotenv calls).
2. Or a `[tool.ruff.lint.per-file-ignores]` block in `pyproject.toml` scoping those rules out of `examples/`, `tests/` and `scripts/`, which is one file and treats example scripts differently from library code on purpose.

Say which and I will send it. This PR on its own just gets the job past black so ruff's output is visible on every PR instead of hidden behind an earlier failure.

I use Claude Code to help me work through these and I checked this against the pinned tool versions rather than assuming my local ones matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
