### PR TITLE
[Bug] arun() drops its own *args with a TypeError, and awaits a synchronous error handler (#1853 item 3)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2024,17 +2024,24 @@ Subtask Breakdown:
             Exception: If an error occurs during the asynchronous operation.
         """
         try:
+            # Forward positionally, in run()'s own parameter order. Passing
+            # task/img as keywords while also splatting *args made every
+            # extra positional collide with `task`:
+            #   TypeError: run() got multiple values for argument 'task'
+            # so arun(task, img, extra) raised instead of running.
             return await asyncio.to_thread(
                 self.run,
-                task=task,
-                img=img,
+                task,
+                img,
                 *args,
                 **kwargs,
             )
         except Exception as error:
-            await self._handle_run_error(
-                error
-            )  # Ensure this is also async if needed
+            # _handle_run_error is sync and re-raises; the other seven call
+            # sites do not await it. The await was only harmless because the
+            # method always raises before returning — the day it stops, this
+            # becomes `await None`.
+            self._handle_run_error(error)
 
     def __call__(
         self,

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2864,3 +2864,69 @@ if __name__ == "__main__":
     results = run_all_tests()
 
     print(results)
+
+
+# ============================================================================
+# arun forwarding and error path (#1853 item 3)
+# ============================================================================
+
+
+class TestArunForwarding:
+    """arun() must forward its arguments to run() and not await a sync method."""
+
+    def _bare_agent(self):
+        # No LLM/model setup — these tests only exercise arun's plumbing.
+        agent = Agent.__new__(Agent)
+        agent.autosave = False
+        agent.agent_name = "arun-test"
+        agent.to_dict = lambda: {}
+        return agent
+
+    def test_extra_positional_args_reach_run(self):
+        """`task=`/`img=` as keywords alongside *args made every extra
+        positional collide with `task`, so arun(task, img, extra) raised
+        `TypeError: run() got multiple values for argument 'task'`.
+        """
+        import asyncio
+
+        agent = self._bare_agent()
+        seen = {}
+
+        def fake_run(*args, **kwargs):
+            seen["args"] = args
+            seen["kwargs"] = kwargs
+            return "ok"
+
+        agent.run = fake_run
+
+        result = asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
+
+        assert result == "ok"
+        assert seen["args"] == ("T", "I", "EXTRA")
+
+    def test_error_path_does_not_await_a_sync_handler(self):
+        """`_handle_run_error` is sync and re-raises; seven other call sites
+        do not await it. The await was harmless only because the method
+        always raises before returning.
+        """
+        import asyncio
+        import inspect
+
+        assert not inspect.iscoroutinefunction(
+            Agent._handle_run_error
+        )
+        assert (
+            "await self._handle_run_error"
+            not in inspect.getsource(Agent.arun)
+        )
+
+        agent = self._bare_agent()
+
+        def boom(*args, **kwargs):
+            raise ValueError("boom")
+
+        agent.run = boom
+
+        # The original error surfaces — not a TypeError from awaiting None.
+        with pytest.raises(ValueError, match="boom"):
+            asyncio.run(Agent.arun(agent, "T"))


### PR DESCRIPTION
Addresses item 3 in #1853, plus a second defect in the same three lines.

## 1. `arun(task, img, extra)` raises instead of running

`arun` forwarded to `run` like this:

```python
return await asyncio.to_thread(
    self.run, task=task, img=img, *args, **kwargs,
)
```

`asyncio.to_thread(func, *a, **kw)` calls `func(*a, **kw)`, so the splatted `*args` arrive **positionally** while `task` is also passed by keyword — and `run`'s first positional parameter *is* `task`. Any extra positional argument therefore collides:

```
TypeError: run() got multiple values for argument 'task'
```

`arun` declares `*args` specifically to accept those arguments, so the one documented way to use them was the one way that failed.

Fixed by forwarding positionally, in `run`'s own parameter order, which makes `arun(t, i, x)` behave exactly like `run(t, i, x)`:

```python
return await asyncio.to_thread(self.run, task, img, *args, **kwargs)
```

## 2. `await` on a synchronous method

```python
except Exception as error:
    await self._handle_run_error(error)  # Ensure this is also async if needed
```

`_handle_run_error` is a plain `def` whose last statement is `raise error`. It is not a coroutine function, and the **seven other call sites** — `agent.py:1679`, `:1688`, `:2060`, `:3114`, `llm_manager.py:889`, `:899`, `autonomous_loop.py:954` — all call it without `await`.

This only ever worked by accident: the method raises before returning, so the `await` never evaluates its operand. The moment `_handle_run_error` stops raising unconditionally, this line becomes `await None` → `TypeError`, on the error path, where it is hardest to notice. Dropped the `await` and the stale "Ensure this is also async if needed" comment.

## Tests

Appended to `tests/structs/test_agent.py` as `TestArunForwarding` — no new file. Neither test constructs a model or makes an LLM call; `run` is replaced on a bare instance, so they exercise `arun`'s plumbing only.

- `test_extra_positional_args_reach_run` — `arun("T", "I", "EXTRA")` reaches `run` as `("T", "I", "EXTRA")`
- `test_error_path_does_not_await_a_sync_handler` — asserts `_handle_run_error` is not a coroutine function, that `arun`'s source no longer awaits it, and that the original `ValueError` surfaces rather than a `TypeError`

```
master source + these tests:   2 failed
this branch:                   2 passed
black --check --line-length 70, ruff:  clean
```

The rest of `test_agent.py` is red on `master` before and after this change (missing provider credentials); this diff does not move those numbers.

Red checks are the repo-wide pre-existing ones, addressed in #1812.
