### PR TITLE
[Bug] arun() binds a third positional argument to run()'s imgs parameter

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2308,7 +2308,6 @@ Subtask Breakdown:
         self,
         task: Optional[str] = None,
         img: Optional[str] = None,
-        *args,
         **kwargs,
     ) -> Any:
         """
@@ -2317,9 +2316,7 @@ Subtask Breakdown:
         Args:
             task (Optional[str]): The task to be performed. Defaults to None.
             img (Optional[str]): The image to be processed. Defaults to None.
-            is_last (bool): Indicates if this is the last task. Defaults to False.
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
+            **kwargs: Additional keyword arguments, forwarded to run().
 
         Returns:
             Any: The result of the asynchronous operation.
@@ -2328,16 +2325,14 @@ Subtask Breakdown:
             Exception: If an error occurs during the asynchronous operation.
         """
         try:
-            # Forward positionally, in run()'s own parameter order. Passing
-            # task/img as keywords while also splatting *args made every
-            # extra positional collide with `task`:
-            #   TypeError: run() got multiple values for argument 'task'
-            # so arun(task, img, extra) raised instead of running.
+            # Forward by keyword. run()'s positionals after `img` are
+            # imgs/correct_answer/streaming_callback/n, so a splatted
+            # extra silently became one of those rather than reaching
+            # run()'s own *args.
             return await asyncio.to_thread(
                 self.run,
-                task,
-                img,
-                *args,
+                task=task,
+                img=img,
                 **kwargs,
             )
         except Exception as error:
@@ -2351,7 +2346,6 @@ Subtask Breakdown:
         self,
         task: Optional[str] = None,
         img: Optional[str] = None,
-        *args,
         **kwargs,
     ) -> Any:
         """Call the agent
@@ -2359,12 +2353,12 @@ Subtask Breakdown:
         Args:
             task (Optional[str]): The task to be performed. Defaults to None.
             img (Optional[str]): The image to be processed. Defaults to None.
+            **kwargs: Additional keyword arguments, forwarded to run().
         """
         try:
             return self.run(
                 task=task,
                 img=img,
-                *args,
                 **kwargs,
             )
         except Exception as error:

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1028,25 +1028,77 @@ class TestArunForwarding:
         agent.to_dict = lambda: {}
         return agent
 
-    def test_extra_positional_args_reach_run(self):
-        """`task=`/`img=` as keywords alongside *args made every extra
-        positional collide with `task`: arun(task, img, extra) raised
-        `TypeError: got multiple values for argument 'task'`.
+    def test_keywords_reach_run_under_the_names_the_caller_used(self):
+        """Forwarding must go by keyword.
+
+        Splatting extras positionally lands them on run()'s next
+        parameters — imgs, correct_answer, streaming_callback, n — never
+        on run()'s own *args. The stub mirrors run()'s real signature so
+        a misbind shows up here instead of being absorbed by a
+        catch-all `*args` stub.
         """
         agent = self._bare_agent()
         seen = {}
 
-        def fake_run(*args, **kwargs):
-            seen["args"] = args
-            seen["kwargs"] = kwargs
+        def fake_run(
+            task=None,
+            img=None,
+            imgs=None,
+            correct_answer=None,
+            **kwargs,
+        ):
+            seen.update(
+                task=task,
+                img=img,
+                imgs=imgs,
+                correct_answer=correct_answer,
+                kwargs=kwargs,
+            )
             return "ok"
 
         agent.run = fake_run
 
-        result = asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
+        result = asyncio.run(
+            Agent.arun(agent, "T", "I", imgs=["a.png"], n=2)
+        )
 
         assert result == "ok"
-        assert seen["args"] == ("T", "I", "EXTRA")
+        assert seen["task"] == "T"
+        assert seen["img"] == "I"
+        assert seen["imgs"] == ["a.png"]
+        assert seen["correct_answer"] is None
+        assert seen["kwargs"] == {"n": 2}
+
+    def test_a_third_positional_is_rejected_not_silently_rebound(
+        self,
+    ):
+        """arun never had a working *args, so it should not advertise one.
+
+        While it did, `arun(task, img, extra)` bound `extra` to run()'s
+        `imgs` — which expects a list of image paths — and the call went
+        through with the wrong argument in the wrong slot.
+        """
+        import asyncio
+
+        agent = self._bare_agent()
+        agent.run = lambda *a, **k: "ok"
+
+        with pytest.raises(TypeError):
+            asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
+
+    def test_call_forwards_the_same_way(self):
+        """__call__ carried the identical dead *args into run()."""
+        agent = self._bare_agent()
+        seen = {}
+
+        def fake_run(task=None, img=None, imgs=None, **kwargs):
+            seen.update(task=task, img=img, imgs=imgs)
+            return "ok"
+
+        agent.run = fake_run
+
+        assert Agent.__call__(agent, "T", imgs=["a.png"]) == "ok"
+        assert seen == {"task": "T", "img": None, "imgs": ["a.png"]}
 
     def test_error_path_does_not_await_a_sync_handler(self):
         """`_handle_run_error` is sync and re-raises; the await was harmless
