### PR TITLE
[Bug] AOP: idle queue workers starve the lock, and a server that exits at once restarts forever

### DIFF
--- a/swarms/structs/aop.py
+++ b/swarms/structs/aop.py
@@ -411,19 +411,26 @@ class TaskQueue:
             try:
                 # Check if we should process tasks
                 with self._lock:
-                    if (
+                    idle = (
                         self._status != QueueStatus.RUNNING
                         or not self._queue
-                    ):
-                        self._stop_event.wait(0.1)
-                        continue
+                    )
+                    if not idle:
+                        # Get next task
+                        task = self._queue.popleft()
+                        self._processing_tasks.add(task.task_id)
+                        task.status = TaskStatus.PROCESSING
+                        self._stats.pending_tasks -= 1
+                        self._stats.processing_tasks += 1
 
-                    # Get next task
-                    task = self._queue.popleft()
-                    self._processing_tasks.add(task.task_id)
-                    task.status = TaskStatus.PROCESSING
-                    self._stats.pending_tasks -= 1
-                    self._stats.processing_tasks += 1
+                # Idle-wait outside the lock. Holding it across the wait let
+                # idle workers own the lock ~100% of the time, so any caller
+                # needing it — get_stats, get_queue_status, add_task, and
+                # AOP.get_server_info through them — could block for tens of
+                # seconds waiting on workers that were doing nothing.
+                if idle:
+                    self._stop_event.wait(0.1)
+                    continue
 
                 # Process the task
                 self._process_task(task)
@@ -2445,13 +2452,20 @@ class AOP:
                     # Wait before restarting
                     time.sleep(self.restart_delay)
 
+                started_at = time.time()
                 self.start_server()
 
