### PR TITLE
fix(dashboard): cap director orders display at 5 in _create_director_panel

### DIFF
--- a/swarms/utils/hierarchical_swarm_dashboard.py
+++ b/swarms/utils/hierarchical_swarm_dashboard.py
@@ -334,7 +334,7 @@ class HierarchicalSwarmDashboard:
         director_text.append("CURRENT ORDERS:\n", style="bold white")
         if self.director_orders:
             for i, order in enumerate(
-                self.director_orders
+                self.director_orders[:5]
             ):  # Show first 5 orders
                 director_text.append(f"{i + 1}. ", style="bold cyan")
                 director_text.append(

--- a/tests/utils/test_hierarchical_swarm_dashboard.py
+++ b/tests/utils/test_hierarchical_swarm_dashboard.py
@@ -1,0 +1,96 @@
+"""Tests for HierarchicalSwarmDashboard UI fixes.
+
+Covers the bug fixed in PR #1917 / issue #1914:
+  director orders loop was missing [:5] cap — all orders rendered and
+  the "...and N more" truncation label was factually wrong.
+
+Uses importlib to load the dashboard module directly so the full
+swarms package (and its heavy dependencies) are not triggered.
+"""
+
+import importlib.util
+import io
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+# Load only the dashboard module — avoids triggering swarms/__init__.py
+_DASHBOARD_PATH = (
+    Path(__file__).parent.parent.parent
+    / "swarms" / "utils" / "hierarchical_swarm_dashboard.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "hierarchical_swarm_dashboard", _DASHBOARD_PATH
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+HierarchicalSwarmDashboard = _mod.HierarchicalSwarmDashboard
+
+
+def _render(renderable, width: int = 200) -> str:
+    buf = io.StringIO()
+    console = Console(file=buf, width=width, highlight=False)
+    console.print(renderable)
+    return buf.getvalue()
+
+
+def _make_orders(n: int) -> list:
+    return [
+        {"agent_name": f"Agent-{i}", "task": f"Task number {i}"}
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# #1914 — director orders panel missing [:5] cap
+# ---------------------------------------------------------------------------
+
+
+class TestDirectorOrdersCap:
+    def test_fewer_than_5_orders_all_shown(self):
+        dash = HierarchicalSwarmDashboard()
+        dash.director_orders = _make_orders(3)
+        output = _render(dash._create_director_panel())
+        for i in range(3):
+            assert f"Agent-{i}" in output
+        assert "more orders" not in output
+
+    def test_exactly_5_orders_all_shown_no_truncation(self):
+        dash = HierarchicalSwarmDashboard()
+        dash.director_orders = _make_orders(5)
+        output = _render(dash._create_director_panel())
+        for i in range(5):
+            assert f"Agent-{i}" in output
+        assert "more orders" not in output
+
+    def test_10_orders_only_first_5_shown(self):
+        dash = HierarchicalSwarmDashboard()
+        dash.director_orders = _make_orders(10)
+        output = _render(dash._create_director_panel())
+
+        for i in range(5):
+            assert f"Agent-{i}" in output
+
+        for i in range(5, 10):
+            assert f"Agent-{i}" not in output
+
+    def test_truncation_label_correct_count(self):
+        dash = HierarchicalSwarmDashboard()
+        dash.director_orders = _make_orders(10)
+        output = _render(dash._create_director_panel())
+        assert "5 more orders" in output
+
+    def test_20_orders_truncation_label_says_15(self):
+        dash = HierarchicalSwarmDashboard()
+        dash.director_orders = _make_orders(20)
+        output = _render(dash._create_director_panel())
+        assert "15 more orders" in output
+        for i in range(5, 20):
+            assert f"Agent-{i}" not in output
+
+    def test_zero_orders_shows_placeholder(self):
+        dash = HierarchicalSwarmDashboard()
+        dash.director_orders = []
+        output = _render(dash._create_director_panel())
+        assert "No orders available" in output


### PR DESCRIPTION
## Fixes

Closes #1914

## Problem

`_create_director_panel()` iterates **all** `director_orders` despite having a `# Show first 5 orders` comment and a truncation label below. The `[:5]` slice was missing from the `enumerate()` call.

With a director that delegates to many agents (common in large swarms):

```python
# Before — iterates ALL orders
for i, order in enumerate(
    self.director_orders        # ← no cap
):  # Show first 5 orders       # ← comment says 5, code disagrees
    ...

if len(self.director_orders) > 5:
    director_text.append(
        f"... and {len(self.director_orders) - 5} more orders"
    )
```

With 10 orders this rendered **all 10 rows** then appended `"... and 5 more orders"` — which is factually wrong because all 5 "extra" were already visible.

## Fix

Add the missing `[:5]` slice:

```python
# After — capped at 5 as the comment and truncation label intended
for i, order in enumerate(
    self.director_orders[:5]
):  # Show first 5 orders
```

## Behaviour

| Orders | Before | After |
|---|---|---|
| 3 orders | 3 rows rendered | 3 rows rendered (no change) |
| 5 orders | 5 rows rendered | 5 rows rendered (no change) |
| 10 orders | **10 rows + "...and 5 more"** | 5 rows + "...and 5 more" ✓ |
| 20 orders | **20 rows + "...and 15 more"** | 5 rows + "...and 15 more" ✓ |

## Files Changed

- `swarms/utils/hierarchical_swarm_dashboard.py` — `_create_director_panel()`, **+1 char** (`[:5]` added)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)