### PR TITLE
Fix CronJob.batched_run scheduling only the first task and never returning (#1905)

### DIFF
--- a/swarms/structs/cron_job.py
+++ b/swarms/structs/cron_job.py
@@ -133,11 +133,11 @@ class CronJob:
                 "seconds": self.every_seconds,
                 "minute": self.every_minutes,
                 "minutes": self.every_minutes,
-                "hour": lambda x: self.schedule.every(x).hours.do(
-                    self._run_job
+                "hour": lambda x, task, **kwargs: self.schedule.every(x).hours.do(
+                    self._run_job, task, **kwargs
                 ),
-                "hours": lambda x: self.schedule.every(x).hours.do(
-                    self._run_job
+                "hours": lambda x, task, **kwargs: self.schedule.every(x).hours.do(
+                    self._run_job, task, **kwargs
                 ),
             }
 
@@ -147,8 +147,8 @@ class CronJob:
                     f"Unsupported time unit: {unit}. Supported units are: {supported_units}"
                 )
 
-            self._interval_method = lambda task: unit_map[unit](
-                number, task
+            self._interval_method = lambda task, **kwargs: unit_map[unit](
+                number, task, **kwargs
             )
             logger.debug(f"Configured {number} {unit} interval")
 
@@ -169,6 +169,9 @@ class CronJob:
             **kwargs: Additional parameters to pass to the agent's run method
                      (e.g., img=image_path, streaming_callback=callback_func)
 
+        Returns:
+            The scheduled job instance
+
         Raises:
             CronJobConfigError: If agent or interval is not configured
             CronJobExecutionError: If task execution fails
@@ -186,11 +189,12 @@ class CronJob:
 
             logger.info(f"Scheduling task for job {self.job_id}")
             # Schedule the task with additional parameters
-            self._interval_method(task, **kwargs)
+            job = self._interval_method(task, **kwargs)
 
             # Start the job
             self.start()
             logger.info(f"Successfully started job {self.job_id}")
+            return job
 
         except Exception as e:
             logger.error(
@@ -200,14 +204,11 @@ class CronJob:
                 f"Failed to run job: {str(e)} Traceback: {traceback.format_exc()}"
             )
 
-    def run(self, task: str, **kwargs):
+    def _block_forever(self):
+        """Block until interrupted or stopped."""
         try:
-            job = self._run(task, **kwargs)
-
-            while True:
+            while self.is_running:
                 time.sleep(1)
-
-            return job
         except KeyboardInterrupt:
             logger.info(
                 f"CronJob: {self.job_id} received keyboard interrupt, stopping cron jobs..."
@@ -219,17 +220,37 @@ class CronJob:
             )
             raise
 
+    def run(self, task: str, **kwargs):
+        """Schedule a single task and block for the life of the process until KeyboardInterrupt,
+        at which point stop() is called.
+
+        Args:
+            task: The task string to be executed by the agent
+            **kwargs: Additional parameters to pass to the agent's run method
+
+        Returns:
+            The scheduled job instance
+        """
+        job = self._run(task, **kwargs)
+        self._block_forever()
+        return job
+
     def batched_run(self, tasks: List[str], **kwargs):
-        """Run the scheduled job with the given tasks and additional parameters.
+        """Schedule every task in tasks before blocking for the life of the process until
+        KeyboardInterrupt, at which point stop() is called.
 
         Args:
             tasks: The list of task strings to be executed by the agent
             **kwargs: Additional parameters to pass to the agent's run method
+
+        Returns:
+            List of scheduled job instances
         """
         outputs = []
         for task in tasks:
-            output = self.run(task, **kwargs)
+            output = self._run(task, **kwargs)
             outputs.append(output)
+        self._block_forever()
         return outputs
 
     def __call__(self, task: str, **kwargs):
@@ -316,7 +337,7 @@ class CronJob:
         logger.debug(
             f"Scheduling job {self.job_id} every {seconds} seconds"
         )
-        self.schedule.every(seconds).seconds.do(
+        return self.schedule.every(seconds).seconds.do(
             self._run_job, task, **kwargs
         )
 
@@ -331,7 +352,7 @@ class CronJob:
         logger.debug(
             f"Scheduling job {self.job_id} every {minutes} minutes"
         )
-        self.schedule.every(minutes).minutes.do(
+        return self.schedule.every(minutes).minutes.do(
             self._run_job, task, **kwargs
         )
 

--- a/tests/structs/test_cron_job.py
+++ b/tests/structs/test_cron_job.py
@@ -1,0 +1,76 @@
+import threading
+import time
+from swarms.structs.cron_job import CronJob
+
+
+class MockAgent:
+    def __init__(self, calls_list=None):
+        self.calls_list = calls_list if calls_list is not None else []
+
+    def run(self, task: str = None, **kwargs):
+        self.calls_list.append(task)
+        return f"result-{task}"
+
+    def __call__(self, task: str = None, **kwargs):
+        return self.run(task=task, **kwargs)
+
+
+def test_cron_job_batched_run_schedules_all_tasks():
+    calls = []
+    agent = MockAgent(calls)
+    job = CronJob(agent=agent, interval="1second")
+
+    t = threading.Thread(
+        target=lambda: job.batched_run(["task-A", "task-B", "task-C"]),
+        daemon=True,
+    )
+    t.start()
+    time.sleep(2.5)
+    job.stop()
+    t.join(timeout=2)
+
+    assert "task-A" in calls
+    assert "task-B" in calls
+    assert "task-C" in calls
+
+
+def test_cron_job_batched_run_returns_list_of_jobs():
+    calls = []
+    agent = MockAgent(calls)
+    job = CronJob(agent=agent, interval="1second")
+
+    results = []
+
+    def runner():
+        res = job.batched_run(["task-1", "task-2", "task-3"])
+        results.append(res)
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    time.sleep(0.5)
+    job.stop()
+    t.join(timeout=2)
+
+    assert len(results) == 1
+    assert len(results[0]) == 3
+
+
+def test_cron_job_single_run_blocks_and_returns_job():
+    calls = []
+    agent = MockAgent(calls)
+    job = CronJob(agent=agent, interval="1second")
+
+    results = []
+
+    def runner():
+        res = job.run("task-single")
+        results.append(res)
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    time.sleep(0.5)
+    job.stop()
+    t.join(timeout=2)
+
+    assert len(results) == 1
+    assert results[0] is not None


### PR DESCRIPTION
## Description
Fixes #1905 where `CronJob.batched_run` scheduled only the first task and never returned because `run()` blocked inside an inline loop during the first iteration.

## Changes
- Extracted blocking wait loop into `_block_forever()`.
- Refactored `batched_run()` to call `_run()` for all tasks first to schedule them, and block once after all tasks are scheduled.
- Ensured `_run()`, `every_seconds()`, and `every_minutes()` return the scheduled `schedule.Job` instance.
- Updated docstrings for `run()` and `batched_run()` describing scheduling/blocking semantics.
- Added unit tests in `tests/structs/test_cron_job.py`.

## Known Related Issues
- Issue #1904 (`isinstance(self.agent, Callable)` check inversion) is present in `_run_job()` and tracked separately.

## Test Results
`pytest tests/ -k cron_job -v` -> 3 passed in 11.10s
