### PR TITLE
[Chore] Scope ruff's example and test findings so the Lint job can go green (follow-up to #1814)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,17 @@ markers = [
 [tool.ruff]
 line-length = 70
 
+# Library code under swarms/ is held to the full rule set. Example scripts,
+# test helpers and one-off scripts are not: an availability probe imports a
+# package to see whether it is installed (F401), a demo loads dotenv before
+# importing (E402), and a teaching example catches everything so it can print
+# a friendly message (E722). Enforcing those there produces churn without
+# making the library safer.
+[tool.ruff.lint.per-file-ignores]
+"examples/**" = ["E402", "E721", "E722", "F401", "F402"]
+"tests/**" = ["E402", "E721", "E722", "F401", "F402"]
+"scripts/**" = ["F401"]
+
 [tool.black]
 target-version = ["py38"]
 line-length = 70


### PR DESCRIPTION
Follow-up to #1814, config only, no code touched.

## Why

The `Lint` job runs `black . --check --diff` then `ruff check .`. #1814 fixes the black half. This fixes the ruff half, so between the two the job can actually go green instead of failing at one step or the other.

`ruff check .` reports 25 findings on master, none of them in `swarms/`:

| where | count |
|---|---|
| `examples/` | 17 |
| `tests/` | 7 |
| `scripts/` | 1 |

By rule: 10 `E722` bare except, 7 `F401` unused import, 6 `E402` import not at top, 1 `F402`, 1 `E721`.

## What this does

```toml
[tool.ruff.lint.per-file-ignores]
"examples/**" = ["E402", "E721", "E722", "F401", "F402"]
"tests/**" = ["E402", "E721", "E722", "F401", "F402"]
"scripts/**" = ["F401"]
```

I offered two ways to finish this in #1814: fix all 25, or scope them out. This is the second, because the findings are mostly correct-as-written for the files they are in. An availability probe imports a package precisely to see whether it is installed, which is `F401`. A demo calls `load_dotenv()` before importing, which is `E402`. A teaching example catches everything so it can print a friendly message instead of a traceback, which is `E722`. Rewriting 20 example files to satisfy rules aimed at library code is churn that does not make the library safer.

If you would rather have the real fixes, say so and I will send that version instead. It is a bigger diff, about 20 files, and it does change behaviour in the `E722` cases.

## Verified with the versions CI pins

Everything below is `ruff==0.2.1`, matching `lint.yml:25`, not my local ruff.

```
ruff check .        ->  exit 0, no output
ruff check swarms/  ->  exit 0, no output
```

The library is still fully enforced. Dropping a probe file into `swarms/` proves the ignores do not leak:

```
swarms/_tmp_probe.py:1:8: F401 [*] `os` imported but unused
swarms/_tmp_probe.py:4:1: E722 Do not use bare `except`
Found 2 errors.
```

The identical file under `examples/` reports nothing, which is the intent.

`black --check` is unchanged by this PR: still the one pre-existing file that #1814 fixes. So the ordering is #1814 then this, and the `Lint` job goes green.

I use Claude Code to help me work through these and I check against the pinned tool versions rather than my local ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
