### PR TITLE
[CI] Fix black failure I introduced in #1877

### DIFF
--- a/tests/structs/test_aop.py
+++ b/tests/structs/test_aop.py
@@ -1488,9 +1488,13 @@ def test_queue_stats_not_starved_by_idle_workers():
 
 def test_is_network_error_matches_typed_network_errors(aop_instance):
     """Typed network errors are classified by isinstance, not keywords."""
-    assert aop_instance._is_network_error(ConnectionError("x")) is True
+    assert (
+        aop_instance._is_network_error(ConnectionError("x")) is True
+    )
     assert aop_instance._is_network_error(TimeoutError("x")) is True
-    assert aop_instance._is_network_error(socket.gaierror("x")) is True
+    assert (
+        aop_instance._is_network_error(socket.gaierror("x")) is True
+    )
 
 
 def test_is_network_error_matches_network_messages(aop_instance):


### PR DESCRIPTION
## What

Two asserts I added in #1877 run past the 70-column limit set in `pyproject.toml`:

```diff
-    assert aop_instance._is_network_error(ConnectionError("x")) is True
+    assert (
+        aop_instance._is_network_error(ConnectionError("x")) is True
+    )
```

(and the same for the `socket.gaierror` line)

## Why

My fault — I did not run `black` on `tests/structs/test_aop.py` before pushing #1877. Since the `lint` job runs `black . --check` over the whole repo, those two lines fail the check on master and on every open PR, which re-breaks the exact thing #1881 had just cleared an hour earlier.

## Verification

`black . --check` on this branch reports `965 files would be left unchanged`, and the eight `_is_network_error` tests still pass.

Formatting only, no behaviour change.