### PR TITLE
feat(agent): add output_schema for validated structured LLM responses

### DIFF
--- a/examples/single_agent/capabilities/structured_output/structured_output_example.py
+++ b/examples/single_agent/capabilities/structured_output/structured_output_example.py
@@ -1,0 +1,37 @@
+"""
+Agent structured output (output_schema).
+
+Pass a Pydantic model to the Agent and every LLM response is:
+1. requested as JSON conforming to the model (via response_format),
+2. validated with model_validate,
+3. retried automatically when the schema does not match,
+4. returned as a validated model instance from agent.run().
+
+Requires an OPENAI_API_KEY (or any LiteLLM-supported provider key).
+"""
+
+from pydantic import BaseModel, Field
+
+from swarms import Agent
+
+
+class WeatherReport(BaseModel):
+    """The exact shape the agent must return."""
+
+    city: str = Field(description="The city the report is about")
+    temperature_c: float = Field(description="Temperature in Celsius")
+    condition: str = Field(description="e.g. sunny, cloudy, rainy")
+
+
+agent = Agent(
+    agent_name="WeatherAgent",
+    model_name="gpt-4o",
+    max_loops=1,
+    output_schema=WeatherReport,
+)
+
+result = agent.run("What is the weather in Paris today?")
+
+# result is a validated WeatherReport instance
+print(result.city, result.temperature_c, result.condition)
+print(result.model_dump())

--- a/swarms/agents/llm_manager.py
+++ b/swarms/agents/llm_manager.py
@@ -235,6 +235,12 @@ class LLMManager:
                 "api_key": agent.llm_api_key,
             }
 
+            # Structured output: ask the provider for JSON conforming to the
+            # agent's output_schema. Only set when present so a user-supplied
+            # llm_args["response_format"] keeps working.
+            if agent.output_schema is not None:
+                common_args["response_format"] = agent.output_schema
+
             # Initialize tools_list_dictionary, if applicable
             tools_list = []
 

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -175,6 +175,13 @@ class Agent:
         custom_exit_command (str): The custom exit command
         tool_schema (ToolUsageType): The tool schema
         output_type (agent_output_type): The output type. Supported: 'str', 'string', 'list', 'json', 'dict', 'yaml', 'xml'.
+        output_schema (Optional[BaseModel]): A Pydantic model class (or instance) the LLM
+            response must conform to. When set, the model is passed to the LLM as
+            ``response_format``, every response is validated with ``model_validate``, and
+            schema mismatches are retried inside the existing retry loop. ``run()`` then
+            returns the validated model instance instead of the formatted conversation
+            history. Applies to the standard run loop (``max_loops=N``); the autonomous
+            loop (``max_loops="auto"``) is unaffected. Defaults to None.
         output_cleaner (Callable): The output cleaner function
         list_base_models (List[BaseModel]): The list of base models
         rules (str): The rules
@@ -341,6 +348,7 @@ class Agent:
         # [Tools]
         tool_schema: ToolUsageType = None,
         output_type: OutputType = "str-all-except-first",
+        output_schema: Optional[BaseModel] = None,
         output_cleaner: Optional[Callable] = None,
         list_base_models: Optional[List[BaseModel]] = None,
         rules: str = None,  # type: ignore
@@ -443,6 +451,18 @@ class Agent:
         self.custom_exit_command = custom_exit_command
         self.tool_schema = tool_schema
         self.output_type = output_type
+        self.output_schema = output_schema
+        if output_schema is not None and not (
+            isinstance(output_schema, BaseModel)
+            or (
+                isinstance(output_schema, type)
+                and issubclass(output_schema, BaseModel)
+            )
+        ):
+            raise ValueError(
+                "output_schema must be a Pydantic BaseModel class or "
+                f"instance, got {type(output_schema).__name__}"
+            )
         self.output_cleaner = output_cleaner
         self.list_base_models = list_base_models
         self.planning_prompt = planning_prompt
@@ -1367,6 +1387,7 @@ class Agent:
 
             # Clear the short memory
             response = None
+            success = False
 
             # Autosave
             if self.autosave:
@@ -1469,9 +1490,22 @@ class Agent:
                         # Parse the response from the agent with the output type
                         response = self.parse_llm_output(response)
 
