### PR TITLE
[Improvement] Autonomous loop: load tool schemas on demand via a search_tools meta-tool

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -213,10 +213,8 @@ class AutonomousAgentLoop:
 
             self._say_user(task)
 
-            # Add planning tools to tools_list_dictionary.
-            # "lazy" ships a small always-on core plus the search_tools
-            # meta-tool; the rest are fetched on demand, which keeps the
-            # resident schema block from being re-sent on every iteration.
+            # "lazy" ships a small core plus search_tools; the rest are
+            # fetched on demand, so the resident block stays flat.
             if self.agent.selected_tools == "lazy":
                 planning_tools = get_lazy_autonomous_tools()
                 logger.info(
@@ -364,9 +362,7 @@ class AutonomousAgentLoop:
                 )
             )
 
-            # Filter tool handlers if selected_tools is not "all".
-            # "lazy" keeps every handler: the model can load any schema at
-            # run time, so the handler has to be there when it does.
+            # "lazy" keeps every handler: any schema can be loaded at run time.
             if (
                 self.agent.selected_tools != "all"
                 and self.agent.selected_tools != "lazy"

--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -39,12 +39,14 @@ from swarms.structs.autonomous_loop_utils import (
     delete_file_tool,
     get_autonomous_planning_tools,
     get_execution_prompt,
+    get_lazy_autonomous_tools,
     get_planning_prompt,
     grep_tool,
     list_directory_tool,
     read_file_tool,
     respond_to_user_tool,
     run_bash_tool,
+    search_tools_tool,
     update_file_tool,
 )
 from swarms.tools.handoffs_tool_schema import get_handoff_tool_schema
@@ -211,12 +213,24 @@ class AutonomousAgentLoop:
 
             self._say_user(task)
 
-            # Add planning tools to tools_list_dictionary
-            planning_tools = get_autonomous_planning_tools()
+            # Add planning tools to tools_list_dictionary.
+            # "lazy" ships a small always-on core plus the search_tools
+            # meta-tool; the rest are fetched on demand, which keeps the
+            # resident schema block from being re-sent on every iteration.
+            if self.agent.selected_tools == "lazy":
+                planning_tools = get_lazy_autonomous_tools()
+                logger.info(
+                    f"Autonomous looper using lazy tool loading: "
+                    f"{len(planning_tools)} core tools, the rest available "
+                    f"via search_tools"
+                )
+            else:
+                planning_tools = get_autonomous_planning_tools()
 
             # Filter planning tools if selected_tools is not "all"
             if (
                 self.agent.selected_tools != "all"
+                and self.agent.selected_tools != "lazy"
                 and self.agent.selected_tools is not None
             ):
                 logger.info(
@@ -344,9 +358,18 @@ class AutonomousAgentLoop:
                 ),
             }
 
-            # Filter tool handlers if selected_tools is not "all"
+            all_planning_tool_handlers["search_tools"] = (
+                lambda **kwargs: search_tools_tool(
+                    self.agent, **kwargs
+                )
+            )
+
+            # Filter tool handlers if selected_tools is not "all".
+            # "lazy" keeps every handler: the model can load any schema at
+            # run time, so the handler has to be there when it does.
             if (
                 self.agent.selected_tools != "all"
+                and self.agent.selected_tools != "lazy"
                 and self.agent.selected_tools is not None
             ):
                 planning_tool_handlers = {

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -594,10 +594,8 @@ def get_autonomous_planning_tools() -> List[Dict[str, Any]]:
     ]
 
 
-# The always-resident set under selected_tools="lazy". Everything the loop
-# structurally depends on (planning, subtask bookkeeping, termination, and the
-# user-facing reply), plus the meta-tool used to fetch the rest. Keeping this
-# small is the point: the resident schema cost stays flat as tools are added.
+# Always resident under selected_tools="lazy": what the loop structurally
+# depends on, plus the meta-tool that fetches the rest.
 LAZY_CORE_TOOL_NAMES = (
     "create_plan",
     "subtask_done",
@@ -769,9 +767,7 @@ def search_tools_tool(agent: Any, query: str = "", **kwargs) -> str:
         agent.tools_list_dictionary = []
     agent.tools_list_dictionary.extend(matches)
 
-    # Rebuild so the newly added schemas reach the provider. Without this the
-    # client keeps the tool list it was constructed with and the model would
-    # be told about tools it cannot actually call.
+    # Rebuild, or the client keeps the tool list it was constructed with.
     try:
         agent.llm = agent.llm_handling()
     except Exception as e:

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -30,7 +30,7 @@ import os
 import re as _re
 import subprocess
 import uuid
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
@@ -594,6 +594,124 @@ def get_autonomous_planning_tools() -> List[Dict[str, Any]]:
     ]
 
 