@@ -1056,10 +1108,6 @@ class TestArunForwarding:
 
         assert not inspect.iscoroutinefunction(
             Agent._handle_run_error
-        )
-        assert (
-            "await self._handle_run_error"
-            not in inspect.getsource(Agent.arun)
         )
 
         agent = self._bare_agent()

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1028,77 +1028,25 @@ class TestArunForwarding:
         agent.to_dict = lambda: {}
         return agent
 
-    def test_keywords_reach_run_under_the_names_the_caller_used(self):
-        """Forwarding must go by keyword.
-
-        Splatting extras positionally lands them on run()'s next
-        parameters — imgs, correct_answer, streaming_callback, n — never
-        on run()'s own *args. The stub mirrors run()'s real signature so
-        a misbind shows up here instead of being absorbed by a
-        catch-all `*args` stub.
+    def test_extra_positional_args_reach_run(self):
+        """`task=`/`img=` as keywords alongside *args made every extra
+        positional collide with `task`, so arun(task, img, extra) raised
+        `TypeError: run() got multiple values for argument 'task'`.
         """
         agent = self._bare_agent()
         seen = {}
 
-        def fake_run(
-            task=None,
-            img=None,
-            imgs=None,
-            correct_answer=None,
-            **kwargs,
-        ):
-            seen.update(
-                task=task,
-                img=img,
-                imgs=imgs,
-                correct_answer=correct_answer,
-                kwargs=kwargs,
-            )
+        def fake_run(*args, **kwargs):
+            seen["args"] = args
+            seen["kwargs"] = kwargs
             return "ok"
 
         agent.run = fake_run
 
-        result = asyncio.run(
-            Agent.arun(agent, "T", "I", imgs=["a.png"], n=2)
-        )
+        result = asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
 
         assert result == "ok"
-        assert seen["task"] == "T"
-        assert seen["img"] == "I"
-        assert seen["imgs"] == ["a.png"]
-        assert seen["correct_answer"] is None
-        assert seen["kwargs"] == {"n": 2}
-
-    def test_a_third_positional_is_rejected_not_silently_rebound(
-        self,
-    ):
-        """arun never had a working *args, so it should not advertise one.
-
-        While it did, `arun(task, img, extra)` bound `extra` to run()'s
-        `imgs` — which expects a list of image paths — and the call went
-        through with the wrong argument in the wrong slot.
-        """
-        import asyncio
-
-        agent = self._bare_agent()
-        agent.run = lambda *a, **k: "ok"
-
-        with pytest.raises(TypeError):
-            asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
-
-    def test_call_forwards_the_same_way(self):
-        """__call__ carried the identical dead *args into run()."""
-        agent = self._bare_agent()
-        seen = {}
-
-        def fake_run(task=None, img=None, imgs=None, **kwargs):
-            seen.update(task=task, img=img, imgs=imgs)
-            return "ok"
-
-        agent.run = fake_run
-
-        assert Agent.__call__(agent, "T", imgs=["a.png"]) == "ok"
-        assert seen == {"task": "T", "img": None, "imgs": ["a.png"]}
+        assert seen["args"] == ("T", "I", "EXTRA")
 
     def test_error_path_does_not_await_a_sync_handler(self):
         """`_handle_run_error` is sync and re-raises; the await was harmless
@@ -1108,6 +1056,10 @@ class TestArunForwarding:
 
         assert not inspect.iscoroutinefunction(
             Agent._handle_run_error
+        )
+        assert (
+            "await self._handle_run_error"
+            not in inspect.getsource(Agent.arun)
         )
 
         agent = self._bare_agent()

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1028,25 +1028,53 @@ class TestArunForwarding:
         agent.to_dict = lambda: {}
         return agent
 
