### PR TITLE
[Bug] HierarchicalSwarmDashboard: progress and order count are wrong, and two hardcoded widths overflow the terminal (#1911, #1913, #1914, #1915)

### DIFF
--- a/swarms/utils/hierarchical_swarm_dashboard.py
+++ b/swarms/utils/hierarchical_swarm_dashboard.py
@@ -199,10 +199,24 @@ class HierarchicalSwarmDashboard:
             status_text.append("RUNTIME: ", style="bold white")
             status_text.append(f"{runtime:.2f}s", style="bold green")
 
-            # Add completion percentage if loops are running
+            # Add completion percentage if loops are running.
+            #
+            # current_loop is 1-based and set at the *top* of each iteration
+            # (hiearchical_swarm.py calls update_loop(current_loop + 1)), so
+            # dividing by max_loops reported 100% before the final loop's
+            # agents had run. Count loops finished instead: the loop in
+            # progress is current_loop, so current_loop - 1 are done.
             if self.max_loops > 0:
+                # Once the swarm reports COMPLETED every loop has finished,
+                # including the last one — otherwise the run would end at
+                # (max_loops - 1) / max_loops and never show 100%.
+                completed_loops = (
+                    self.max_loops
+                    if self.director_status == "COMPLETED"
+                    else max(0, self.current_loop - 1)
+                )
                 completion_percent = (
-                    self.current_loop / self.max_loops
+                    completed_loops / self.max_loops
                 ) * 100
                 status_text.append("  |  ", style="white")
                 status_text.append("PROGRESS: ", style="bold white")
@@ -232,7 +246,17 @@ class HierarchicalSwarmDashboard:
         table.add_column("LOOP", style="bold white", width=8)
         table.add_column("STATUS", style="bold white", width=15)
         table.add_column("TASK", style="white", width=40)
-        table.add_column("OUTPUT", style="white", width=150)
+        # OUTPUT takes whatever is left rather than a hardcoded 150, which
+        # made the table ~250 chars and overflowed almost every terminal.
+        # ratio=1 lets Rich shrink it to the console; the minimum keeps it
+        # readable on a narrow one.
+        table.add_column(
+            "OUTPUT",
+            style="white",
+            ratio=1,
+            min_width=20,
+            overflow="fold",
+        )
 
         # Display agents with their history across loops
         for agent_name, history in self.agent_history.items():
@@ -333,9 +357,10 @@ class HierarchicalSwarmDashboard:
         # Orders section
         director_text.append("CURRENT ORDERS:\n", style="bold white")
         if self.director_orders:
-            for i, order in enumerate(
-                self.director_orders
-            ):  # Show first 5 orders
+            # Actually show only the first 5. Without the slice every order
+            # was rendered and the "... and N more" line below contradicted
+            # what the panel had just printed.
+            for i, order in enumerate(self.director_orders[:5]):
                 director_text.append(f"{i + 1}. ", style="bold cyan")
                 director_text.append(
                     f"{order.get('agent_name', 'Unknown')}: ",
@@ -537,7 +562,8 @@ class HierarchicalSwarmDashboard:
                 title=f"[bold white]FULL OUTPUT - {agent_name}[/bold white]",
                 border_style="red",
                 padding=(1, 2),
-                width=120,
+                # No hardcoded width: 120 overflowed an 80-char terminal.
+                # Rich sizes the panel to the console on its own.
             )
 
             # Temporarily show the full output


### PR DESCRIPTION
Fixes #1911, #1913, #1914 and #1915 — four reports against `swarms/utils/hierarchical_swarm_dashboard.py`, all of them the dashboard showing something that is not true. One file, four independent hunks.

## #1914 — the truncation label contradicted the panel

The comment said "Show first 5 orders"; the loop had no slice, so all orders were rendered and *then* `"... and N more orders"` was appended. With 8 orders the panel printed all 8 and claimed 3 more were hidden.

```
  orders rendered = 5 of 8, label says "and 3 more": True   (consistent: True)
```

## #1915 — progress reached 100% before the last loop ran

`current_loop / max_loops`, with `current_loop` set at the *top* of each iteration (`hiearchical_swarm.py:934` calls `update_loop(current_loop + 1)`), so the final loop began at 100%. Counting *finished* loops instead:

```
  max_loops=3            before    after
  loop 1 starts          33.3%     0.0%
  loop 2 starts          66.7%    33.3%
  loop 3 starts         100.0%    66.7%
  run COMPLETED         100.0%   100.0%
```

The `COMPLETED` branch matters: without it the run would end at 66.7% and never show 100%, which is why the fix is not just `current_loop - 1`. The swarm already sets that status (`hiearchical_swarm.py:979`) immediately before `stop()`, so no call-site change was needed.

## #1911 — OUTPUT column hardcoded to 150

Fixed widths totalled 238, so the table overflowed almost any terminal. OUTPUT is now `ratio=1, min_width=20, overflow="fold"`, which lets Rich shrink it to the console:

```
  fixed column width total: 238 -> 88, OUTPUT now (width=None, ratio=1)
```

## #1913 — full-output Panel hardcoded to 120

Dropped the `width=120`; Rich sizes a Panel to the console by default, so an 80-char terminal no longer gets a 120-char panel.

## Verification and scope

Each fix is asserted above against the real objects (`_create_director_panel`, `_create_agents_table`, `show_full_output`) rather than by eye.

`tests/structs/test_hierarchical_swarm.py` shows 8 failures both with and without this change — they are pre-existing on master, unrelated to the dashboard.

No test file: these are rendering-layer fixes and the repo has no dashboard test module. If you want one, the progress formula is the piece worth pinning and I will add it.

Grouped into one PR because they are four instances of the same problem in one module, and splitting them would mean four PRs touching the same file. Happy to split if you would rather review them separately.
