### PR TITLE
[Bug] Return all conversation messages except the first

### DIFF
--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -1303,7 +1303,7 @@ class Conversation:
         Returns:
             list: List of messages except the first one.
         """
-        return self.conversation_history[2:]
+        return self.conversation_history[1:]
 
     def return_all_except_first_string(self):
         """Return all messages except the first one as a string.
@@ -1314,7 +1314,7 @@ class Conversation:
         return "\n".join(
             [
                 f"{msg['content']}"
-                for msg in self.conversation_history[2:]
+                for msg in self.conversation_history[1:]
             ]
         )
 

--- a/tests/structs/test_conversation.py
+++ b/tests/structs/test_conversation.py
@@ -442,16 +442,10 @@ def test_return_all_except_first():
     conv.add("system", "System")
     conv.add("user", "Hello")
     conv.add("assistant", "Hi")
-    try:
-        result = conv.return_all_except_first()
-        assert len(result) == 2
-        assert result[0]["role"] == "user"
-        assert result[1]["role"] == "assistant"
-        logger.success("test_return_all_except_first passed")
-        return True
-    except AssertionError as e:
-        logger.error(f"test_return_all_except_first failed: {str(e)}")
-        return False
+    result = conv.return_all_except_first()
+    assert len(result) == 2
+    assert result[0]["role"] == "user"
+    assert result[1]["role"] == "assistant"
 
 
 def test_return_all_except_first_string():
@@ -460,18 +454,10 @@ def test_return_all_except_first_string():
     conv.add("system", "System")
     conv.add("user", "Hello")
     conv.add("assistant", "Hi")
-    try:
-        result = conv.return_all_except_first_string()
-        assert "Hello" in result
-        assert "Hi" in result
-        assert "System" not in result
-        logger.success("test_return_all_except_first_string passed")
-        return True
-    except AssertionError as e:
-        logger.error(
-            f"test_return_all_except_first_string failed: {str(e)}"
-        )
-        return False
+    result = conv.return_all_except_first_string()
+    assert "Hello" in result
+    assert "Hi" in result
+    assert "System" not in result
 
 
 def test_batch_add():


### PR DESCRIPTION
Description: Correct both `Conversation.return_all_except_first` variants to skip exactly one message instead of two. The existing focused tests now use direct assertions, so this regression can no longer be swallowed.

Issue: Addresses item 1 in #1853.

Dependencies: None.

Tag maintainer: General / structures maintainers.

Twitter handle: N/A.

Testing:

- `pytest -q tests/structs/test_conversation.py` — 51 passed
- `black swarms/structs/conversation.py tests/structs/test_conversation.py --check --diff` — passed
- `ruff check swarms/structs/conversation.py tests/structs/test_conversation.py` — passed with the CI-pinned Ruff 0.2.1
