### PR TITLE
[Bug] Prevent empty non-interactive tasks from reading stdin

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -4030,15 +4030,15 @@ Subtask Breakdown:
             >>> agent.run("Describe this image", img=img_base64)
         """
 
-        # # If interactive mode is enabled and no task is provided, prompt the user
-        # if self.interactive and (
-        #     task is None
-        #     or (isinstance(task, str) and task.strip() == "")
-        if (
-            task is None
-            or isinstance(task, str)
-            and task.strip() == ""
-        ):
+        empty_task = task is None or (
+            isinstance(task, str) and task.strip() == ""
+        )
+        if empty_task and not self.interactive:
+            raise ValueError(
+                "A non-empty task is required when interactive mode is disabled."
+            )
+
+        if self.interactive and empty_task:
             # Always show prompt when asking for initial task, even if print_on is False
             self.pretty_print(
                 "Interactive mode enabled. Please enter your initial task:",

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -136,6 +136,19 @@ class TestBasicAgent:
         response = flow_with_condition.run("Stop")
         assert response is not None
 
+    @pytest.mark.parametrize("task", [None, "", "   "])
+    def test_noninteractive_empty_task_does_not_read_stdin(
+        self, test_agent, task
+    ):
+        with (
+            patch(
+                "swarms.structs.agent.formatter.console.input",
+                side_effect=AssertionError("stdin must not be read"),
+            ),
+            pytest.raises(ValueError, match="non-empty task"),
+        ):
+            test_agent.run(task)
+
     def test_bulk_run(self, basic_flow):
         """Test bulk run functionality"""
         inputs = [{"task": "Test1"}, {"task": "Test2"}]


### PR DESCRIPTION
Thank you for contributing to Swarms!

- Description: Prevent non-interactive agents from reading stdin when `run()` receives `None`, an empty string, or whitespace. Such calls now raise a clear `ValueError`; interactive agents retain their prompt behavior. Adds focused regression coverage that fails if stdin is accessed.
- Issue: Fixes #1852
- Dependencies: None
- Tag maintainer: @kyegomez
- Twitter handle: N/A

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc:
https://github.com/kyegomez/swarms/blob/master/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.


Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: kye@swarms.world
  - DataLoaders / VectorStores / Retrievers: kye@swarms.world
  - swarms.models: kye@swarms.world
  - swarms.memory: kye@swarms.world
  - swarms.structures: kye@swarms.world

If no one reviews your PR within a few days, feel free to email Kye at kye@swarms.world

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/kyegomez/swarms

Validation performed:
- `.venv/bin/python -m pytest tests/structs/test_agent.py::TestBasicAgent::test_noninteractive_empty_task_does_not_read_stdin -q` — 3 passed
- `.venv/bin/black . --check --diff` — 955 files unchanged
- `.venv/bin/ruff check .` — passed
