### PR TITLE
[Bug] Pydantic tool schemas are named after the metaclass or the last docstring param, never the model (#1848)

### DIFF
--- a/swarms/tools/pydantic_to_json.py
+++ b/swarms/tools/pydantic_to_json.py
@@ -17,26 +17,6 @@ def _remove_a_key(d: dict, remove_key: str) -> None:
                 _remove_a_key(d[key], remove_key)
 
 
-def check_pydantic_name(pydantic_type: type[BaseModel]) -> str:
-    """
-    Check the name of the Pydantic model.
-
-    Args:
-        pydantic_type (type[BaseModel]): The Pydantic model type to check.
-
-    Returns:
-        str: The name of the Pydantic model.
-
-    """
-    try:
-        return type(pydantic_type).__name__
-    except AttributeError as error:
-        logger.error(
-            f"The Pydantic model does not have a name. {error}"
-        )
-        raise error
-
-
 def base_model_to_openai_function(
     pydantic_type: type[BaseModel],
     output_str: bool = False,
@@ -54,8 +34,10 @@ def base_model_to_openai_function(
     """
     schema = pydantic_type.model_json_schema()
 
-    # Fetch the name of the class
-    name = type(pydantic_type).__name__
+    # The model's own name. `type(pydantic_type).__name__` read the
+    # metaclass instead, because pydantic_type is the class, not an
+    # instance — every schema through this path was named "ModelMetaclass".
+    name = pydantic_type.__name__
 
     docstring = parse(pydantic_type.__doc__ or "")
     parameters = {
@@ -64,12 +46,17 @@ def base_model_to_openai_function(
         if k not in ("title", "description")
     }
 
+    # `prop_name`, not `name`: this walrus used to rebind `name`, so the
+    # emitted function name became whichever docstring param matched last.
     for param in docstring.params:
-        if (name := param.arg_name) in parameters["properties"] and (
-            description := param.description
-        ):
-            if "description" not in parameters["properties"][name]:
-                parameters["properties"][name][
+        if (prop_name := param.arg_name) in parameters[
+            "properties"
+        ] and (description := param.description):
+            if (
+                "description"
+                not in parameters["properties"][prop_name]
+            ):
+                parameters["properties"][prop_name][
                     "description"
                 ] = description
 

--- a/tests/tools/test_output_str_fix.py
+++ b/tests/tools/test_output_str_fix.py
@@ -148,3 +148,42 @@ if __name__ == "__main__":
         import traceback
 
         traceback.print_exc()
+
+
+def test_function_name_is_the_model_name():
+    """The emitted schema must name the model, not the metaclass or a field.
+
+    Two bugs compounded here. `type(pydantic_type).__name__` read the
+    metaclass — pydantic_type is the class, not an instance — so the name
+    was "ModelMetaclass". And the docstring loop's walrus bound `name`,
+    so whenever a docstring param matched a property the name became
+    whichever param matched last. Either way the LLM was told the tool had
+    a name it does not have.
+    """
+    from pydantic import BaseModel, Field
+
+    from swarms.tools.pydantic_to_json import (
+        base_model_to_openai_function,
+    )
+
+    class WeatherQuery(BaseModel):
+        """Look up the weather.
+
+        Args:
+            city: The city to look up.
+            units: Temperature units.
+        """
+
+        city: str = Field(...)
+        units: str = Field("celsius")
+
+    result = base_model_to_openai_function(WeatherQuery)
+
+    assert result["function_call"]["name"] == "WeatherQuery"
+    assert result["functions"][0]["name"] == "WeatherQuery"
+
+    # The rename must not cost the per-parameter descriptions the loop
+    # exists to attach.
+    props = result["functions"][0]["parameters"]["properties"]
+    assert props["city"]["description"] == "The city to look up."
+    assert props["units"]["description"] == "Temperature units."


### PR DESCRIPTION
Fixes the bug half of #1848 (the part the issue says to fix regardless of the dedup).

## What

`base_model_to_openai_function` emitted the **wrong function name** into the schema handed to the LLM. Two independent bugs compounded:

1. **`swarms/tools/pydantic_to_json.py:58`** — `name = type(pydantic_type).__name__`. `pydantic_type` is the class, not an instance, so this reads the *metaclass*: `"ModelMetaclass"`.
2. **The docstring loop's walrus** — `if (name := param.arg_name) in parameters["properties"]` rebinds `name` on every match, so whenever the model's docstring documents its fields, the emitted name becomes **whichever parameter matched last**.

The second one masks the first, which is why this reads as "wrong name" rather than a constant. On a model with a documented docstring:

```
master:  function_call.name: units          <- the last documented field
fixed:   function_call.name: WeatherQuery
```

Strip the docstring params and it falls through to `ModelMetaclass` instead. Either way the model is told the tool has a name it does not have — and the name is what the LLM emits back to call it.

This is not an internal helper: it is exported from `swarms.tools` and used by `base_tool.py` (`:281`, `:673`), so it reaches real tool schemas.

## Fix

- `name = pydantic_type.__name__`
- The walrus binds `prop_name` instead of `name`, so attaching per-parameter descriptions can no longer overwrite the function name. Those descriptions still attach — asserted in the test.
- Deleted `check_pydantic_name` (`:20-37`): it has zero callers, is not exported from `swarms/tools/__init__.py`, and carried the same `type(...)` mistake, so leaving it there is a live copy of the bug waiting to be picked up.

## Deliberately out of scope

#1848 also covers the three-way duplication of pydantic→OpenAI schema conversion and the legacy `{"function_call": …, "functions": […]}` envelope. Those change the shape callers receive; this PR does not touch them, so it stays reviewable on its own and safe to land first. Happy to take the consolidation separately.

## Test

Appended to `tests/tools/test_output_str_fix.py` — no new file, it already owns this function. It uses a model whose docstring documents its fields, so it covers the walrus path (the one that actually fires in practice) and asserts the parameter descriptions survive.

```
master source + this test:   1 failed
this branch:                 5 passed  (tests/tools/test_output_str_fix.py)
black --check --line-length 70, ruff:  clean
```

Red checks are the repo-wide pre-existing ones (`build` never installs the package; `test-main-features` dies on Poetry 2.x `--no-dev`), both addressed in #1812.
