### PR TITLE
[Bug] create_agent_map returns an empty map for plain callables, and one bad entry discards the whole roster

### DIFF
--- a/swarms/structs/ma_utils.py
+++ b/swarms/structs/ma_utils.py
@@ -2,8 +2,6 @@ import random
 from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from loguru import logger
-
 from swarms.prompts.collaborative_prompts import (
     get_multi_agent_collaboration_prompt_one,
 )
@@ -145,18 +143,26 @@ def _create_agent_map_cached(
     agent_tuple: tuple,
 ) -> Dict[str, Union[Callable, Any]]:
     """Internal cached version of create_agent_map that takes a tuple for hashability."""
-    try:
-        return {
-            (
-                agent.agent_name
-                if isinstance(agent, Callable)
-                else agent.__name__
-            ): agent
-            for agent in agent_tuple
-        }
-    except (AttributeError, TypeError) as e:
-        logger.error(f"Error creating agent map: {e}")
-        return {}
+    # An Agent instance and a plain function are both `Callable`, so branching
+    # on isinstance sent functions down the `agent_name` path and raised. Ask
+    # for the attributes in preference order instead.
+    agent_map: Dict[str, Union[Callable, Any]] = {}
+
+    for agent in agent_tuple:
+        name = getattr(agent, "agent_name", None) or getattr(
+            agent, "__name__", None
+        )
+        if name is None:
+            # Raise rather than return an empty map: lru_cache memoises a
+            # returned value, so one unusable agent would keep serving an
+            # empty map for this roster for the life of the process.
+            raise TypeError(
+                f"Cannot key {agent!r} in the agent map: it has neither "
+                "an agent_name attribute nor a __name__."
+            )
+        agent_map[name] = agent
+
+    return agent_map
 
 
 def create_agent_map(


### PR DESCRIPTION
`create_agent_map` returns an **empty map** for the first case its own docstring documents, and one bad entry discards the whole roster.

## Reproduce

```python
def agent1(): pass
def agent2(): pass
create_agent_map([agent1, agent2])
```

Docstring says:

```
>>> print(agent_map.keys())
dict_keys(['agent1', 'agent2'])
```

Actual: `dict_keys([])`, with the reason logged and swallowed:

```
ERROR | swarms.structs.ma_utils:_create_agent_map_cached:158 - Error creating agent map: 'function' object has no attribute 'agent_name'
```

Worse, mixing the two supported shapes loses the valid entries too, because the comprehension raises partway and the handler replaces the whole result:

```python
create_agent_map([real_agent, agent1])   # -> [] , the Agent is gone as well
```

And because `_create_agent_map_cached` is `@lru_cache`, the empty dict is memoised — that roster keeps returning `{}` for the life of the process.

## Cause

```python
agent.agent_name if isinstance(agent, Callable) else agent.__name__
```

An `Agent` instance and a plain function are **both** `Callable`, so the `else` branch is dead and every plain function is sent down the `agent_name` path. Agents happened to work; the documented callable case never could.

## Fix

Ask for the attributes in preference order instead of branching on a type that does not discriminate:

```python
name = getattr(agent, "agent_name", None) or getattr(agent, "__name__", None)
```

An agent with neither now raises `TypeError` — which is what the docstring's own `Raises:` section already promises — rather than returning an empty map. That also matters for the cache: `lru_cache` memoises return values but not exceptions, so a raise cannot poison the roster the way `return {}` did.

The `loguru` import is dropped with the handler that used it.

## Verification

Every documented shape, before and after:

```
                    before        after
docstring ex.1      []            ['agent1', 'agent2']
docstring ex.2      ['bot1',...]  ['bot1', 'bot2']
real Agent          ['Analyst']   ['Analyst']
mixed roster        []            ['Analyst', 'agent1']
unusable agent      {} (cached)   TypeError, not memoised
empty list          ValueError    ValueError
```

Caching still does its job — `CacheInfo(hits=2, misses=1, maxsize=128, currsize=1)` over three identical calls.

No test file: this is a small change to one function. `tests/structs` shows one failure, `test_agent_router_initialization_custom`, which fails identically on unmodified master.

## Adjacent findings

Filed as #1901 rather than folded in here — same function, but a different defect and a design decision I should not make unilaterally: the cache is keyed on agent *identity*, so renaming an agent keeps serving the old key, and two agents sharing a name silently collapse to one entry.