### PR TITLE
[Bug] BatchedGridWorkflow documents an output_type it never reads

### DIFF
--- a/swarms/structs/batched_grid_workflow.py
+++ b/swarms/structs/batched_grid_workflow.py
@@ -7,7 +7,6 @@ from swarms.structs.multi_agent_exec import (
     batched_grid_agent_execution,
 )
 from swarms.structs.omni_agent_types import AgentType
-from swarms.utils.output_types import OutputType
 from swarms.telemetry.otel import capture_init, trace_run
 from swarms.utils.generate_id import generate_id
 
@@ -32,7 +31,6 @@ class BatchedGridWorkflow:
         description (str): Description of the workflow's purpose.
         agents (List[AgentType]): List of agents to execute tasks.
         max_loops (int): Maximum number of execution loops to perform.
-        output_type (OutputType): Type of output to return.
 
     Example:
         >>> from swarms.structs.batched_grid_workflow import BatchedGridWorkflow
@@ -51,7 +49,6 @@ class BatchedGridWorkflow:
         description: str = "For every agent, run the task on a different task",
         agents: List[AgentType] = None,
         max_loops: int = 1,
-        output_type: OutputType = "dict",
     ):
         """
         Initialize a BatchedGridWorkflow instance.


### PR DESCRIPTION
`BatchedGridWorkflow` accepts `output_type`, documents it as *"Type of output to return"*, and never reads it. `run()` always returns the same raw list of per-loop results, so anyone who sets it gets silence.

```python
def __init__(self, ..., max_loops: int = 1, output_type: OutputType = "dict"):
    self.id = ...
    self.name = ...
    self.agents = agents
    self.max_loops = max_loops
    # output_type is never stored
```

`grep output_type swarms/structs/batched_grid_workflow.py` matched only the import, the docstring line and the parameter itself.

It is not just a stray default. Every other structure honours `output_type` through `history_output_formatter`, and `SwarmRouter` sets it on all of them — so switching `swarm_type` to `"BatchedGridWorkflow"` silently drops the caller's output formatting, with no error to explain it. (`SwarmRouter._create_batched_grid_workflow` does not forward it either, which is consistent with it having no effect.)

## Why remove rather than implement

`HistoryOutputType` has 17 values and they are all conversation-shaped — `final`, `last`, `dict-all-except-first`, `basemodel`, `yaml`, `xml`. This workflow keeps no `Conversation`; it returns a list of per-loop agent outputs. Honouring those values would mean inventing what each one means for a bare list, which is a design decision rather than a bug fix, and a bigger change than the defect warrants.

Deleting the parameter makes the signature honest: no caller silently loses formatting, and `SwarmRouter`'s behaviour is unchanged because it never passed it.

## Blast radius — checked, not assumed

Nothing in either repo passes it:

```
swarms/structs/swarm_router.py:624          name/description/agents/max_loops only
examples/.../batched_grid_*.py (7 sites)    0 pass output_type
Swarms-API api/batched_grid_workflow.py     name/description/agents/max_loops only
```

`tests/structs/test_batched_grid_workflow.py`: 14 passed. Construction and `run()` are unchanged:

```
  constructed ok, max_loops = 2
  run -> [['a1:t1', 'a2:t2'], ['a1:t1', 'a2:t2']]
```

The `OutputType` import goes with it, since it becomes unused.

## The one trade-off

An external caller that passes `output_type=` today gets silence; after this it gets `TypeError: __init__() got an unexpected keyword argument 'output_type'`. I think that is the right direction — it tells them the formatting they asked for was never happening — but it is a visible change, so if you would rather keep the signature and implement a subset (`list`/`str`/`json` on the raw results, erroring on the conversation-only values), say so and I will send that instead.
