### PR TITLE
[Examples][MCP] Add four MCP examples, including the first multi-agent one, and correct two stale server entries

### DIFF
--- a/examples/mcp/agents/07_huggingface_model_search.py
+++ b/examples/mcp/agents/07_huggingface_model_search.py
@@ -1,0 +1,66 @@
+"""
+Example 7 — Hugging Face MCP (free, optional token).
+
+The Hugging Face Hub exposes an MCP server for searching models, datasets,
+Spaces, and papers. It works anonymously; adding a free token raises limits
+and exposes tools that touch your own account.
+
+    Server : https://huggingface.co/mcp
+    Auth   : none required (optional HF token unlocks more)
+    Tools  : model_search, dataset_search, space_search, paper_search, ...
+
+This example shows the *optional auth* pattern: the same agent works with or
+without a key, and only attaches the Bearer token when one is present. That
+matters because a missing environment variable should degrade to anonymous
+access, not crash on startup.
+
+Run:
+    export OPENAI_API_KEY=...        # or ANTHROPIC_API_KEY, etc.
+    export HF_TOKEN=...              # optional, free at
+                                     # https://huggingface.co/settings/tokens
+    python examples/mcp/agents/07_huggingface_model_search.py
+"""
+
+import os
+
+from swarms import Agent
+
+MODEL = "gpt-5.4"
+
+HF_TOKEN = os.getenv("HF_TOKEN")
+
+HF_SYSTEM_PROMPT = (
+    "You are a machine learning model scout. Help users find the right model "
+    "or dataset on the Hugging Face Hub by searching it directly rather than "
+    "recalling names from memory. For each candidate you recommend, report "
+    "what the search returned: the exact repo id, task, size or parameter "
+    "count, and license. Rank recommendations by fitness for the user's "
+    "stated constraints — license, hardware budget, and language or domain "
+    "coverage — and say explicitly when a popular model is a poor fit for "
+    "those constraints. Never invent a repo id; only cite ones the search "
+    "actually returned."
+)
+
+agent = Agent(
+    agent_name="HuggingFace-Scout",
+    agent_description=(
+        "Finds models and datasets on the Hugging Face Hub via MCP."
+    ),
+    system_prompt=HF_SYSTEM_PROMPT,
+    model_name=MODEL,
+    mcp_url="https://huggingface.co/mcp",
+    # Optional: anonymous access works, a token just raises the ceiling.
+    mcp_api_key=("env:HF_TOKEN" if HF_TOKEN else None),
+    max_loops=2,
+)
+
+if __name__ == "__main__":
+    if not HF_TOKEN:
+        print("No HF_TOKEN set - running anonymously (lower rate limits).\n")
+
+    result = agent.run(
+        "Find three open-weight embedding models under 500M parameters that "
+        "are permissively licensed for commercial use. For each, give the "
+        "repo id, parameter count, and license."
+    )
+    print(result)

--- a/examples/mcp/agents/10_firecrawl_web_scraping.py
+++ b/examples/mcp/agents/10_firecrawl_web_scraping.py
@@ -1,0 +1,75 @@
+"""
+Example 10 — Firecrawl MCP (API key, free tier available).
+
+Firecrawl turns arbitrary web pages into clean markdown an LLM can actually
+read: it renders JavaScript, strips navigation and ads, and follows links when
+you ask it to crawl rather than scrape a single page.
+
+    Server : https://mcp.firecrawl.dev/{API_KEY}/v2/mcp
+    Auth   : API key embedded in the URL path
+    Tools  : firecrawl_scrape, firecrawl_crawl, firecrawl_map,
+             firecrawl_search, firecrawl_extract
+
+A third auth shape, alongside the two already shown in this folder:
+
+    Example 05 (Exa)     — key as a query parameter  ?exaApiKey=...
+    Example 09 (GitHub)  — key as a Bearer header    Authorization: Bearer ...
+    Example 10 (this)    — key as a URL path segment /{API_KEY}/
+
+Because the key is part of the URL here, keep it out of logs: build the URL
+from the environment at startup and never print the constructed value.
+
+Crawling is the expensive operation — it is billed per page and can walk a
+large site quickly. Scrape one page first; crawl only when you mean to.
+
+Get a key (free tier): https://www.firecrawl.dev/
+
+Run:
+    export OPENAI_API_KEY=...        # or ANTHROPIC_API_KEY, etc.
+    export FIRECRAWL_API_KEY=fc-...
+    python examples/mcp/agents/10_firecrawl_web_scraping.py
+"""
+
+import os
+import sys
+
+from swarms import Agent
+
+MODEL = "gpt-5.4"
+
+FIRECRAWL_API_KEY = os.getenv("FIRECRAWL_API_KEY")
+
+SCRAPER_SYSTEM_PROMPT = (
+    "You are a web content analyst. Fetch pages before describing them — "
+    "never answer from memory about what a site says, because sites change. "
+    "Prefer scraping the specific page that answers the question over "
+    "crawling a whole site, since crawling is slow and expensive; crawl only "
+    "when the user explicitly wants breadth. Quote the page's own wording for "
+    "any factual claim, note the URL each fact came from, and say clearly "
+    "when a page failed to load or was empty rather than substituting "
+    "assumptions."
+)
+
+if __name__ == "__main__" and not FIRECRAWL_API_KEY:
+    sys.exit(
+        "FIRECRAWL_API_KEY is not set.\n"
+        "Get a free-tier key at https://www.firecrawl.dev/ and export it."
+    )
+
+agent = Agent(
+    agent_name="Firecrawl-Analyst",
+    agent_description="Reads and analyzes live web pages via Firecrawl MCP.",
+    system_prompt=SCRAPER_SYSTEM_PROMPT,
+    model_name=MODEL,
+    # The key is a path segment for Firecrawl. Never log this URL.
+    mcp_url=f"https://mcp.firecrawl.dev/{FIRECRAWL_API_KEY}/v2/mcp",
+    max_loops=2,
+)
+
+if __name__ == "__main__":
+    result = agent.run(
+        "Scrape https://modelcontextprotocol.io/introduction and explain, in "
+        "the docs' own terms, what problem MCP solves and what the three "
+        "core primitives are. Quote the definitions."
+    )
+    print(result)

