### PR TITLE
[Bug] SkillOrchestra drops imgs and execution kwargs before the agents run (#1906)

### DIFF
--- a/swarms/structs/skill_orchestra.py
+++ b/swarms/structs/skill_orchestra.py
@@ -580,9 +580,16 @@ class SkillOrchestra:
         selected: List[AgentSelectionResult],
         task: str,
         img: Optional[str] = None,
+        imgs: Optional[List[str]] = None,
         **kwargs,
     ) -> List[Dict[str, Any]]:
-        """Run selected agents on the task."""
+        """Run selected agents on the task.
+
+        ``imgs`` and any extra ``kwargs`` are forwarded to every selected
+        agent. They used to stop here: the agents were invoked with only
+        ``task`` and ``img``, so a caller passing multiple images or e.g.
+        ``streaming_callback`` got silence rather than an error.
+        """
         results = []
 
         if len(selected) == 1:
@@ -597,7 +604,9 @@ class SkillOrchestra:
                     f"Executing agent '{sel.agent_name}' on task"
                 )
 
-            response = agent.run(task=agent_task, img=img)
+            response = agent.run(
+                task=agent_task, img=img, imgs=imgs, **kwargs
+            )
 
             self.conversation.add(
                 role=sel.agent_name, content=str(response)
@@ -621,7 +630,11 @@ class SkillOrchestra:
                     )
                     agent_task = sel.assigned_task or task
                     future = executor.submit(
-                        agent.run, task=agent_task, img=img
+                        agent.run,
+                        task=agent_task,
+                        img=img,
+                        imgs=imgs,
+                        **kwargs,
                     )
                     future_to_agent[future] = sel.agent_name
 
@@ -859,7 +872,11 @@ class SkillOrchestra:
 
                 # Step 4: Execute
                 results = self._execute_agents(
-                    selected, current_task, img=img, **kwargs
+                    selected,
+                    current_task,
+                    img=img,
+                    imgs=imgs,
+                    **kwargs,
                 )
 
                 # Step 5: Learn


### PR DESCRIPTION
Fixes #1906.

`SkillOrchestra.run()` accepts `imgs` and `**kwargs`, documents `imgs` as *"Optional list of image inputs"*, and then drops both before the agents run. The issue's trace is exactly right; here is the same thing measured, with stub agents recording what they actually receive:

```
BEFORE   single-agent path    img=one.png imgs=None                    kwargs=[]
         concurrent path      img=one.png imgs=None                    kwargs=[]

AFTER    single-agent path    img=one.png imgs=['a.png', 'b.png']      kwargs=['streaming_callback']
         concurrent path      img=one.png imgs=['a.png', 'b.png']      kwargs=['streaming_callback']
```

So a caller passing a second image, or `streaming_callback`, got silence — no error, no warning, just an agent that never saw them.

## Fix

Three call sites, one parameter added:

- `run()` now passes `imgs=imgs` when it delegates to `_execute_agents` (it already forwarded `img` and `**kwargs`).
- `_execute_agents` takes `imgs` and forwards it, along with `**kwargs`, to `agent.run(...)` on **both** paths — the single-agent direct call and the `executor.submit` fan-out. The issue names the single-agent line; the concurrent one drops them identically, so both are fixed.

Same defect class as #1822 (`SequentialWorkflow.run` accepted `imgs` and dropped it) and #1902 (HeavySwarm threaded `img` two levels then never passed it), both of which came from a parameter that looked wired up at every level except the last.

No test file: the change is a parameter forwarded at three call sites, and the numbers above are reproducible against stub agents with no LLM call.
