### PR TITLE
[Cleanup] Delete dead format_dict_to_string helper (#1851)

### DIFF
--- a/swarms/utils/__init__.py
+++ b/swarms/utils/__init__.py
@@ -19,7 +19,6 @@ from swarms.utils.history_output_formatter import (
 from swarms.utils.index import (
     exists,
     format_data_structure,
-    format_dict_to_string,
 )
 from swarms.utils.litellm_tokenizer import count_tokens
 from swarms.utils.litellm_wrapper import (
@@ -50,6 +49,5 @@ __all__ = [
     "LiteLLMException",
     "exists",
     "format_data_structure",
-    "format_dict_to_string",
     "initialize_logger",
 ]

--- a/swarms/utils/index.py
+++ b/swarms/utils/index.py
@@ -10,39 +10,6 @@ def exists(val):
     return val is not None
 
 
-def format_dict_to_string(data: dict, indent_level=0, use_colon=True):
-    """
-    Recursively format a dictionary into a multi-line string.
-
-    Args:
-        data (dict): The dictionary to format.
-        indent_level (int, optional): The current indentation level for nested structures.
-        use_colon (bool, optional): If True, use "key: value" formatting;
-            if False, use "key value" formatting.
-
-    Returns:
-        str: Multi-line readable string representing the structure of the input dictionary.
-    """
-    if not isinstance(data, dict):
-        return str(data)
-
-    lines = []
-    indent = "  " * indent_level
-    separator = ": " if use_colon else " "
-
-    for key, value in data.items():
-        if isinstance(value, dict):
-            lines.append(f"{indent}{key}:")
-            nested_string = format_dict_to_string(
-                value, indent_level + 1, use_colon
-            )
-            lines.append(nested_string)
-        else:
-            lines.append(f"{indent}{key}{separator}{value}")
-
-    return "\n".join(lines)
-
-
 def format_data_structure(
     data: any, indent_level: int = 0, max_depth: int = 10
 ) -> str:


### PR DESCRIPTION
## What
Addresses the first item of #1851. `format_dict_to_string` in `swarms/utils/index.py` has no callers anywhere in the repo (or `examples/`) — only its own recursion and the `swarms/utils/__init__.py` re-export. `format_data_structure` already covers the same rendering.

## Change
Remove the 31-line helper and its import + `__all__` entry from `swarms/utils/__init__.py`.

## Verification
`import swarms` works, `format_data_structure` works, and `swarms.utils` no longer exposes `format_dict_to_string`. The `any_to_str`/`func_to_str` consolidation in that issue is left for a follow-up (it changes output cosmetics across call sites).