+# The always-resident set under selected_tools="lazy". Everything the loop
+# structurally depends on (planning, subtask bookkeeping, termination, and the
+# user-facing reply), plus the meta-tool used to fetch the rest. Keeping this
+# small is the point: the resident schema cost stays flat as tools are added.
+LAZY_CORE_TOOL_NAMES = (
+    "create_plan",
+    "subtask_done",
+    "complete_task",
+    "respond_to_user",
+    "search_tools",
+)
+
+
+def get_search_tools_schema() -> Dict[str, Any]:
+    """
+    Schema for the ``search_tools`` meta-tool.
+
+    Returns:
+        Dict[str, Any]: An OpenAI function-calling definition.
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": "search_tools",
+            "description": (
+                "Look up additional tools you can use. Only a small core set "
+                "is loaded up front; call this with a short description of "
+                "what you need (for example 'read a file', 'run a shell "
+                "command', 'delegate to a sub agent') to load the matching "
+                "tools, after which you can call them directly."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": (
+                            "What you are trying to do, or a tool name."
+                        ),
+                    }
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def search_autonomous_tools(
+    query: str, exclude: Optional[List[str]] = None
+) -> List[Dict[str, Any]]:
+    """
+    Find built-in tool schemas matching a free-text query.
+
+    Scores each non-core tool on whether the query's words appear in its name
+    or description, so "read a file" surfaces read_file and list_directory
+    without needing the caller to know the exact names.
+
+    Args:
+        query (str): Free-text description of the capability wanted.
+        exclude (Optional[List[str]]): Tool names already loaded.
+
+    Returns:
+        List[Dict[str, Any]]: Matching schemas, best match first. An empty
+        query returns every unloaded tool; a query that matches nothing
+        returns an empty list, so a repeated search cannot quietly load the
+        whole catalogue and undo the saving. The caller surfaces the
+        available names instead, which costs a few tokens rather than a few
+        hundred.
+    """
+    exclude_set = set(exclude or ()) | set(LAZY_CORE_TOOL_NAMES)
+    candidates = [
+        t
+        for t in get_autonomous_planning_tools()
+        if t.get("function", {}).get("name") not in exclude_set
+    ]
+
+    words = [
+        w
+        for w in _re.findall(r"[a-z0-9]+", query.lower())
+        if len(w) > 2
+    ]
+    if not words:
+        return candidates
+
+    scored = []
+    for tool in candidates:
+        fn = tool.get("function", {})
+        name = fn.get("name", "").lower()
+        haystack = f"{name} {fn.get('description', '').lower()}"
+        score = sum(
+            (3 if w in name else 0) + (1 if w in haystack else 0)
+            for w in words
+        )
+        if score:
+            scored.append((score, name, tool))
+
+    if not scored:
+        return []
+
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return [tool for _, _, tool in scored]
+
+
+def get_lazy_autonomous_tools() -> List[Dict[str, Any]]:
+    """
+    The core tool set for ``selected_tools="lazy"``.
+
+    Returns:
+        List[Dict[str, Any]]: Core schemas plus the ``search_tools`` meta-tool.
+    """
+    core = [
+        t
+        for t in get_autonomous_planning_tools()
+        if t.get("function", {}).get("name") in LAZY_CORE_TOOL_NAMES
+    ]
+    return core + [get_search_tools_schema()]
+
+
 def get_autonomous_loop_tool_names() -> List[str]:
     """
     Return a list of all autonomous loop tool names.
@@ -611,6 +729,61 @@ def get_autonomous_loop_tool_names() -> List[str]:
 # ============================================================================
 # TOOL HANDLERS
 # ============================================================================
