### PR TITLE
[Bug] SequentialWorkflow.run accepts imgs and then drops it

### DIFF
--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -2,7 +2,7 @@ import ast
 import json
 import os
 from concurrent.futures import as_completed
-from typing import Callable, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from loguru import logger as loguru_logger
 from swarms.prompts.multi_agent_collab_prompt import (
@@ -326,7 +326,9 @@ class SequentialWorkflow:
         """
         try:
             # prompt = f"{MULTI_AGENT_COLLAB_PROMPT}\n\n{task}"
-            run_kwargs = {"task": task}
+            # Annotated because imgs is a list: without it the dict is
+            # inferred as Dict[str, str] from the task entry alone.
+            run_kwargs: Dict[str, Any] = {"task": task}
             if img is not None:
                 run_kwargs["img"] = img
             if imgs is not None:

--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -329,6 +329,8 @@ class SequentialWorkflow:
             run_kwargs = {"task": task}
             if img is not None:
                 run_kwargs["img"] = img
+            if imgs is not None:
+                run_kwargs["imgs"] = imgs
             result = self.agent_rearrange.run(**run_kwargs)
 
             # Run drift detection if configured

--- a/tests/structs/test_sequential_workflow.py
+++ b/tests/structs/test_sequential_workflow.py
@@ -612,3 +612,30 @@ def test_workflow_drift_max_retries_zero_never_reruns():
 def test_negative_drift_max_retries_is_rejected():
     with pytest.raises(ValueError, match="drift_max_retries"):
         _make_workflow(drift_detection=True, drift_max_retries=-1)
+
+
+def test_run_forwards_imgs_to_the_pipeline():
+    """run(imgs=[...]) must reach the agents, not be dropped.
+
+    imgs is an accepted, documented parameter, but it was never put
+    into the kwargs handed to AgentRearrange, so multi-image runs
+    silently became text-only runs.
+    """
+    wf = _make_workflow()
+    with patch.object(
+        wf.agent_rearrange, "run", return_value="out"
+    ) as pipeline:
+        wf.run("describe these", imgs=["a.png", "b.png"])
+
+    assert pipeline.call_args.kwargs["imgs"] == ["a.png", "b.png"]
+
+
+def test_run_omits_imgs_when_not_supplied():
+    """No imgs key when the caller didn't pass one."""
+    wf = _make_workflow()
+    with patch.object(
+        wf.agent_rearrange, "run", return_value="out"
+    ) as pipeline:
+        wf.run("plain task")
+
+    assert "imgs" not in pipeline.call_args.kwargs


### PR DESCRIPTION
### What

`SequentialWorkflow.run` takes `imgs` and documents it:

> `imgs (Optional[List[str]], optional)`: Optional list of images for the agents.

but never forwards it:

```python
run_kwargs = {"task": task}
if img is not None:
    run_kwargs["img"] = img
result = self.agent_rearrange.run(**run_kwargs)
```

Only `task` and `img` reach the pipeline. `imgs` is bound and discarded.

### Why it matters

The failure is silent. `run(task, imgs=[...])` is accepted, returns normally, and produces a plausible answer — the agents simply never saw the images. There is no error and no warning to indicate the run degraded to text-only, so the caller has no signal that anything went wrong. Single-image `img` works, which makes the multi-image case look supported.

### Change

Forward `imgs` the same way `img` is forwarded. `AgentRearrange.run` passes `**kwargs` through `_run` to `_run_sequential_workflow`, which calls `agent.run(task=..., img=img, *args, **kwargs)`, and `Agent.run` has an `imgs` parameter — so the value lands where it should without any further plumbing.

Keeping the `is not None` guard means no `imgs` key is added when the caller didn't pass one, so nothing changes for existing callers. The reconstructed `run_kwargs` is also what `_run_drift_detection` reuses for pipeline reruns, so drift retries now carry the images too.

### Tests

In `tests/structs/test_sequential_workflow.py`:

- `test_run_forwards_imgs_to_the_pipeline` — asserts `imgs` reaches `AgentRearrange.run`. Fails on master with `KeyError: 'imgs'`, passes with this change.
- `test_run_omits_imgs_when_not_supplied` — pins that no `imgs` key appears when the caller omits it.

```
# before: 1 failed, 1 passed
# after:  2 passed
```