### PR TITLE
[Bug] HeavySwarm accepts img, threads it down two levels, then never passes it to the agents

### DIFF
--- a/swarms/structs/heavy_swarm.py
+++ b/swarms/structs/heavy_swarm.py
@@ -600,7 +600,7 @@ class HeavySwarm(SerializableMixin):
         def execute_agent(agent_info):
             agent_type, agent, question = agent_info
             try:
-                result = agent.run(question)
+                result = agent.run(question, img=img)
 
                 self.conversation.add(
                     role=agent.agent_name,
@@ -927,7 +927,7 @@ class HeavySwarm(SerializableMixin):
                     tracker.processing(agent_key, agent_type)
                     tracker.executing(agent_key, agent_type)
 
-                    result = agent.run(question)
+                    result = agent.run(question, img=img)
 
                     tracker.responding(agent_key, agent_type)
 


### PR DESCRIPTION
`HeavySwarm.run(task, img=...)` accepts an image, documents it, threads it down two levels — and then neither executor passes it to the agents. Every visual-analysis task runs blind.

## The path

```
run(task, img)                                    heavy_swarm.py:281
  -> _execute_agents_parallel(..., img=img)              :424
       -> _execute_agents_basic(questions, agents, img)  :557
            -> agent.run(question)                       :603   <- img dropped
       -> _execute_agents_with_dashboard(..., img)       :554
            -> agent.run(question)                       :930   <- img dropped
```

`img` is a declared parameter on all three functions and documented on each (*"Image input if needed for visual analysis tasks"*), so it looks wired up at every level except the last one that matters.

## Verification

Stub agents that record what they receive, driving both executors directly:

```
BEFORE   basic executor     -> img seen by agents: {None}
         dashboard executor -> img seen by agents: {None}

AFTER    basic executor     -> img seen by agents: {'chart.png'}
         dashboard executor -> img seen by agents: {'chart.png'}
```

Both paths were broken and both are fixed; I checked the dashboard variant separately rather than assuming it followed the basic one.

## Fix

`agent.run(question, img=img)` at both sites. `img` is already in the enclosing scope of each, and `Agent.run`'s `img` defaults to `None`, so the no-image case is byte-for-byte what it was.

Same defect as #1822 (`SequentialWorkflow.run` accepted `imgs` and dropped it), which you merged — this is the HeavySwarm instance of it.

No test file: two-line change, no new function.

## Adjacent finding

Filed as #1903 rather than folded in: `execute_question_generation(self, task)` has no `img` parameter at all, so the decomposer writes the four (or fifteen) sub-questions without ever seeing the image. That is a design change — the image has to reach the question schema and prompt — so it needs your call, not a quiet expansion of this diff.