+
+
+def search_tools_tool(agent: Any, query: str = "", **kwargs) -> str:
+    """
+    Handler for the ``search_tools`` meta-tool: load matching schemas on demand.
+
+    Appends the matched definitions to the agent's ``tools_list_dictionary``
+    and rebuilds the LLM client, so the tools are callable from the next
+    iteration onward. Already-loaded tools are excluded, so repeated searches
+    do not duplicate schemas.
+
+    Args:
+        agent (Any): The agent making the call.
+        query (str): What the agent is trying to do.
+
+    Returns:
+        str: A human-readable summary of what was loaded.
+    """
+    loaded = [
+        t.get("function", {}).get("name")
+        for t in (agent.tools_list_dictionary or [])
+    ]
+    matches = search_autonomous_tools(query, exclude=loaded)
+    if not matches:
+        remaining = [
+            t.get("function", {}).get("name")
+            for t in get_autonomous_planning_tools()
+            if t.get("function", {}).get("name") not in loaded
+        ]
+        if not remaining:
+            return "Every available tool is already loaded."
+        return (
+            f"No tool matched '{query}'. Still available, by name: "
+            f"{', '.join(remaining)}. Search again using one of these names."
+        )
+
+    if agent.tools_list_dictionary is None:
+        agent.tools_list_dictionary = []
+    agent.tools_list_dictionary.extend(matches)
+
+    # Rebuild so the newly added schemas reach the provider. Without this the
+    # client keeps the tool list it was constructed with and the model would
+    # be told about tools it cannot actually call.
+    try:
+        agent.llm = agent.llm_handling()
+    except Exception as e:
+        logger.error(
+            f"search_tools could not rebuild the LLM client: {e}"
+        )
+
+    names = [t.get("function", {}).get("name") for t in matches]
+    return (
+        f"Loaded {len(names)} tool(s) for '{query}': {', '.join(names)}. "
+        f"You can now call them directly."
+    )
 
 
 def respond_to_user_tool(

--- a/tests/structs/test_async_subagent.py
+++ b/tests/structs/test_async_subagent.py
@@ -22,7 +22,6 @@ from swarms.structs.autonomous_loop_utils import (
     cancel_sub_agent_tasks_tool,
 )
 
-
 load_dotenv()
 
 MODEL = "gpt-5.4"
@@ -1282,3 +1281,132 @@ if __name__ == "__main__":
         f"RESULTS: {passed} passed, {failed} failed out of {len(tests)}"
     )
     print("=" * 60)
+
+
+# ============================================================================
+# Lazy autonomous tool loading (#1753)
+# ============================================================================
+
+
+class _ToolAgentStub:
+    """Minimal stand-in exposing what search_tools_tool touches."""
+
+    def __init__(self, tools):
+        self.tools_list_dictionary = list(tools)
+        self.rebuilds = 0
+
+    def llm_handling(self):
+        self.rebuilds += 1
+        return "llm"
+
+    def names(self):
+        return [
+            t.get("function", {}).get("name")
+            for t in self.tools_list_dictionary
+        ]
+
+
+def test_lazy_core_is_a_strict_subset_and_much_smaller():
+    import json
+
+    from swarms.structs.autonomous_loop_utils import (
+        LAZY_CORE_TOOL_NAMES,
+        get_autonomous_planning_tools,
+        get_lazy_autonomous_tools,
+    )
+
+    full = get_autonomous_planning_tools()
+    lazy = get_lazy_autonomous_tools()
+
+    lazy_names = {t["function"]["name"] for t in lazy}
+    assert lazy_names == set(LAZY_CORE_TOOL_NAMES)
+    assert len(lazy) < len(full)
+
+    full_size = len(json.dumps(full))
+    lazy_size = len(json.dumps(lazy))
+    # The whole point is a large reduction, not a marginal one.
+    assert lazy_size < full_size * 0.5
+
+
+def test_search_matches_by_intent_not_just_exact_name():
+    from swarms.structs.autonomous_loop_utils import (
+        search_autonomous_tools,
+    )
+
+    assert (
+        search_autonomous_tools("run a shell command")[0]["function"][
+            "name"
+        ]
+        == "run_bash"
+    )
+    assert (
+        search_autonomous_tools("read a file")[0]["function"]["name"]
+        == "read_file"
+    )
+    assert (
+        search_autonomous_tools("search text in files")[0][
+            "function"
+        ]["name"]
+        == "grep"
+    )
+
+
+def test_search_never_returns_core_tools():
+    from swarms.structs.autonomous_loop_utils import (
+        LAZY_CORE_TOOL_NAMES,
+        search_autonomous_tools,
+    )
+
+    for tool in search_autonomous_tools(""):
+        assert tool["function"]["name"] not in LAZY_CORE_TOOL_NAMES
+
+
+def test_search_tools_loads_schemas_and_rebuilds_the_client():
+    from swarms.structs.autonomous_loop_utils import (
+        get_lazy_autonomous_tools,
+        search_tools_tool,
+    )
+
+    agent = _ToolAgentStub(get_lazy_autonomous_tools())
+    before = len(agent.tools_list_dictionary)
+
+    message = search_tools_tool(agent, query="run a shell command")
+
+    assert "run_bash" in agent.names()
+    assert len(agent.tools_list_dictionary) > before
+    # Without the rebuild the model is told about tools it cannot call.
+    assert agent.rebuilds == 1
+    assert "run_bash" in message
+
+
+def test_repeating_a_search_does_not_reload_or_dump_the_catalogue():
+    from swarms.structs.autonomous_loop_utils import (
+        get_lazy_autonomous_tools,
+        search_tools_tool,
+    )
+
+    agent = _ToolAgentStub(get_lazy_autonomous_tools())
+    search_tools_tool(agent, query="run a shell command")
+    count = len(agent.tools_list_dictionary)
+
+    message = search_tools_tool(agent, query="run a shell command")
+
+    assert len(agent.tools_list_dictionary) == count
+    assert "No tool matched" in message
+    # The fallback lists names, which is cheap, rather than loading schemas.
+    assert "think" in message
+
+
+def test_unmatched_query_reports_remaining_names():
+    from swarms.structs.autonomous_loop_utils import (
+        get_lazy_autonomous_tools,
+        search_tools_tool,
+    )
+
+    agent = _ToolAgentStub(get_lazy_autonomous_tools())
+    message = search_tools_tool(agent, query="zzzz nonexistent")
+
+    assert "No tool matched" in message
+    assert len(agent.tools_list_dictionary) == len(
+        get_lazy_autonomous_tools()
+    )