--- a/examples/mcp/agents/12_semgrep_security_scan.py
+++ b/examples/mcp/agents/12_semgrep_security_scan.py
@@ -1,0 +1,98 @@
+"""
+Example 12 — Semgrep MCP (free account, token required) for security review.
+
+Semgrep runs static analysis over code you hand it and returns concrete
+findings: rule id, severity, line number, and why the pattern is dangerous.
+Pairing it with an LLM is a good division of labour — the scanner finds
+occurrences deterministically, the model explains impact and drafts the fix.
+
+    Server : https://mcp.semgrep.ai/mcp
+    Auth   : Semgrep AppSec Platform token, Bearer  (free account)
+    Tools  : semgrep_scan, security_check, get_abstract_syntax_tree, ...
+
+Note: this endpoint accepted anonymous traffic historically and now returns
+401 without a token. Verified 2026-08-12. Get a free token at
+https://semgrep.dev/login -> Settings -> Tokens.
+
+The point of the system prompt below is to stop the model doing what LLMs
+love to do with security questions: inventing plausible-sounding
+vulnerabilities. Findings come from the scanner; the model's job is triage,
+not imagination.
+
+Run:
+    export OPENAI_API_KEY=...        # or ANTHROPIC_API_KEY, etc.
+    export SEMGREP_APP_TOKEN=...     # free at https://semgrep.dev
+    python examples/mcp/agents/12_semgrep_security_scan.py
+"""
+
+import os
+import sys
+
+from swarms import Agent
+
+MODEL = "gpt-5.4"
+
+SECURITY_SYSTEM_PROMPT = (
+    "You are a security reviewer. Report only vulnerabilities the scanner "
+    "actually returned — never speculate about issues you did not find, and "
+    "never pad a report to look thorough. For each finding give the rule id, "
+    "severity, the exact line, why it is exploitable in this specific code, "
+    "and a concrete patch. Rank by real-world exploitability rather than by "
+    "the scanner's own severity label, and say plainly when a flagged line is "
+    "a false positive in context. If the scan comes back clean, report that "
+    "it is clean and note what the scan does not cover."
+)
+
+VULNERABLE_SAMPLE = '''
+import os
+import sqlite3
+import subprocess
+
+
+def get_user(conn, user_id):
+    # String-interpolated SQL
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users WHERE id = '%s'" % user_id)
+    return cur.fetchone()
+
+
+def run_report(report_name):
+    # Shell invocation built from user input
+    subprocess.call("generate_report " + report_name, shell=True)
+
+
+def load_config(blob):
+    # Deserializing untrusted input
+    import pickle
+    return pickle.loads(blob)
+
+
+# Deliberately not shaped like any real provider's key: a realistic
+# prefix here would trip secret scanners in every fork of this repo.
+API_TOKEN = "hardcoded-credential-placeholder-do-not-use"
+'''
+
+agent = Agent(
+    agent_name="Semgrep-Security-Agent",
+    agent_description="Reviews code for vulnerabilities using Semgrep MCP.",
+    system_prompt=SECURITY_SYSTEM_PROMPT,
+    model_name=MODEL,
+    mcp_url="https://mcp.semgrep.ai/mcp",
+    mcp_api_key="env:SEMGREP_APP_TOKEN",
+    max_loops=2,
+)
+
+if __name__ == "__main__":
+    if not os.getenv("SEMGREP_APP_TOKEN"):
+        sys.exit(
+            "SEMGREP_APP_TOKEN is not set.\n"
+            "Create a free token at https://semgrep.dev "
+            "(Settings -> Tokens) and export it before running."
+        )
+
+    result = agent.run(
+        "Scan this Python file with Semgrep and write up every finding: rule "
+        "id, severity, line, why it is exploitable, and the fix.\n\n"
+        f"```python\n{VULNERABLE_SAMPLE}\n```"
+    )
+    print(result)

