### PR TITLE
[CI] Strip the trailing whitespace that is failing black on every open PR

### DIFF
--- a/swarms/tools/pydantic_to_json.py
+++ b/swarms/tools/pydantic_to_json.py
@@ -11,7 +11,7 @@ def _remove_a_key(d: dict, remove_key: str) -> None:
     Args:
         d (dict): The dictionary from which to remove the key.
         remove_key (str): The key to remove from the dictionary.
-    
+
     Returns:
         None: The provided dictionary is modified in-place.
     """


### PR DESCRIPTION
## What

One blank docstring line in `swarms/tools/pydantic_to_json.py` carries trailing whitespace:

```diff
         remove_key (str): The key to remove from the dictionary.
-    
+
     Returns:
```

## Why it matters beyond one file

The `lint` job runs `black . --check --diff` across the repo, so a single unformatted line fails the check for **every** open PR and every branch cut from master — not just for changes that touch this file. `lint` was green as recently as #1871 and went red with `830b54c8`.

That matters mostly as signal: `build`, `test`, `pyre` and `test-main-features` are already red on master for unrelated reasons, so `lint` was the one check that still distinguished "this PR is fine" from "this PR broke something". Getting it back to green costs one line.

## Verification

`black . --check` on this branch reports `965 files would be left unchanged`. That is the exact command the workflow runs.

No functional change — whitespace only.