### PR TITLE
fix(agent): build a call-scoped pool for concurrent execution (#1793)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2144,20 +2144,36 @@ Subtask Breakdown:
 
         Args:
             tasks (List[str]): A list of tasks to run.
+
+        Returns:
+            List[Any]: One result per task, in the order the tasks were given.
+
+        Raises:
+            Exception: Whatever the underlying runs raise. Failures are logged
+                and re-raised rather than swallowed, so a caller never receives
+                None in place of results.
         """
         try:
             logger.info(f"Running concurrent tasks: {tasks}")
-            futures = [
-                self.executor.submit(
-                    self.run, task=task, *args, **kwargs
-                )
-                for task in tasks
-            ]
-            results = [future.result() for future in futures]
+            # Pool is scoped to the call, matching how the rest of the codebase
+            # runs concurrent work (heavy_swarm, majority_voting,
+            # multi_agent_router). An Agent-level pool would keep idle threads
+            # alive for the process lifetime of every agent a swarm builds.
+            with ContextThreadPoolExecutor(
+                max_workers=os.cpu_count()
+            ) as executor:
+                futures = [
+                    executor.submit(
+                        self.run, *args, task=task, **kwargs
+                    )
+                    for task in tasks
+                ]
+                results = [future.result() for future in futures]
             logger.info(f"Completed tasks: {results}")
             return results
         except Exception as error:
             logger.error(f"Error running concurrent tasks: {error}")
+            raise
 
     def bulk_run(self, inputs: List[Dict[str, Any]]) -> List[str]:
         """
@@ -2480,12 +2496,10 @@ Subtask Breakdown:
                     rules=self.rules,
                 )
 
-            # Reinitialize executor if needed
-            # if not hasattr(self, "executor") or self.executor is None:
-            with ContextThreadPoolExecutor(
-                max_workers=os.cpu_count()
-            ) as executor:
-                self.executor = executor
+            # No executor to reinitialize: concurrent work creates its own
+            # call-scoped pool. The assignment that used to live here stored an
+            # executor the enclosing `with` had already shut down, so anything
+            # reading it back would have submitted to a dead pool.
 
         except Exception as e:
             logger.error(f"Error reinitializing components: {e}")
@@ -3401,24 +3415,39 @@ Subtask Breakdown:
     ) -> Any:
         """
         Talk to multiple agents.
-        """
-        # Create futures for each agent conversation
-        futures = [
-            self.executor.submit(
-                self.talk_to, agent, task, *args, **kwargs
-            )
-            for agent in agents
-        ]
 