+                        # Validate against the output schema if one is
+                        # configured. A ValidationError raised here is caught
+                        # by the retry loop below and retried like any other
+                        # LLM failure.
+                        if self.output_schema is not None:
+                            response = self._validate_structured_output(
+                                response
+                            )
+
                         self.short_memory.add(
                             role=self.agent_name,
-                            content=response,
+                            content=(
+                                response.model_dump_json()
+                                if isinstance(response, BaseModel)
+                                else response
+                            ),
                         )
 
                         # Print
@@ -1669,6 +1703,12 @@ class Agent:
                 log_agent_data(self.to_dict())
                 self.save()
                 self._autosave_config_step(loop_count=loop_count)
+
+            # Structured output: return the validated model instance. When retries
+            # are exhausted the last raw response never passed validation, so
+            # return None rather than an unvalidated payload.
+            if self.output_schema is not None:
+                return response if success else None
 
             # Output formatting based on output_type
             return history_output_formatter(
@@ -3438,6 +3478,47 @@ Subtask Breakdown:
                 response,
                 f"Agent Name {self.agent_name} [Max Loops: {loop_count} ]",
             )
+
+    def _validate_structured_output(self, response: Any) -> Any:
+        """Validate the LLM response against ``output_schema``.
+
+        Accepts a Pydantic model class or instance as the schema. The response
+        may arrive as a JSON string, a dict, or a ``BaseModel`` instance; it is
+        normalized and validated with ``model_validate``.
+
+        Returns:
+            BaseModel: The validated model instance.
+
+        Raises:
+            pydantic.ValidationError: When the response does not conform to the
+                schema — the caller's retry loop treats it as a failed attempt.
+            ValueError: When the schema is not a Pydantic model, or the response
+                shape cannot be validated (e.g. a tool-call list).
+        """
+        schema = self.output_schema
+        model_cls = (
+            schema if isinstance(schema, type) else type(schema)
+        )
+
+        if not issubclass(model_cls, BaseModel):
+            raise ValueError(
+                "output_schema must be a Pydantic BaseModel class or "
+                f"instance, got {type(schema).__name__}"
+            )
+
+        if isinstance(response, BaseModel):
+            data = response.model_dump()
+        elif isinstance(response, str):
+            data = json.loads(response)
+        elif isinstance(response, dict):
+            data = response
+        else:
+            raise ValueError(
+                "Cannot validate response of type "
+                f"{type(response).__name__} against output_schema"
+            )
+
+        return model_cls.model_validate(data)
 
     def parse_llm_output(self, response: Any):
         """Parse and standardize the output from the LLM.

--- a/tests/structs/test_agent_output_schema.py
+++ b/tests/structs/test_agent_output_schema.py
@@ -1,0 +1,137 @@
+"""Tests for Agent-level structured output (``output_schema``).
+
+Covers:
+- ``response_format`` threading into the built ``LiteLLM`` instance
+- validation of valid JSON responses into the Pydantic model
+- retry-on-schema-mismatch inside the existing retry loop
+- retry exhaustion returning None
+- accepting a model instance as well as a model class
+- JSON (not repr) storage in conversation memory
+- fail-fast rejection of non-Pydantic schemas
+- unchanged default behaviour when ``output_schema`` is unset
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from swarms import Agent
+
+
+class Weather(BaseModel):
+    city: str
+    temperature: float
+
+
+class FakeLLM:
+    """Network-free stand-in for LiteLLM with scripted replies.
+
+    ``replies`` is consumed in order; the last reply repeats once the list
+    is exhausted, so ``replies=["invalid"]`` means "always invalid".
+    """
+
+    def __init__(self, replies):
+        self.replies = list(replies)
+        self.calls = 0
+        self.stream = False
+        self.temperature = 0.5
+
+    def run(self, task=None, img=None, **kwargs):
+        reply = self.replies[min(self.calls, len(self.replies) - 1)]
+        self.calls += 1
+        return reply
+
+
+def make_agent(**kwargs):
+    settings = dict(
+        agent_name="schema-agent",
+        model_name="gpt-4o-mini",
+        max_loops=1,
+        persistent_memory=False,
+        print_on=False,
+        verbose=False,
+    )
+    settings.update(kwargs)
+    agent = Agent(**settings)
+    return agent
+
+
+VALID = '{"city": "Paris", "temperature": 18.5}'
+INVALID = '{"city": "Paris"}'  # missing required field "temperature"
+
+
+def test_output_schema_threaded_to_llm():
+    agent = make_agent(output_schema=Weather)
+    assert agent.llm.response_format is Weather
+
+
+def test_output_schema_valid_response():
+    agent = make_agent(output_schema=Weather, retry_attempts=2)
+    agent.llm = FakeLLM([VALID])
+
+    result = agent.run("What is the weather in Paris?")
+
+    assert isinstance(result, Weather)
+    assert result.city == "Paris"
+    assert result.temperature == 18.5
+
+
+def test_output_schema_retries_on_invalid_then_succeeds():
+    agent = make_agent(output_schema=Weather, retry_attempts=2)
+    llm = FakeLLM([INVALID, VALID])
+    agent.llm = llm
+
+    result = agent.run("What is the weather in Paris?")
+
+    assert isinstance(result, Weather)
+    assert result.city == "Paris"
+    assert llm.calls == 2  # invalid first, valid second
+
+
+def test_output_schema_exhausts_retries():
+    agent = make_agent(output_schema=Weather, retry_attempts=2)
+    llm = FakeLLM([INVALID])
+    agent.llm = llm
+
+    result = agent.run("What is the weather in Paris?")
+
+    assert result is None
+    assert llm.calls == 2  # every retry attempt was consumed
+
+
+def test_output_schema_accepts_model_instance():
+    agent = make_agent(
+        output_schema=Weather(city="Paris", temperature=18.5),
+        retry_attempts=2,
+    )
+    agent.llm = FakeLLM(['{"city": "Lyon", "temperature": 21.0}'])
+
+    result = agent.run("What is the weather in Lyon?")
+
+    assert isinstance(result, Weather)
+    assert result.city == "Lyon"
+    assert result.temperature == 21.0
+
+
+def test_output_schema_memory_stores_json_not_repr():
+    agent = make_agent(output_schema=Weather, retry_attempts=2)
+    agent.llm = FakeLLM([VALID])
+
+    agent.run("What is the weather in Paris?")
+
+    history = agent.short_memory.return_history_as_string()
+    assert '"city":"Paris"' in history  # model_dump_json() is compact
+    assert "city='Paris'" not in history  # pydantic repr would leak
+
+
+def test_output_schema_rejects_non_pydantic():
+    with pytest.raises(ValueError, match="output_schema"):
+        make_agent(output_schema=dict)
+
+
+def test_no_output_schema_keeps_default_behavior():
+    agent = make_agent()
+    agent.llm = FakeLLM(["plain reply"])
+
+    result = agent.run("Say hi")
+
+    assert result == "plain reply"


