### PR TITLE
[Cleanup] formatter.py: remove 3 dead print methods, collapse log-strip regexes

### DIFF
--- a/swarms/utils/formatter.py
+++ b/swarms/utils/formatter.py
@@ -1,15 +1,9 @@
-import time
 import re
 from typing import Any, Callable, Dict, List, Optional
 
 from rich.console import Console, Group
 from rich.live import Live
 from rich.panel import Panel
-from rich.progress import (
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-)
 from rich.table import Table
 from rich.text import Text
 from rich.spinner import Spinner
@@ -43,24 +37,12 @@ class MarkdownOutputHandler:
         if not output:
             return ""
 
-        # Remove log prefixes and timestamps
+        # Remove log prefixes and timestamps. The alternation covers every
+        # loguru level (not just the four originally hardcoded here), so a
+        # level like SUCCESS or TRACE is stripped the same as INFO/DEBUG.
         output = re.sub(
-            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| INFO.*?\|.*?\|",
-            "",
-            output,
-        )
-        output = re.sub(
-            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| DEBUG.*?\|.*?\|",
-            "",
-            output,
-        )
-        output = re.sub(
-            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| WARNING.*?\|.*?\|",
-            "",
-            output,
-        )
-        output = re.sub(
-            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| ERROR.*?\|.*?\|",
+            r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| "
+            r"(?:INFO|DEBUG|WARNING|ERROR|SUCCESS|TRACE|CRITICAL).*?\|.*?\|",
             "",
             output,
         )
@@ -73,11 +55,12 @@ class MarkdownOutputHandler:
         )
         output = re.sub(rf"{spinner_chars} Loop \d+/\d+", "", output)
 
-        # Remove any remaining log messages
-        output = re.sub(r"INFO.*?\|.*?\|.*?\|", "", output)
-        output = re.sub(r"DEBUG.*?\|.*?\|.*?\|", "", output)
-        output = re.sub(r"WARNING.*?\|.*?\|.*?\|", "", output)
-        output = re.sub(r"ERROR.*?\|.*?\|.*?\|", "", output)
+        # Remove any remaining log messages (same level alternation as above).
+        output = re.sub(
+            r"(?:INFO|DEBUG|WARNING|ERROR|SUCCESS|TRACE|CRITICAL).*?\|.*?\|.*?\|",
+            "",
+            output,
+        )
 
         # Clean up extra whitespace and empty lines
         output = re.sub(r"\n\s*\n\s*\n", "\n\n", output)
@@ -459,20 +442,13 @@ class Formatter:
         title: str = "",
         border_style: str = "blue",
     ) -> None:
-        """Print content as markdown with syntax highlighting.
+        """Alias for print_panel; kept for backward compatibility.
 
