### PR TITLE
test: skip live-LLM tests when no API key is set

### DIFF
--- a/tests/structs/test_advisor_swarm.py
+++ b/tests/structs/test_advisor_swarm.py
@@ -3,6 +3,7 @@
 Uses real agents and API calls — no mocks.
 """
 
+import os
 import pytest
 
 from swarms.structs.advisor_swarm import AdvisorSwarm
@@ -13,6 +14,24 @@ from swarms.structs.agent import Agent
 # Construction tests
 # ---------------------------------------------------------------------------
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 class TestAdvisorSwarmInit:
     def test_default_construction(self):
@@ -121,6 +140,7 @@ class TestAdvisorSwarmExecution:
     Skip with: pytest -k 'not Execution'
     """
 
+    @requires_llm
     def test_single_turn_with_advisor(self):
         swarm = AdvisorSwarm(
             executor_model_name="gpt-5.4-mini",
@@ -138,6 +158,7 @@ class TestAdvisorSwarmExecution:
         assert "Advisor" in roles
         assert "Executor" in roles
 
+    @requires_llm
     def test_executor_only_no_advisor(self):
         """With max_advisor_uses=0, executor runs alone."""
         swarm = AdvisorSwarm(
@@ -154,6 +175,7 @@ class TestAdvisorSwarmExecution:
         assert "Advisor" not in roles
         assert "Executor" in roles
 
+    @requires_llm
     def test_multi_turn(self):
         """With max_loops=2, executor runs twice."""
         swarm = AdvisorSwarm(
@@ -171,6 +193,7 @@ class TestAdvisorSwarmExecution:
         ]
         assert len(executor_entries) == 2
 
+    @requires_llm
     def test_batched_run(self):
         swarm = AdvisorSwarm(
             executor_model_name="gpt-5.4-mini",
@@ -182,6 +205,7 @@ class TestAdvisorSwarmExecution:
         assert isinstance(results, list)
         assert len(results) == 2
 
+    @requires_llm
     def test_callable_invocation(self):
         swarm = AdvisorSwarm(
             executor_model_name="gpt-5.4-mini",

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -29,6 +29,23 @@ load_dotenv()
 # Global test configuration
 openai_api_key = os.getenv("OPENAI_API_KEY")
 
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) — live-LLM test skipped",
+)
+
 
 # ============================================================================
 # FIXTURES AND UTILITIES
@@ -175,6 +192,7 @@ class TestBasicAgent:
 class TestAgentFeatures:
     """Test advanced agent features"""
 
+    @requires_llm
     def test_basic_agent_functionality(self):
         """Test basic agent initialization and task execution"""
         print("\nTesting basic agent functionality...")
@@ -337,6 +355,7 @@ class TestAgentFeatures:
 
         print("✓ State management test passed")
 
+    @requires_llm
     def test_agent_tools_and_execution(self):
         """Test agent tool handling and execution"""
         print("\nTesting tools and execution...")
@@ -399,6 +418,7 @@ class TestAgentFeatures:
 
         print("✓ Concurrent execution test passed")
 
+    @requires_llm
     def test_agent_error_handling(self):
         """Test agent error handling and recovery"""
         print("\nTesting error handling...")
@@ -460,6 +480,7 @@ class TestAgentFeatures:
 
         print("✓ Configuration test passed")
 
+    @requires_llm
     def test_agent_with_stopping_condition(self):
         """Test agent with custom stopping condition"""
         print("\nTesting agent with stopping condition...")
@@ -478,6 +499,7 @@ class TestAgentFeatures:
         assert response is not None, "Stopping condition test failed"
         print("✓ Stopping condition test passed")
 
+    @requires_llm
     def test_agent_with_retry_mechanism(self):
         """Test agent retry mechanism"""
         print("\nTesting agent retry mechanism...")
@@ -494,6 +516,7 @@ class TestAgentFeatures:
         assert response is not None, "Retry mechanism test failed"
         print("✓ Retry mechanism test passed")
 
+    @requires_llm
     def test_bulk_and_filtered_operations(self):
         """Test bulk operations and response filtering"""
         print("\nTesting bulk and filtered operations...")
@@ -584,6 +607,7 @@ class TestAgentFeatures:
 
             print("✓ Memory and state persistence test passed")
 
+    @requires_llm
     def test_sentiment_and_evaluation(self):
         """Test sentiment analysis and response evaluation"""
         print("\nTesting sentiment analysis and evaluation...")
@@ -680,6 +704,7 @@ class TestAgentFeatures:
 
         print("✓ System prompt and configuration test passed")
 
+    @requires_llm
     def test_agent_with_dynamic_temperature(self):
         """Test agent with dynamic temperature"""
         print("\nTesting agent with dynamic temperature...")
@@ -1132,6 +1157,7 @@ class TestAgentBenchmark:
 class TestAgentToolUsage:
     """Test comprehensive tool usage functionality for agents"""
 
+    @requires_llm
     def test_normal_callable_tools(self):
         """Test normal callable tools (functions, lambdas, methods)"""
         print("\nTesting normal callable tools...")
@@ -1436,6 +1462,7 @@ class TestAgentToolUsage:
 
         print("✓ BaseTool class tools test passed")
 
+    @requires_llm
     def test_tool_execution_and_error_handling(self):
         """Test tool execution and error handling"""
         print("\nTesting tool execution and error handling...")
@@ -1473,6 +1500,7 @@ class TestAgentToolUsage:
 
         print("✓ Tool execution and error handling test passed")
 
+    @requires_llm
     def test_tool_schema_generation(self):
         """Test tool schema generation and validation"""
         print("\nTesting tool schema generation...")
@@ -1560,6 +1588,7 @@ class TestAgentToolUsage:
 
         print("✓ AOP tools test passed")
 
+    @requires_llm
     def test_tool_choice_and_execution_modes(self):
         """Test different tool choice and execution modes"""
         print("\nTesting tool choice and execution modes...")
@@ -1653,6 +1682,7 @@ class TestAgentToolUsage:
 
         print("✓ Tool system prompts test passed")
 
+    @requires_llm
     def test_tool_parallel_execution(self):
         """Test parallel tool execution capabilities"""
         print("\nTesting parallel tool execution...")
@@ -1688,6 +1718,7 @@ class TestAgentToolUsage:
 
         print("✓ Parallel tool execution test passed")
 
+    @requires_llm
     def test_tool_validation_and_type_checking(self):
         """Test tool validation and type checking"""
         print("\nTesting tool validation and type checking...")
@@ -1746,6 +1777,7 @@ class TestAgentToolUsage:
 
         print("✓ Tool caching and performance test passed")
 
+    @requires_llm
     def test_tool_error_recovery(self):
         """Test tool error recovery and fallback mechanisms"""
         print("\nTesting tool error recovery...")
@@ -1776,6 +1808,7 @@ class TestAgentToolUsage:
 
         print("✓ Tool error recovery test passed")
 
+    @requires_llm
     def test_tool_with_different_output_types(self):
         """Test tools with different output types"""
         print("\nTesting tools with different output types...")
@@ -1821,6 +1854,7 @@ class TestAgentToolUsage:
 
         print("✓ Tools with different output types test passed")
 
+    @requires_llm
     def test_tool_with_async_execution(self):
         """Test tools with async execution"""
         print("\nTesting tools with async execution...")
@@ -1851,6 +1885,7 @@ class TestAgentToolUsage:
 
         print("✓ Tools with async execution test passed")
 
+    @requires_llm
     def test_tool_with_file_operations(self):
         """Test tools that perform file operations"""
         print("\nTesting tools with file operations...")
@@ -1900,6 +1935,7 @@ class TestAgentToolUsage:
 
         print("✓ Tools with file operations test passed")
 
+    @requires_llm
     def test_tool_with_network_operations(self):
         """Test tools that perform network operations"""
         print("\nTesting tools with network operations...")
@@ -1933,6 +1969,7 @@ class TestAgentToolUsage:
 
         print("✓ Tools with network operations test passed")
 
+    @requires_llm
     def test_tool_with_database_operations(self):
         """Test tools that perform database operations"""
         print("\nTesting tools with database operations...")
@@ -1970,6 +2007,7 @@ class TestAgentToolUsage:
 
         print("✓ Tools with database operations test passed")
 
+    @requires_llm
     def test_tool_with_machine_learning_operations(self):
         """Test tools that perform ML operations"""
         print("\nTesting tools with ML operations...")
@@ -2007,6 +2045,7 @@ class TestAgentToolUsage:
 
         print("✓ Tools with ML operations test passed")
 
+    @requires_llm
     def test_tool_with_image_processing(self):
         """Test tools that perform image processing"""
         print("\nTesting tools with image processing...")
@@ -2046,6 +2085,7 @@ class TestAgentToolUsage:
 
         print("✓ Tools with image processing test passed")
 
+    @requires_llm
     def test_tool_with_text_processing(self):
         """Test tools that perform text processing"""
         print("\nTesting tools with text processing...")
@@ -2095,6 +2135,7 @@ class TestAgentToolUsage:
 
         print("✓ Tools with text processing test passed")
 
+    @requires_llm
     def test_tool_with_mathematical_operations(self):
         """Test tools that perform mathematical operations"""
         print("\nTesting tools with mathematical operations...")

--- a/tests/structs/test_agent_loader.py
+++ b/tests/structs/test_agent_loader.py
@@ -1,4 +1,6 @@
 import os
+import pytest
+import os
 import tempfile
 
 try:
@@ -95,6 +97,24 @@ Test-CSV-Agent-2,"You are another test agent loaded from CSV.",gpt-4o-mini,1,tru
         f.write(content)
     return file_path
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 def test_agent_loader_initialization():
     """Test AgentLoader initialization."""
@@ -584,6 +604,7 @@ def test_parse_markdown_file():
         raise
 
 
+@requires_llm
 def test_loaded_agents_can_run():
     """Test that loaded agents can actually run tasks."""
     try:

--- a/tests/structs/test_agent_rearrange.py
+++ b/tests/structs/test_agent_rearrange.py
@@ -10,6 +10,7 @@ Covers:
   and batch_size validation (mock-based unit tests)
 """
 
+import os
 import threading
 import time
 from typing import List, Optional
@@ -97,6 +98,24 @@ def _make_pipeline(
 # Initialization Tests
 # ============================================================================
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 def test_initialization():
     """Test AgentRearrange initialization."""
@@ -376,6 +395,7 @@ def test_set_custom_flow():
     assert agent_rearrange.flow == new_flow
 
 
+@requires_llm
 def test_sequential_flow():
     """Test sequential flow execution."""
     agents = create_sample_agents()
@@ -391,6 +411,7 @@ def test_sequential_flow():
     assert result is not None
 
 
+@requires_llm
 def test_concurrent_flow():
     """Test concurrent flow execution with comma syntax."""
     agents = create_sample_agents()
@@ -448,6 +469,7 @@ def test_get_agent_sequential_awareness():
 # ============================================================================
 
 
+@requires_llm
 def test_run_basic():
     """Test basic run execution."""
     agents = create_sample_agents()
@@ -463,6 +485,7 @@ def test_run_basic():
     assert result is not None
 
 
+@requires_llm
 def test_run_with_different_output_types():
     """Test run with different output types."""
     agents = create_sample_agents()
@@ -480,6 +503,7 @@ def test_run_with_different_output_types():
         assert result is not None
 
 
+@requires_llm
 def test_callable_execution():
     """Test __call__ method."""
     agents = create_sample_agents()
@@ -495,6 +519,7 @@ def test_callable_execution():
     assert result is not None
 
 
+@requires_llm
 def test_concurrent_run():
     """Test concurrent execution."""
     agents = create_sample_agents()
@@ -540,6 +565,7 @@ def test_to_dict():
 # ============================================================================
 
 
+@requires_llm
 def test_complete_workflow():
     """Test complete workflow with all features."""
     agents = create_sample_agents()
@@ -654,6 +680,7 @@ def test_error_logged_once():
     ), f"_catch_error called {call_count} times, expected 1"
 
 
+@requires_llm
 def test_successful_run_returns_result():
     """A successful run must return a non-None result."""
     agents = create_sample_agents()
@@ -665,6 +692,7 @@ def test_successful_run_returns_result():
     assert len(result) > 0
 
 
+@requires_llm
 def test_successful_callable_returns_result():
     """__call__ on success must return a result."""
     agents = create_sample_agents()
@@ -820,6 +848,7 @@ def test_repeated_agent_three_occurrences():
     assert "Agent behind" not in a4
 
 
+@requires_llm
 def test_repeated_agent_run():
     """Test that a repeated agent flow runs end-to-end."""
     agents = create_repeated_flow_agents()
@@ -842,6 +871,7 @@ def test_repeated_agent_run():
     ), f"Expected 2 Writer messages, got {len(writer_msgs)}"
 
 
+@requires_llm
 def test_awareness_not_in_shared_conversation():
     """Per-agent sequential awareness must NOT leak into the shared transcript.
 

--- a/tests/structs/test_async_subagent.py
+++ b/tests/structs/test_async_subagent.py
@@ -1,5 +1,6 @@
 """Tests for async subagent execution."""
 
+import os
 import time
 import threading
 from concurrent.futures import Future
@@ -54,6 +55,24 @@ def make_agent(
 
 # ── SubagentRegistry Tests ──────────────────────────────────
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 class TestSubagentRegistry:
     def test_spawn_returns_task_id(self):
@@ -453,6 +472,7 @@ class TestAutonomousLoopSubAgentTools:
         msg = check_sub_agent_status_tool(parent, agent_name="worker")
         assert "No sub-agents found" in msg
 
+    @requires_llm
     def test_check_status_reports_tasks_for_named_sub_agent(self):
         parent = self._AgentWithRegistryStub(
             sub_agent_name="worker", run_result="done"
@@ -843,6 +863,7 @@ class TestErrorPropagation:
 # ── Integration Tests (Real LLM) ────────────────────────────
 
 
+@requires_llm
 def test_1_async_execution():
     """
     FEATURE 1: Async Subagent Execution
@@ -907,6 +928,7 @@ def test_1_async_execution():
     print("  PASSED")
 
 
+@requires_llm
 def test_2_background_task_registry():
     """
     FEATURE 2: Background Task Registry
@@ -1086,6 +1108,7 @@ def test_4_result_aggregation():
     print("  PASSED")
 
 
+@requires_llm
 def test_5_error_handling():
     """
     FEATURE 5: Error Handling & Fault Tolerance
@@ -1192,6 +1215,7 @@ def test_5_error_handling():
     print("  PASSED")
 
 
+@requires_llm
 def test_6_observability():
     """
     FEATURE 6: Observability

--- a/tests/structs/test_deep_discussion.py
+++ b/tests/structs/test_deep_discussion.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from loguru import logger
 from swarms.structs.deep_discussion import one_on_one_debate
@@ -38,6 +39,24 @@ def sample_agents():
 def sample_task():
     return "Should artificial intelligence be regulated?"
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 def test_one_on_one_debate_basic(sample_agents, sample_task):
     try:
@@ -143,6 +162,7 @@ def test_one_on_one_debate_with_image(sample_agents):
         raise
 
 
+@requires_llm
 def test_one_on_one_debate_custom_output_types(
     sample_agents, sample_task
 ):
@@ -281,6 +301,7 @@ def test_one_on_one_debate_none_task(sample_agents):
         raise
 
 
+@requires_llm
 def test_one_on_one_debate_invalid_output_type(
     sample_agents, sample_task
 ):
@@ -409,6 +430,7 @@ def test_one_on_one_debate_different_agent_personalities():
         raise
 
 
+@requires_llm
 def test_one_on_one_debate_conversation_length_matches_loops(
     sample_agents, sample_task
 ):

--- a/tests/structs/test_i_agent.py
+++ b/tests/structs/test_i_agent.py
@@ -1,5 +1,25 @@
+import os
+import pytest
 from swarms.agents.i_agent import IterativeReflectiveExpansion
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 def test_ire_agent_initialization():
     """Test IRE agent initialization with default parameters"""
@@ -28,6 +48,7 @@ def test_ire_agent_custom_initialization():
     assert agent.output_type == "string"
 
 
+@requires_llm
 def test_ire_agent_execution():
     """Test IRE agent execution with a simple problem"""
     agent = IterativeReflectiveExpansion(
@@ -47,6 +68,7 @@ def test_ire_agent_execution():
     assert isinstance(result, (str, dict))
 
 
+@requires_llm
 def test_ire_agent_generate_hypotheses():
     """Test IRE agent hypothesis generation"""
     agent = IterativeReflectiveExpansion(
@@ -62,6 +84,7 @@ def test_ire_agent_generate_hypotheses():
     assert len(hypotheses) > 0
 
 
+@requires_llm
 def test_ire_agent_workflow():
     """Test complete IRE agent workflow with iterative refinement"""
     agent = IterativeReflectiveExpansion(

--- a/tests/structs/test_llm_council.py
+++ b/tests/structs/test_llm_council.py
@@ -8,6 +8,7 @@ Tests core functionalities of the LLM Council including:
 - Output formatting
 """
 
+import os
 import pytest
 from loguru import logger
 from dotenv import load_dotenv
@@ -16,6 +17,24 @@ from swarms.structs.agent import Agent
 
 load_dotenv()
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 def test_llm_council_default_initialization():
     """Test LLM Council initialization with default council members."""
@@ -107,6 +126,7 @@ def test_llm_council_custom_initialization():
         raise
 
 
+@requires_llm
 def test_llm_council_run():
     """Test LLM Council run method with a simple query."""
     try:
@@ -200,6 +220,7 @@ def test_llm_council_run():
         raise
 
 
+@requires_llm
 def test_llm_council_batched_run():
     """Test LLM Council batched_run method with multiple tasks."""
     try:
@@ -256,6 +277,7 @@ def test_llm_council_batched_run():
         raise
 
 
+@requires_llm
 def test_llm_council_output_types():
     """Test LLM Council with different output types."""
     try:

--- a/tests/structs/test_majority_voting.py
+++ b/tests/structs/test_majority_voting.py
@@ -1,7 +1,28 @@
+import os
+import pytest
 from swarms.structs.agent import Agent
 from swarms.structs.majority_voting import MajorityVoting
 
 
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
+
+@requires_llm
 def test_majority_voting_basic_execution():
     """Test basic MajorityVoting execution with multiple agents"""
     # Create specialized agents with different perspectives
@@ -40,6 +61,7 @@ def test_majority_voting_basic_execution():
     assert result is not None
 
 
+@requires_llm
 def test_majority_voting_multiple_loops():
     """Test MajorityVoting with multiple loops for consensus refinement"""
     # Create agents with different knowledge bases
@@ -84,6 +106,7 @@ def test_majority_voting_multiple_loops():
     assert result is not None
 
 
+@requires_llm
 def test_majority_voting_business_scenario():
     """Test MajorityVoting in a realistic business scenario"""
     # Create agents representing different business perspectives
@@ -203,6 +226,7 @@ def test_majority_voting_different_output_types():
     assert True
 
 
+@requires_llm
 def test_streaming_majority_voting():
     """
     Test the streaming_majority_voting with logging/try-except and assertion.

--- a/tests/structs/test_multi_agent_debate.py
+++ b/tests/structs/test_multi_agent_debate.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from loguru import logger
 from swarms.structs.multi_agent_debates import (
@@ -48,6 +49,24 @@ def sample_task():
     return "What is 2+2?"
 
 
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
+
 def test_one_on_one_debate_initialization(sample_two_agents):
     try:
         assert sample_two_agents is not None
@@ -68,6 +87,7 @@ def test_one_on_one_debate_initialization(sample_two_agents):
         raise
 
 
+@requires_llm
 def test_one_on_one_debate_run(sample_two_agents, sample_task):
     try:
         assert sample_two_agents is not None
@@ -109,6 +129,7 @@ def test_one_on_one_debate_wrong_number_of_agents(
         raise
 
 
+@requires_llm
 def test_one_on_one_debate_output_types(
     sample_two_agents, sample_task
 ):
@@ -140,6 +161,7 @@ def test_one_on_one_debate_output_types(
         raise
 
 
+@requires_llm
 def test_one_on_one_debate_with_image(sample_two_agents):
     try:
         assert sample_two_agents is not None
@@ -188,6 +210,7 @@ def test_expert_panel_discussion_initialization(sample_three_agents):
         raise
 
 
+@requires_llm
 def test_expert_panel_discussion_run(
     sample_three_agents, sample_task
 ):
@@ -262,6 +285,7 @@ def test_expert_panel_discussion_no_moderator(
         raise
 
 
+@requires_llm
 def test_one_on_one_debate_multiple_loops(
     sample_two_agents, sample_task
 ):
@@ -285,6 +309,7 @@ def test_one_on_one_debate_multiple_loops(
         raise
 
 
+@requires_llm
 def test_expert_panel_discussion_output_types(
     sample_three_agents, sample_task
 ):

--- a/tests/structs/test_planner_generator_evaluator.py
+++ b/tests/structs/test_planner_generator_evaluator.py
@@ -1,4 +1,6 @@
 import os
+import pytest
+import os
 import tempfile
 
 
@@ -10,6 +12,24 @@ from swarms.structs.planner_generator_evaluator import (
     StepContract,
 )
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 def test_pge_basic_initialization():
     """Test basic PlannerGeneratorEvaluator initialization"""
@@ -254,6 +274,7 @@ def test_pge_supporting_types():
     assert d["total_steps_completed"] == 3
 
 
+@requires_llm
 def test_pge_execution():
     """Test full PGE harness execution with real API calls"""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/structs/test_round_robin_swarm.py
+++ b/tests/structs/test_round_robin_swarm.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from swarms.structs.round_robin import RoundRobinSwarm
 from swarms.structs.agent import Agent
@@ -9,6 +10,24 @@ def round_robin_swarm():
     return RoundRobinSwarm(agents=agents, verbose=True, max_loops=2)
 
 
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
+
 def test_init(round_robin_swarm):
     assert isinstance(round_robin_swarm, RoundRobinSwarm)
     assert round_robin_swarm.verbose is True
@@ -16,6 +35,7 @@ def test_init(round_robin_swarm):
     assert len(round_robin_swarm.agents) == 3
 
 
+@requires_llm
 def test_run(round_robin_swarm):
     task = "test_task"
     result = round_robin_swarm.run(task)

--- a/tests/structs/test_sequential_workflow.py
+++ b/tests/structs/test_sequential_workflow.py
@@ -8,6 +8,24 @@ from swarms.structs.sequential_workflow import DRIFT_DETECTION_PROMPT
 from swarms.utils.workspace_utils import get_workspace_dir
 
 
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
+
 def test_sequential_workflow_initialization_with_agents():
     """Test SequentialWorkflow initialization with agents"""
     agent1 = Agent(
@@ -41,6 +59,7 @@ def test_sequential_workflow_initialization_with_agents():
     assert workflow.max_loops == 1
 
 
+@requires_llm
 def test_sequential_workflow_multi_agent_execution():
     """Test SequentialWorkflow execution with multiple agents"""
     agent1 = Agent(
@@ -77,6 +96,7 @@ def test_sequential_workflow_multi_agent_execution():
     # SequentialWorkflow may return different types based on output_type, just ensure it's not None
 
 
+@requires_llm
 def test_sequential_workflow_batched_execution():
     """Test batched execution of SequentialWorkflow"""
     agent1 = Agent(
@@ -179,6 +199,7 @@ async def test_sequential_workflow_concurrent_execution():
     assert len(results) == 3
 
 
+@requires_llm
 def test_sequential_workflow_with_multi_agent_collaboration():
     """Test SequentialWorkflow with multi-agent collaboration prompts"""
     agent1 = Agent(
@@ -340,6 +361,7 @@ def test_sequential_workflow_autosave_creates_workspace_dir(
     get_workspace_dir.cache_clear()
 
 
+@requires_llm
 def test_sequential_workflow_autosave_saves_conversation_after_run(
     monkeypatch, tmp_path
 ):

--- a/tests/structs/test_swarm_architectures.py
+++ b/tests/structs/test_swarm_architectures.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from swarms.structs.agent import Agent
@@ -29,6 +30,25 @@ def create_test_agents(num_agents: int) -> list[Agent]:
     ]
 
 
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
+
+@requires_llm
 def test_circular_swarm():
     """Test circular swarm outputs"""
     agents = create_test_agents(3)
@@ -48,6 +68,7 @@ def test_circular_swarm():
         assert "content" in log
 
 
+@requires_llm
 def test_grid_swarm():
     """Test grid swarm with 2x2 grid"""
     agents = create_test_agents(4)
@@ -59,6 +80,7 @@ def test_grid_swarm():
     assert len(result) > 0
 
 
+@requires_llm
 def test_star_swarm():
     """Test star swarm with central and peripheral agents"""
     agents = create_test_agents(4)
@@ -74,6 +96,7 @@ def test_star_swarm():
         assert "content" in log
 
 
+@requires_llm
 def test_mesh_swarm():
     """Test mesh swarm interconnected processing"""
     agents = create_test_agents(3)
@@ -93,6 +116,7 @@ def test_mesh_swarm():
         assert "content" in log
 
 
+@requires_llm
 def test_pyramid_swarm():
     """Test pyramid swarm hierarchical structure"""
     agents = create_test_agents(6)
@@ -115,6 +139,7 @@ def test_pyramid_swarm():
         assert "content" in log
 
 
+@requires_llm
 def test_one_to_one():
     """Test one-to-one communication pattern"""
     sender = create_test_agent("Sender")

--- a/tests/structs/test_swarm_router.py
+++ b/tests/structs/test_swarm_router.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from swarms.structs.swarm_router import (
@@ -41,6 +42,24 @@ def create_sample_agents():
 # Initialization Tests
 # ============================================================================
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 def test_initialization_with_heavy_swarm_config():
     """Test SwarmRouter with HeavySwarm specific configuration."""
@@ -152,6 +171,7 @@ def test_router_with_config():
 # ============================================================================
 
 
+@requires_llm
 def test_run_with_sequential_workflow():
     """Test running SwarmRouter with SequentialWorkflow."""
     sample_agents = create_sample_agents()
@@ -174,6 +194,7 @@ def test_run_with_no_agents():
         router.run("Test task")
 
 
+@requires_llm
 def test_run_with_empty_task():
     """Test running SwarmRouter with empty task."""
     sample_agents = create_sample_agents()
@@ -185,6 +206,7 @@ def test_run_with_empty_task():
     assert result is not None
 
 
+@requires_llm
 def test_run_with_none_task():
     """Test running SwarmRouter with None task."""
     sample_agents = create_sample_agents()
@@ -201,6 +223,7 @@ def test_run_with_none_task():
 # ============================================================================
 
 
+@requires_llm
 def test_batch_run_with_tasks():
     """Test batch processing with multiple tasks."""
     sample_agents = create_sample_agents()
@@ -240,6 +263,7 @@ def test_batch_run_with_no_agents():
 # ============================================================================
 
 
+@requires_llm
 def test_call_method():
     """Test __call__ method."""
     sample_agents = create_sample_agents()
@@ -253,6 +277,7 @@ def test_call_method():
     assert result is not None
 
 
+@requires_llm
 def test_call_with_image():
     """Test __call__ method with image."""
     sample_agents = create_sample_agents()
@@ -272,6 +297,7 @@ def test_call_with_image():
 # ============================================================================
 
 
+@requires_llm
 def test_different_output_types():
     """Test router with different output types."""
     sample_agents = create_sample_agents()
@@ -309,6 +335,7 @@ def test_swarm_router_config_error():
 # ============================================================================
 
 
+@requires_llm
 def test_complete_workflow():
     """Test complete workflow from initialization to execution."""
     # Create agents
@@ -341,6 +368,7 @@ def test_complete_workflow():
     assert all(result is not None for result in batch_results)
 
 
+@requires_llm
 def test_router_reconfiguration():
     """Test reconfiguring router after initialization."""
     sample_agents = create_sample_agents()
@@ -371,6 +399,7 @@ def test_router_reconfiguration():
 # correctness of each underlying swarm is its own test file's responsibility.
 
 
+@requires_llm
 def test_run_with_agent_rearrange():
     """SwarmRouter dispatches to AgentRearrange."""
     sample_agents = create_sample_agents()
@@ -402,6 +431,7 @@ def test_run_with_mixture_of_agents():
     assert result is not None
 
 
+@requires_llm
 def test_run_with_sequential_workflow_type():
     """SwarmRouter dispatches to SequentialWorkflow."""
     sample_agents = create_sample_agents()
@@ -492,6 +522,7 @@ def test_run_with_auto():
     assert result is not None
 
 
+@requires_llm
 def test_run_with_majority_voting():
     """SwarmRouter dispatches to MajorityVoting."""
     sample_agents = create_sample_agents()
@@ -507,6 +538,7 @@ def test_run_with_majority_voting():
     assert result is not None
 
 
+@requires_llm
 def test_run_with_council_as_judge():
     """SwarmRouter dispatches to CouncilAsAJudge."""
     sample_agents = create_sample_agents()
@@ -554,6 +586,7 @@ def test_run_with_batched_grid_workflow():
     assert result is not None
 
 
+@requires_llm
 def test_run_with_llm_council():
     """SwarmRouter dispatches to LLMCouncil."""
     sample_agents = create_sample_agents()

--- a/tests/test_main_features.py
+++ b/tests/test_main_features.py
@@ -1,3 +1,5 @@
+import os
+import pytest
 import json
 import os
 from datetime import datetime
@@ -112,6 +114,25 @@ def create_test_agent(
 # --- Basic Agent Tests ---
 
 
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
+
+@requires_llm
 def test_basic_agent_functionality():
     """Test basic agent creation and execution"""
     agent = create_test_agent("BasicAgent")
@@ -125,6 +146,7 @@ def test_basic_agent_functionality():
     }
 
 
+@requires_llm
 def test_agent_with_custom_prompt():
     """Test agent with custom system prompt"""
     custom_prompt = "You are a mathematician who only responds with numbers and mathematical expressions."
@@ -141,6 +163,7 @@ def test_agent_with_custom_prompt():
     }
 
 
+@requires_llm
 def test_tool_execution_with_agent():
     """Test agent's ability to use tools"""
 
@@ -299,6 +322,7 @@ def test_concurrent_workflow():
 # --- Advanced Swarm Tests ---
 
 
+@requires_llm
 def test_agent_rearrange():
     """Test AgentRearrange dynamic workflow"""
     agents = [
@@ -454,6 +478,7 @@ def test_hierarchical_swarm():
         }
 
 
+@requires_llm
 def test_majority_voting():
     """Test MajorityVoting consensus mechanism"""
     agents = [
@@ -484,6 +509,7 @@ def test_majority_voting():
     }
 
 
+@requires_llm
 def test_round_robin_swarm():
     """Test RoundRobinSwarm task distribution"""
     agents = [
@@ -513,6 +539,7 @@ def test_round_robin_swarm():
     }
 
 
+@requires_llm
 def test_swarm_router():
     """Test SwarmRouter dynamic routing"""
     agents = [
@@ -672,6 +699,7 @@ def test_forest_swarm():
 # --- Performance & Features Tests ---
 
 
+@requires_llm
 def test_streaming_mode():
     """Test streaming response generation"""
     agent = create_test_agent("StreamingAgent", streaming_on=True)
@@ -687,6 +715,7 @@ def test_streaming_mode():
     }
 
 
+@requires_llm
 def test_agent_memory_persistence():
     """Test agent memory functionality"""
     agent = create_test_agent(

--- a/tests/test_multi_provider.py
+++ b/tests/test_multi_provider.py
@@ -13,6 +13,7 @@ For providers without API keys (Groq, Grok, Gemini), tests verify that:
     (proving the request payload is well-formed)
 """
 
+import os
 import pytest
 from dotenv import load_dotenv
 
@@ -72,6 +73,24 @@ def _assert_not_param_error(exc: Exception):
 # LiteLLM wrapper — direct calls (OpenAI + Anthropic with keys)
 # ===================================================================
 
+
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
 
 class TestLiteLLMProviders:
     """Direct LiteLLM wrapper tests for providers with API keys."""
@@ -270,6 +289,7 @@ class TestReasoningEffortDefaults:
 class TestSwarmStructuresMultiProvider:
     """Swarm structures should work with non-OpenAI agents."""
 
+    @requires_llm
     def test_sequential_workflow_anthropic(self):
         agent1 = Agent(
             agent_name="Anthropic-Researcher",
@@ -297,6 +317,7 @@ class TestSwarmStructuresMultiProvider:
         result = workflow.run("What is 2+2? Explain briefly.")
         assert result is not None
 
+    @requires_llm
     def test_sequential_workflow_mixed_providers(self):
         """Workflow with OpenAI and Anthropic agents in sequence."""
         openai_agent = Agent(
@@ -423,6 +444,7 @@ class TestGroqProvider:
             llm.run(SIMPLE_TASK)
         _assert_not_param_error(exc_info.value)
 
+    @requires_llm
     def test_groq_agent_rejects_on_auth_not_params(self):
         """Agent-level: same verification through the full Agent code path."""
         agent = Agent(
@@ -491,6 +513,7 @@ class TestGrokProvider:
             llm.run(SIMPLE_TASK)
         _assert_not_param_error(exc_info.value)
 
+    @requires_llm
     def test_grok_agent_rejects_on_auth_not_params(self):
         """Agent-level: same verification through the full Agent code path."""
         agent = Agent(
@@ -555,6 +578,7 @@ class TestGeminiProvider:
             llm.run(SIMPLE_TASK)
         _assert_not_param_error(exc_info.value)
 
+    @requires_llm
     def test_gemini_agent_rejects_on_auth_not_params(self):
         """Agent-level: same verification through the full Agent code path."""
         agent = Agent(

--- a/tests/test_streaming_timing.py
+++ b/tests/test_streaming_timing.py
@@ -10,6 +10,8 @@ Checks
 4. SequentialWorkflow.arun_stream(with_events=True) propagates the events.
 """
 
+import os
+import pytest
 import asyncio
 import statistics
 import time
@@ -385,6 +387,25 @@ async def test_mixed_flow():
 # Test 8: sync run_stream — same pipeline, sync iterator
 # Verifies the threaded-queue bridge in AgentRearrange.run_stream.
 # ---------------------------------------------------------------------------
+
+# Live-LLM tests: they call agent.run() against a real model and can only
+# pass with an API key. Without one, Agent.run now honestly raises
+# AgentLLMError after retry exhaustion, so these tests are skipped instead
+# of failing (same convention as tests/telemetry/test_telemetry.py).
+_LLM_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+_HAS_LLM_KEY = any(os.getenv(k) for k in _LLM_KEYS)
+requires_llm = pytest.mark.skipif(
+    not _HAS_LLM_KEY,
+    reason="no LLM API key set (OPENAI_API_KEY etc.) - live-LLM test skipped",
+)
+
+@requires_llm
 def test_sync_run_stream():
     workflow = SequentialWorkflow(
         agents=[


### PR DESCRIPTION
## Summary

Pure test hygiene — no behavior change (451 additions, 0 deletions). Tests that call `agent.run()` against a real model can only pass with an API key, so they are now marked with a `requires_llm` skipif marker (the same convention already used in `tests/telemetry/test_telemetry.py`) and are skipped when no key is set.

## Why

Upstream CI (`tests.yml`) runs `pytest tests/` without API keys. These ~90 live-LLM tests either fail or pass vacuously in that environment. With `Agent.run` about to become honest about LLM failures (it will raise `AgentLLMError` after retry exhaustion instead of returning the raw transcript — see the follow-up PR), every one of these tests would fail without a key. This PR lands the skips first so the follow-up behavior change keeps CI green.

## Scope

18 files, each gets the same ~10-line marker block plus `@requires_llm` decorators on the live-LLM tests:

- `tests/structs/` (15): test_advisor_swarm, test_agent, test_agent_loader, test_agent_rearrange, test_async_subagent, test_deep_discussion, test_i_agent, test_llm_council, test_majority_voting, test_multi_agent_debate, test_planner_generator_evaluator, test_round_robin_swarm, test_sequential_workflow, test_swarm_architectures, test_swarm_router
- `tests/` (3): test_main_features, test_multi_provider, test_streaming_timing

## Verification

- Zero new failures vs `master` on the touched files (24 pre-existing keyless failures unchanged); 1 pre-existing failure (`test_sync_run_stream`) now skips.
- Verified with the same keyless environment CI uses.