-    def test_extra_positional_args_reach_run(self):
-        """`task=`/`img=` as keywords alongside *args made every extra
-        positional collide with `task`, so arun(task, img, extra) raised
-        `TypeError: run() got multiple values for argument 'task'`.
-        """
+    def test_task_and_img_reach_run_with_kwargs(self):
+        """The forwarding arun is actually able to do."""
+        import asyncio
+
         agent = self._bare_agent()
         seen = {}
 
-        def fake_run(*args, **kwargs):
-            seen["args"] = args
+        def fake_run(task=None, img=None, **kwargs):
+            seen["task"] = task
+            seen["img"] = img
             seen["kwargs"] = kwargs
             return "ok"
 
         agent.run = fake_run
 
-        result = asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
+        result = asyncio.run(
+            Agent.arun(agent, "T", "I", streaming_callback=None)
+        )
 
         assert result == "ok"
-        assert seen["args"] == ("T", "I", "EXTRA")
+        assert seen["task"] == "T"
+        assert seen["img"] == "I"
+        assert seen["kwargs"] == {"streaming_callback": None}
+
+    def test_a_third_positional_is_refused_not_bound_to_imgs(self):
+        """It has to fail loudly, because there is no correct place for it.
+
+        run()'s positionals after `img` are imgs/correct_answer/
+        streaming_callback/n, so forwarding a third positional through does
+        not reach run()'s own *args -- it lands on `imgs`, a List[str] of
+        image paths:
+
+            >>> inspect.signature(Agent.run).bind_partial(
+            ...     None, "T", "I", "EXTRA").arguments
+            {'task': 'T', 'img': 'I', 'imgs': 'EXTRA'}
+
+        A stub declared as ``fake_run(*args, **kwargs)`` cannot see that --
+        it accepts anything positionally -- which is why the real signature
+        is used here.
+        """
+        import asyncio
+
+        agent = self._bare_agent()
+        agent.run = lambda task=None, img=None, imgs=None, **kw: "ok"
+
+        with pytest.raises(TypeError):
+            asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
 
     def test_error_path_does_not_await_a_sync_handler(self):
         """`_handle_run_error` is sync and re-raises; the await was harmless


### PR DESCRIPTION
## What

`Agent.arun()` and `Agent.__call__()` both declare `*args` that they cannot forward to `run()`.

`run()`'s signature is:

```python
def run(self, task=None, img=None, imgs=None, correct_answer=None,
        streaming_callback=None, n=1, *args, **kwargs)
```

There are four parameters between `img` and `run()`'s own `*args`. Nothing splatted after `task` and `img` can get past them.

`arun()` splats anyway:

```python
return await asyncio.to_thread(self.run, task, img, *args, **kwargs)
```

so a third positional lands on `imgs`:

```
arun("Summarize", "chart.png", "EXTRA")
  -> run(task="Summarize", img="chart.png", imgs="EXTRA")
```

`imgs` expects `List[str]` and is iterated as one, so `"EXTRA"` is consumed a character at a time. The call does not fail — it runs with the wrong argument in the wrong slot.

`__call__()` has the same dead `*args` but passes `task=`/`img=` as keywords beside it, so it raises `TypeError: run() got multiple values for argument 'task'` as soon as `*args` is non-empty. Loud rather than silent, but equally unreachable.

## Why this way

I introduced the `arun` half of this in #1871 while fixing that same `TypeError`. Making the forward positional removed the exception but did not make `*args` reachable — it only moved the extras onto the four named parameters in between. Deleting the parameter is the honest fix: it never carried a value under either version.

Nothing that worked stops working. Extra positionals could not reach `run()` before this change either, and every parameter they would have targeted (`imgs`, `correct_answer`, `streaming_callback`, `n`) is still reachable by name through `**kwargs`.

## Tests

Appended to the existing `TestArunForwarding` class in `tests/structs/test_agent.py`.

The previous test used a `fake_run(*args, **kwargs)` stub, which accepts any binding and so could not observe the misbind. The replacement mirrors `run()`'s real parameter names, and a second test pins that a third positional is now rejected rather than silently rebound — that one fails on `master` with `DID NOT RAISE TypeError`.

Both live in `tests/structs/test_agent.py`, the file this diff already touches. Verified by swapping only `swarms/structs/agent.py` for master's copy:

```
FAILED TestArunForwarding::test_a_third_positional_is_refused_not_bound_to_imgs
1 failed, 2 passed
```

and the whole file is `master=27 branch=27 IDENTICAL FAILURE SET` against a clean master worktree.

> An earlier revision of this PR dropped the test file and this section said so. That is no longer true — the tests are back, because the merged test from #1871 asserted the mis-bind was correct and had to be replaced rather than deleted.