--- a/examples/mcp/agents/13_mcp_sequential_workflow.py
+++ b/examples/mcp/agents/13_mcp_sequential_workflow.py
@@ -1,0 +1,102 @@
+"""
+Example 13 — MCP tools inside a multi-agent workflow.
+
+Every other example in this folder is a single agent. This one wires MCP
+servers into a ``SequentialWorkflow``, which is the more interesting case for
+a multi-agent framework: each agent gets *only* the server it needs, and the
+pipeline hands findings down the chain.
+
+    Researcher : DeepWiki   (https://mcp.deepwiki.com/mcp)   — repo Q&A
+    Librarian  : Context7   (https://mcp.context7.com/mcp)   — current library docs
+    Reporter   : no tools                                    — synthesis only
+
+    Auth : none for either server (verified 2026-08-12)
+
+**Why split the tools per agent instead of giving one agent all of them?**
+
+- *Focus.* A model choosing among many tools for a narrow job picks wrong more
+  often than one choosing among two. Each agent here sees a small surface.
+- *Context.* Tool schemas occupy the window on every call. Loading Context7's
+  schemas into the agent that only reads a repo is pure overhead.
+- *Attribution.* When the output is wrong you can tell which stage produced it.
+- *Cost.* The reporter needs no tools at all, so it never pays for them.
+
+The stages are genuinely dependent — the librarian looks up whatever
+dependencies the researcher found — which is why this is a chain. When stages
+*don't* depend on each other, swap ``SequentialWorkflow`` for
+``ConcurrentWorkflow`` and they run in parallel; the constructor call is
+otherwise identical.
+
+Run:
+    export OPENAI_API_KEY=...        # or ANTHROPIC_API_KEY, etc.
+    python examples/mcp/agents/13_mcp_sequential_workflow.py
+"""
+
+from swarms import Agent, SequentialWorkflow
+
+MODEL = "gpt-5.4"
+
+# --- Stage 1: understand the repository (DeepWiki only) -------------------
+researcher = Agent(
+    agent_name="Repo-Researcher",
+    agent_description="Explains a repository's architecture using DeepWiki.",
+    system_prompt=(
+        "You map codebases. Use DeepWiki to establish what a repository "
+        "actually does before describing it. Report the module layout, the "
+        "entry points, and — most important for the next stage — the "
+        "third-party libraries it depends on, named exactly. Be concrete "
+        "about module and package names; a downstream agent cannot look up "
+        "something you described only in prose."
+    ),
+    model_name=MODEL,
+    mcp_url="https://mcp.deepwiki.com/mcp",
+    max_loops=2,
+)
+
+# --- Stage 2: check those dependencies' current docs (Context7 only) ------
+librarian = Agent(
+    agent_name="Docs-Librarian",
+    agent_description="Checks current library documentation via Context7.",
+    system_prompt=(
+        "You verify how libraries are *currently* meant to be used. Take the "
+        "dependencies identified for you and look each one up — resolve the "
+        "library id, then fetch its docs. Report the current recommended API "
+        "for each, and flag anything deprecated or superseded, since that is "
+        "the whole point of checking live docs rather than trusting memory. "
+        "If a library cannot be found, say so and move on rather than "
+        "inventing its API."
+    ),
+    model_name=MODEL,
+    mcp_url="https://mcp.context7.com/mcp",
+    max_loops=3,
+)
+
+# --- Stage 3: synthesis (no tools -- nothing left to look up) -------------
+reporter = Agent(
+    agent_name="Report-Writer",
+    agent_description="Turns research and docs findings into a brief.",
+    system_prompt=(
+        "You write engineering briefs for a technical lead who has five "
+        "minutes. Open with the single most important conclusion, then the "
+        "supporting detail. Preserve every concrete finding you were handed — "
+        "package names, versions, deprecations — and invent none. Where the "
+        "earlier stages disagreed or hedged, surface that rather than "
+        "smoothing it into false confidence. End with specific next actions."
+    ),
+    model_name=MODEL,
+    max_loops=1,
+)
+
+workflow = SequentialWorkflow(
+    agents=[researcher, librarian, reporter],
+    max_loops=1,
+)
+
+if __name__ == "__main__":
+    result = workflow.run(
+        "Review the modelcontextprotocol/python-sdk repository: map its "
+        "architecture, identify its main third-party dependencies, check "
+        "whether the APIs it relies on are current or deprecated, and write "
+        "a brief for the maintainers."
+    )
+    print(result)

