### PR TITLE
[Test] Cover the dashboard path's on_error policy (follow-up to #1889)

### DIFF
--- a/tests/structs/test_concurrent_workflow.py
+++ b/tests/structs/test_concurrent_workflow.py
@@ -490,5 +490,53 @@ def test_concurrent_workflow_autosave_saves_conversation_after_run(
     get_workspace_dir.cache_clear()
 
 
+class _ExplodingAgent:
+    """Minimal agent stand-in whose run() always raises."""
+
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+        self.print_on = True
+
+    def run(self, *args, **kwargs):
+        raise RuntimeError("agent exploded")
+
+
+def test_dashboard_path_honors_on_error_raise(monkeypatch):
+    """show_dashboard must not downgrade on_error='raise'.
+
+    The dashboard path used to swallow every agent exception, so the
+    documented "propagates the exception and aborts the run" policy
+    only held while the dashboard was switched off.
+    """
+    workflow = ConcurrentWorkflow(
+        name="On-Error-Raise-Dashboard",
+        agents=[_ExplodingAgent("Boom")],
+        show_dashboard=True,
+        on_error="raise",
+    )
+    monkeypatch.setattr(
+        workflow, "display_agent_dashboard", lambda *a, **k: None
+    )
+
+    with pytest.raises(RuntimeError, match="agent exploded"):
+        workflow.run("anything")
+
+
+def test_dashboard_path_stores_errors_by_default(monkeypatch):
+    """on_error='store' still lets the run finish and records the error."""
+    workflow = ConcurrentWorkflow(
+        name="On-Error-Store-Dashboard",
+        agents=[_ExplodingAgent("Boom")],
+        show_dashboard=True,
+    )
+    monkeypatch.setattr(
+        workflow, "display_agent_dashboard", lambda *a, **k: None
+    )
+
+    workflow.run("anything")
+
+    assert "agent exploded" in workflow.conversation.get_str()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Reduced to tests only — you merged the fix itself as #1889, so this no longer touches `swarms/structs/concurrent_workflow.py`.

Rebased onto master and dropped the code hunk; what is left is the regression coverage for the bug that just landed a fix. Master currently has no test asserting either half of the dashboard path's error policy, and this is a bug that already occurred twice (the non-dashboard path had the policy, the dashboard path silently did not), so it is worth pinning.

Two cases, both against a stand-in agent whose `run()` raises — no LLM call, no network:

- `test_dashboard_path_honors_on_error_raise` — `show_dashboard=True, on_error="raise"` must propagate.
- `test_dashboard_path_stores_errors_by_default` — the default still finishes the run and records the failure in the conversation.

Verified they actually bite: with #1889's `if self.on_error == "raise": raise` removed from the dashboard branch, the first test fails and the second still passes.

```
with the fix:      2 passed
fix reverted:      1 failed, 1 passed
```

Conflict-free against master.