-                # Reset restart count on successful start. This has to
-                # happen after start_server() returns, otherwise a failed
-                # attempt clears the count it just incremented and the
-                # max_restart_attempts failsafe below can never fire.
-                self._restart_count = 0
+                # start_server() returning means the server stopped. Only
+                # treat that as a success if it actually stayed up; a server
+                # that exits immediately is restarting, not running.
+                # Resetting unconditionally (as this did) pinned the count at
+                # 0 forever, so max_restart_attempts never fired and the
+                # delay below was never reached — a server that died on
+                # startup respawned in a hot loop instead.
+                if time.time() - started_at >= self.restart_delay:
+                    self._restart_count = 0
+                else:
+                    self._restart_count += 1
 
             except KeyboardInterrupt:
                 if (

--- a/tests/structs/test_aop.py
+++ b/tests/structs/test_aop.py
@@ -1,4 +1,5 @@
 import socket
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -8,6 +9,7 @@ from swarms.structs.aop import (
     AOP,
     AOPCluster,
     QueueStatus,
+    TaskQueue,
     TaskStatus,
 )
 
@@ -18,7 +20,7 @@ def real_agent():
     from swarms import Agent
 
     agent = Agent(
-        agent_name="Test-Agent",
+        agent_name="test_agent",
         agent_description="Test agent for AOP testing",
         model_name="gpt-3.5-turbo",
         max_loops=1,
@@ -359,12 +361,18 @@ def test_add_agent_duplicate_tool_name(
     with patch.object(aop_instance, "_register_tool"), patch.object(
         aop_instance, "_register_agent_discovery_tool"
     ):
-        aop_instance.add_agent(new_agent, tool_name="test_agent")
+        # Not "test_agent": that is the fixture agent's own name, so the
+        # first add would collide and the duplicate this test is about
+        # would never be reached.
+        aop_instance.add_agent(new_agent, tool_name="duplicate_agent")
 
         with pytest.raises(
-            ValueError, match="Tool name 'test_agent' already exists"
+            ValueError,
+            match="Tool name 'duplicate_agent' already exists",
         ):
-            aop_instance.add_agent(new_agent, tool_name="test_agent")
+            aop_instance.add_agent(
+                new_agent, tool_name="duplicate_agent"
+            )
 
 
 def test_add_agents_batch_basic(
@@ -1075,10 +1083,23 @@ def test_run_without_persistence(aop_instance, mock_fastmcp):
 
 
 def test_run_with_persistence_success(aop_instance, mock_fastmcp):
-    """Test running server with persistence on successful execution."""
-    aop_instance._persistence_enabled = True
+    """Test running server with persistence on successful execution.
 
-    with patch.object(aop_instance, "start_server") as mock_start:
+    A real start_server() blocks until the server stops, so the mock has to
+    end the loop the way a served-then-shut-down server does. Without that
+    this test never returns: run()'s whole job is to restart the server when
+    it stops, so a mock that returns instantly and leaves the loop condition
+    true is an infinite restart, not a success.
+    """
+    aop_instance._persistence_enabled = True
+    aop_instance.restart_delay = 0
+
+    def serve():
+        aop_instance._shutdown_requested = True
+
+    with patch.object(
+        aop_instance, "start_server", side_effect=serve
+    ) as mock_start:
         aop_instance.run()
 
         mock_start.assert_called_once()
@@ -1415,3 +1436,46 @@ def test_persistence_restart_count_bounds_a_failing_server():
     assert start.call_count == 6
     assert aop._restart_count == 3
     assert aop.get_persistence_status()["remaining_restarts"] == 0
+
+
+def test_persistence_bounds_a_server_that_exits_immediately():
+    """A clean return is a restart, not a success.
+
+    start_server() returning means the server stopped. Resetting the count
+    on every clean return pinned it at 0, so max_restart_attempts could
+    never fire and the restart delay was never reached — a server that dies
+    on startup respawned in a hot loop. Bounded, this is 1 start + 2
+    restarts.
+    """
+    aop = AOP(
+        persistence=True, max_restart_attempts=2, restart_delay=0.05
+    )
+
+    with patch.object(aop, "start_server") as start:
+        aop.run()
+
+    assert start.call_count == 3
+    assert aop.get_persistence_status()["remaining_restarts"] == 0
+
+
+def test_queue_stats_not_starved_by_idle_workers():
+    """Idle workers must not hold the queue lock while they wait.
+
+    The worker loop waited on its stop event inside `with self._lock`, so
+    idle workers owned the lock nearly all the time and any caller needing
+    it — get_stats, and AOP.get_server_info through it — could block for
+    tens of seconds. Measured at over 20s before the fix; the 2s bound here
+    is loose enough not to be flaky on a loaded CI box.
+    """
+    queue = TaskQueue(agent_name="idle", agent=Mock(), max_workers=4)
+    queue.start_workers()
+    try:
+        time.sleep(0.2)  # let every worker reach the idle wait
+        started = time.perf_counter()
+        for _ in range(20):
+            queue.get_stats()
+        elapsed = time.perf_counter() - started
+    finally:
+        queue.stop_workers()
+
+    assert elapsed < 2.0, f"20 get_stats() calls took {elapsed:.1f}s"


### PR DESCRIPTION
## What

Two bugs in `aop.py` that make AOP block or spin forever. Both are reachable from normal use, and together they are why `tests/structs/test_aop.py` never finishes — the suite currently hangs until CI kills the runner.

## 1. Idle queue workers hold the lock while they wait

`TaskQueue._worker_loop` waited on its stop event **inside** `with self._lock`:

```python
with self._lock:
    if self._status != QueueStatus.RUNNING or not self._queue:
        self._stop_event.wait(0.1)   # <- 100ms of sleep, holding the lock
        continue
```

With `max_workers` idle workers, the lock is held essentially all the time by whichever worker is sleeping in it, and they hand it off among themselves. Any outside caller that needs the same lock — `get_stats()`, and `AOP.get_server_info()` through it — is starved. Python locks are not fair, so there is no bound on the wait.

Measured on an otherwise idle machine, 4 workers, 20 `get_stats()` calls:

```
before:  worst get_stats() latency 20665.0 ms
after:   worst get_stats() latency     0.0 ms
```

Fix: compute the idle condition under the lock, wait outside it.

## 2. A server that exits immediately restarts forever

`AOP.run()` reset the restart counter on every clean return from `start_server()`:

```python
self.start_server()
self._restart_count = 0
```

`start_server()` returning means the server stopped. Resetting unconditionally pinned the counter at 0, so `max_restart_attempts` could never fire, and because the backoff is guarded by `if self._restart_count > 0`, no delay was applied either. A server that dies on startup respawns in a hot loop.

With `max_restart_attempts=3` and a `start_server` that returns at once:

```
before:  1,665,075 calls in 5s, run() never returns, _restart_count == 0
after:   4 calls (1 start + 3 restarts), run() returns, failsafe logs
         "Server failed permanently due to exceeding maximum restart attempts"
```

Fix: only treat a clean return as success if the server actually stayed up for `restart_delay`; otherwise count it as a restart.

This preserves the behaviour #1806 added — a healthy run clears the failure streak — which `test_persistence_restart_count_bounds_a_failing_server` covers and which still passes.

## Effect on the test suite

`tests/structs/test_aop.py` hung at `test_get_server_info` (bug 1) and, once past it, at `test_run_with_persistence_success` (bug 2). Because it never terminated, the 26 failures behind it were invisible.

| | master (`f894187d`) | this branch |
|---|---|---|
| outcome | **hangs, SIGKILL** | completes in 39s |
| passed | 47 | 65 |
| failed | 26 | 12 |

Baseline measured by deselecting the two hanging tests, since master cannot finish otherwise. **No test that passed on master fails here** — verified by diffing the failure sets.

## Two test changes that are not mine to hide

**`test_run_with_persistence_success`** asserted `run()` returns after one successful start. That is not what persistence does — its whole job is to restart a stopped server. The mock returned instantly and left the loop condition true, which is an infinite restart, not a success. It now ends the loop the way a served-then-shut-down server does.

**The `real_agent` fixture was named `Test-Agent` while 15 tests refer to `test_agent`.** This is pre-existing drift, unrelated to the bugs above, but bug 1 was hiding it: `test_get_server_info` is the first test to reach the mismatch, so unhanging the suite exposes it. Renaming the fixture (one line) clears 14 of the 26 pre-existing failures. `test_add_agent_duplicate_tool_name` needed the paired change, because it registers a *second* tool called `test_agent` and that name is now the fixture's own.

Happy to split the fixture rename into its own PR if you would rather keep this to the two `aop.py` fixes — say the word and I will.

## Verification

```
tests/structs/test_aop.py                    12 failed, 65 passed in 39.08s
black --check --line-length 70               clean (aop.py, test_aop.py)
ruff check                                   clean
```

The 12 remaining failures are all pre-existing on `master` and untouched here.

The red checks on this PR are the repo-wide ones — `build` never installs the package, `test-main-features` dies on Poetry 2.x `--no-dev`, both addressed in #1812.
