### PR TITLE
[Bug] run_agents_concurrently returns completion order, so MajorityVoting and AgentRearrange file every answer under the wrong agent (#1788)

### DIFF
--- a/swarms/structs/multi_agent_exec.py
+++ b/swarms/structs/multi_agent_exec.py
@@ -112,10 +112,10 @@ def run_agents_concurrently(
         img (Optional[str]): Optional image data to pass to agent run() if supported.
         max_workers (Optional[int]): Maximum threads for the executor (default: 95% of CPU cores).
         return_agent_output_dict (bool): If True, returns a dict mapping agent names to outputs.
-                                         Otherwise returns a list of results in completion order.
+                                         Otherwise returns a list of results in input order.
 
     Returns:
-        List[Any] or Dict[str, Any]: List of results from each agent's run() method in completion order,
+        List[Any] or Dict[str, Any]: List of results from each agent's run() method in input order,
                                      or a dict of agent names to results (preserving agent order)
                                      if return_agent_output_dict is True.
                                      If an agent fails, the corresponding result is the Exception.
@@ -125,7 +125,7 @@ def run_agents_concurrently(
         - By default, utilizes nearly all available CPU cores for optimal performance.
         - Any Exception during agent execution is caught and included in the results.
         - If return_agent_output_dict is True, the results dict preserves agent input order.
-        - Otherwise, the results list is in order of completion (not input order).
+        - Otherwise, the results list is in input order, so results[i] is agents[i]'s.
 
     Example:
         >>> agents = [Agent1(), Agent2()]
@@ -142,7 +142,6 @@ def run_agents_concurrently(
             max_workers = max_workers_95_percent()
 
         futures = []
-        agent_id_map = {}
 
         with ContextThreadPoolExecutor(
             max_workers=max_workers
@@ -155,7 +154,6 @@ def run_agents_concurrently(
                     agent_kwargs["img"] = img
                 future = executor.submit(agent.run, **agent_kwargs)
                 futures.append(future)
-                agent_id_map[future] = agent
 
             if return_agent_output_dict:
                 # Use agent name as key, preserve input order
@@ -174,13 +172,15 @@ def run_agents_concurrently(
                     output_dict[name] = result
                 return output_dict
             else:
+                # Input order, not completion order: every caller pairs
+                # this list positionally with `agents`, so yielding it by
+                # finish time filed each answer under another agent's name.
+                # future.result() blocks, but all the work was submitted
+                # above, so this waits no longer than as_completed did.
                 results = []
-                for future in concurrent.futures.as_completed(
-                    futures
-                ):
+                for future in futures:
                     try:
-                        result = future.result()
-                        results.append(result)
+                        results.append(future.result())
                     except Exception as e:
                         results.append(e)
                 return results


### PR DESCRIPTION
## The bug

`run_agents_concurrently` collected results with `as_completed`, so the returned list was ordered by finish time rather than by agent.

Every caller pairs that list against the agent list positionally:

- `MajorityVoting` (`majority_voting.py:206`)
- `AgentRearrange._run_concurrent_workflow` (`agent_rearrange.py:569`)
- `ma_blocks.aggregate` (`ma_blocks.py:69`)

So as soon as agents finish in a different order than they were submitted — the normal case once their outputs differ in length — every answer is filed under a different agent's name.

Nothing raises. The list is the right length and every entry is a real answer; only the attribution is wrong, which is why this can sit unnoticed.

## The fix

Iterate `futures` in submission order instead of `as_completed`. `future.result()` blocks, but all the work was submitted before the loop starts, so total wall time is unchanged — the last result is ready at the same moment either way.

Ten lines, one file, no behaviour change beyond the ordering this is about.

## Verified

Reproduced against `master` with three agents chained so the last submitted finishes first: `results[0]` came back as the third agent's answer. With this change it is the first agent's.