--- a/examples/mcp/agents/FREE_MCP_SERVERS.md
+++ b/examples/mcp/agents/FREE_MCP_SERVERS.md
@@ -2,11 +2,14 @@
 
 A catalog of real, public [MCP](https://modelcontextprotocol.io) servers you can
 plug straight into the Swarms `Agent` class — most require **no authentication**,
-a few use a **free-tier API key**. Runnable examples live in
-this folder, numbered `01`–`05`.
+a few use a **free-tier API key**. Runnable examples live in this folder.
 
-> Availability and URLs change over time — verify a server before depending on it.
-> Last reviewed against known-public servers as of early 2026.
+> Availability, URLs, and **auth requirements** change over time — verify a
+> server before depending on it. Servers that were once open can start
+> requiring a token: Semgrep and Globalping both did.
+>
+> Last verified by live probe on **2026-08-12**. Reachable without auth at
+> that time: DeepWiki, Microsoft Learn, Context7, Hugging Face, AWS Knowledge.
 
 ---
 
@@ -57,8 +60,6 @@ streamable-HTTP endpoint; prefer it when available.
 | **Cloudflare Docs** | `https://docs.mcp.cloudflare.com/mcp` | Cloudflare product documentation |
 | **Hugging Face** | `https://huggingface.co/mcp` | Search models / datasets / Spaces (optional HF token unlocks more) |
 | **Context7** | `https://mcp.context7.com/mcp` | Up-to-date docs for thousands of libraries (rate-limited without a free key) |
-| **Globalping** | `https://mcp.globalping.dev/sse` | Run ping / traceroute / DNS / MTR from a global probe network |
-| **Semgrep** | `https://mcp.semgrep.ai/mcp` | Static-analysis security scanning of code |
 
 ```python
 # Example: repo-scoped documentation assistant via GitMCP
@@ -78,6 +79,8 @@ These are free to use but require a key. How the key is passed differs per serve
 | Server | Endpoint / auth | What it does |
 |---|---|---|
 | **Exa** | `https://mcp.exa.ai/mcp?exaApiKey=…` (query param) | Web search + content retrieval |
+| **Semgrep** | `https://mcp.semgrep.ai/mcp` + Bearer token | Static-analysis security scanning (was open, now 401 without a token) |
+| **Globalping** | `https://mcp.globalping.dev/sse` + Bearer token | ping / traceroute / DNS / MTR from a global probe network (was open, now 401) |
 | **Tavily** | `https://mcp.tavily.com/mcp/?tavilyApiKey=…` (query param) | Web search built for agents |
 | **Firecrawl** | hosted MCP + `FIRECRAWL_API_KEY` | Scrape/crawl sites into clean markdown |
 | **Ref** (ref.tools) | hosted + key | Fast documentation search across frameworks |
@@ -176,6 +179,10 @@ The numbered examples in this folder:
 | [`03_microsoft_learn_docs.py`](03_microsoft_learn_docs.py) | Microsoft Learn | none |
 | [`04_multi_server_agent.py`](04_multi_server_agent.py) | DeepWiki + Microsoft Learn | none |
 | [`05_exa_web_search.py`](05_exa_web_search.py) | Exa | free API key |
+| [`07_huggingface_model_search.py`](07_huggingface_model_search.py) | Hugging Face | none (optional token) |
+| [`10_firecrawl_web_scraping.py`](10_firecrawl_web_scraping.py) | Firecrawl | API key in URL path |
+| [`12_semgrep_security_scan.py`](12_semgrep_security_scan.py) | Semgrep | free token |
+| [`13_mcp_sequential_workflow.py`](13_mcp_sequential_workflow.py) | DeepWiki + Context7 (multi-agent) | none |
 
 ```bash
 export OPENAI_API_KEY=...        # or ANTHROPIC_API_KEY, etc.

--- a/examples/mcp/agents/README.md
+++ b/examples/mcp/agents/README.md
@@ -14,6 +14,15 @@ Each runs against a real public server. The first four need **no MCP API key**.
 | 03 | [`03_microsoft_learn_docs.py`](03_microsoft_learn_docs.py) | Microsoft Learn — official Azure/.NET docs | none |
 | 04 | [`04_multi_server_agent.py`](04_multi_server_agent.py) | Two servers on one agent | none |
 | 05 | [`05_exa_web_search.py`](05_exa_web_search.py) | Exa — web search | free API key |
+| 07 | [`07_huggingface_model_search.py`](07_huggingface_model_search.py) | Hugging Face — find models & datasets | none (optional token) |
+| 10 | [`10_firecrawl_web_scraping.py`](10_firecrawl_web_scraping.py) | Firecrawl — scrape pages to markdown | API key (in URL path) |
+| 12 | [`12_semgrep_security_scan.py`](12_semgrep_security_scan.py) | Semgrep — static-analysis security scan | free token |
+| 13 | [`13_mcp_sequential_workflow.py`](13_mcp_sequential_workflow.py) | **Multi-agent**: MCP tools in a `SequentialWorkflow` | none |
+
+Between them these cover all three ways a server takes a key — query parameter
+(05), Bearer token (12), and URL path segment (10) — plus the optional-auth
+case (07), where a missing key degrades to anonymous access instead of
+failing.
 
 See [`FREE_MCP_SERVERS.md`](FREE_MCP_SERVERS.md) for the full catalog of public servers.
 


### PR DESCRIPTION
## Summary

Four new examples in `examples/mcp/agents/`, plus corrections to the server catalog based on probing every endpoint rather than trusting the existing listing.

## New examples

| File | Server | What it teaches |
|---|---|---|
| `07_huggingface_model_search.py` | Hugging Face Hub | **Optional auth** — a missing `HF_TOKEN` degrades to anonymous access instead of failing at startup |
| `10_firecrawl_web_scraping.py` | Firecrawl | The **third auth shape**: key as a URL path segment (so the URL must stay out of logs) |
| `12_semgrep_security_scan.py` | Semgrep | Scanner finds deterministically, model triages — with a prompt written to stop it inventing findings |
| `13_mcp_sequential_workflow.py` | DeepWiki + Context7 | **MCP inside a multi-agent workflow** |

### Why 13 matters

Every existing MCP example in this folder is a single agent — in a multi-agent framework. This one wires MCP servers into a `SequentialWorkflow` and gives **each agent only the server it needs**: DeepWiki for the researcher, Context7 for the librarian, no tools at all for the reporter. The docstring explains why that beats one agent holding every tool — fewer wrong tool choices, less context spent on unused schemas, attributable failures, and a synthesis stage that pays nothing for tools it never calls.

The stages are genuinely dependent (the librarian looks up whatever dependencies the researcher found), which is why it's a chain rather than a fan-out; the docstring notes that swapping in `ConcurrentWorkflow` is otherwise a one-line change.

### Auth coverage

With these, the folder demonstrates all three ways a server takes a key — query parameter (05, existing), Bearer token (12), URL path segment (10) — plus the optional-auth case (07). Previously only the query-parameter form had a worked example; `mcp_api_key` appeared solely in comments.

## Catalog corrections

`FREE_MCP_SERVERS.md` listed servers as no-auth that no longer are. I probed every endpoint on **2026-08-12**:

| Server | Listed as | Actual |
|---|---|---|
| Semgrep | no auth | **401** — needs a free token |
| Globalping | no auth | **401** — needs a free token |
| DeepWiki, Microsoft Learn, Context7, Hugging Face, AWS Knowledge | no auth | confirmed open |

Both stale entries moved to the key-required table with a note that they were previously open, and the header now warns that auth requirements drift and records the verification date. This mattered concretely: an earlier draft of the Semgrep example claimed `Auth: none` and would have failed for anyone who ran it.

## Note on the Semgrep sample

`12_semgrep_security_scan.py` includes a deliberately vulnerable code sample for the scanner to find. Its hardcoded-credential line uses a placeholder that is **not** shaped like any real provider's key — a realistic `sk_live_…` prefix trips GitHub secret scanning in every fork, which this PR ran into directly.

## Verification

- The no-auth examples were run end to end and genuinely connect and load tools (Hugging Face 4 tools; the workflow's two agents 3 and 2)
- The keyed examples exit early with a clear message when their variable is unset, rather than failing inside a retry loop
- `compileall` and `ruff check` clean across the folder
- README and catalog example tables both updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)