### PR TITLE
[Bug] CronJob rejects every plain callable it documents supporting — the Callable check is inverted

### DIFF
--- a/swarms/structs/cron_job.py
+++ b/swarms/structs/cron_job.py
@@ -258,9 +258,13 @@ class CronJob:
         try:
             logger.debug(f"Executing task for job {self.job_id}")
 
-            # Execute the agent
-            if isinstance(self.agent, Callable):
-                original_output = self.agent.run(task=task, **kwargs)
+            # Execute the agent. Discriminate on having a run() method, not
+            # on isinstance(Callable): a plain function is Callable too, so
+            # that test sent every function down the .run() path and left the
+            # branch below unreachable.
+            runner = getattr(self.agent, "run", None)
+            if callable(runner):
+                original_output = runner(task=task, **kwargs)
             else:
                 original_output = self.agent(task, **kwargs)
 


### PR DESCRIPTION
`CronJob` is documented as *"A wrapper class that turns any callable (including Swarms agents) into a scheduled cron job"* and typed `agent: Optional[Union[Any, Callable]]`. Only the Agent half works. The discriminator is inverted, so **both** non-Agent shapes fail — each one down the branch meant for the other.

## Reproduce

```python
def my_callable(task, **kw):
    return f"handled: {task}"

CronJob(agent=my_callable, interval="1second").run("do it")
```

```
                        BEFORE                                                      AFTER
plain function       -> CronJobExecutionError: 'function' object has no attribute 'run'    handled: do it
object with run()    -> CronJobExecutionError: 'HasRun' object is not callable             obj.run: do it
Agent                -> agent.run: do it                                                  agent.run: do it
```

## Cause

```python
if isinstance(self.agent, Callable):
    original_output = self.agent.run(task=task, **kwargs)
else:
    original_output = self.agent(task, **kwargs)
```

`isinstance(x, Callable)` tests for `__call__`, which is the wrong question here — it is true for plain functions and false for a plain object that only defines `run()`. So:

- a function is `Callable` → takes the `.run()` branch → `AttributeError`
- an object with `run()` but no `__call__` is not `Callable` → takes the direct-call branch → `TypeError`

An `Agent` satisfies both, which is why the only shape that works is the one that hides the bug. The `else` branch is unreachable for every function, i.e. the documented "any callable" path never executed.

## Fix

Ask the question the branch actually cares about — does this thing have a `run()` to call:

```python
runner = getattr(self.agent, "run", None)
if callable(runner):
    original_output = runner(task=task, **kwargs)
else:
    original_output = self.agent(task, **kwargs)
```

Agent behaviour is unchanged (it has `run`, so it takes the same branch as before, with the same `task=`/`**kwargs` call shape). Callbacks and kwargs forwarding verified unaffected: `handled: cb task [cb] | meta=1`.

Same root cause as #1900 (`create_agent_map` used the same test to tell Agents from functions). Separate PR because it is a different module and a different symptom — that one silently returns an empty map, this one raises.

No test file: four-line change inside one branch.

## Adjacent finding

Filed as #1905: `batched_run(tasks)` can only ever schedule the first task. `run()` ends in `while True: time.sleep(1)`, so `batched_run`'s loop never reaches iteration two and never returns. Verified — three tasks in, `['task-A']` scheduled, thread still alive.

