### PR TITLE
[Bug] Conversation can't load the file it just saved — history comes back empty

### DIFF
--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -163,8 +163,14 @@ class Conversation:
             extension = (
                 ".json" if self.export_method == "json" else ".yaml"
             )
-            self.save_filepath = (
-                f"conversation_{self.name}{extension}"
+            # Under conversations_dir, not the process's working directory:
+            # a bare relative name dropped conversation_<name>.json wherever
+            # the program happened to run from, and two conversations sharing
+            # a name in different directories silently loaded each other's
+            # history.
+            self.save_filepath = os.path.join(
+                self.conversations_dir or get_conversation_dir(),
+                f"conversation_{self.name}{extension}",
             )
             logger.debug(
                 f"Setting default save filepath to: {self.save_filepath}"

--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -934,6 +934,41 @@ class Conversation:
             )
             raise  # Re-raise to ensure the error is visible
 
+    def _restore(self, data: Union[dict, list]):
+        """Apply a loaded save file to this conversation.
+
+        Accepts both shapes a save file can have. ``save_as_json`` and
+        ``save_as_yaml`` write ``to_dict()``, which is the bare list of
+        messages, while this loader only understood a
+        ``{"metadata": ..., "conversation_history": ...}`` wrapper — so
+        reloading a file this class had just written raised
+        ``AttributeError: 'list' object has no attribute 'get'``.
+
+        Args:
+            data (Union[dict, list]): Parsed contents of a save file.
+        """
+        if isinstance(data, list):
+            self.conversation_history = data
+            self._str_cache = None
+            return
+
+        if not isinstance(data, dict):
+            logger.warning(
+                f"Ignoring save file with unexpected top-level "
+                f"{type(data).__name__}; expected a list or a dict."
+            )
+            return
+
+        # Conversation-level settings, when the file carries the wrapper.
+        for key, value in (data.get("metadata") or {}).items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+
+        self.conversation_history = data.get(
+            "conversation_history", []
+        )
+        self._str_cache = None
+
     def load_from_json(self, filename: str):
         """Load the conversation history and metadata from a JSON file.
 
@@ -945,18 +980,7 @@ class Conversation:
                 with open(filename, "r", encoding="utf-8") as f:
                     data = json.load(f)
 
-                # Load metadata
-                metadata = data.get("metadata", {})
-                # Update all metadata attributes
-                for key, value in metadata.items():
-                    if hasattr(self, key):
-                        setattr(self, key, value)
-
-                # Load conversation history
-                self.conversation_history = data.get(
-                    "conversation_history", []
-                )
-                self._str_cache = None
+                self._restore(data)
 
                 logger.info(
                     f"Successfully loaded conversation from {filename}"
@@ -978,18 +1002,7 @@ class Conversation:
                 with open(filename, "r", encoding="utf-8") as f:
                     data = yaml.safe_load(f)
 
-                # Load metadata
-                metadata = data.get("metadata", {})
-                # Update all metadata attributes
-                for key, value in metadata.items():
-                    if hasattr(self, key):
-                        setattr(self, key, value)
-
-                # Load conversation history
-                self.conversation_history = data.get(
-                    "conversation_history", []
-                )
-                self._str_cache = None
+                self._restore(data)
 
                 logger.info(
                     f"Successfully loaded conversation from {filename}"


### PR DESCRIPTION
`Conversation` saves history that it can never load back. Save a conversation, construct it again, and you get an empty history plus a logged traceback — the data is on disk and silently unreachable.

```
BEFORE (master)                       AFTER
  json  save -> reload : 0 messages     json  save -> reload : 2 messages restored
  yaml  save -> reload : 0 messages     yaml  save -> reload : 1 message restored
```

with this in the log each time:

```
AttributeError: 'list' object has no attribute 'get'
  conversation.py:949 in load_from_json  ->  metadata = data.get("metadata", {})
  conversation.py:1017 in load
```

## Cause

`save_as_json` / `save_as_yaml` write `to_dict()`. Despite its docstring — *"a dictionary containing: metadata … conversation_history …"* — `to_dict()` is:

```python
def to_dict(self) -> Dict[Any, Any]:
    return self.conversation_history      # a bare list
```

Both loaders only understood the documented wrapper, so they call `.get` on a list. `setup_file_path` auto-loads `conversation_<name>.<ext>` on construction, which is where the traceback comes from — the failure is swallowed upstream and the conversation just comes back empty.

`to_dict()` itself is deliberately left alone: `history_output_formatter` uses it for `output_type="dict"`/`"yaml"`/`"json"`, so those callers need the list. The mismatch is fixed where it belongs, on the load side.

## Change

1. `_restore(data)`, shared by both loaders, accepts either shape — a bare list of messages, or the `{"metadata", "conversation_history"}` wrapper — and ignores anything else with a warning instead of raising.
2. The default `save_filepath` now resolves under `conversations_dir` instead of being a bare relative name.

(2) is part of the same defect rather than scope creep: with loading fixed, a CWD-relative default means any program that constructs `Conversation(name="X")` from a different directory silently picks up — or misses — an unrelated file of the same name. It is also why `conversation_conversation-test.json` keeps appearing in the repo root, which a reviewer already flagged on #1785 and #1787 as a stray artifact. It is not a fixture; it is the suite writing to the working directory.

```
  save_filepath: /tmp/demo/conversations/conversation_demo.json
  files in CWD: agent_workspace conversations
```

## Verification

```
  json  save -> reload : ok, 2 messages restored
  yaml  save -> reload : ok, 1 messages restored
  wrapper shape        : 1 message(s), metadata applied: user='Ayaan'
  garbage top level    : ignored, history=[]
```

`tests/structs/test_conversation.py`: **51 passed**, with no test changed.

Worth saying plainly: fixing only (1) broke three of those tests, because they share the default conversation name and — once reloading actually worked — each one inherited the previous test's leftover file from the repo root. That is the clearest evidence that (2) belongs in the same change: with the save path scoped to `conversations_dir`, each test's `tmp_path` isolates it and the suite goes green untouched.

No new test file: the round trip is covered by the existing suite, which now exercises a load path that previously always failed.

## Adjacent finding, not included

`Conversation.add(metadata=...)` is accepted, documented as *"Optional metadata for the message"*, and dropped — `add_in_memory` has no `metadata` parameter, so it never reaches the message. The fix is two lines mirroring the `category` handling directly above it, and I have it ready; I left it out to keep this diff to the persistence bug. Say the word and I will send it.
