### PR TITLE
[Bug] AOP._is_network_error over-broad keyword match + duplicate "timeout" (#1853 item 6)

### DIFF
--- a/swarms/structs/aop.py
+++ b/swarms/structs/aop.py
@@ -2593,7 +2593,12 @@ class AOP:
         if isinstance(error, network_errors):
             return True
 
-        # Check error message for network-related keywords
+        # Check error message for network-related keywords. Keep these
+        # specific: bare tokens like "socket", "network", "connection",
+        # "reset" or "aborted" match ordinary non-network messages (e.g.
+        # "reset the counter", "socket_id must be an int") and would route
+        # them into the network-retry loop, which can never resolve them.
+        # The isinstance check above already covers the typed network errors.
         error_msg = str(error).lower()
         network_keywords = [
             "connection refused",
@@ -2601,14 +2606,6 @@ class AOP:
             "connection aborted",
             "network is unreachable",
             "no route to host",
-            "timeout",
-            "socket",
-            "network",
-            "connection",
-            "refused",
-            "reset",
-            "aborted",
-            "unreachable",
             "timeout",
         ]
 

--- a/tests/structs/test_aop.py
+++ b/tests/structs/test_aop.py
@@ -1479,3 +1479,45 @@ def test_queue_stats_not_starved_by_idle_workers():
         queue.stop_workers()
 
     assert elapsed < 2.0, f"20 get_stats() calls took {elapsed:.1f}s"
+
+
+# ---------------------------------------------------------------------------
+# _is_network_error keyword classification (#1853 item 6)
+# ---------------------------------------------------------------------------
+
+
+def test_is_network_error_matches_typed_network_errors(aop_instance):
+    """Typed network errors are classified by isinstance, not keywords."""
+    assert aop_instance._is_network_error(ConnectionError("x")) is True
+    assert aop_instance._is_network_error(TimeoutError("x")) is True
+    assert aop_instance._is_network_error(socket.gaierror("x")) is True
+
+
+def test_is_network_error_matches_network_messages(aop_instance):
+    """Genuinely network-ish plain errors still match via keywords."""
+    for msg in [
+        "Connection refused",
+        "Connection reset by peer",
+        "Network is unreachable",
+        "No route to host",
+        "Read timeout while waiting for response",
+    ]:
+        assert (
+            aop_instance._is_network_error(RuntimeError(msg)) is True
+        ), msg
+
+
+def test_is_network_error_ignores_non_network_messages(aop_instance):
+    """Ordinary failures whose text merely contains a bare token like
+    'reset', 'socket', 'aborted' or 'connection' must not be misclassified
+    as network errors and sent to the network-retry loop."""
+    for msg in [
+        "reset the counter to zero",
+        "socket_id must be an integer",
+        "operation aborted by user",
+        "connection pool exhausted: too many rows",
+        "invalid network_config key",
+    ]:
+        assert (
+            aop_instance._is_network_error(ValueError(msg)) is False
+        ), msg


### PR DESCRIPTION
## Problem
Addresses item 6 of #1853. `AOP._is_network_error`'s keyword fallback listed `"timeout"` twice and included bare tokens (`"socket"`, `"network"`, `"connection"`, `"refused"`, `"reset"`, `"aborted"`, `"unreachable"`) broad enough to match ordinary non-network messages ("reset the counter", "socket_id must be an integer"), routing them into the network-retry loop that can never resolve them.

## Fix
The `isinstance(error, (ConnectionError, TimeoutError, socket.gaierror))` check already covers typed network errors, so narrow the keyword fallback to the specific phrases plus a single `"timeout"`.

## Tests
`tests/structs/test_aop.py`: typed errors and genuine network phrases still classify as network errors; non-network messages containing a bare token no longer do. `pytest -k is_network_error` → `8 passed`.