-        # Wait for all futures to complete and collect results
-        outputs = []
-        for future in futures:
-            try:
-                result = future.result()
-                outputs.append(result)
-            except Exception as e:
-                logger.error(f"Error in agent communication: {e}")
-                outputs.append(None)  # or handle error case as needed
+        Args:
+            agents (List[Union[Any, Callable]]): The agents to talk to.
+            task (str): The message to send to each agent.
+
+        Returns:
+            List[Any]: One entry per agent, in the order the agents were given.
+                An agent whose conversation raised contributes None.
+        """
+        # Pool is scoped to the call — see run_concurrent_tasks for why this is
+        # not an Agent-level executor.
+        with ContextThreadPoolExecutor(
+            max_workers=os.cpu_count()
+        ) as executor:
+            # Create futures for each agent conversation
+            futures = [
+                executor.submit(
+                    self.talk_to, agent, task, *args, **kwargs
+                )
+                for agent in agents
+            ]
+
+            # Wait for all futures to complete and collect results
+            outputs = []
+            for future in futures:
+                try:
+                    result = future.result()
+                    outputs.append(result)
+                except Exception as e:
+                    logger.error(f"Error in agent communication: {e}")
+                    outputs.append(
+                        None
+                    )  # or handle error case as needed
 
         return outputs
 

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import tempfile
+import threading
 import time
 import unittest
 from statistics import mean, median, stdev, variance
@@ -3069,3 +3070,103 @@ class TestToolExecutionRetry:
             assert (
                 len(calls) == 1
             ), f"attempts={attempts!r} should still run once"
+
+
+class TestConcurrentExecutionPool:
+    """#1793: Agent's concurrent entry points referenced self.executor, which
+    __init__ never assigned. run_concurrent_tasks caught the resulting
+    AttributeError and returned None; talk_to_multiple_agents raised it. Both
+    now build a call-scoped pool, so neither depends on an Agent attribute.
+    """
+
+    @staticmethod
+    def _agent(name="A"):
+        """A bare Agent carrying only what the concurrent paths touch — no
+        __init__, so no model client, memory files or provider calls.
+        """
+        agent = Agent.__new__(Agent)
+        agent.agent_name = name
+        return agent
+
+    def test_no_executor_attribute_is_required(self):
+        """The regression itself: the concurrent paths must not depend on an
+        instance attribute that __init__ does not set."""
+        agent = self._agent()
+        assert not hasattr(agent, "executor")
+
+    def test_run_concurrent_tasks_returns_one_result_per_task_in_order(
+        self,
+    ):
+        agent = self._agent()
+        with patch.object(
+            Agent,
+            "run",
+            side_effect=lambda task, *a, **kw: f"ran:{task}",
+        ):
+            results = Agent.run_concurrent_tasks(
+                agent, ["t1", "t2", "t3"]
+            )
+
+        # Order matters: results are zipped against the caller's task list.
+        assert results == ["ran:t1", "ran:t2", "ran:t3"]
+
+    def test_run_concurrent_tasks_propagates_failure(self):
+        """Previously the except branch logged and fell through, so a failed
+        batch returned None and the caller saw no error at all."""
+        agent = self._agent()
+        with patch.object(
+            Agent, "run", side_effect=RuntimeError("boom")
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                Agent.run_concurrent_tasks(agent, ["t1"])
+
+    def test_talk_to_multiple_agents_returns_one_entry_per_agent(
+        self,
+    ):
+        agent = self._agent()
+        others = [self._agent("B"), self._agent("C")]
+        with patch.object(
+            Agent,
+            "talk_to",
+            side_effect=lambda other, task, *a, **kw: f"to:{other.agent_name}",
+        ):
+            outputs = Agent.talk_to_multiple_agents(
+                agent, others, "hi"
+            )
+
+        assert outputs == ["to:B", "to:C"]
+
+    def test_talk_to_multiple_agents_isolates_a_failing_agent(self):
+        """One bad conversation contributes None; the others still return."""
+        agent = self._agent()
+        others = [self._agent("B"), self._agent("C")]
+
+        def talk(other, task, *a, **kw):
+            if other.agent_name == "B":
+                raise RuntimeError("dead")
+            return f"to:{other.agent_name}"
+
+        with patch.object(Agent, "talk_to", side_effect=talk):
+            outputs = Agent.talk_to_multiple_agents(
+                agent, others, "hi"
+            )
+
+        assert outputs == [None, "to:C"]
+
+    def test_pool_is_shut_down_after_each_call(self):
+        """The pool is call-scoped, so an agent used repeatedly must not leak a
+        thread pool per call."""
+        agent = self._agent()
+        before = threading.active_count()
+        with patch.object(
+            Agent, "run", side_effect=lambda task, *a, **kw: task
+        ):
+            for _ in range(3):
+                Agent.run_concurrent_tasks(agent, ["t1", "t2"])
+
+        # Worker threads are joined on __exit__; allow a moment for teardown.
+        for _ in range(50):
+            if threading.active_count() <= before:
+                break
+            time.sleep(0.02)
+        assert threading.active_count() <= before


### PR DESCRIPTION
Closes #1793.

`run_concurrent_tasks` and `talk_to_multiple_agents` both submit to `self.executor`, **an attribute `__init__` never assigns**. Neither method has ever worked. They now open a `ContextThreadPoolExecutor` scoped to the call, matching how the rest of the codebase runs concurrent work.

## Problem

`swarms/structs/agent.py:2151` and `:3407` both call `self.executor.submit(...)`. The only assignment to `self.executor` anywhere in the class is at `:2488`, inside `_reinitialize_after_load` — a method that runs only on state load, and which assigns the executor **inside a `with` block**, so the object it stores is already shut down by the time the block exits.

The two methods fail differently, and the first one is the reason this went unnoticed:

| Method | Behaviour on `master` |
|---|---|
| `run_concurrent_tasks` | catches the `AttributeError`, logs it, falls out of the function → **returns `None`** |
| `talk_to_multiple_agents` | no handler → **raises `AttributeError`** to the caller |

On `master` @ `a5764139` (v14.0.0):

```
has attribute 'executor'   : False
run_concurrent_tasks ->    : None (swallowed, no results)
talk_to_multiple_agents    : AttributeError: 'Agent' object has no attribute 'executor'
```

`run_concurrent_tasks` returning `None` is what disguised the bug. The existing test `TestAgentFeatures::test_agent_concurrent_execution` (`tests/structs/test_agent.py:392`) asserts `len(concurrent_responses) == 3` and fails with `TypeError: object of type 'NoneType' has no len()` — which reads like a missing-credentials problem, not a method that cannot work.

## Note on the issue's stated reproducer

#1793 reports the symptom as `run(imgs=[...])` raising `AttributeError`. That is **not reproducible on current `master`**: `Agent.run` accepts `imgs`, but its body never references `executor` (`"executor" in inspect.getsource(Agent.run)` → `False`), and there is no `run_multiple_images`/`run_many_images` method. That path appears to have been refactored since the issue was filed on 2026-08-01. The underlying defect the issue identifies — `self.executor` never assigned — is real and is what this PR fixes; only the entry point named in the reproducer has moved.

## Fix

- **Both methods build a call-scoped pool.** `with ContextThreadPoolExecutor(max_workers=os.cpu_count())`, the pattern already used by `heavy_swarm.py:689`, `majority_voting.py:286` and `multi_agent_router.py:502`.
- **The attribute is not reinstated.** An `Agent`-level pool would hold idle threads for the process lifetime of *every* agent a swarm constructs — a `HierarchicalSwarm` with 100 workers would carry 100 pools. Call-scoped costs nothing when the methods are unused, which is the common case.
- **The dead assignment in `_reinitialize_after_load` is removed**, not repaired. It stored an already-closed executor; leaving it would be a trap for the next reader.
- **`run_concurrent_tasks` re-raises.** The bare `except` that logged and returned `None` is the thing that hid this for so long.

## Behavior-change note

`run_concurrent_tasks` previously returned `None` when anything raised; it now propagates the exception. Any caller relying on the `None` return to mean "batch failed" must catch instead. Given the method could not complete successfully at all before this PR, no working caller can depend on that path.

`talk_to_multiple_agents` keeps its per-agent isolation — one failed conversation still contributes `None` rather than failing the batch.

## Verification

- **New coverage**: `TestConcurrentExecutionPool` added to the existing `tests/structs/test_agent.py` (no new file, per prior review guidance). Six network-free tests built on `Agent.__new__` — no model client, no provider call: result-per-task ordering, failure propagation, per-agent result ordering, isolation of one failing agent, absence of the `executor` attribute, and no thread-pool leak across repeated calls.
- **They are real regression tests**: run against unfixed `master`, **4 of the 6 fail**. The other two (`no_executor_attribute_is_required`, `pool_is_shut_down_after_each_call`) pass vacuously there, since `master` never creates a pool to leak.
- **Full file**: `tests/structs/test_agent.py` goes from **57 passed / 20 failed / 8 errors** on clean `master` to **64 passed / 19 failed / 8 errors**. The remaining failures and errors are the pre-existing live-API tests, identical on both sides; a set difference of the two failure lists shows **nothing newly broken**.
- **One pre-existing test repaired**: `TestAgentFeatures::test_agent_concurrent_execution` now passes without credentials — each run returns its error string, so the batch is a list of 3 and the assertion holds, which is what the test was written to check.
- **Lint** with the CI-pinned versions (`black==24.2.0`, `ruff==0.2.1`, line-length 70): `black --check` clean on both files, `ruff check .` clean repo-wide. Ruff findings in `agent.py` drop from 247 to 245.

**Not verified here**: no live provider call was made — no API keys are present in this environment. Every test stubs `Agent.run` / `Agent.talk_to` at the method boundary, so the executor plumbing is exercised for real while the LLM call is not.
