### PR TITLE
[Bug] Agent.run() blocks on stdin for an empty task even when interactive=False (#1852)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -3016,15 +3016,16 @@ Subtask Breakdown:
             >>> agent.run("Describe this image", img=img_base64)
         """
 
-        # # If interactive mode is enabled and no task is provided, prompt the user
-        # if self.interactive and (
-        #     task is None
-        #     or (isinstance(task, str) and task.strip() == "")
-        if (
-            task is None
-            or isinstance(task, str)
-            and task.strip() == ""
+        # If no task is provided, prompt for one only in interactive mode.
+        # Outside interactive mode, fail fast instead of blocking on stdin.
+        if task is None or (
+            isinstance(task, str) and task.strip() == ""
         ):
+            if not self.interactive:
+                raise ValueError(
+                    "No task provided. Pass a non-empty `task`, or set "
+                    "interactive=True to be prompted for one."
+                )
             # Always show prompt when asking for initial task, even if print_on is False
             self.pretty_print(
                 "Interactive mode enabled. Please enter your initial task:",

--- a/tests/structs/test_agent_empty_task.py
+++ b/tests/structs/test_agent_empty_task.py
@@ -1,0 +1,38 @@
+"""Regression tests for empty-task handling in Agent.run().
+
+Covers the bug where a commented-out `self.interactive and ...` guard caused
+`run()` to block on stdin for an empty or None task even when
+`interactive=False`. The non-interactive path must fail fast with a clear
+error and never read from the console.
+"""
+
+import pytest
+
+from swarms.structs.agent import Agent
+from swarms.utils.formatter import formatter
+
+
+@pytest.mark.parametrize("empty_task", ["", "   ", "\n\t ", None])
+def test_empty_task_non_interactive_raises_value_error(empty_task):
+    agent = Agent(agent_name="NoTaskAgent", interactive=False, max_loops=1)
+    with pytest.raises(ValueError, match="No task provided"):
+        agent.run(empty_task)
+
+
+def test_empty_task_non_interactive_does_not_read_stdin(monkeypatch):
+    """The non-interactive empty-task path must not touch console input."""
+    called = {"input": False}
+
+    def _fail_input(*args, **kwargs):
+        called["input"] = True
+        raise AssertionError(
+            "console.input() was called with interactive=False"
+        )
+
+    monkeypatch.setattr(formatter.console, "input", _fail_input)
+
+    agent = Agent(agent_name="NoStdinAgent", interactive=False, max_loops=1)
+    with pytest.raises(ValueError, match="No task provided"):
+        agent.run("")
+
+    assert called["input"] is False


### PR DESCRIPTION
## Problem

Closes #1852.

The guard in `Agent.run()` that prompts for a task when none is supplied had its `self.interactive and ...` condition commented out:

```python
# # If interactive mode is enabled and no task is provided, prompt the user
# if self.interactive and (
#     task is None
#     or (isinstance(task, str) and task.strip() == "")
if (
    task is None
    or isinstance(task, str)
    and task.strip() == ""
):
    ...
    task = formatter.console.input(...)   # blocks on stdin
```

Because the `self.interactive` predicate was dropped, **any** empty/`None` task fell into `formatter.console.input(...)` and blocked on stdin — even for the default `interactive=False`. A non-interactive caller that passed `""` would hang instead of returning, and the "Interactive mode enabled" banner printed when interactive was actually off.

## Fix

Restore the original intent:

- `interactive=True` + empty task → prompt as before.
- `interactive=False` (default) + empty/`None` task → raise a clear `ValueError` telling the caller to pass a task or enable interactive mode. No stdin read.

## Tests

Adds `tests/structs/test_agent_empty_task.py`:

- Parametrized over `""`, `"   "`, `"\n\t "`, `None` — asserts `ValueError("No task provided ...")` with `interactive=False`.
- Asserts the non-interactive path never calls `formatter.console.input` (monkeypatched to fail if reached).

```
$ pytest tests/structs/test_agent_empty_task.py -q
5 passed
```

No behavior change for interactive mode or for non-empty tasks.