### PR TITLE
[Cleanup] Delete dead format_dict_to_string helper (#1851)

### DIFF
--- a/swarms/utils/__init__.py
+++ b/swarms/utils/__init__.py
@@ -19,7 +19,6 @@ from swarms.utils.history_output_formatter import (
 from swarms.utils.index import (
     exists,
     format_data_structure,
-    format_dict_to_string,
 )
 from swarms.utils.litellm_tokenizer import count_tokens
 from swarms.utils.litellm_wrapper import (
@@ -50,6 +49,5 @@ __all__ = [
     "LiteLLMException",
     "exists",
     "format_data_structure",
-    "format_dict_to_string",
     "initialize_logger",
 ]

--- a/swarms/utils/index.py
+++ b/swarms/utils/index.py
@@ -10,39 +10,6 @@ def exists(val):
     return val is not None
 
 
-def format_dict_to_string(data: dict, indent_level=0, use_colon=True):
-    """
-    Recursively format a dictionary into a multi-line string.
-
-    Args:
-        data (dict): The dictionary to format.
-        indent_level (int, optional): The current indentation level for nested structures.
-        use_colon (bool, optional): If True, use "key: value" formatting;
-            if False, use "key value" formatting.
-
-    Returns:
-        str: Multi-line readable string representing the structure of the input dictionary.
-    """
-    if not isinstance(data, dict):
-        return str(data)
-
-    lines = []
-    indent = "  " * indent_level
-    separator = ": " if use_colon else " "
-
-    for key, value in data.items():
-        if isinstance(value, dict):
-            lines.append(f"{indent}{key}:")
-            nested_string = format_dict_to_string(
-                value, indent_level + 1, use_colon
-            )
-            lines.append(nested_string)
-        else:
-            lines.append(f"{indent}{key}{separator}{value}")
-
-    return "\n".join(lines)
-
-
 def format_data_structure(
     data: any, indent_level: int = 0, max_depth: int = 10
 ) -> str:


### PR DESCRIPTION
## What

Addresses the first item of #1851: delete `format_dict_to_string` (zero callers) and its re-export.

`format_dict_to_string` in `swarms/utils/index.py` recursively renders a dict to an indented string, but nothing calls it. A repo-wide search (including `examples/`) finds only:

- its own definition and recursive self-call, and
- the import + `__all__` entry in `swarms/utils/__init__.py`.

`format_data_structure` in the same module already covers the same dict/list rendering and is the helper `agent.py` actually uses. So this one is pure dead code.

## Change

- Remove the 31-line `format_dict_to_string` function.
- Remove its import and `__all__` entry from `swarms/utils/__init__.py`.

## Verification

```
$ python -c "import swarms; from swarms.utils import format_data_structure; \
             import swarms.utils as u; assert not hasattr(u, 'format_dict_to_string')"
# top-level import OK, format_data_structure works, symbol gone
```

No test referenced the removed symbol. This is the safe, self-contained slice of #1851; the `any_to_str`/`func_to_str` consolidation in that issue is left for a follow-up since it changes output cosmetics across call sites.