### PR TITLE
style: format two MCP examples so black passes on master

### DIFF
--- a/examples/mcp/agents/07_huggingface_model_search.py
+++ b/examples/mcp/agents/07_huggingface_model_search.py
@@ -56,7 +56,9 @@ agent = Agent(
 
 if __name__ == "__main__":
     if not HF_TOKEN:
-        print("No HF_TOKEN set - running anonymously (lower rate limits).\n")
+        print(
+            "No HF_TOKEN set - running anonymously (lower rate limits).\n"
+        )
 
     result = agent.run(
         "Find three open-weight embedding models under 500M parameters that "

--- a/examples/mcp/agents/12_semgrep_security_scan.py
+++ b/examples/mcp/agents/12_semgrep_security_scan.py
@@ -43,7 +43,7 @@ SECURITY_SYSTEM_PROMPT = (
     "it is clean and note what the scan does not cover."
 )
 
-VULNERABLE_SAMPLE = '''
+VULNERABLE_SAMPLE = """
 import os
 import sqlite3
 import subprocess
@@ -70,7 +70,7 @@ def load_config(blob):
 # Deliberately not shaped like any real provider's key: a realistic
 # prefix here would trip secret scanners in every fork of this repo.
 API_TOKEN = "hardcoded-credential-placeholder-do-not-use"
-'''
+"""
 
 agent = Agent(
     agent_name="Semgrep-Security-Agent",


### PR DESCRIPTION
## Why

The `lint` job is failing on `master` right now, not just on this branch. `black --check .` reports:

```
would reformat examples/mcp/agents/07_huggingface_model_search.py
would reformat examples/mcp/agents/12_semgrep_security_scan.py
2 files would be reformatted, 967 files would be left unchanged.
```

Those two files came in with 47d94eba (#1883). They are formatted correctly for black's default line length, but this repo sets `line-length = 70` in `pyproject.toml`, and at 70 black wants a wrapped `print(...)` in one and `"""` instead of `'''` for the sample block in the other.

The reason this matters beyond tidiness: GitHub runs checks against the merge commit, so a red `lint` on master shows up as a red `lint` on every open pull request. Right now lint cannot tell a reviewer whether a contributor actually broke formatting, because it is red either way.

## What

`black examples/mcp/agents/07_huggingface_model_search.py examples/mcp/agents/12_semgrep_security_scan.py` and nothing else. Five lines, no logic touched.

Verified with the repo's own config, black 24.2.0:

```
before: 2 files would be reformatted, 967 files would be left unchanged.
after:  969 files would be left unchanged.
```

I am a freshman working through this codebase and I built this with Claude Code's help, so please push back if the repo would rather fix this a different way.