### PR TITLE
[Bug] GraphWorkflow.visualize sanitizes the workflow name in a branch that never runs (#1853 item 5)

### DIFF
--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -2554,7 +2554,15 @@ class GraphWorkflow:
             ImportError: If graphviz is not installed.
             Exception: If visualization generation fails.
         """
-        output_path = f"{self.name}_visualization_{str(uuid.uuid4())}"
+        # Sanitize here, in the path that is actually used. graphviz treats
+        # the argument as a filesystem path, so a name containing "/" (or
+        # any other separator) renders into a directory that does not exist
+        # instead of producing a file.
+        safe_name = "".join(
+            c if c.isalnum() or c in "-_" else "_"
+            for c in (self.name or "GraphWorkflow")
+        )
+        output_path = f"{safe_name}_visualization_{str(uuid.uuid4())}"
 
         if not GRAPHVIZ_AVAILABLE:
             error_msg = "Graphviz is not installed. Install it with: pip install graphviz"
@@ -2745,14 +2753,6 @@ class GraphWorkflow:
                         # Add invisible nodes to maintain layer structure
                         for node_id in layer:
                             layer_graph.node(node_id)
-
-            # Generate output path
-            if output_path is None:
-                safe_name = "".join(
-                    c if c.isalnum() or c in "-_" else "_"
-                    for c in (self.name or "GraphWorkflow")
-                )
-                output_path = f"{safe_name}_visualization"
 
             # Render the graph
             output_file = dot.render(

--- a/tests/structs/test_graph_workflow.py
+++ b/tests/structs/test_graph_workflow.py
@@ -1308,5 +1308,34 @@ def test_compile_calls_validate_and_reports_errors():
     assert len(result["errors"]) > 0
 
 
+def test_visualize_sanitizes_the_workflow_name_into_the_output_path():
+    """A name with a path separator must not become a directory.
+
+    The sanitization used to live in an `if output_path is None:` branch
+    that was unreachable — `output_path` is assigned unconditionally above
+    it — so the live path used the raw name and graphviz tried to render
+    into a directory that does not exist.
+    """
+    import inspect
+
+    source = inspect.getsource(GraphWorkflow.visualize)
+
+    # The dead branch that used to hold the sanitization is gone.
+    assert "if output_path is None" not in source
+
+    # And the sanitization now runs before graphviz availability is checked,
+    # i.e. in the path that actually builds the filename.
+    live_path = source.split("if not GRAPHVIZ_AVAILABLE")[0]
+    assert "safe_name" in live_path
+
+    workflow = GraphWorkflow(name="team/alpha")
+    safe = "".join(
+        c if c.isalnum() or c in "-_" else "_"
+        for c in (workflow.name or "GraphWorkflow")
+    )
+    assert "/" not in safe
+    assert safe == "team_alpha"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Addresses item 5 in #1853.

## What

`GraphWorkflow.visualize` sanitized the workflow name in a branch that can never run, and used the raw name in the branch that always does.

`output_path` is assigned unconditionally at the top of the method:

```python
output_path = f"{self.name}_visualization_{str(uuid.uuid4())}"
```

so the `if output_path is None:` guard ~190 lines later — the only place `safe_name` was ever built — was unreachable. graphviz treats its argument as a filesystem path, so a workflow named `team/alpha` rendered to `team/alpha_visualization_<uuid>`, a directory that does not exist, and the call failed. The sanitization written to prevent exactly that was sitting in dead code.

```
before:  team/alpha_visualization_<uuid>   -> renders into a missing directory
after:   team_alpha_visualization_<uuid>   -> renders
```

## Fix

Moved the sanitization into the live assignment and deleted the unreachable branch (6 lines). Net effect is the behaviour the dead code intended, in the path that runs.

The `uuid4()` suffix is kept — the dead branch omitted it, so had it ever run it would also have collided between two visualizations of the same workflow.

## Test

Appended to `tests/structs/test_graph_workflow.py` — no new file. It asserts the dead branch is gone, that `safe_name` is built in the live path, and that a name containing `/` maps to `team_alpha`.

```
master source + this test:   1 failed
this branch:                 1 passed
tests/structs/test_graph_workflow.py:  48 passed, 11 skipped
black --check --line-length 70, ruff:  clean
```

## Not included

The other items in #1853 are deliberately out of scope here, and two of them are already covered:

- item 2 (redundant exception tuple in `agent.py`) is part of #1773
- item 4 (`_reinitialize_after_load` storing a shut-down executor) is part of #1801
- item 1 is #1857
- item 6 touches `aop.py`, which #1861 is already changing — better done after that lands than as a conflicting parallel edit

That leaves item 3 (the bogus `await` on a sync `_handle_run_error`) genuinely unclaimed; happy to take it separately.

The red checks are the repo-wide ones (`build` never installs the package, `test-main-features` dies on Poetry 2.x `--no-dev`), both addressed in #1812.
