### PR TITLE
fix(tools): execute bash commands as argv with shell=False

### DIFF
--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -28,6 +28,7 @@ Available Tools:
 
 import os
 import re as _re
+import shlex
 import subprocess
 import uuid
 from typing import Any, Dict, List
@@ -933,6 +934,11 @@ _BASH_BLOCKLIST = [
     ("rm", "-rf"),
     ("rm", "-fr"),
     ("rm", "-r"),
+    # Bypass forms: flags split across tokens ("rm -r -f /") or long-form
+    # flags ("rm --recursive --force /") evade the substring checks above.
+    ("rm", "-r", "-f"),
+    ("rm", "--recursive", "--force"),
+    ("rm", "-rf", "/"),
     # Pipe command output into a shell interpreter
     ("| sh",),
     ("| bash",),
@@ -959,6 +965,7 @@ _BASH_BLOCKLIST = [
     ("poweroff",),
     # Privilege escalation
     ("chmod 777 /",),
+    ("chmod", "777"),
     ("chown", "/etc"),
     ("chown", "/bin"),
     ("sudo",),
@@ -1011,6 +1018,27 @@ def _check_bash_command(command: str) -> str | None:
     return None
 
 
+def _check_bash_argv(argv: List[str]) -> str | None:
+    """Return a rejection reason if *argv* matches a dangerous pattern, else None.
+
+    Operates on the parsed argument list (post-``shlex.split``), so shell
+    quoting/escape tricks that hide a pattern from the raw-string check
+    (``r""m -rf /``, ``r\\m -rf /``) are seen for what they are: the tokens
+    ``rm`` and ``-rf`` sitting next to each other in the argument list.
+    """
+    if not argv:
+        return "Command is empty."
+    for token in argv:
+        if "\x00" in token:
+            return "Command contains NUL bytes."
+    argv_lower = [token.lower() for token in argv]
+    for pattern in _BASH_BLOCKLIST:
+        pattern_tokens = [token.lower() for token in pattern]
+        if all(pt in argv_lower for pt in pattern_tokens):
+            return f"Command blocked: matches dangerous pattern {pattern!r}."
+    return None
+
+
 def run_bash_tool(
     agent: Any, command: str, timeout_seconds: int = 60, **kwargs
 ) -> str:
@@ -1037,14 +1065,43 @@ def run_bash_tool(
             content=f"Blocked (security): {command[:100]}{'...' if len(command) > 100 else ''}",
         )
         return f"Error: {rejection}"
+
+    # Parse into argv and re-check at token level: shell quoting/escape tricks
+    # (e.g. r""m -rf /) hide patterns from the raw-string check above, but
+    # shlex.split sees the real tokens.
+    try:
+        argv = shlex.split(command, posix=True)
+    except ValueError as e:
+        logger.warning(
+            f"run_bash_tool could not parse command: {command!r} — {e}"
+        )
+        agent.short_memory.add(
+            role="Terminal",
+            content=f"Blocked (security): {command[:100]}{'...' if len(command) > 100 else ''}",
+        )
+        return f"Error: could not parse command: {e}"
+
+    rejection = _check_bash_argv(argv)
+    if rejection:
+        logger.warning(
+            f"run_bash_tool blocked command: {command!r} — {rejection}"
+        )
+        agent.short_memory.add(
+            role="Terminal",
+            content=f"Blocked (security): {command[:100]}{'...' if len(command) > 100 else ''}",
+        )
+        return f"Error: {rejection}"
     # -------------------------------------------------------------------------
 
     try:
-        # Run in process cwd (where the user started the script) so commands like
-        # ls -la and python script.py see the project directory, not the agent workspace.
+        # Run the parsed argv directly — no shell, so shell metacharacters
+        # (|, >, $(), ;, backticks) are inert literal arguments and cannot be
+        # used to smuggle commands past the blocklist. Run in process cwd (where
+        # the user started the script) so commands like ls -la and python
+        # script.py see the project directory, not the agent workspace.
         result = subprocess.run(
-            command,
-            shell=True,
+            argv,
+            shell=False,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,

--- a/tests/structs/test_autonomous_loop_utils.py
+++ b/tests/structs/test_autonomous_loop_utils.py
@@ -1,0 +1,120 @@
+"""Tests for the hardened run_bash_tool.
+
+Covers the security fix: commands are executed as parsed argv with
+``shell=False`` (shell metacharacters are inert), and dangerous patterns are
+rejected both on the raw string and on the parsed token list.
+"""
+
+import pytest
+
+from swarms.structs.autonomous_loop_utils import (
+    _check_bash_argv,
+    _check_bash_command,
+    run_bash_tool,
+)
+
+
+class _StubMemory:
+    def __init__(self):
+        self.entries = []
+
+    def add(self, role, content):
+        self.entries.append((role, content))
+
+
+class _StubAgent:
+    def __init__(self):
+        self.short_memory = _StubMemory()
+        self.verbose = False
+
+
+@pytest.fixture
+def stub_agent():
+    return _StubAgent()
+
+
+class TestRawStringBlocklist:
+    def test_classic_rm_rf_blocked(self):
+        assert _check_bash_command("rm -rf /") is not None
+
+    def test_split_flag_bypass_blocked(self):
+        # "rm -r -f /" evades the ("rm", "-rf") substring check.
+        assert _check_bash_command("rm -r -f /") is not None
+
+    def test_long_flag_bypass_blocked(self):
+        assert _check_bash_command("rm --recursive --force /") is not None
+
+    def test_chmod_recursive_bypass_blocked(self):
+        assert _check_bash_command("chmod -R 777 /") is not None
+
+    def test_benign_command_allowed(self):
+        assert _check_bash_command("echo hello") is None
+
+
+class TestArgvBlocklist:
+    def test_quoted_concat_bypass_blocked(self):
+        # r""m -rf / hides "rm" from the raw-string check; the parsed argv is
+        # ["rm", "-rf", "/"] and must be caught at token level.
+        argv = ["rm", "-rf", "/"]
+        assert _check_bash_argv(argv) is not None
+
+    def test_backslash_escape_bypass_blocked(self):
+        argv = ["rm", "-rf", "/"]
+        assert _check_bash_argv(argv) is not None
+
+    def test_split_flag_bypass_blocked_at_argv_level(self):
+        argv = ["rm", "-r", "-f", "/"]
+        assert _check_bash_argv(argv) is not None
+
+    def test_chmod_bypass_blocked_at_argv_level(self):
+        argv = ["chmod", "-R", "777", "/"]
+        assert _check_bash_argv(argv) is not None
+
+    def test_empty_argv_rejected(self):
+        assert _check_bash_argv([]) is not None
+
+    def test_nul_byte_rejected(self):
+        assert _check_bash_argv(["echo", "\x00"]) is not None
+
+    def test_benign_argv_allowed(self):
+        assert _check_bash_argv(["echo", "hello"]) is None
+
+
+class TestRunBashTool:
+    def test_rm_rf_blocked(self, stub_agent):
+        result = run_bash_tool(stub_agent, "rm -r -f /")
+        assert result.startswith("Error:")
+        assert "blocked" in result.lower() or "dangerous" in result.lower()
+
+    def test_quoted_concat_blocked(self, stub_agent):
+        result = run_bash_tool(stub_agent, 'r""m -rf /')
+        assert result.startswith("Error:")
+
+    def test_chmod_recursive_blocked(self, stub_agent):
+        result = run_bash_tool(stub_agent, "chmod -R 777 /")
+        assert result.startswith("Error:")
+
+    def test_unparseable_command_rejected(self, stub_agent):
+        result = run_bash_tool(stub_agent, 'echo "unclosed')
+        assert result.startswith("Error:")
+
+    def test_shell_metacharacters_are_inert(self, stub_agent):
+        # With shell=False, ">/dev/sda" is a literal argv token, not a
+        # redirection: it cannot write to the disk, it just fails to exec.
+        result = run_bash_tool(stub_agent, ">/dev/sda")
+        assert result.startswith("Error")
+
+    def test_pipe_to_sh_is_inert(self, stub_agent):
+        result = run_bash_tool(stub_agent, "|sh")
+        assert result.startswith("Error")
+
+    def test_benign_command_executes(self, stub_agent):
+        result = run_bash_tool(stub_agent, "echo hello")
+        assert "hello" in result
+        assert "exited with code 0" in result
+
+    def test_blocked_command_recorded_in_memory(self, stub_agent):
+        run_bash_tool(stub_agent, "rm -rf /")
+        assert any(
+            "Blocked" in content for _, content in stub_agent.short_memory.entries
+        )


### PR DESCRIPTION
## Summary

`run_bash_tool` previously ran `subprocess.run(command, shell=True)`, handing the command string to `/bin/sh`. Shell metacharacters were live, so a prompt like `echo hi > /dev/sda` or `|sh` could execute arbitrary commands — the tool was effectively a remote shell for any agent with tool access.

## Changes

- Commands are parsed with `shlex.split` and executed as argv with `shell=False`: metacharacters become inert literal tokens (a redirection attempt fails to exec instead of writing to disk).
- The dangerous-command blocklist is checked **both** on the raw string and on the parsed token list, closing two bypasses of the old substring check:
  - `r""m -rf /` (quoted-concat hides the `rm` substring)
  - `rm -r -f /` (split flags evade the `rm -rf` substring)
- New blocklist entries: `rm -r -f`, `rm --recursive --force`, `rm -rf /`, `chmod 777`.
- Rejected commands are logged and recorded in agent short memory as `Blocked (security): ...`; unparseable input (unbalanced quotes, NUL bytes) is rejected without execution.

## Tests

- New `tests/structs/test_autonomous_loop_utils.py` (20 tests): raw-string and argv-level blocklist coverage, quoted-concat and split-flag bypasses, NUL/empty argv rejection, shell-metacharacter inertness (`>/dev/sda`, `|sh` fail to exec), benign command execution, and short-memory recording of blocked commands.