### PR TITLE
[Bug] find_agent_by_name can return another swarm's agents — its cache is keyed on id(agents)

### DIFF
--- a/swarms/structs/ma_blocks.py
+++ b/swarms/structs/ma_blocks.py
@@ -124,10 +124,6 @@ def run_agent(
         raise RuntimeError(f"Error running agent: {str(e)}")
 
 
-_FIND_AGENT_INDEX_CACHE: dict = {}
-_FIND_AGENT_INDEX_CACHE_MAX = 256
-
-
 def _build_agent_name_index(agents):
     index = {}
     for agent in agents:
@@ -146,9 +142,11 @@ def find_agent_by_name(
     """
     Find an agent by its name in a list of agents.
 
-    Builds a name -> agent index on first call for a given list and
-    reuses it on subsequent calls, turning repeated lookups from O(n)
-    into O(1).
+    Builds a name -> agent index per call. A previous version memoised the
+    index under ``id(agents)``, which is unsound: the cache held no
+    reference to the list, so once the list was freed CPython reused the
+    address and an unrelated roster of the same length got the dead
+    swarm's agents.
 
     Args:
         agents (List[Union[Agent, Callable]]): List of agents to search through
@@ -170,27 +168,7 @@ def find_agent_by_name(
     if not agent_name.strip():
         raise ValueError("Agent name cannot be empty or whitespace")
 
-    key = id(agents)
-    length = len(agents)
-    cached = _FIND_AGENT_INDEX_CACHE.get(key)
-    if cached is None or cached[0] != length:
-        if (
-            len(_FIND_AGENT_INDEX_CACHE)
-            >= _FIND_AGENT_INDEX_CACHE_MAX
-        ):
-            _FIND_AGENT_INDEX_CACHE.clear()
-        index = _build_agent_name_index(agents)
-        _FIND_AGENT_INDEX_CACHE[key] = (length, index)
-    else:
-        index = cached[1]
-
-    agent = index.get(agent_name)
-    if agent is not None:
-        return agent
-
-    index = _build_agent_name_index(agents)
-    _FIND_AGENT_INDEX_CACHE[key] = (length, index)
-    agent = index.get(agent_name)
+    agent = _build_agent_name_index(agents).get(agent_name)
     if agent is None:
         raise ValueError(f"Agent with name '{agent_name}' not found")
     return agent


### PR DESCRIPTION
## Problem

`find_agent_by_name` memoises its name → agent index under the **address** of the list:

```python
key = id(agents)
length = len(agents)
cached = _FIND_AGENT_INDEX_CACHE.get(key)
if cached is None or cached[0] != length:
    ...
    _FIND_AGENT_INDEX_CACHE[key] = (length, index)
else:
    index = cached[1]
```

The cache holds strong references to the *agents* but none to the *list*. So the list is garbage collected while its cache entry lives on, and CPython immediately reuses that address for the next list allocated. A later, unrelated roster of the same length gets a cache hit and resolves names against a **discarded swarm's agent objects**.

`len()` is the only invalidation signal, so this also fires for any in-place same-length mutation, e.g. `agents[0] = replacement`.

## Why the existing fallback does not save it

There is a rebuild-on-miss path, but it only triggers when the name is *absent* from the stale index. When both swarms use the same agent names — the common case, and what every `"Researcher -> Writer"` flow looks like — the stale lookup **succeeds** and returns the wrong object. Nothing raises. The run completes and returns confident, wrong output.

## Reproduction

Hits on the first trial:

```python
from swarms.structs.ma_blocks import find_agent_by_name

class Fake:
    def __init__(s, n, tag): s.agent_name, s.tag = n, tag

for i in range(2000):
    a1 = [Fake("A", "swarm1"), Fake("B", "swarm1")]
    find_agent_by_name(a1, "A")      # populates cache under id(a1)
    key = id(a1); del a1
    a2 = [Fake("A", "swarm2"), Fake("B", "swarm2")]
    if id(a2) == key:
        print(find_agent_by_name(a2, "A").tag)   # -> 'swarm1'
        break
    del a2
```

```
TRIAL 0: address reused; find_agent_by_name(swarm2 list,'A').tag = swarm1
```

`a2` is built entirely from `swarm2` agents; the lookup returns `swarm1`'s.

Every orchestrator that resolves agents by name routes through this one function — `agent_rearrange`, `hiearchical_swarm`, `multi_agent_router`, `agent_registry`, `base_swarm`, `aop`, among others — so the fix belongs here rather than at any call site.

## Fix

Delete the cache; build the index per call.

It is not worth repairing. 10,000 lookups over a 50-agent roster take **25 ms** — about 2.5 µs each — and every lookup is immediately followed by an LLM call taking orders of magnitude longer. A correct cache would have to live on the object that owns the roster and be invalidated by `add_agent`/`remove_agent`; that is a lot of machinery to save microseconds, and it is what introduced this bug.

Net −22 lines.

## Verification

- The reproduction above now prints `swarm2` at the same trial.
- Lookup still resolves (`A17`), and a missing name still raises `ValueError: Agent with name 'nope' not found`.
- `tests/structs/test_agent_registry.py` (the suite that exercises this function): 2 failed, 16 passed — **identical on `master`**, same failing test, pre-existing.

*(`tests/structs/test_agent_rearrange.py` and `test_multi_agent_router.py` make live LiteLLM calls and are not reproducible run-to-run in a sandbox; they report the same 33 failed / 55 passed with and without this change.)*