### PR DESCRIPTION
## Summary

Adds an `output_schema` parameter to `Agent` for validated structured output:

```python
from pydantic import BaseModel
from swarms import Agent

class WeatherReport(BaseModel):
    city: str
    temperature_c: float
    condition: str

agent = Agent(model_name="gpt-4o", output_schema=WeatherReport)
result = agent.run("What is the weather in Paris today?")
# result is a validated WeatherReport instance
```

## What it does

1. **Threads the schema to the provider** — `LLMManager.build` passes the model as `response_format` (the same pattern already used by `ModelRouter`, `MultiAgentRouter`, `SkillOrchestra` and `AutoSwarmBuilder`; the core `Agent` was the only structure missing it).
2. **Validates every response** — `_validate_structured_output` normalizes the response (JSON string / dict / BaseModel) and runs `model_validate`.
3. **Retries on schema mismatch** — a `ValidationError` raised inside the existing retry loop is retried like any other LLM failure; after `retry_attempts` are exhausted `run()` returns `None` rather than an unvalidated payload.
4. **Returns the validated model** — `run()` returns the model instance instead of the formatted conversation history.
5. **Keeps memory clean** — the validated JSON (`model_dump_json`) is stored in conversation memory, not the pydantic repr.
6. **Fails fast** — non-Pydantic schemas raise `ValueError` at construction.

Accepts a model class or an instance. The autonomous loop (`max_loops="auto"`) is unaffected.

## Why

`output_type="basemodel"` is declared in `OutputType` (`swarms/utils/output_types.py`) but was never handled by `history_output_formatter` — it raises `ValueError` at runtime. This PR provides the working path for structured output at the `Agent` level, consistent with the rest of the framework.

## Tests

`tests/structs/test_agent_output_schema.py` — 8 tests, network-free (FakeLLM pattern used across the telemetry suite): response_format threading, valid/invalid/retry/exhaustion paths, model-instance schemas, memory JSON storage, non-Pydantic rejection, and unchanged default behavior.

Example: `examples/single_agent/capabilities/structured_output/structured_output_example.py`.

Verified: full `tests/structs/` + `tests/telemetry/` suites show zero new failures vs `master` (pre-existing environment failures unchanged).