### PR TITLE
[Bug] AgentRearrange drops img on parallel flow steps, but forwards it on sequential ones

### DIFF
--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -566,9 +566,13 @@ class AgentRearrange(SerializableMixin):
             )
 
         # Run agents concurrently
+        # `img` was accepted and dropped, so a flow step written with a comma
+        # ("A, B") silently ran without the image while the sequential path
+        # ("A -> B") forwarded it. The async twin below forwards it too.
         results = run_agents_concurrently(
             agents=agents_to_run,
             task=self.conversation.get_str(),
+            img=img,
         )
 
         # Process results and update conversation


### PR DESCRIPTION
## Problem

`_run_concurrent_workflow` accepts `img` and never uses it:

```python
def _run_concurrent_workflow(self, agent_names, img: str = None, *args, **kwargs):
    ...
    results = run_agents_concurrently(
        agents=agents_to_run,
        task=self.conversation.get_str(),
    )
```

`run_agents_concurrently` takes an `img` parameter — the call just omitted it.

So the same request behaves differently depending on whether its flow contains a comma:

```
flow "A, B"    ->  A saw img=None,          B saw img=None
flow "A -> B"  ->  A saw img='chart.png',   B saw img='chart.png'
```

No error, no warning — the agents simply answer a multimodal question without the image.

## Why the sync parallel path is the outlier

Two of the three paths already forward it:

- `_run_sequential_workflow` forwards `img`
- `_run_concurrent_workflow_stream` (the async twin) forwards `img`
- `_run_concurrent_workflow` did not

## Reach

Anything with a parallel step in its flow: `AgentRearrange(flow="A, B").run(task, img=...)`, `SequentialWorkflow.run(task, img=...)` where the derived flow has one, and `SwarmRouter(swarm_type="AgentRearrange")`.

## Verification

```
after:
flow "A, B"    ->  A saw img='chart.png',   B saw img='chart.png'
flow "A -> B"  ->  A saw img='chart.png',   B saw img='chart.png'
```

`tests/structs/test_agent_rearrange.py` — 11 failed / 54 passed, identical on `master` (that suite makes live LiteLLM calls, so it is red in a sandbox either way; the counts and the failing set match).

One file, one argument.

*(Left alone deliberately: the `*args`/`**kwargs` on this method also have no destination on `run_agents_concurrently`. Removing them is a signature change rather than a bug fix, so it did not belong in this diff.)*