### PR TITLE
[Bug] Agent.run_batched raises before running anything when imgs is omitted, and mislabels images when it is not

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -3349,20 +3349,36 @@ Subtask Breakdown:
         **kwargs,
     ):
         """
-        Run a batch of tasks concurrently.
+        Run a batch of tasks, one after another.
 
         Args:
             tasks (List[str]): List of tasks to run.
-            imgs (List[str], optional): List of images to run. Defaults to None.
+            imgs (List[str], optional): One image per task, paired by position.
+                Omit to run the tasks without images. Defaults to None.
             *args: Additional positional arguments to be passed to the execution method.
             **kwargs: Additional keyword arguments to be passed to the execution method.
 
         Returns:
             List[Any]: List of results from each task execution.
         """
+        # `for task, imgs in zip(...)` rebound the parameter to one image per
+        # iteration, so a List[str] field received a bare str -- and with the
+        # documented default of imgs=None the zip raised before any task ran.
+        if imgs is None:
+            return [
+                self.run(task=task, *args, **kwargs) for task in tasks
+            ]
+
+        if len(imgs) != len(tasks):
+            raise ValueError(
+                f"run_batched got {len(tasks)} tasks and {len(imgs)} images; "
+                "pass one image per task, or omit imgs entirely. Zipping them "
+                "would silently drop the extras."
+            )
+
         return [
-            self.run(task=task, imgs=imgs, *args, **kwargs)
-            for task, imgs in zip(tasks, imgs)
+            self.run(task=task, img=img, *args, **kwargs)
+            for task, img in zip(tasks, imgs)
         ]
 
     def showcase_config(self):

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -3170,3 +3170,42 @@ class TestConcurrentExecutionPool:
                 break
             time.sleep(0.02)
         assert threading.active_count() <= before
+
+
+class TestRunBatchedImagePairing:
+    """`for task, imgs in zip(tasks, imgs)` rebound the parameter to a single
+    image, so the List[str] `imgs` field received a bare str — and with the
+    documented default of imgs=None the zip raised before any task ran.
+    """
+
+    @staticmethod
+    def _agent():
+        agent = Agent.__new__(Agent)
+        agent.agent_name = "batched"
+        return agent
+
+    def test_tasks_without_images_run(self):
+        """The documented default: imgs is optional."""
+        agent = self._agent()
+        with patch.object(Agent, "run", side_effect=lambda **kw: kw):
+            assert Agent.run_batched(agent, ["t1", "t2"]) == [
+                {"task": "t1"},
+                {"task": "t2"},
+            ]
+
+    def test_each_task_gets_its_own_image_as_a_single_image(self):
+        agent = self._agent()
+        with patch.object(Agent, "run", side_effect=lambda **kw: kw):
+            assert Agent.run_batched(
+                agent, ["t1", "t2"], imgs=["a.png", "b.png"]
+            ) == [
+                {"task": "t1", "img": "a.png"},
+                {"task": "t2", "img": "b.png"},
+            ]
+
+    def test_mismatched_lengths_raise_instead_of_dropping_tasks(self):
+        """zip() would have run one task and discarded the rest in silence."""
+        agent = self._agent()
+        with patch.object(Agent, "run", side_effect=lambda **kw: kw):
+            with pytest.raises(ValueError, match="one image per task"):
+                Agent.run_batched(agent, ["t1", "t2", "t3"], imgs=["a.png"])


### PR DESCRIPTION
## Problem

`Agent.run_batched` uses `imgs` as both the parameter and the loop variable:

```python
return [
    self.run(task=task, imgs=imgs, *args, **kwargs)
    for task, imgs in zip(tasks, imgs)
]
```

Three separate failures come out of those four lines:

**1. The documented default call raises.** `imgs` defaults to `None` and the docstring says it is optional, but `zip(tasks, None)` fails before any task runs:

```
>>> agent.run_batched(["t1", "t2"])
TypeError: 'NoneType' object is not iterable
```

**2. With images, each task gets a `str` in a `List[str]` field.** The loop variable rebinds the parameter, so `self.run` receives one image path in `imgs`, which `Agent.run` → `call_llm` → `llm_manager.call` forwards to the provider as `run_args["imgs"] = "a.png"`. The parameter for a single image is `img`.

```
>>> agent.run_batched(["t1", "t2"], imgs=["a.png", "b.png"])
[{'task': 't1', 'imgs': 'a.png'}, {'task': 't2', 'imgs': 'b.png'}]
                        ^^^^ a list field holding one string
```

**3. Unequal lengths silently drop tasks.** `zip` stops at the shorter sequence, so three tasks and one image runs one task and discards two, with no error and no log line.

## Fix

```python
if imgs is None:
    return [self.run(task=task, *args, **kwargs) for task in tasks]

if len(imgs) != len(tasks):
    raise ValueError(...)

return [
    self.run(task=task, img=img, *args, **kwargs)
    for task, img in zip(tasks, imgs)
]
```

After:

```
no imgs        -> [{'task': 't1'}, {'task': 't2'}]
paired imgs    -> [{'task': 't1', 'img': 'a.png'}, {'task': 't2', 'img': 'b.png'}]
length mismatch-> ValueError: run_batched got 3 tasks and 1 images; pass one image
                  per task, or omit imgs entirely. Zipping them would silently drop the extras.
```

The docstring said "Run a batch of tasks concurrently" while the body has always been a plain list comprehension, so it now says what it does. Making it genuinely concurrent is a behaviour change — the sibling paths use a call-scoped `ContextThreadPoolExecutor` after #1909 — and belongs in its own PR rather than smuggled into a crash fix.

## Tests

Three cases added to `tests/structs/test_agent.py`, next to `TestConcurrentExecutionPool`, which is where the other `Agent` batch-path tests live. They build the agent with `Agent.__new__` like that class does, so there is no model client, no memory file and no provider call.

All three fail on master with the source reverted and the tests kept:

```
FAILED TestRunBatchedImagePairing::test_tasks_without_images_run
FAILED TestRunBatchedImagePairing::test_each_task_gets_its_own_image_as_a_single_image
FAILED TestRunBatchedImagePairing::test_mismatched_lengths_raise_instead_of_dropping_tasks
E   Failed: DID NOT RAISE ValueError
```

`tests/structs/test_agent.py` goes from `19 failed, 71 passed, 8 errors` on master to `19 failed, 74 passed, 8 errors` here — same failure set, plus the three new tests. Those 19 are pre-existing and need provider credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)