### PR TITLE
fix(telemetry): make telemetry opt-in and redact credentials

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Security Feature              | Benefit                                  | Description                                                                 |
 |-------------------------------|------------------------------------------|-----------------------------------------------------------------------------|
 | Environment Variables         | Secure Configuration                     | Uses environment variables to manage sensitive configurations securely.     |
-| No Telemetry                  | Enhanced Privacy                         | Prioritizes user privacy by not collecting telemetry data.                  |
+| No Telemetry by Default       | Enhanced Privacy                         | Outbound telemetry is **off by default**; it is only sent when explicitly enabled via `SWARMS_TELEMETRY_ON=true`. Credential-bearing configuration (API keys, tokens, secrets) is redacted before serialization in all cases. |
 | Data Encryption               | Data Protection                          | Encrypts sensitive data to protect it from unauthorized access.             |
 | Authentication                | Access Control                           | Ensures that only authorized users can access the system.                   |
 | Authorization                 | Fine-grained Access                      | Provides specific access rights to users based on roles and permissions.    |

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2735,6 +2735,12 @@ Subtask Breakdown:
         dict_copy = self.__dict__.copy()
         dict_copy.pop("llm", None)
 
+        # Never serialize credentials: to_dict() feeds autosave state and
+        # telemetry payloads, both of which can leave the process.
+        for secret_attr in ("llm_api_key", "mcp_api_key"):
+            if secret_attr in dict_copy and dict_copy[secret_attr] is not None:
+                dict_copy[secret_attr] = "***REDACTED***"
+
         return {
             attr_name: self._serialize_attr(attr_name, attr_value)
             for attr_name, attr_value in dict_copy.items()

--- a/swarms/telemetry/otel.py
+++ b/swarms/telemetry/otel.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from functools import lru_cache
@@ -42,6 +43,25 @@ TELEMETRY_OFF_VALUES = frozenset(
     {"false", "0", "no", "off", "disable", "disabled"}
 )
 
+TELEMETRY_ON_VALUES = frozenset(
+    {"true", "1", "yes", "on", "enable", "enabled"}
+)
+
+# Attribute/parameter names whose values must never leave the process. Applied
+# by key name in ``init_config`` and ``_sanitize`` so secrets are masked before
+# any payload is serialized, regardless of where they appear in a config.
+_SECRET_KEY_PATTERN = re.compile(
+    r"(api[_-]?key|auth[_-]?key|token|secret|password|authorization)",
+    re.IGNORECASE,
+)
+
+REDACTED = "***REDACTED***"
+
+
+def _is_secret_key(name: str) -> bool:
+    """Return whether ``name`` looks like a credential-bearing key."""
+    return _SECRET_KEY_PATTERN.search(name) is not None
+
 
 def telemetry_on() -> bool:
     """Return whether outbound telemetry is enabled.
@@ -50,22 +70,22 @@ def telemetry_on() -> bool:
     :func:`swarms.telemetry.main.log_agent_data`, so the whole framework has one
     on/off gate.
 
-    Telemetry is **on by default** — it must be switched off explicitly. Set
-    ``SWARMS_TELEMETRY_ON`` to any of ``"false"``, ``"0"``, ``"no"``, ``"off"``,
-    ``"disable"`` or ``"disabled"`` (case-insensitive) to opt out. An empty or
-    whitespace-only value also counts as off, so ``SWARMS_TELEMETRY_ON=`` in a
-    ``.env`` file disables it rather than silently enabling it.
+    Telemetry is **off by default** — it must be switched on explicitly. Set
+    ``SWARMS_TELEMETRY_ON`` to any of ``"true"``, ``"1"``, ``"yes"``, ``"on"``,
+    ``"enable"`` or ``"enabled"`` (case-insensitive) to opt in. An empty or
+    whitespace-only value counts as off, so ``SWARMS_TELEMETRY_ON=`` in a
+    ``.env`` file keeps it disabled rather than silently enabling it.
 
     Returns:
-        bool: ``False`` only when the variable is set to a recognized off value;
-        ``True`` otherwise, including when the variable is unset.
+        bool: ``True`` only when the variable is set to a recognized on value;
+        ``False`` otherwise, including when the variable is unset.
     """
     value = os.getenv("SWARMS_TELEMETRY_ON")
 
     if value is None:
-        return True
+        return False
 
-    return value.strip().lower() not in TELEMETRY_OFF_VALUES | {""}
+    return value.strip().lower() in TELEMETRY_ON_VALUES
 
 
 def _truncate(value: Any, limit: int = MAX_PAYLOAD_CHARS) -> str:
@@ -180,7 +200,11 @@ def _sanitize(value: Any, seen: frozenset = frozenset()) -> Any:
         nested = seen | {id(value)}
         try:
             return {
-                str(key): _sanitize(item, nested)
+                str(key): (
+                    REDACTED
+                    if _is_secret_key(str(key))
+                    else _sanitize(item, nested)
+                )
                 for key, item in value.items()
             }
         except _CyclicReference:
@@ -220,7 +244,11 @@ def init_config(obj: Any) -> str:
         params = {}
 
     config = {
-        name: _sanitize(getattr(obj, name, None))
+        name: (
+            REDACTED
+            if _is_secret_key(name)
+            else _sanitize(getattr(obj, name, None))
+        )
         for name in params
         if name not in ("self", "args", "kwargs")
     }

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -60,6 +60,9 @@ def _exporter():
     import swarms.telemetry.otel as _otel
 
     _otel.TELEMETRY_BASE_URL = "http://127.0.0.1:9/telemetry-test"
+    # Telemetry is opt-in: these tests exercise the emission path, so they
+    # explicitly enable it (the disabled path is covered by TestDisabledPath).
+    os.environ["SWARMS_TELEMETRY_ON"] = "true"
     swarm_telemetry.cache_clear()
     telem = swarm_telemetry()
     assert (
@@ -108,10 +111,15 @@ def _agent(name="TelemetryTestAgent"):
 # ===========================================================================
 class TestHelpers:
     def test_telemetry_on_truthy(self, monkeypatch):
-        # anything that is not a recognized off value means on
-        for val in ("true", "True", "1", "yes", "on", "anything"):
+        # only explicit allowlisted values enable telemetry
+        for val in ("true", "True", "1", "yes", "on", "enable", "enabled"):
             monkeypatch.setenv("SWARMS_TELEMETRY_ON", val)
             assert telemetry_on() is True
+
+    def test_telemetry_on_unknown_value_is_off(self, monkeypatch):
+        # opt-in: anything not allowlisted stays off
+        monkeypatch.setenv("SWARMS_TELEMETRY_ON", "anything")
+        assert telemetry_on() is False
 
     def test_telemetry_on_falsy(self, monkeypatch):
         for val in (
@@ -128,10 +136,10 @@ class TestHelpers:
             monkeypatch.setenv("SWARMS_TELEMETRY_ON", val)
             assert telemetry_on() is False
 
-    def test_telemetry_on_unset_defaults_to_on(self, monkeypatch):
-        """Telemetry is opt-out: unset means enabled."""
+    def test_telemetry_on_unset_defaults_to_off(self, monkeypatch):
+        """Telemetry is opt-in: unset means disabled."""
         monkeypatch.delenv("SWARMS_TELEMETRY_ON", raising=False)
-        assert telemetry_on() is True
+        assert telemetry_on() is False
 
     def test_telemetry_on_empty_value_is_off(self, monkeypatch):
         """`SWARMS_TELEMETRY_ON=` in a .env disables rather than enables."""

--- a/tests/telemetry/test_telemetry_opt_in.py
+++ b/tests/telemetry/test_telemetry_opt_in.py
@@ -1,0 +1,111 @@
+"""Tests for telemetry opt-in gating and secret redaction.
+
+Covers the security fix: outbound telemetry is OFF by default and
+credential-bearing configuration values are redacted before serialization.
+"""
+
+import pytest
+
+from swarms.telemetry.otel import (
+    REDACTED,
+    _is_secret_key,
+    _sanitize,
+    init_config,
+    telemetry_on,
+)
+
+
+class _Configurable:
+    """Minimal stand-in for a component whose __init__ params are captured."""
+
+    def __init__(
+        self,
+        llm_api_key: str = None,
+        mcp_api_key: str = None,
+        model_name: str = "gpt-5.4",
+        temperature: float = 0.5,
+    ):
+        self.llm_api_key = llm_api_key
+        self.mcp_api_key = mcp_api_key
+        self.model_name = model_name
+        self.temperature = temperature
+
+
+class TestTelemetryOptIn:
+    def test_off_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("SWARMS_TELEMETRY_ON", raising=False)
+        assert telemetry_on() is False
+
+    def test_on_when_explicitly_enabled(self, monkeypatch):
+        for value in ("true", "1", "yes", "on", "enable", "enabled", "TRUE"):
+            monkeypatch.setenv("SWARMS_TELEMETRY_ON", value)
+            assert telemetry_on() is True, value
+
+    def test_off_for_off_values(self, monkeypatch):
+        for value in ("false", "0", "no", "off", "disable", "disabled"):
+            monkeypatch.setenv("SWARMS_TELEMETRY_ON", value)
+            assert telemetry_on() is False, value
+
+    def test_off_for_empty_value(self, monkeypatch):
+        monkeypatch.setenv("SWARMS_TELEMETRY_ON", "")
+        assert telemetry_on() is False
+
+    def test_off_for_whitespace_value(self, monkeypatch):
+        monkeypatch.setenv("SWARMS_TELEMETRY_ON", "   ")
+        assert telemetry_on() is False
+
+
+class TestSecretRedaction:
+    def test_secret_key_detection(self):
+        for name in (
+            "llm_api_key",
+            "mcp_api_key",
+            "api_key",
+            "auth_key",
+            "token",
+            "access_token",
+            "secret",
+            "password",
+            "authorization",
+        ):
+            assert _is_secret_key(name), name
+        for name in ("model_name", "temperature", "max_loops", "agent_name"):
+            assert not _is_secret_key(name), name
+
+    def test_sanitize_redacts_secret_dict_keys(self):
+        payload = {
+            "llm_api_key": "sk-live-secret-123",
+            "model_name": "gpt-5.4",
+            "nested": {"mcp_api_key": "mcp-secret", "ok": 1},
+        }
+        cleaned = _sanitize(payload)
+        assert cleaned["llm_api_key"] == REDACTED
+        assert cleaned["nested"]["mcp_api_key"] == REDACTED
+        assert cleaned["model_name"] == "gpt-5.4"
+        assert cleaned["nested"]["ok"] == 1
+
+    def test_init_config_redacts_secret_params(self):
+        obj = _Configurable(
+            llm_api_key="sk-live-secret-123",
+            mcp_api_key="mcp-secret-456",
+        )
+        rendered = init_config(obj)
+        assert "sk-live-secret-123" not in rendered
+        assert "mcp-secret-456" not in rendered
+        assert REDACTED in rendered
+        assert '"model_name": "gpt-5.4"' in rendered
+
+    def test_agent_to_dict_redacts_keys(self):
+        from swarms.structs.agent import Agent
+
+        agent = Agent(
+            agent_name="telemetry-redact-test",
+            llm_api_key="sk-live-secret-123",
+            mcp_api_key="mcp-secret-456",
+            persistent_memory=False,
+        )
+        dumped = agent.to_dict()
+        assert dumped["llm_api_key"] == "***REDACTED***"
+        assert dumped["mcp_api_key"] == "***REDACTED***"
+        assert "sk-live-secret-123" not in str(dumped)
+        assert "mcp-secret-456" not in str(dumped)


### PR DESCRIPTION
## Summary

Outbound telemetry is now **OFF by default**. Previously, every `Agent`/workflow construction sent agent configuration to a hard-coded receiver unless `SWARMS_TELEMETRY_ON` was set to a recognized off value — an exfiltration risk for anyone running the framework with default settings.

## Changes

- `telemetry_on()` returns `True` only when `SWARMS_TELEMETRY_ON` is explicitly set to an allowlisted value (`true`/`1`/`yes`/`on`/`enable`/`enabled`, case-insensitive). Unset or unknown values → off.
- Credential-bearing config values (api keys, auth keys, tokens, secrets, passwords) are redacted as `***REDACTED***` before serialization:
  - `_sanitize` (telemetry payloads) and `init_config` (init spans)
  - `Agent.to_dict()`, which feeds autosave state and telemetry payloads
- `SECURITY.md` updated: "No Telemetry by Default" row documents the opt-in default.

## Tests

- New `tests/telemetry/test_telemetry_opt_in.py`: opt-in gating (unset/unknown/off values → off; allowlisted → on) and redaction (`_is_secret_key`, `_sanitize`, `init_config`, `Agent.to_dict()`).
- `tests/telemetry/test_telemetry.py` updated to the new contract: the span-emission tests explicitly enable telemetry; the helper tests assert opt-in semantics.
- Telemetry suite: 167 passed, 5 skipped (live-LLM tests, no key).