### PR TITLE
fix(agent): re-export error classes from swarms.structs.agent

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -52,9 +52,13 @@ from swarms.prompts.multi_modal_autonomous_instruction_prompt import (
 from swarms.prompts.react_base_prompt import REACT_SYS_PROMPT
 from swarms.prompts.safety_prompt import SAFETY_PROMPT
 from swarms.schemas.agent_errors import (
+    AgentError,  # noqa: F401  re-exported for swarms.structs.agent consumers
     AgentInitializationError,
     AgentLLMError,
+    AgentLLMInitializationError,  # noqa: F401
+    AgentMemoryError,  # noqa: F401
     AgentRunError,
+    AgentToolError,  # noqa: F401
     AgentToolExecutionError,
 )
 from swarms.schemas.base_schemas import (

--- a/tests/structs/test_agent_run_errors.py
+++ b/tests/structs/test_agent_run_errors.py
@@ -1,0 +1,34 @@
+"""Tests for the Agent error-class re-exports.
+
+``swarms.structs.agent`` re-exports every class from
+``swarms.schemas.agent_errors`` so consumers can import errors from either
+location and get the same object.
+"""
+
+import pytest
+
+from swarms.schemas import agent_errors as schema_errors
+
+ERROR_CLASS_NAMES = [
+    "AgentError",
+    "AgentInitializationError",
+    "AgentRunError",
+    "AgentLLMError",
+    "AgentToolError",
+    "AgentMemoryError",
+    "AgentLLMInitializationError",
+    "AgentToolExecutionError",
+]
+
+
+class TestErrorClassExports:
+    """The schema error classes must be importable from swarms.structs.agent."""
+
+    @pytest.mark.parametrize("class_name", ERROR_CLASS_NAMES)
+    def test_importable_from_structs_agent(self, class_name):
+        from_structs = __import__(
+            "swarms.structs.agent", fromlist=[class_name]
+        )
+        assert getattr(from_structs, class_name) is getattr(
+            schema_errors, class_name
+        )


### PR DESCRIPTION
## Summary

Small, focused fix: `swarms.structs.agent` now re-exports **all** error classes from `swarms/schemas/agent_errors.py`, so consumers can import errors from either location and get the same object.

Four classes were missing (`AgentError`, `AgentLLMInitializationError`, `AgentMemoryError`, `AgentToolError`), which broke `from swarms.structs.agent import AgentError` and left 4 tests failing on `master`:

- `TestAgentErrorHierarchy::test_importable_from_schemas_and_structs_agent_same_object[AgentError]`
- `...[AgentLLMInitializationError]`
- `...[AgentMemoryError]`
- `...[AgentToolError]`

## Changes

- `swarms/structs/agent.py` — 4 imports added (with `# noqa: F401` since they are deliberate re-exports).
- `tests/structs/test_agent_run_errors.py` — new: `TestErrorClassExports` (8 parametrized identity tests, one per class).

## Verification

- The 4 previously-failing marketplace tests now pass (verified: 4 failed on `master`, 0 after).
- New export tests: 8/8 pass.
- No behavior change — imports only.