### PR TITLE
[Bug] planning_enabled permanently strips the director's SwarmSpec schema

### DIFF
--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -762,7 +762,6 @@ class HierarchicalSwarm:
         """
         try:
             if self.planning_enabled is True:
-                self.director.tools_list_dictionary = None
                 out = self.setup_director_with_planning(
                     task=f"History: {self.conversation.get_str()} \n\n Task: {task}",
                     img=img,
@@ -2000,7 +1999,6 @@ class HierarchicalSwarm:
             # Optional planning sub-step (non-streaming — creates a
             # throwaway agent with modified tools)
             if self.planning_enabled:
-                self.director.tools_list_dictionary = None
                 plan_out = await asyncio.to_thread(
                     self.setup_director_with_planning,
                     task=director_task_str,

--- a/tests/structs/test_hierarchical_swarm.py
+++ b/tests/structs/test_hierarchical_swarm.py
@@ -1056,5 +1056,41 @@ def test_reassignment_targets_nested_swarm_worker_by_name():
     assert "[RECOVERY NOTICE]" not in swarm.conversation.get_str()
 
 
+def test_planning_keeps_the_director_tool_schema(monkeypatch):
+    """The planning sub-step must not disarm the real director.
+
+    setup_director_with_planning builds its own throwaway agent, so
+    clearing the director's tools_list_dictionary bought nothing and
+    cost the SwarmSpec schema the very next call depends on.
+    """
+    schema = [{"type": "function", "function": {"name": "SwarmSpec"}}]
+    director = StubAgent(
+        "Director",
+        [
+            {
+                "plan": "Hand the task to the worker.",
+                "orders": [
+                    {"agent_name": "Worker", "task": "do the thing"}
+                ],
+            }
+        ],
+    )
+    director.tools_list_dictionary = schema
+
+    swarm = make_recovery_swarm(
+        director, [StubAgent("Worker", ["done"])]
+    )
+    swarm.planning_enabled = True
+    monkeypatch.setattr(
+        swarm,
+        "setup_director_with_planning",
+        lambda task, img=None: "a plan",
+    )
+
+    swarm.run_director(task="ship it")
+
+    assert director.tools_list_dictionary == schema
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/structs/test_hierarchical_swarm.py
+++ b/tests/structs/test_hierarchical_swarm.py
@@ -1056,41 +1056,5 @@ def test_reassignment_targets_nested_swarm_worker_by_name():
     assert "[RECOVERY NOTICE]" not in swarm.conversation.get_str()
 
 
-def test_planning_keeps_the_director_tool_schema(monkeypatch):
-    """The planning sub-step must not disarm the real director.
-
-    setup_director_with_planning builds its own throwaway agent, so
-    clearing the director's tools_list_dictionary bought nothing and
-    cost the SwarmSpec schema the very next call depends on.
-    """
-    schema = [{"type": "function", "function": {"name": "SwarmSpec"}}]
-    director = StubAgent(
-        "Director",
-        [
-            {
-                "plan": "Hand the task to the worker.",
-                "orders": [
-                    {"agent_name": "Worker", "task": "do the thing"}
-                ],
-            }
-        ],
-    )
-    director.tools_list_dictionary = schema
-
-    swarm = make_recovery_swarm(
-        director, [StubAgent("Worker", ["done"])]
-    )
-    swarm.planning_enabled = True
-    monkeypatch.setattr(
-        swarm,
-        "setup_director_with_planning",
-        lambda task, img=None: "a plan",
-    )
-
-    swarm.run_director(task="ship it")
-
-    assert director.tools_list_dictionary == schema
-
-
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
### What

`HierarchicalSwarm.run_director` and the async streaming loop both clear the director's tool schema before the planning sub-step:

```python
if self.planning_enabled is True:
    self.director.tools_list_dictionary = None   # hiearchical_swarm.py:765
    out = self.setup_director_with_planning(...)
```

The same line appears again in the async path at `hiearchical_swarm.py:2003`.

### Why it's wrong

That assignment cannot achieve what it looks like it's for. `setup_director_with_planning` doesn't use `self.director` at all — it constructs its own throwaway `Agent`, and it already filters `base_model` and `tools_list_dictionary` out of the settings it forwards:

```python
settings.update({
    key: value
    for key, value in self.director_settings.items()
    if key not in {"base_model", "tools_list_dictionary", "planning_system_prompt"}
})
```

So planning has always run schema-free on its own. Nulling the field reaches only the *real* director — the object the swarm needs structured `SwarmSpec` output from on the very next call at line 775, and the object the caller owns when a director is passed in as `HierarchicalSwarm(director=Agent(...))`.

The mutation is permanent and unconditional. `Agent` gates its structured-output handling on that same attribute (`if exists(self.tools_list_dictionary)` in `agent.py:1503`, which is what converts a `SwarmSpec` `BaseModel` response into the dict `parse_orders` walks), and any later `llm_handling()` rebuild would drop the schema from the client outright. With `max_loops > 1` every loop after the first runs against a director that has been quietly disarmed.

### Change

Delete both assignments. No replacement needed — the behaviour they appear to set up is already provided by the separate planning agent.

### Test

`test_planning_keeps_the_director_tool_schema` in `tests/structs/test_hierarchical_swarm.py` runs `run_director` with `planning_enabled=True` and asserts the director's schema survives. It fails on master and passes with this change:

```
$ pytest tests/structs/test_hierarchical_swarm.py -k planning_keeps
# before: 1 failed  —  where None = StubAgent.tools_list_dictionary
# after:  1 passed
```

Existing hierarchical tests still pass. `black --line-length 70` and the changed-file `ruff` findings are clean.

---

**Update — test file dropped.** This is a small change to one function, so it ships without a test per the repo's preference for keeping diffs to the fix itself. The verification described above was run directly (reproduction before, same reproduction after); nothing about the fix or the evidence changed, only the absence of a committed test file.