-        Args:
-            content (str): The content to display as markdown
-            title (str): The title of the panel
-            border_style (str): The border style for the panel
+        Historically this rendered markdown independently, but its body was
+        identical to print_panel's markdown branch, so it now just forwards
+        to print_panel instead of duplicating that logic.
         """
-        if self.markdown_handler:
-            self.markdown_handler.render_markdown_output(
-                content, title, border_style
-            )
-        else:
-            # Fallback to regular panel if markdown is disabled
-            self.print_panel(content, title, border_style)
+        self.print_panel(content, title, border_style)
 
     def print_table(
         self, title: str, data: Dict[str, List[str]]
@@ -493,69 +469,6 @@ class Formatter:
 
         self.console.print(f"\n🔥 {title}:", style="bold yellow")
         self.console.print(table)
-
-    def print_progress(
-        self,
-        description: str,
-        task_fn: Callable,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
-        """
-        Prints a progress bar to the console and executes a task function.
-
-        Args:
-            description (str): The description of the task.
-            task_fn (Callable): The function to execute.
-            *args (Any): Arguments to pass to the task function.
-            **kwargs (Any): Keyword arguments to pass to the task function.
-
-        Returns:
-            Any: The result of the task function.
-        """
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-        ) as progress:
-            task = progress.add_task(description, total=None)
-            result = task_fn(*args, **kwargs)
-            progress.update(task, completed=True)
-        return result
-
-    def print_panel_token_by_token(
-        self,
-        tokens: str,
-        title: str = "Output",
-        style: str = "bold cyan",
-        delay: float = 0.01,
-        by_word: bool = False,
-    ) -> None:
-        """
-        Prints a string in real-time, token by token (character or word) inside a Rich panel.
-
-        Args:
-            tokens (str): The string to display in real-time.
-            title (str): Title of the panel.
-            style (str): Style for the panel border.
-            delay (float): Delay in seconds between displaying each token.
-            by_word (bool): If True, display by words; otherwise, display by characters.
-        """
-        text = Text(style=DEFAULT_CONTENT_STYLE)
-
-        # Split tokens into characters or words
-        token_list = tokens.split() if by_word else tokens
-
-        with Live(
-            Panel(text, title=title, border_style=style),
-            console=self.console,
-            refresh_per_second=10,
-        ) as live:
-            for token in token_list:
-                text.append(token + (" " if by_word else ""))
-                live.update(
-                    Panel(text, title=title, border_style=style)
-                )
-                time.sleep(delay)
 
     def print_streaming_panel(
         self,
@@ -754,85 +667,6 @@ class Formatter:
             self._dashboard_live.stop()
             self.console.print()  # Add blank line after stopping
             self._dashboard_live = None
-
-    def print_plan_tree(
-        self,
-        task_description: str,
-        steps: List[Dict[str, Any]],
-        print_on: bool = True,
-    ) -> None:
-        """
-        Print the plan as a beautiful tree using Rich.
-
-        Args:
-            task_description: Description of the main task
-            steps: List of step dictionaries with step_id, description, priority, and optional dependencies
-            print_on: Whether to print to console (True) or just log (False)
-        """
-        import logging
-
-        logger = logging.getLogger(__name__)
-
-        # Create root tree
-        tree = Tree(
-            f"[bold cyan]📋 Plan: {task_description}[/bold cyan]"
-        )
-
-        # Priority color mapping
-        priority_colors = {
-            "critical": "red",
-            "high": "yellow",
-            "medium": "blue",
-            "low": "green",
-        }
-
-        priority_icons = {
-            "critical": "🔴",
-            "high": "🟠",
-            "medium": "🟡",
-            "low": "🟢",
-        }
-
-        # Create a mapping of step_id to tree nodes for dependency handling
-        step_nodes = {}
-
-        # First pass: create all nodes
-        for step in steps:
-            step_id = step.get("step_id", "")
-            description = step.get("description", "")
-            priority = step.get("priority", "medium").lower()
-            dependencies = step.get("dependencies", [])
-
-            priority_color = priority_colors.get(priority, "white")
-            priority_icon = priority_icons.get(priority, "○")
-
-            # Create step label with priority indicator
-            step_label = (
-                f"[{priority_color}]{priority_icon} {step_id}[/{priority_color}]: "
-                f"{description}"
-            )
-
-            # Add dependencies info if present
-            if dependencies:
-                deps_text = ", ".join(dependencies)
-                step_label += f" [dim](depends on: {deps_text})[/dim]"
-
-            # Add node to tree
-            step_node = tree.add(step_label)
-            step_nodes[step_id] = step_node
-
-        # Print the tree
-        if print_on:
-            self.console.print("\n")
-            self.console.print(tree)
-            self.console.print("")
-        else:
-            # Even if print_on is False, log the tree structure
-            logger.info(f"Plan created: {task_description}")
-            for step in steps:
-                logger.info(
-                    f"  - {step.get('step_id')} ({step.get('priority')}): {step.get('description')}"
-                )
 
     def display_hierarchy(
         self,

--- a/tests/utils/test_formatter.py
+++ b/tests/utils/test_formatter.py
@@ -1,4 +1,5 @@
 from swarms.utils.formatter import Formatter
+import pytest
 
 
 def test_formatter():
@@ -186,3 +187,56 @@ def test_director_panel_does_not_parse_markup_in_a_task():
 
 if __name__ == "__main__":
     test_formatter()
+
+
+@pytest.mark.parametrize(
+    "level",
+    [
+        "INFO",
+        "DEBUG",
+        "WARNING",
+        "ERROR",
+        "SUCCESS",
+        "TRACE",
+        "CRITICAL",
+    ],
+)
+def test_clean_output_strips_every_log_level(level):
+    """_clean_output's level alternation must cover every loguru level,
+    not just the four (INFO/DEBUG/WARNING/ERROR) originally hardcoded.
+    SUCCESS in particular is used throughout swarms (e.g. graph_workflow.py)
+    and previously passed through _clean_output untouched."""
+    handler = Formatter(md=True).markdown_handler
+    line = (
+        f"2026-08-09 12:00:00 | {level} | mymodule:myfunc:42 | "
+        "some log line"
+    )
+    content = line + "\nActual content that should survive"
+    cleaned = handler._clean_output(content)
+    assert level not in cleaned
+    assert "Actual content that should survive" in cleaned
+
+
+def test_clean_output_handles_empty_string():
+    handler = Formatter(md=True).markdown_handler
+    assert handler._clean_output("") == ""
+
+
+def test_dead_print_methods_are_removed():
+    """print_progress, print_panel_token_by_token, and print_plan_tree had
+    zero callers anywhere in the codebase and are removed as dead code.
+    """
+    formatter = Formatter(md=True)
+    assert not hasattr(formatter, "print_progress")
+    assert not hasattr(formatter, "print_panel_token_by_token")
+    assert not hasattr(formatter, "print_plan_tree")
+
+
+def test_print_markdown_still_works_as_alias():
+    """print_markdown now forwards to print_panel instead of duplicating
+    its markdown-rendering branch; it must still be callable with the same
+    signature and not raise."""
+    formatter = Formatter(md=True)
+    formatter.print_markdown(
+        "# Title\n\nBody", title="t", border_style="cyan"
+    )


### PR DESCRIPTION
Closes #1838.

## 1. Dead print methods (142 lines)

Removed `print_progress`, `print_panel_token_by_token`, and `print_plan_tree` from `swarms/utils/formatter.py`. Verified 0 callers across `swarms/`, `tests/`, and `examples/` before removing. Also dropped the now-unused `import time` and the `Progress`/`SpinnerColumn`/`TextColumn` imports, which only `print_progress` used.

## 2. `print_markdown` redundant alias

`print_markdown`'s `markdown_handler` branch was byte-identical to `print_panel`'s markdown branch (:434-437 in the original). Its only caller outside this file was `tests/utils/test_formatter.py`. Rather than delete it and touch the test, I kept it as a one-line documented alias forwarding to `print_panel`, so existing/external callers keep working unchanged.

## 3. `_clean_output` — 8 regexes → 2

The two blocks of four near-identical `re.sub` calls (differing only by level name: INFO/DEBUG/WARNING/ERROR) collapse to two regexes using an alternation group, per the issue's suggestion.

While doing this I noticed the hardcoded level list only ever covered 4 of loguru's 7 levels — `swarms` uses `logger.success(...)` throughout (e.g. `graph_workflow.py`), so SUCCESS-level lines were passing through `_clean_output` unstripped, and same for TRACE/CRITICAL. The alternation now includes all 7: `INFO|DEBUG|WARNING|ERROR|SUCCESS|TRACE|CRITICAL`. This is a small behavior improvement bundled with the consolidation, not just a refactor.

I verified byte-identical output vs. the original 8-regex version for every case the original code path already covered (empty string, plain text with no matching pattern, INFO/DEBUG/WARNING/ERROR lines, `"Generated content:"` stripping, whitespace collapsing) — the consolidation changes nothing except adding coverage for the 3 previously-missed levels.

## Testing

Couldn't fully install the project's heavier dependencies (litellm, mcp, opentelemetry) in my sandbox, so I verified two ways:

1. Loaded `swarms/utils/formatter.py` directly via `importlib` (bypassing `swarms/__init__.py`, which only formatter.py's own top-level imports are needed for) and ran the new assertions directly against both the original and modified file to confirm identical behavior on shared cases and correct new behavior on the 3 added levels.
2. Confirmed via git blob SHA-1 that the pushed file content is byte-identical to what was locally verified (no transcription drift).

Added to `tests/utils/test_formatter.py`:
- `test_clean_output_strips_every_log_level` (parametrized over all 7 loguru levels)
- `test_clean_output_handles_empty_string`
- `test_dead_print_methods_are_removed`
- `test_print_markdown_still_works_as_alias`

Also ran `ruff check` and `black --check` against the project's actual configured rules (`pyproject.toml`: `line-length = 70`, CI pins `ruff==0.2.1` with no explicit `[tool.ruff.lint] select`, so only the default `E4,E7,E9,F` rules apply) — both clean on the two changed files. `black --line-length 70` was applied to the new test additions.