### PR TITLE
fix(heavy_swarm): reflect agent failures and timeouts in dashboard final status (#1908)

### DIFF
--- a/swarms/structs/heavy_swarm.py
+++ b/swarms/structs/heavy_swarm.py
@@ -1032,6 +1032,10 @@ class HeavySwarm(SerializableMixin):
                     ),
                 ]
 
+            success_count = 0
+            failed_count = 0
+            timeout_count = 0
+
             # Execute agents in parallel
             with ContextThreadPoolExecutor(
                 max_workers=self.max_workers
@@ -1060,14 +1064,23 @@ class HeavySwarm(SerializableMixin):
                             .replace("⚡ ", "")
                             .replace("✅ ", "")
                         ] = result
+                        if (
+                            isinstance(result, str)
+                            and result.startswith("Error: ")
+                        ):
+                            failed_count += 1
+                        else:
+                            success_count += 1
                     except concurrent.futures.TimeoutError:
                         tracker.timeout(agent_key, agent_key)
                         results[agent_key] = (
                             f"Timeout after {self.timeout} seconds"
                         )
+                        timeout_count += 1
                     except Exception as e:
                         tracker.error(agent_key, agent_key)
                         results[agent_key] = f"Exception: {str(e)}"
+                        failed_count += 1
 
         # Show completion summary
         agent_count = (
@@ -1085,7 +1098,11 @@ class HeavySwarm(SerializableMixin):
             )
         )
         self.dashboard.show_execution_complete(
-            agent_count, synth_label
+            agent_count,
+            synth_label,
+            success_count=success_count,
+            failed_count=failed_count,
+            timeout_count=timeout_count,
         )
 
         return results

--- a/swarms/utils/heavy_swarm_dashboard.py
+++ b/swarms/utils/heavy_swarm_dashboard.py
@@ -178,17 +178,67 @@ class HeavySwarmDashboard:
         self.console.print()
 
     def show_execution_complete(
-        self, agent_count: int, synth_label: str
+        self,
+        agent_count: int,
+        synth_label: str,
+        success_count: Optional[int] = None,
+        failed_count: int = 0,
+        timeout_count: int = 0,
     ) -> None:
