### PR TITLE
[Bug] RoundRobinSwarm: self.index is never read, so agents[0] opens every task in a batch (#1864)

### DIFF
--- a/swarms/structs/round_robin.py
+++ b/swarms/structs/round_robin.py
@@ -119,6 +119,7 @@ class RoundRobinSwarm(SerializableMixin):
         verbose: bool = False,
         max_loops: int = 1,
         output_type: OutputType = "final",
+        persist_rotation: bool = False,
     ):
 
         self.name = name
@@ -128,6 +129,7 @@ class RoundRobinSwarm(SerializableMixin):
         self.max_loops = max_loops
         self.index = 0
         self.output_type = output_type
+        self.persist_rotation = persist_rotation
 
         # Initialize conversation for tracking agent interactions
         self.conversation = Conversation(
@@ -215,6 +217,15 @@ class RoundRobinSwarm(SerializableMixin):
             n = len(self.agents)
             agent_names = return_all_agent_names(self.agents)
 
+            # Start this run where the last one left off. `self.index` used to
+            # be written every turn and read by nothing, so each run() restarted
+            # at agents[0] and run_batch handed the opening turn — the one that
+            # frames the transcript every later agent builds on — to the same
+            # agent for every task. Off by default: a run is turn-for-turn
+            # reproducible unless the caller opts in.
+            start = self.index % n
+            rotation = self.agents[start:] + self.agents[:start]
+
             self._log(
                 "info",
                 f"Starting round-robin execution with task on {n} agents: {agent_names}",
@@ -226,23 +237,21 @@ class RoundRobinSwarm(SerializableMixin):
                     f"Starting loop {loop + 1}/{self.max_loops}",
                 )
 
-                for i, current_agent in enumerate(self.agents):
-                    self.index = (loop * n) + i
-
+                for i, current_agent in enumerate(rotation):
                     prev_name = (
-                        self.agents[i - 1].agent_name
+                        rotation[i - 1].agent_name
                         if i > 0
                         else (
-                            self.agents[-1].agent_name
+                            rotation[-1].agent_name
                             if loop > 0
                             else None
                         )
                     )
                     next_name = (
-                        self.agents[i + 1].agent_name
+                        rotation[i + 1].agent_name
                         if i + 1 < n
                         else (
-                            self.agents[0].agent_name
+                            rotation[0].agent_name
                             if loop + 1 < self.max_loops
                             else None
                         )
@@ -281,6 +290,13 @@ class RoundRobinSwarm(SerializableMixin):
                             f"Agent {current_agent.agent_name} failed: {str(e)}",
                         )
                         raise
+
+            # max_loops * n turns is a whole number of cycles, so it returns the
+            # offset to where it started — advancing the opener needs this
+            # explicit +1. Without it, resuming would still seat agents[start]
+            # first on every task.
+            if self.persist_rotation:
+                self.index = (start + 1) % n
 
             self._log(
                 "success",

--- a/tests/structs/test_round_robin_swarm.py
+++ b/tests/structs/test_round_robin_swarm.py
@@ -21,3 +21,59 @@ def test_run(round_robin_swarm):
     result = round_robin_swarm.run(task)
     assert result == task
     assert round_robin_swarm.index == 0
+
+
+def _visit_order(swarm, task="t"):
+    """Agent names in the order they were given a turn, without LLM calls."""
+    from unittest.mock import patch
+
+    seen = []
+    with patch.object(
+        swarm,
+        "_execute_agent",
+        side_effect=lambda agent, *a, **k: seen.append(
+            agent.agent_name
+        ),
+    ):
+        swarm.run(task)
+    return seen
+
+
+def test_rotation_does_not_persist_by_default():
+    """Default stays turn-for-turn reproducible.
+
+    `persist_rotation` is opt-in because callers rely on run() replaying the
+    same order; this pins that the default did not change.
+    """
+    agents = [Agent(agent_name=f"A{i}") for i in range(3)]
+    swarm = RoundRobinSwarm(agents=agents, max_loops=2)
+
+    first = _visit_order(swarm)
+    assert _visit_order(swarm) == first
+    assert first[0] == "A0"
+
+
+def test_persist_rotation_gives_every_agent_the_opening_turn():
+    """`self.index` was written every turn and read by nothing, so every run()
+    restarted at agents[0] — run_batch handed the opening turn, which frames
+    the transcript every later agent builds on, to the same agent for every
+    task in the batch.
+    """
+    agents = [Agent(agent_name=f"A{i}") for i in range(3)]
+    swarm = RoundRobinSwarm(
+        agents=agents, max_loops=2, persist_rotation=True
+    )
+
+    runs = [_visit_order(swarm) for _ in range(3)]
+
+    # Each task opens with a different agent.
+    assert [r[0] for r in runs] == ["A0", "A1", "A2"]
+
+    # And within a run every agent still gets exactly max_loops turns.
+    for r in runs:
+        assert len(r) == 6
+        assert {name: r.count(name) for name in set(r)} == {
+            "A0": 2,
+            "A1": 2,
+            "A2": 2,
+        }


### PR DESCRIPTION
Fixes #1864.

## What

`RoundRobinSwarm.self.index` was written on every turn and read by nothing. Agent selection came entirely from `enumerate(self.agents)`, so the rotation restarted at `agents[0]` on every `run()` — and since `run_batch` is `[self.run(task) for task in tasks]`, **`agents[0]` opened every task in the batch and `agents[N-1]` opened none of them.**

That matters more than turn ordering usually would: `build_collaborative_task` tells each agent to build on the prior speaker, so the opening seat frames the transcript everything downstream anchors on. Round-robin exists to distribute exactly that, and batching was quietly handing it to one agent every time.

## Fix

Made `self.index` load-bearing, as the issue proposes:

- `run()` starts from `self.index` — the agent list is rotated by that offset once, and the existing turn loop runs over the rotation, so `prev_name` / `next_name` and the turn headers follow it without further change.
- The dead `self.index = (loop * n) + i` write inside the loop is gone.
- After a run, the pointer advances by **one**, not by the number of turns taken. `max_loops * n` turns is a whole number of cycles and returns the offset to where it started, so advancing by turn count would leave the opener fixed — the `+1` is the part that actually distributes the seat.

## Opt-in, per the issue

`persist_rotation: bool = False`. Callers depend on `run()` replaying the same order, so the default is unchanged and turn-for-turn reproducible; only an explicit opt-in resumes across calls.

```
default (3 agents, max_loops=2)
  run 1: A0 A1 A2 A0 A1 A2
  run 2: A0 A1 A2 A0 A1 A2      <- unchanged from master

persist_rotation=True
  run 1: A0 A1 A2 A0 A1 A2
  run 2: A1 A2 A0 A1 A2 A0
  run 3: A2 A0 A1 A2 A0 A1
  openers: A0, A1, A2
```

Within-run fairness is untouched — every agent still gets exactly `max_loops` turns per run, verified in the test.

## Tests

Appended to `tests/structs/test_round_robin_swarm.py` — no new file. Turns are captured by patching `_execute_agent`, so neither test makes an LLM call.

- `test_rotation_does_not_persist_by_default` — pins that the default behaviour did not change
- `test_persist_rotation_gives_every_agent_the_opening_turn` — openers cycle `A0, A1, A2`, and each run is still 6 turns split 2/2/2

```
master source + these tests:   1 failed (the new opt-in test), 1 passed
this branch:                   3 passed
black --check --line-length 70, ruff:  clean
```

One caveat worth stating plainly: `test_round_robin_swarm.py::test_run` fails on `master` before this change and still fails after it — it is unrelated to this diff and I have not touched it.