--- a/tests/structs/test_async_subagent.py
+++ b/tests/structs/test_async_subagent.py
@@ -1283,11 +1283,6 @@ if __name__ == "__main__":
     print("=" * 60)
 
 
-# ============================================================================
-# Lazy autonomous tool loading (#1753)
-# ============================================================================
-
-
 class _ToolAgentStub:
     """Minimal stand-in exposing what search_tools_tool touches."""
 
@@ -1324,7 +1319,6 @@ def test_lazy_core_is_a_strict_subset_and_much_smaller():
 
     full_size = len(json.dumps(full))
     lazy_size = len(json.dumps(lazy))
-    # The whole point is a large reduction, not a marginal one.
     assert lazy_size < full_size * 0.5
 
 
@@ -1393,7 +1387,6 @@ def test_repeating_a_search_does_not_reload_or_dump_the_catalogue():
 
     assert len(agent.tools_list_dictionary) == count
     assert "No tool matched" in message
-    # The fallback lists names, which is cheap, rather than loading schemas.
     assert "think" in message
 
 


### PR DESCRIPTION
Fixes #1753

### Measurement

Reproducing the issue's numbers on current master, and after this change:

```
full: 16 tools ~2319 tok | lazy: 5 tools ~712 tok | saved ~1607 tok (69%)
```

The resident block also stops growing with the catalogue — adding a 17th built-in tool no longer costs anything on every call.

### What

`selected_tools="lazy"` ships a five-tool core and lets the agent fetch the rest by intent:

| resident | `create_plan`, `subtask_done`, `complete_task`, `respond_to_user`, `search_tools` |
| --- | --- |
| on demand | the other 11, loaded when `search_tools` matches them |

```python
agent = Agent(model_name="gpt-5.4", max_loops="auto", selected_tools="lazy")
```

The core is exactly what the loop structurally depends on: planning, subtask bookkeeping, termination, the user-facing reply, and the meta-tool to reach everything else.

### Why not the existing `selected_tools` filter

Filtering already existed, but it requires the caller to name the tools up front — which, as the issue puts it, defeats the purpose, since the point is that the *agent* decides what it needs. `search_tools` scores query words against each tool's name and description, so intent works without knowing names:

```
"run a shell command"     -> run_bash, grep
"read a file"             -> read_file, create_file, delete_file
"search text in files"    -> grep, list_directory
"delegate to a sub agent" -> create_sub_agent, assign_task, check_sub_agent_status
```

On a match the handler appends the schemas to `tools_list_dictionary` **and rebuilds the LLM client**. Without that rebuild the client keeps the tool list it was constructed with, and the model would be told about tools it cannot actually call — the same class of bug as #1820.

### The design decision worth reviewing

A query matching nothing returns the remaining tool **names**, not the remaining schemas:

```
No tool matched 'zzzz'. Still available, by name: think, create_file, update_file, …
Search again using one of these names.
```

My first version returned everything on a miss, as a safety valve so the model was never stuck. That's wrong: a second identical search loaded the whole catalogue and silently undid the entire saving (there's a test pinning this now). Names cost a handful of tokens and still give the model a way forward, since a name matches strongly on the next search.

### Compatibility

`selected_tools` still defaults to `"all"`, so nothing changes unless you opt in. The `"lazy"` value is handled before the existing list-membership filter — worth noting, because `"lazy"` is a string and `tool_name in "lazy"` would have done substring matching against it. Handlers are never filtered under `"lazy"`, since the model can load any schema at run time and the handler has to be present when it does.

### Tests

Six cases appended to `tests/structs/test_async_subagent.py`. Not a new file — that's the only existing test module that imports `autonomous_loop_utils`, so it's the de-facto owner. They use a stub agent, so no API key and no network:

lazy core is a strict subset and under half the size · search matches by intent for three different phrasings · search never returns core tools · loading appends schemas and rebuilds the client exactly once · a repeated search neither reloads nor dumps the catalogue · an unmatched query reports remaining names.

```
13 failed, 40 passed      (master baseline: 13 failed, 34 passed)
```

The 13 failures are pre-existing on an unmodified master — that module has live tests needing credentials. All 6 new tests pass; no test that passed before fails now.

Three files touched, `black --line-length 70` clean.