### PR TITLE
fix(agent): make tool_execution_retry actually retry and surface failures (#1794)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -4025,12 +4025,13 @@ Summary: {summary}
         - If tool execution fails, the method automatically retries
         - Maximum retry attempts are controlled by self.tool_retry_attempts (default: 3)
         - Each retry is logged with detailed error information
-        - After all retries are exhausted, the exception is re-raised
+        - After all retries are exhausted, AgentToolExecutionError is raised,
+          chained from the last underlying error via `raise ... from`
 
         **Error Handling:**
         - None responses: Logs warning and skips execution (does not raise)
-        - AgentToolExecutionError: Logs error with full traceback and retries
-        - Other exceptions: Logs error and retries
+        - Any exception from execute_tools: Logs error with full traceback and
+          retries, since execute_tools re-raises the tool's own exception type
 
         **Logging:**
         All errors are logged with:
@@ -4073,20 +4074,40 @@ Summary: {summary}
             >>> agent.tool_execution_retry(None, loop_count=2)
             >>> # Logs warning but does not raise exception
         """
-        try:
-            if response is not None:
+        if response is None:
+            logger.warning(
+                f"Agent '{self.agent_name}' received None response from LLM in loop {loop_count}. "
+                f"This may indicate an issue with the model or prompt. Skipping tool execution."
+            )
+            return
+
+        # execute_tools re-raises whatever the tool raised, and nothing in the
+        # framework raises AgentToolExecutionError, so catching only that type
+        # caught nothing. Catch broadly here, which is also what the docstring
+        # promises ("Other exceptions: Logs error and retries").
+        attempts = max(1, int(self.tool_retry_attempts or 1))
+        last_error: Optional[Exception] = None
+
+        for attempt in range(1, attempts + 1):
+            try:
                 self.execute_tools(
                     response=response,
                     loop_count=loop_count,
                 )
-            else:
-                logger.warning(
-                    f"Agent '{self.agent_name}' received None response from LLM in loop {loop_count}. "
-                    f"This may indicate an issue with the model or prompt. Skipping tool execution."
+                return
+            except Exception as e:
+                last_error = e
+                logger.error(
+                    f"Agent '{self.agent_name}' tool execution failed on attempt "
+                    f"{attempt}/{attempts} in loop {loop_count}: {str(e)}. "
+                    f"Full traceback: {traceback.format_exc()}"
                 )
-        except AgentToolExecutionError as e:
-            logger.error(
-                f"Agent '{self.agent_name}' encountered error during tool execution in loop {loop_count}: {str(e)}. "
-                f"Full traceback: {traceback.format_exc()}. "
-                f"Attempting to retry tool execution with 3 attempts"
-            )
+
+        # Attempts exhausted. Raising is what the docstring specifies, and it is
+        # the only way the caller learns the tools did not run — returning here
+        # left `short_memory` with no Tool Executor entry, so the model saw the
+        # call as having produced nothing and carried on as if it had succeeded.
+        raise AgentToolExecutionError(
+            f"Agent '{self.agent_name}' failed to execute tools in loop "
+            f"{loop_count} after {attempts} attempt(s): {last_error}"
+        ) from last_error

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -21,6 +21,7 @@ from swarms import (
     create_agents_from_yaml,
 )
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
+from swarms.schemas.agent_errors import AgentToolExecutionError
 
 # Load environment variables
 load_dotenv()
@@ -2952,3 +2953,119 @@ class TestEmptyTaskGuard:
 
         with pytest.raises(ValueError, match="No task provided"):
             Agent.run(agent, empty_task)
+
+
+class TestToolExecutionRetry:
+    """#1794: tool_execution_retry promised `tool_retry_attempts` retries and a
+    re-raise once exhausted. It called execute_tools exactly once, caught only
+    AgentToolExecutionError — a type nothing in the framework raises — and
+    returned, so a failed tool run left no Tool Executor entry in short_memory
+    and the model carried on as though the call had succeeded.
+    """
+
+    @staticmethod
+    def _agent(attempts=3, name="A"):
+        """A bare Agent carrying only what tool_execution_retry reads."""
+        agent = Agent.__new__(Agent)
+        agent.agent_name = name
+        agent.tool_retry_attempts = attempts
+        return agent
+
+    def test_retries_up_to_the_configured_attempts(self):
+        agent = self._agent(attempts=5)
+        calls = []
+
+        def failing(response, loop_count):
+            calls.append(loop_count)
+            raise RuntimeError("simulated tool failure")
+
+        agent.execute_tools = failing
+        with pytest.raises(AgentToolExecutionError):
+            Agent.tool_execution_retry(agent, [{"function": {}}], 1)
+
+        # The regression: this was 1 regardless of tool_retry_attempts.
+        assert len(calls) == 5
+
+    def test_default_attempts_are_honoured(self):
+        agent = self._agent(attempts=3)
+        calls = []
+        agent.execute_tools = lambda response, loop_count: (
+            calls.append(1),
+            (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        with pytest.raises(AgentToolExecutionError):
+            Agent.tool_execution_retry(agent, [{"function": {}}], 1)
+        assert len(calls) == 3
+
+    def test_failure_is_raised_not_swallowed(self):
+        """Returning None here is what hid tool failures: the caller saw no
+        error and short_memory carried no Tool Executor entry."""
+        agent = self._agent(attempts=1)
+
+        def failing(response, loop_count):
+            raise RuntimeError("simulated tool failure")
+
+        agent.execute_tools = failing
+        with pytest.raises(AgentToolExecutionError) as excinfo:
+            Agent.tool_execution_retry(agent, [{"function": {}}], 1)
+
+        # The underlying error is chained, not discarded.
+        assert isinstance(excinfo.value.__cause__, RuntimeError)
+        assert "simulated tool failure" in str(
+            excinfo.value.__cause__
+        )
+
+    def test_catches_the_exception_types_actually_raised(self):
+        """execute_tools re-raises the tool's own exception verbatim and nothing
+        raises AgentToolExecutionError, so catching only that type caught
+        nothing. A plain ValueError must be retried like any other failure.
+        """
+        agent = self._agent(attempts=2)
+        calls = []
+
+        def failing(response, loop_count):
+            calls.append(1)
+            raise ValueError("a tool's own error type")
+
+        agent.execute_tools = failing
+        with pytest.raises(AgentToolExecutionError):
+            Agent.tool_execution_retry(agent, [{"function": {}}], 1)
+        assert len(calls) == 2
+
+    def test_stops_retrying_once_a_attempt_succeeds(self):
+        agent = self._agent(attempts=4)
+        calls = []
+
+        def flaky(response, loop_count):
+            calls.append(1)
+            if len(calls) < 3:
+                raise RuntimeError("transient")
+
+        agent.execute_tools = flaky
+        Agent.tool_execution_retry(agent, [{"function": {}}], 1)
+
+        # Third attempt succeeded, so the fourth must not run.
+        assert len(calls) == 3
+
+    def test_none_response_does_not_execute_or_raise(self):
+        agent = self._agent()
+        called = []
+        agent.execute_tools = lambda **kw: called.append(1)
+
+        Agent.tool_execution_retry(agent, None, 1)
+        assert called == []
+
+    def test_a_zero_or_none_attempt_count_still_runs_once(self):
+        """tool_retry_attempts is caller-supplied; 0 must not mean 'never run
+        the tools', which would silently disable tool execution entirely.
+        """
+        for attempts in (0, None):
+            agent = self._agent(attempts=attempts)
+            calls = []
+            agent.execute_tools = (
+                lambda response, loop_count: calls.append(1)
+            )
+            Agent.tool_execution_retry(agent, [{"function": {}}], 1)
+            assert (
+                len(calls) == 1
+            ), f"attempts={attempts!r} should still run once"


### PR DESCRIPTION
Closes #1794.

`tool_execution_retry` promised `tool_retry_attempts` retries and a re-raise once exhausted. It called `execute_tools` **once**, caught a type nothing raises, logged a line announcing three attempts that never happened, and returned — so a failed tool call was invisible to both the caller and the model.

## Problem

`swarms/structs/agent.py:4075-4092`, the entire body under a 59-line docstring:

```python
try:
    if response is not None:
        self.execute_tools(response=response, loop_count=loop_count)
    else:
        logger.warning(...)
except AgentToolExecutionError as e:
    logger.error(
        f"... Attempting to retry tool execution with 3 attempts"
    )
```

No loop, no re-raise, no reference to `self.tool_retry_attempts`.

Two things make this worse than a missing loop:

1. **The handler never fires.** `AgentToolExecutionError` is raised nowhere in the framework — `grep -rn "raise AgentToolExecutionError" swarms/` returns nothing — and `execute_tools` re-raises the tool's own exception verbatim. Real tool failures escaped the method entirely and landed in `_run`'s handler at `agent.py:1566`.
2. **When it did fire, the failure vanished.** `_run` continued to the next loop with no `Tool Executor` entry in `short_memory`, so the model saw the call as having produced nothing and carried on as though it had succeeded.

On `master` @ `a5764139` (v14.0.0):

```
tool_retry_attempts configured : 5
execute_tools invocations      : 1
exception propagated to caller : False
return value                   : None
```

`tool_retry_attempts=5`, one call, no exception, and a log line advertising three attempts.

## Fix

- Loop `tool_retry_attempts` times, returning as soon as an attempt succeeds.
- **Catch `Exception`, not `AgentToolExecutionError`** — that is what `execute_tools` actually raises, and what the docstring already promised under *"Other exceptions: Logs error and retries"*.
- Once attempts are spent, raise `AgentToolExecutionError` **chained from the last underlying error** via `raise ... from`, so the original type and message survive. This finally gives that exception class a raise site.
- Log the real attempt number (`{attempt}/{attempts}`) instead of a hardcoded 3.
- `tool_retry_attempts` of `0` or `None` still runs once. It is caller-supplied, and reading `0` as "never execute tools" would silently disable tool calling — a worse failure than the one being fixed.
- The two stale docstring claims (the caught type, and what is raised on exhaustion) are corrected in the same change.

## Behavior-change note

A tool that fails every attempt now raises where it previously returned `None`. That is the point of the issue — the silent return is what let a broken tool look like a successful one — but it does change what `_run` sees.

**It does not change what `_run` does.** The call at `agent.py:1541` already sits inside `try@1436-1592`, whose handler at `:1566` catches `Exception`. Before this change a tool failure reached that handler as the tool's own exception type; now it reaches it as `AgentToolExecutionError`. Either way the handler treats it as a generation failure and retries the LLM call, so no caller sees a new exception escape `run()`.

That handler behaviour is itself wrong — a tool bug is reported as `Agent.llm_error` and recovered from by re-running the model, and the two retry budgets now compound (`tool_retry_attempts` × `retry_attempts`). That is a separate concern from the method this issue is about, so it is filed as its own issue rather than expanded into this PR.

## Verification

- **7 new tests** in `TestToolExecutionRetry`, added to the existing `tests/structs/test_agent.py` (no new file, per prior review guidance). Network-free, built on `Agent.__new__` — no model client, no provider call: the configured attempt count is honoured, the default of 3 is honoured, failure raises rather than returning `None`, the underlying error is chained, a plain `ValueError` is retried (the type the old handler missed), retrying stops on the first success, a `None` response neither executes nor raises, and `0`/`None` attempts still run once.
- **They are real regression tests**: against unfixed `master`, **5 of the 7 fail**. The other two (`none_response`, `zero_or_none_attempt_count`) pass there because the old code always ran exactly once.
- **Full file**: `tests/structs/test_agent.py` goes from **57 passed** on clean `master` to **64 passed**, with **20 failed / 8 errors on both sides** — a set difference of the two failure lists is empty in both directions, so nothing was broken and nothing else was fixed. The remaining failures are the pre-existing live-API tests.
- **Lint** with the CI-pinned versions (`black==24.2.0`, `ruff==0.2.1`, line-length 70): `black --check` clean on both files, `ruff check .` clean repo-wide.

**Not verified here**: no live provider call and no real tool execution — no API keys are present in this environment. Every test substitutes `execute_tools` at the method boundary, so the retry loop, the chaining and the raise are exercised for real while the tool call itself is not.