-        self.console.print(
-            Panel(
-                "[bold red]⚡ ALL AGENTS COMPLETED SUCCESSFULLY![/bold red]\n"
-                f"[white]Results from all {agent_count} specialized agents "
-                f"are ready for {synth_label}[/white]",
-                title="[bold red]EXECUTION COMPLETE[/bold red]",
-                border_style="red",
+        if success_count is None:
+            success_count = max(
+                0, agent_count - failed_count - timeout_count
             )
-        )
+
+        if failed_count == 0 and timeout_count == 0:
+            self.console.print(
+                Panel(
+                    "[bold red]⚡ ALL AGENTS COMPLETED SUCCESSFULLY![/bold red]\n"
+                    f"[white]Results from all {agent_count} specialized agents "
+                    f"are ready for {synth_label}[/white]",
+                    title="[bold red]EXECUTION COMPLETE[/bold red]",
+                    border_style="red",
+                )
+            )
+        elif success_count > 0:
+            failure_details = []
+            if failed_count > 0:
+                failure_details.append(f"{failed_count} failed")
+            if timeout_count > 0:
+                failure_details.append(f"{timeout_count} timed out")
+            details_str = (
+                f" ({', '.join(failure_details)})"
+                if failure_details
+                else ""
+            )
+            self.console.print(
+                Panel(
+                    "[bold yellow]⚠️ AGENT EXECUTION COMPLETED WITH WARNINGS[/bold yellow]\n"
+                    f"[white]{success_count}/{agent_count} agents completed successfully{details_str}. "
+                    f"Available results are ready for {synth_label}[/white]",
+                    title="[bold yellow]EXECUTION COMPLETE WITH WARNINGS[/bold yellow]",
+                    border_style="yellow",
+                )
+            )
+        else:
+            failure_details = []
+            if failed_count > 0:
+                failure_details.append(f"{failed_count} failed")
+            if timeout_count > 0:
+                failure_details.append(f"{timeout_count} timed out")
+            details_str = (
+                f" ({', '.join(failure_details)})"
+                if failure_details
+                else ""
+            )
+            self.console.print(
+                Panel(
+                    "[bold red]❌ AGENT EXECUTION FAILED[/bold red]\n"
+                    f"[white]0/{agent_count} agents succeeded{details_str}.[/white]",
+                    title="[bold red]EXECUTION FAILED[/bold red]",
+                    border_style="red",
+                )
+            )
         self.console.print()
 
     # ----- Progress contexts ----------------------------------------------

--- a/tests/structs/test_heavy_swarm.py
+++ b/tests/structs/test_heavy_swarm.py
@@ -12,9 +12,13 @@ Covers:
 """
 
 import os
+from unittest.mock import MagicMock, patch
+import io
 
 import pytest
 from dotenv import load_dotenv
+from rich.console import Console
+from swarms.utils.heavy_swarm_dashboard import HeavySwarmDashboard
 
 from swarms.prompts.heavy_swarm_prompts import (
     BENJAMIN_HEAVY_PROMPT,
@@ -702,6 +706,136 @@ class TestGrokHeavyFullPipeline:
         assert result is not None
         assert isinstance(result, str)
         assert len(result) > 100
+
+
+# ============================================================================
+# Dashboard Status & Execution Failure Tracking (Issue #1908)
+# ============================================================================
+
+
+class TestHeavySwarmDashboardStatus:
+    """Verify HeavySwarmDashboard.show_execution_complete reflects failures/timeouts."""
+
+    def test_show_execution_complete_all_success(self):
+        output = io.StringIO()
+        console = Console(file=output, force_terminal=False, color_system=None, width=120)
+        dashboard = HeavySwarmDashboard(console=console)
+
+        dashboard.show_execution_complete(
+            agent_count=4,
+            synth_label="synthesis",
+            success_count=4,
+            failed_count=0,
+            timeout_count=0,
+        )
+        content = output.getvalue()
+        assert "ALL AGENTS COMPLETED SUCCESSFULLY!" in content
+        assert "Results from all 4 specialized agents are ready for synthesis" in content
+
+    def test_show_execution_complete_partial_failure(self):
+        output = io.StringIO()
+        console = Console(file=output, force_terminal=False, color_system=None, width=120)
+        dashboard = HeavySwarmDashboard(console=console)
+
+        dashboard.show_execution_complete(
+            agent_count=4,
+            synth_label="synthesis",
+            success_count=2,
+            failed_count=1,
+            timeout_count=1,
+        )
+        content = output.getvalue()
+        assert "AGENT EXECUTION COMPLETED WITH WARNINGS" in content
+        assert "2/4 agents completed successfully" in content
+        assert "1 failed, 1 timed out" in content
+        assert "Available results are ready for synthesis" in content
+
+    def test_show_execution_complete_all_failed(self):
+        output = io.StringIO()
+        console = Console(file=output, force_terminal=False, color_system=None, width=120)
+        dashboard = HeavySwarmDashboard(console=console)
+
+        dashboard.show_execution_complete(
+            agent_count=4,
+            synth_label="synthesis",
+            success_count=0,
+            failed_count=3,
+            timeout_count=1,
+        )
+        content = output.getvalue()
+        assert "AGENT EXECUTION FAILED" in content
+        assert "0/4 agents succeeded" in content
+        assert "3 failed, 1 timed out" in content
+
+    def test_show_execution_complete_default_backward_compatible(self):
+        output = io.StringIO()
+        console = Console(file=output, force_terminal=False, color_system=None, width=120)
+        dashboard = HeavySwarmDashboard(console=console)
+
+        dashboard.show_execution_complete(
+            agent_count=3,
+            synth_label="Captain Swarm",
+        )
+        content = output.getvalue()
+        assert "ALL AGENTS COMPLETED SUCCESSFULLY!" in content
+        assert "Results from all 3 specialized agents are ready for Captain Swarm" in content
+
+
+class TestHeavySwarmExecutionDashboardAggregation:
+    """Verify _execute_agents_with_dashboard tracks counts correctly."""
+
+    def test_execute_agents_with_dashboard_mixed_outcomes(self):
+        swarm = HeavySwarm(
+            worker_model_name=MODEL,
+            question_agent_model_name=MODEL,
+            variant="medium",
+            show_dashboard=True,
+        )
+
+        mock_dashboard = MagicMock()
+        swarm.dashboard = mock_dashboard
+
+        # Mock agents: 1 success, 1 returning error, 1 exception
+        agent_success = MagicMock()
+        agent_success.run.return_value = "Success output"
+        agent_success.agent_name = "Harper"
+
+        agent_error = MagicMock()
+        agent_error.run.side_effect = RuntimeError("Agent failed")
+        agent_error.agent_name = "Benjamin"
+
+        agent_success2 = MagicMock()
+        agent_success2.run.return_value = "Another success"
+        agent_success2.agent_name = "Lucas"
+
+        agents = {
+            "harper": agent_success,
+            "benjamin": agent_error,
+            "lucas": agent_success2,
+        }
+
+        questions = {
+            "harper_question": "Harper task",
+            "benjamin_question": "Benjamin task",
+            "lucas_question": "Lucas task",
+        }
+
+        results = swarm._execute_agents_with_dashboard(questions, agents)
+
+        assert "harper" in results
+        assert results["harper"] == "Success output"
+        assert "benjamin" in results
+        assert "Error: Agent failed" in results["benjamin"]
+        assert "lucas" in results
+        assert results["lucas"] == "Another success"
+
+        mock_dashboard.show_execution_complete.assert_called_once_with(
+            3,
+            "Captain Swarm",
+            success_count=2,
+            failed_count=1,
+            timeout_count=0,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1908
This pull request resolves an issue in HeavySwarm where the final execution dashboard always displayed All Agents Completed Successfully regardless of whether any parallel agent tasks failed or timed out.

Key Changes Made:

1.HeavySwarmDashboard (swarms/utils/heavy_swarm_dashboard.py):

    Updated show_execution_complete to accept optional execution metrics: success_count, failed_count, and timeout_count.
    All Successful: Renders the complete success panel when all agents complete without errors.
     Partial Failure / Warnings: Renders a warning panel showing how many agents succeeded along with failed and timed-out           counts.
      Complete Failure: Renders a failure panel when zero agents succeed.
      Preserves full backward compatibility if count arguments are omitted.

2. HeavySwarm Execution Logic (swarms/structs/heavy_swarm.py):
        In _execute_agents_with_dashboard, tracked aggregate outcomes (success_count, failed_count, timeout_count) while gathering parallel agent tasks.
        Accurately captures agent exceptions, unhandled errors, and timeouts, then forwards these counts to the dashboard completion method.

3. Regression Tests (tests/structs/test_heavy_swarm.py):
Added unit tests covering all success states, partial failure/timeout warning states, full failure states, backward compatibility, and execution outcome aggregation.