### PR TITLE
[Bug] on_error="raise" is silently ignored whenever show_dashboard=True

### DIFF
--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -410,6 +410,19 @@ class ConcurrentWorkflow:
                         output = future.result()
                         results.append((agent.agent_name, output))
                     except Exception as e:
+                        # Same failure policy as `_run`. This path used to
+                        # convert every failure into an "Error: ..." string
+                        # regardless, so `on_error="raise"` was silently
+                        # revoked by turning the dashboard on, and the
+                        # failure never reached telemetry either.
+                        if self.on_error == "raise":
+                            raise
+                        capture_error(
+                            e,
+                            self,
+                            name="ConcurrentWorkflow.agent_error",
+                            agent=getattr(agent, "agent_name", None),
+                        )
                         logger.error(
                             f"Agent {agent.agent_name} failed: {str(e)}"
                         )


### PR DESCRIPTION
## Problem

`ConcurrentWorkflow.run()` forks on `show_dashboard`, and only one branch applies the failure policy.

`_run` honours it:

```python
except Exception as e:
    if self.on_error == "raise":
        raise
    capture_error(e, self, name="ConcurrentWorkflow.agent_error", ...)
```

`run_with_dashboard` did not — it converted every agent exception into an `"Error: ..."` string unconditionally.

So a caller who set `on_error="raise"` specifically to abort on provider failures has that guarantee revoked by an unrelated **display** flag:

```
on_error="raise", show_dashboard=False  ->  RuntimeError: provider 500
on_error="raise", show_dashboard=True   ->  returns normally, no exception
```

The failure also skipped `capture_error` on that path, so it never reached telemetry either — the run looks clean from both the caller's side and the instrumentation's.

## Fix

Apply the same policy in both branches: re-raise when `on_error == "raise"`, otherwise `capture_error` and record the failure as a result, exactly as `_run` already does.

## Verification

```
on_error="raise", show_dashboard=False  ->  RAISED RuntimeError: provider 500
on_error="raise", show_dashboard=True   ->  RAISED RuntimeError: provider 500
```

`on_error="store"` is unchanged and still records the failure on either path:

```
store, show_dashboard=False  ->  [{'role': 'B (failed)', 'content': 'Error: provider 500'}]
store, show_dashboard=True   ->  [{'role': 'B',          'content': 'Error: provider 500'}]
```

`tests/structs/test_concurrent_workflow.py` — 10 passed.

One file, 14 lines.

*(Noted while verifying, not fixed here: the two paths label a failed agent's role differently — `"B (failed)"` vs `"B"`. Cosmetic and separable, so I left it out rather than widening this diff.)*