### PR TITLE
[Bug] Function-calling warning fires for every agent that has no tools

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -3143,7 +3143,10 @@ Subtask Breakdown:
                 "Context length is not provided. Please set a valid context length."
             )
 
-        if self.tools_list_dictionary is not None:
+        # Truthiness, not "is not None": the attribute is normalised to an
+        # empty list for every agent built without tools, so the None check
+        # warned about function calling for agents that never use it.
+        if self.tools_list_dictionary:
             if not supports_function_calling(self.model_name):
                 logger.warning(
                     f"The model '{self.model_name}' does not support function calling. Please use a model that supports function calling."

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2513,6 +2513,44 @@ class TestContextLength:
 
 
 # ============================================================================
+# RELIABILITY CHECK WARNINGS
+# ============================================================================
+
+
+class TestFunctionCallingWarning:
+    """The function-calling warning is for agents that actually have tools."""
+
+    @staticmethod
+    def _warnings_for(**kwargs):
+        with patch("swarms.structs.agent.LiteLLM"), patch(
+            "swarms.structs.agent.supports_function_calling",
+            return_value=False,
+        ), patch("swarms.structs.agent.logger") as log:
+            Agent(
+                agent_name="warn_agent",
+                model_name="gpt-5.4",
+                max_loops=1,
+                print_on=False,
+                verbose=False,
+                persistent_memory=False,
+                **kwargs,
+            )
+        return " ".join(str(c) for c in log.warning.call_args_list)
+
+    def test_no_tools_no_function_calling_warning(self):
+        assert (
+            "does not support function calling"
+            not in self._warnings_for()
+        )
+
+    def test_with_tools_the_warning_still_fires(self):
+        warnings = self._warnings_for(
+            tools_list_dictionary=[{"function": {"name": "x"}}]
+        )
+        assert "does not support function calling" in warnings
+
+
+# ============================================================================
 # TOOLS LIST ISOLATION
 # ============================================================================
 
@@ -2551,44 +2589,6 @@ class TestToolsListIsolation:
             ).tools_list_dictionary
             == given
         )
-
-
-# ============================================================================
-# RELIABILITY CHECK WARNINGS
-# ============================================================================
-
-
-class TestFunctionCallingWarning:
-    """The function-calling warning is for agents that actually have tools."""
-
-    @staticmethod
-    def _warnings_for(**kwargs):
-        with patch("swarms.structs.agent.LiteLLM"), patch(
-            "swarms.structs.agent.supports_function_calling",
-            return_value=False,
-        ), patch("swarms.structs.agent.logger") as log:
-            Agent(
-                agent_name="warn_agent",
-                model_name="gpt-5.4",
-                max_loops=1,
-                print_on=False,
-                verbose=False,
-                persistent_memory=False,
-                **kwargs,
-            )
-        return " ".join(str(c) for c in log.warning.call_args_list)
-
-    def test_no_tools_no_function_calling_warning(self):
-        assert (
-            "does not support function calling"
-            not in self._warnings_for()
-        )
-
-    def test_with_tools_the_warning_still_fires(self):
-        warnings = self._warnings_for(
-            tools_list_dictionary=[{"function": {"name": "x"}}]
-        )
-        assert "does not support function calling" in warnings
 
 
 # ============================================================================

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2554,6 +2554,44 @@ class TestToolsListIsolation:
 
 
 # ============================================================================
+# RELIABILITY CHECK WARNINGS
+# ============================================================================
+
+
+class TestFunctionCallingWarning:
+    """The function-calling warning is for agents that actually have tools."""
+
+    @staticmethod
+    def _warnings_for(**kwargs):
+        with patch("swarms.structs.agent.LiteLLM"), patch(
+            "swarms.structs.agent.supports_function_calling",
+            return_value=False,
+        ), patch("swarms.structs.agent.logger") as log:
+            Agent(
+                agent_name="warn_agent",
+                model_name="gpt-5.4",
+                max_loops=1,
+                print_on=False,
+                verbose=False,
+                persistent_memory=False,
+                **kwargs,
+            )
+        return " ".join(str(c) for c in log.warning.call_args_list)
+
+    def test_no_tools_no_function_calling_warning(self):
+        assert (
+            "does not support function calling"
+            not in self._warnings_for()
+        )
+
+    def test_with_tools_the_warning_still_fires(self):
+        warnings = self._warnings_for(
+            tools_list_dictionary=[{"function": {"name": "x"}}]
+        )
+        assert "does not support function calling" in warnings
+
+
+# ============================================================================
 # MAIN TEST RUNNER
 # ============================================================================
 


### PR DESCRIPTION
## Problem

Every agent built without tools, on a model litellm does not mark as function-calling, gets this warning at construction:

```
WARNING | swarms.structs.agent:reliability_check:3148 -
The model 'totally-made-up-xyz' does not support function calling.
Please use a model that supports function calling.
```

Reproduced on master with no tools passed at all:

```python
with patch("swarms.structs.agent.LiteLLM"):
    a = Agent(agent_name="t", model_name="totally-made-up-xyz", max_loops=1)

tools_list_dictionary = []   is not None -> True
```

`agent.py:3146` gates the warning on `is not None`:

```python
        if self.tools_list_dictionary is not None:
            if not supports_function_calling(self.model_name):
```

but the attribute is normalised to an empty list for every agent built without tools, so the guard is true for all of them. The advice is also wrong for those agents: they are not going to call functions, so there is nothing to fix by switching model.

## Fix

One line, matching how the rest of the file already reads this attribute (`:2021` and `:2267` both use truthiness):

```python
        if self.tools_list_dictionary:
            if not supports_function_calling(self.model_name):
```

An agent with tools on a non-function-calling model still gets warned, which is the case the check was written for.

## Related, deliberately not changed

`agent.py:1503` has the same shape, `if exists(self.tools_list_dictionary):`, where `exists()` is `is not None`. That one converts a `BaseModel` response via `model_dump()`, so it is also true for toolless agents. I left it alone because flipping it changes the returned response type rather than a log line, and that deserves its own PR and its own discussion. Say the word and I will send it.

## Test

Two tests appended to the existing `tests/structs/test_agent.py`, no new file. They patch `supports_function_calling` to `False` so the check is exercised deterministically, then read `logger.warning` calls.

On master the first fails:

```
assert 'does not su...tion calling' not in 'call("The m...n calling.")'
```

The second pins that the warning still fires when tools are present, so this cannot regress into never warning.

Full `tests/structs/test_agent.py`, master vs this branch:

| | failed | passed | errors |
|---|---|---|---|
| master `16afc758` | 21 | 43 | 8 |
| this branch | 20 | 44 | 8 |

The only difference is the new test. `black --check` and `ruff check` clean at line-length 70.

I use Claude Code to help me work through these and I reproduce each claim against a real run first. If the warning was meant to fire for every agent, tell me and I will close this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
