### PR TITLE
CronJob: survive failed executions, and add run_many for agents on different schedules

### DIFF
--- a/examples/guides/deployment/cron_job_examples/README.md
+++ b/examples/guides/deployment/cron_job_examples/README.md
@@ -4,6 +4,16 @@ This directory contains examples demonstrating scheduled task execution using cr
 
 ## Examples
 
+### Start here
+
+- [single_agent_cron.py](single_agent_cron.py) - One agent on one interval, the smallest useful job
+- [one_agent_many_tasks_cron.py](one_agent_many_tasks_cron.py) - One agent running several tasks on a shared cadence
+- [multi_agent_schedules_cron.py](multi_agent_schedules_cron.py) - Several agents, each on its own cadence, via `CronJob.run_many`
+- [non_blocking_cron.py](non_blocking_cron.py) - Start a fleet without blocking, inspect it mid-flight, stop it
+- [resilient_cron.py](resilient_cron.py) - Failure handling, error budgets, and live monitoring
+
+### Callbacks and domain examples
+
 - [callback_cron_example.py](callback_cron_example.py) - Cron job with callbacks
 - [cron_job_example.py](cron_job_example.py) - Basic cron job example
 - [cron_job_figma_stock_swarms_tools_example.py](cron_job_figma_stock_swarms_tools_example.py) - Figma stock swarms tools cron job
@@ -14,6 +24,16 @@ This directory contains examples demonstrating scheduled task execution using cr
 - [solana_price_tracker.py](solana_price_tracker.py) - Solana price tracker cron job
 
 ## Overview
+
+A `CronJob` binds one agent to one interval and runs it until you stop it. For several agents on
+different cadences, `CronJob.run_many` starts one job per agent so they run together while staying
+isolated from each other.
+
+Failures are treated the way cron treats them: a task that raises is logged and retried on the next
+tick rather than taking the schedule down. Set `max_consecutive_errors` to stop a job that is failing
+every time; when that budget runs out the job stops and `run()` raises, so a dead schedule is never
+mistaken for a healthy one. Poll `get_execution_stats()` at any point for successes, failures and the
+last error.
 
 Cron job examples demonstrate how to schedule and execute agent tasks on a recurring basis. These examples show various patterns including callback handling, concurrent execution, and domain-specific scheduled tasks like price tracking and stock monitoring.
 

--- a/examples/guides/deployment/cron_job_examples/multi_agent_schedules_cron.py
+++ b/examples/guides/deployment/cron_job_examples/multi_agent_schedules_cron.py
@@ -1,0 +1,73 @@
+"""
+Multiple Agents, Different Schedules
+
+A CronJob binds one agent to one interval, so a fleet on mixed cadences needs
+one job per agent. `CronJob.run_many` builds them, starts them together, and
+blocks once.
+
+Each job gets its own scheduler thread, so the agents are isolated: a slow or
+failing agent does not delay or stop the others, and each carries its own
+error budget.
+
+Here: a price checker every 30 seconds, an anomaly scan every 10 minutes, and
+an hourly digest, all in one process.
+"""
+
+from swarms import Agent, CronJob
+
+
+def build_agent(name: str, description: str, prompt: str) -> Agent:
+    return Agent(
+        agent_name=name,
+        agent_description=description,
+        system_prompt=prompt,
+        model_name="gpt-5.4",
+        max_loops=1,
+        print_on=True,
+    )
+
+
+price_agent = build_agent(
+    "Price-Checker",
+    "Checks prices frequently and flags large moves",
+    "Report the current price and flag any move over 2%. Two lines maximum.",
+)
+
+anomaly_agent = build_agent(
+    "Anomaly-Scanner",
+    "Looks for unusual patterns on a slower cadence",
+    "Scan for unusual patterns. Report only genuine anomalies, not noise.",
+)
+
+digest_agent = build_agent(
+    "Hourly-Digest",
+    "Summarises the hour for a human reader",
+    "Write a short digest of the last hour. Lead with what changed.",
+)
+
+if __name__ == "__main__":
+    print("Three agents, three cadences. Ctrl-C to stop.\n")
+
+    CronJob.run_many(
+        [
+            {
+                "agent": price_agent,
+                "interval": "30seconds",
+                "task": "Check the BTC price.",
+            },
+            {
+                "agent": anomaly_agent,
+                "interval": "10minutes",
+                "task": "Scan recent market data for anomalies.",
+                # This one talks to a flaky data source, so give it a budget:
+                # five failures in a row and it stops rather than retrying
+                # forever. The other two are unaffected either way.
+                "max_consecutive_errors": 5,
+            },
+            {
+                "agent": digest_agent,
+                "interval": "1hour",
+                "task": "Summarise the last hour of market activity.",
+            },
+        ]
+    )

--- a/examples/guides/deployment/cron_job_examples/non_blocking_cron.py
+++ b/examples/guides/deployment/cron_job_examples/non_blocking_cron.py
@@ -1,0 +1,77 @@
+"""
+Non-Blocking Fleet Control
+
+`CronJob.run_many(..., block=False)` starts every job and returns immediately,
+handing back the job objects. Use this when the schedule is not the main thing
+your process does: a web server, a bot, a notebook.
+
+You own the lifecycle from that point. Stop them with `CronJob.stop_many`.
+
+This example starts three agents, lets them run, inspects them mid-flight, and
+shuts them down.
+"""
+
+import time
+
+from swarms.structs.cron_job import CronJob
+
+
+class EchoAgent:
+    """Stands in for a real Agent so the example runs without API keys."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.runs = 0
+
+    def run(self, task: str = None, **kwargs):
+        self.runs += 1
+        print(f"  [{self.name}] run #{self.runs}: {task}")
+        return f"{self.name}:{self.runs}"
+
+
+if __name__ == "__main__":
+    agents = {
+        "fast": EchoAgent("fast"),
+        "medium": EchoAgent("medium"),
+        "slow": EchoAgent("slow"),
+    }
+
+    jobs = CronJob.run_many(
+        [
+            {
+                "agent": agents["fast"],
+                "interval": "2seconds",
+                "task": "poll",
+                "job_id": "fast-poller",
+            },
+            {
+                "agent": agents["medium"],
+                "interval": "5seconds",
+                "task": "check",
+                "job_id": "medium-checker",
+            },
+            {
+                "agent": agents["slow"],
+                "interval": "10seconds",
+                "task": "summarise",
+                "job_id": "slow-summariser",
+            },
+        ],
+        block=False,  # start them, hand control back
+    )
+
+    print("Three jobs started. Doing other work for 20 seconds...\n")
+    time.sleep(20)
+
+    print("\nMid-flight status:")
+    for job in jobs:
+        stats = job.get_execution_stats()
+        print(
+            f"  {stats['job_id']:<18} every {stats['interval']:<10} "
+            f"ok={stats['execution_count']:<3} "
+            f"failed={stats['error_count']:<3} "
+            f"up={stats['uptime']:.0f}s"
+        )
+
+    CronJob.stop_many(jobs)
+    print("\nAll jobs stopped.")

--- a/examples/guides/deployment/cron_job_examples/one_agent_many_tasks_cron.py
+++ b/examples/guides/deployment/cron_job_examples/one_agent_many_tasks_cron.py
@@ -1,0 +1,33 @@
+"""
+One Agent, Several Tasks, One Cadence
+
+`batched_run` schedules every task in the list at the job's interval, so all of
+them run on each tick. This is one agent doing several things on one schedule.
+
+Use this when the tasks share a cadence. When they need *different* cadences,
+use `CronJob.run_many` instead (see multi_agent_schedules_cron.py).
+"""
+
+from swarms import Agent, CronJob
+
+agent = Agent(
+    agent_name="Ops-Monitor",
+    agent_description="Runs the recurring operational checks",
+    system_prompt=(
+        "You are an operations monitor. Answer the specific check you are "
+        "given. Be terse: state the finding and whether it needs attention."
+    ),
+    model_name="gpt-5.4",
+    max_loops=1,
+    print_on=True,
+)
+
+CHECKS = [
+    "Check whether inventory levels are below reorder thresholds.",
+    "Check whether refund volume is above its weekly average.",
+    "Check whether any support queue has waited longer than an hour.",
+]
+
+if __name__ == "__main__":
+    print(f"{len(CHECKS)} checks every 15 minutes. Ctrl-C to stop.\n")
+    CronJob(agent=agent, interval="15minutes").batched_run(CHECKS)

--- a/examples/guides/deployment/cron_job_examples/resilient_cron.py
+++ b/examples/guides/deployment/cron_job_examples/resilient_cron.py
@@ -1,0 +1,87 @@
+"""
+Failure Handling and Monitoring
+
+A long-running job will hit failures: a rate limit, a dropped connection, a
+provider hiccup. CronJob treats those the way cron does. The failure is logged
+and the task is retried on the next tick. One bad call does not stop the
+schedule.
+
+Two things let you control and observe that:
+
+    max_consecutive_errors   stop a job that is failing *every* time, instead
+                             of retrying forever. Omit it to never give up.
+                             When the budget is exhausted the job stops AND
+                             run() raises, so a dead schedule is never mistaken
+                             for a healthy one.
+
+    get_execution_stats()    poll from another thread while the job runs, to
+                             see successes, failures and the last error.
+
+This example runs a deliberately flaky agent so you can watch both.
+"""
+
+import random
+import threading
+import time
+
+from swarms.structs.cron_job import CronJob, CronJobExecutionError
+
+
+class FlakyAgent:
+    """Fails roughly half the time, to stand in for an unreliable API."""
+
+    def run(self, task: str = None, **kwargs):
+        if random.random() < 0.5:
+            raise ConnectionError("upstream API timed out")
+        return f"ok: {task}"
+
+
+def monitor(job: CronJob, every: float = 5.0) -> None:
+    """Print a health line periodically while the job runs.
+
+    Waits for the job to come up first: this thread is started before
+    ``job.run()``, so ``is_running`` is still False at this point and looping
+    on it directly would exit immediately.
+    """
+    while not job.is_running:
+        time.sleep(0.1)
+
+    while job.is_running:
+        time.sleep(every)
+        stats = job.get_execution_stats()
+        print(
+            f"  [monitor] ok={stats['execution_count']} "
+            f"failed={stats['error_count']} "
+            f"in-a-row={stats['consecutive_errors']} "
+            f"last_error={stats['last_error']}"
+        )
+
+
+if __name__ == "__main__":
+    job = CronJob(
+        agent=FlakyAgent(),
+        interval="2seconds",
+        # Ten failures in a row means something is genuinely wrong, not just
+        # flaky. Give up then, rather than hammering a dead endpoint forever.
+        max_consecutive_errors=10,
+    )
+
+    threading.Thread(target=monitor, args=(job,), daemon=True).start()
+
+    # Stop after a minute so the example terminates on its own.
+    threading.Timer(60, job.stop).start()
+
+    print("Flaky agent, retrying through failures. Ctrl-C to stop.\n")
+
+    try:
+        job.run("Fetch the latest reading.")
+    except CronJobExecutionError as e:
+        # Only reached if max_consecutive_errors was exhausted. A clean stop()
+        # returns normally instead.
+        print(f"\nJob gave up: {e}")
+    else:
+        stats = job.get_execution_stats()
+        print(
+            f"\nStopped cleanly after {stats['execution_count']} "
+            f"successful run(s) and {stats['error_count']} failure(s)."
+        )

--- a/examples/guides/deployment/cron_job_examples/single_agent_cron.py
+++ b/examples/guides/deployment/cron_job_examples/single_agent_cron.py
@@ -1,0 +1,34 @@
+"""
+Single Agent CronJob
+
+The smallest useful CronJob: one agent, one interval, running until you stop it.
+
+`run()` blocks the calling thread. The agent runs on a background thread every
+interval. Press Ctrl-C to stop.
+
+Interval format is "<number><unit>", where unit is second(s), minute(s) or
+hour(s): "30seconds", "10minutes", "1hour".
+"""
+
+from swarms import Agent, CronJob
+
+agent = Agent(
+    agent_name="Market-Watcher",
+    agent_description="Watches the market and reports anything notable",
+    system_prompt=(
+        "You are a market analyst. Report only what is notable since the "
+        "last check. Three bullets maximum. If nothing is notable, say so "
+        "in one line rather than padding."
+    ),
+    model_name="gpt-5.4",
+    max_loops=1,
+    print_on=True,
+)
+
+job = CronJob(agent=agent, interval="30seconds")
+
+if __name__ == "__main__":
+    print("Running every 30 seconds. Ctrl-C to stop.\n")
+    job.run(
+        "Summarise anything notable in the AI chip market right now."
+    )

--- a/swarms/structs/cron_job.py
+++ b/swarms/structs/cron_job.py
@@ -1,7 +1,7 @@
 import threading
 import time
 import traceback
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import schedule
 from loguru import logger
@@ -32,18 +32,52 @@ class CronJobExecutionError(CronJobError):
 
 
 class CronJob:
-    """A wrapper class that turns any callable (including Swarms agents) into a scheduled cron job.
+    """Turn any callable, including a Swarms ``Agent``, into a scheduled job.
 
-    This class provides functionality to schedule and run tasks at specified intervals using
-    the schedule library with cron-style scheduling.
+    One ``CronJob`` binds **one** agent to **one** interval. It schedules the
+    task, runs it on its own background thread, and keeps running it until you
+    stop it. For a fleet of agents on different cadences, see :meth:`run_many`.
+
+    **Failure behaviour.** A task that raises is logged and retried on the next
+    tick, the way cron behaves. It does not take the schedule down. Set
+    ``max_consecutive_errors`` to stop a job that is failing every single time;
+    when that budget is exhausted the job stops *and* :meth:`run` raises, so a
+    dead schedule is never mistaken for a healthy one.
+
+    Args:
+        agent: The Swarms ``Agent`` instance or plain callable to schedule.
+            Anything exposing ``run(task=...)`` is called through it; anything
+            else is called directly as ``agent(task)``.
+        interval: How often to run, as ``"<number><unit>"`` where unit is one of
+            ``second(s)``, ``minute(s)``, ``hour(s)``. For example ``"30seconds"``,
+            ``"10minutes"``, ``"1hour"``. Must be greater than zero.
+        job_id: Unique identifier. Generated if omitted.
+        callback: Optional post-processor, called as
+            ``callback(output, task, metadata)`` and returning the value the job
+            should yield. A callback that raises is logged and the original
+            output is used.
+        max_consecutive_errors: Stop after this many back-to-back failures.
+            ``None`` (default) retries forever.
 
     Attributes:
-        agent: The Swarms Agent instance or callable to be scheduled
-        interval: The interval string (e.g., "5seconds", "10minutes", "1hour")
-        job_id: Unique identifier for the job
-        is_running: Flag indicating if the job is currently running
-        thread: Thread object for running the job
-        callback: Optional callback function to customize output processing
+        is_running (bool): Whether the scheduler thread is live.
+        execution_count (int): Successful executions so far.
+        error_count (int): Total failed executions.
+        consecutive_errors (int): Failures since the last success. Reset to 0
+            on any successful tick.
+        last_error (Optional[Exception]): The most recent failure, if any.
+        start_time (Optional[float]): Epoch seconds when the job started.
+
+    Raises:
+        CronJobConfigError: If ``agent`` is missing, or ``interval`` is empty,
+            zero, or malformed.
+
+    Example:
+        >>> from swarms import Agent
+        >>> from swarms.structs.cron_job import CronJob
+        >>> agent = Agent(agent_name="Reporter", model_name="gpt-5.4", max_loops=1)
+        >>> job = CronJob(agent=agent, interval="10minutes")
+        >>> job.run("Summarise anything new since the last check")  # blocks
     """
 
     def __init__(
@@ -52,12 +86,17 @@ class CronJob:
         interval: Optional[str] = None,
         job_id: Optional[str] = None,
         callback: Optional[Callable[[Any, str, dict], Any]] = None,
+        max_consecutive_errors: Optional[int] = None,
     ):
         """Initialize the CronJob wrapper.
 
         Args:
             agent: The Swarms Agent instance or callable to be scheduled
             interval: The interval string (e.g., "5seconds", "10minutes", "1hour")
+            max_consecutive_errors: Give up after this many back-to-back failed
+                executions. ``None`` (the default) never gives up, which is what
+                cron does: a task that fails is logged and retried on the next
+                tick. Set an integer to stop a job that is failing every time.
             job_id: Optional unique identifier for the job. If not provided, one will be generated.
             callback: Optional callback function to customize output processing.
                      Signature: callback(output: Any, task: str, metadata: dict) -> Any
@@ -79,6 +118,17 @@ class CronJob:
         self.execution_count = 0
         self.start_time = None
 
+        # Failure accounting. A task that raises must not take the schedule
+        # down with it, but the failures still have to be visible: the loop
+        # used to set is_running=False and re-raise, which killed the
+        # scheduler thread on the first error while run() returned normally,
+        # so a dead job was indistinguishable from a healthy one.
+        self.error_count = 0
+        self.consecutive_errors = 0
+        self.last_error = None
+        self.max_consecutive_errors = max_consecutive_errors
+        self._stopped_due_to_error = False
+
         logger.info(f"Initializing CronJob with ID: {self.job_id}")
 
         self.reliability_check()
@@ -87,6 +137,19 @@ class CronJob:
         if self.agent is None:
             raise CronJobConfigError(
                 "Agent must be provided during initialization"
+            )
+
+        # An empty string is not "no interval given", it is a bad interval.
+        # It used to fall through this guard and only surface much later, from
+        # _run(), as "Interval must be provided during initialization" -- which
+        # is confusing, because it was provided.
+        if (
+            self.interval is not None
+            and not str(self.interval).strip()
+        ):
+            raise CronJobConfigError(
+                f"Interval cannot be empty, got {self.interval!r}. "
+                'Use a value like "5seconds", "10minutes" or "1hour".'
             )
 
         # Parse interval if provided
@@ -126,6 +189,14 @@ class CronJob:
 
             number = int(match.group(1))
             unit = match.group(2)
+
+            # "0second" parsed fine and then scheduled a job that never fired:
+            # no error, no log line, just a cron job that silently does nothing.
+            if number == 0:
+                raise CronJobConfigError(
+                    f"Interval must be greater than zero, got {interval!r}. "
+                    "A zero interval schedules a job that never runs."
+                )
 
             # Map units to scheduling methods
             unit_map = {
@@ -206,6 +277,21 @@ class CronJob:
                 f"Failed to run job: {str(e)} Traceback: {traceback.format_exc()}"
             )
 
+    def _raise_if_stopped_by_errors(self):
+        """Surface a schedule that gave up instead of returning normally.
+
+        ``_block_forever`` loops on ``is_running``, which the scheduler clears
+        both on a clean ``stop()`` and on giving up after repeated failures.
+        Without this check the two are indistinguishable to the caller: ``run``
+        hands back a ``Job`` object and the schedule is quietly dead.
+        """
+        if self._stopped_due_to_error:
+            raise CronJobExecutionError(
+                f"Job {self.job_id} stopped after "
+                f"{self.consecutive_errors} consecutive failed executions "
+                f"({self.error_count} total). Last error: {self.last_error}"
+            )
+
     def _block_forever(self):
         """Block until interrupted or stopped."""
         try:
@@ -223,36 +309,64 @@ class CronJob:
             raise
 
     def run(self, task: str, **kwargs):
-        """Schedule a single task and block for the life of the process until KeyboardInterrupt,
-        at which point stop() is called.
+        """Schedule ``task`` and block, running it every interval until stopped.
+
+        Blocks the calling thread. The task runs on a background thread, so use
+        ``KeyboardInterrupt`` (Ctrl-C) or :meth:`stop` from another thread to end
+        it. A failing task is logged and retried on the next tick.
 
         Args:
-            task: The task string to be executed by the agent
-            **kwargs: Additional parameters to pass to the agent's run method
+            task: The task string handed to the agent on every tick.
+            **kwargs: Forwarded to the agent's ``run`` on every tick, for example
+                ``img="chart.png"`` or ``streaming_callback=fn``.
 
         Returns:
-            The scheduled job instance
+            schedule.Job: The scheduled job, returned once the schedule stops.
+
+        Raises:
+            CronJobConfigError: If no agent or interval was configured.
+            CronJobExecutionError: If scheduling failed, or if the job gave up
+                after exhausting ``max_consecutive_errors``. The message names
+                the failure count and the last error.
+
+        Example:
+            >>> job = CronJob(agent=agent, interval="30seconds")
+            >>> job.run("Check the BTC price and flag moves over 2%")
         """
         job = self._run(task, **kwargs)
         self._block_forever()
+        self._raise_if_stopped_by_errors()
         return job
 
     def batched_run(self, tasks: List[str], **kwargs):
-        """Schedule every task in tasks before blocking for the life of the process until
-        KeyboardInterrupt, at which point stop() is called.
+        """Schedule several tasks on the **same** interval, then block.
+
+        Every task in ``tasks`` is registered before blocking, so all of them
+        run on each tick. This is one agent doing several things on one cadence.
+        For several agents on *different* cadences use :meth:`run_many`.
 
         Args:
-            tasks: The list of task strings to be executed by the agent
-            **kwargs: Additional parameters to pass to the agent's run method
+            tasks: Task strings, each scheduled at this job's interval.
+            **kwargs: Forwarded to the agent's ``run`` for every task.
 
         Returns:
-            List of scheduled job instances
+            List[schedule.Job]: One scheduled job per task, in input order.
+
+        Raises:
+            CronJobConfigError: If no agent or interval was configured.
+            CronJobExecutionError: If scheduling failed, or if the job gave up
+                after exhausting ``max_consecutive_errors``.
+
+        Example:
+            >>> job = CronJob(agent=agent, interval="1hour")
+            >>> job.batched_run(["Check inventory", "Check refunds"])
         """
         outputs = []
         for task in tasks:
             output = self._run(task, **kwargs)
             outputs.append(output)
         self._block_forever()
+        self._raise_if_stopped_by_errors()
         return outputs
 
     def __call__(self, task: str, **kwargs):
@@ -392,10 +506,18 @@ class CronJob:
             )
 
     def stop(self):
-        """Stop the scheduled job.
+        """Stop the job and join its scheduler thread.
+
+        Safe to call from another thread while :meth:`run` is blocking, and safe
+        to call on a job that is already stopped. Waits up to 5 seconds for the
+        scheduler thread to exit.
 
         Raises:
-            CronJobExecutionError: If the job fails to stop properly
+            CronJobExecutionError: If the job fails to stop properly.
+
+        Example:
+            >>> threading.Timer(60, job.stop).start()  # stop after a minute
+            >>> job.run("Poll the queue")
         """
         try:
             logger.info(f"Stopping job {self.job_id}")
@@ -424,15 +546,40 @@ class CronJob:
         while self.is_running:
             try:
                 self.schedule.run_pending()
-                time.sleep(1)
+                self.consecutive_errors = 0
             except Exception as e:
+                # Log and keep going. Setting is_running=False and re-raising
+                # here killed the scheduler thread on the first failed
+                # execution, so a single transient error (a rate limit, a
+                # dropped connection) permanently stopped the job -- and
+                # because _block_forever also loops on is_running, run()
+                # returned normally and the caller was never told.
+                self.error_count += 1
+                self.consecutive_errors += 1
+                self.last_error = e
                 logger.error(
-                    f"Error in schedule loop for job {self.job_id}: {str(e)}"
+                    f"Execution failed for job {self.job_id} "
+                    f"(failure {self.consecutive_errors} in a row, "
+                    f"{self.error_count} total): {str(e)}\n"
+                    f"{traceback.format_exc()}"
                 )
-                self.is_running = False
-                raise CronJobExecutionError(
-                    f"Schedule loop failed: {str(e)}"
-                )
+
+                if (
+                    self.max_consecutive_errors is not None
+                    and self.consecutive_errors
+                    >= self.max_consecutive_errors
+                ):
+                    logger.error(
+                        f"Job {self.job_id} stopping: "
+                        f"{self.consecutive_errors} consecutive failures "
+                        f"reached max_consecutive_errors="
+                        f"{self.max_consecutive_errors}"
+                    )
+                    self._stopped_due_to_error = True
+                    self.is_running = False
+                    return
+
+            time.sleep(1)
 
     def set_callback(self, callback: Callable[[Any, str, dict], Any]):
         """Set or update the callback function for output customization.
@@ -445,10 +592,20 @@ class CronJob:
         logger.info(f"Callback updated for job {self.job_id}")
 
     def get_execution_stats(self) -> dict:
-        """Get execution statistics for the cron job.
+        """Snapshot of how the job is doing, safe to poll while it runs.
 
         Returns:
-            dict: Statistics including execution count, start time, running status, etc.
+            dict: ``job_id``, ``is_running``, ``execution_count`` (successes),
+            ``start_time``, ``uptime`` in seconds, ``interval``, plus the failure
+            picture: ``error_count`` (total failures), ``consecutive_errors``
+            (since the last success), ``last_error`` as a string or ``None``, and
+            ``stopped_due_to_error`` which is ``True`` only when the job gave up
+            after exhausting ``max_consecutive_errors``.
+
+        Example:
+            >>> stats = job.get_execution_stats()
+            >>> if stats["consecutive_errors"] > 3:
+            ...     alert(f"{stats['job_id']} is struggling: {stats['last_error']}")
         """
         return {
             "job_id": self.job_id,
@@ -461,7 +618,138 @@ class CronJob:
                 else 0
             ),
             "interval": self.interval,
+            "error_count": self.error_count,
+            "consecutive_errors": self.consecutive_errors,
+            "last_error": (
+                str(self.last_error) if self.last_error else None
+            ),
+            "stopped_due_to_error": self._stopped_due_to_error,
         }
+
+    @classmethod
+    def run_many(
+        cls,
+        schedules: List[Dict[str, Any]],
+        block: bool = True,
+    ) -> List["CronJob"]:
+        """Run several agents together, each on its own interval.
+
+        A ``CronJob`` binds one agent to one interval, so a fleet on mixed
+        cadences needs one job per agent. This builds them, starts them all,
+        and optionally blocks until interrupted.
+
+        Each job keeps its own scheduler thread, so the agents are isolated:
+        one failing does not delay or stop the others, and each carries its
+        own error counters and ``max_consecutive_errors`` budget.
+
+        Args:
+            schedules: One mapping per agent. ``agent``, ``interval`` and
+                ``task`` are required. Optional keys: ``job_id``, ``callback``,
+                ``max_consecutive_errors``, and ``kwargs`` (a dict forwarded to
+                the agent's ``run``).
+            block: Hold the calling thread until KeyboardInterrupt, then stop
+                every job. Pass ``False`` to start them and return immediately,
+                leaving the caller responsible for ``stop_many``.
+
+        Returns:
+            List[CronJob]: The started jobs, in the order given, so they can be
+            inspected via ``get_execution_stats()`` or stopped individually.
+
+        Raises:
+            CronJobConfigError: If ``schedules`` is empty or an entry is
+                missing a required key.
+            CronJobExecutionError: If, once blocking ends, any job had stopped
+                because it exhausted ``max_consecutive_errors``.
+
+        Example:
+            >>> CronJob.run_many([
+            ...     {"agent": price_agent, "interval": "30seconds",
+            ...      "task": "Check BTC price"},
+            ...     {"agent": digest_agent, "interval": "1hour",
+            ...      "task": "Summarise the last hour"},
+            ... ])
+        """
+        if not schedules:
+            raise CronJobConfigError(
+                "run_many requires at least one schedule"
+            )
+
+        jobs: List["CronJob"] = []
+        for index, spec in enumerate(schedules):
+            missing = [
+                key
+                for key in ("agent", "interval", "task")
+                if not spec.get(key)
+            ]
+            if missing:
+                raise CronJobConfigError(
+                    f"schedules[{index}] is missing required "
+                    f"key(s): {', '.join(missing)}"
+                )
+
+            job = cls(
+                agent=spec["agent"],
+                interval=spec["interval"],
+                job_id=spec.get("job_id"),
+                callback=spec.get("callback"),
+                max_consecutive_errors=spec.get(
+                    "max_consecutive_errors"
+                ),
+            )
+            # _run schedules the task and starts this job's own thread; it
+            # does not block, which is what lets the fleet run together.
+            job._run(spec["task"], **(spec.get("kwargs") or {}))
+            jobs.append(job)
+
+        logger.info(
+            f"run_many started {len(jobs)} job(s): "
+            + ", ".join(f"{j.job_id}@{j.interval}" for j in jobs)
+        )
+
+        if not block:
+            return jobs
+
+        try:
+            # Hold here while the per-job threads do the work. Exit as soon as
+            # every job has stopped, so a fleet that has given up does not
+            # leave the caller parked forever.
+            while any(job.is_running for job in jobs):
+                time.sleep(1)
+        except KeyboardInterrupt:
+            logger.info(
+                "run_many received keyboard interrupt, stopping all jobs"
+            )
+        finally:
+            cls.stop_many(jobs)
+
+        failed = [job for job in jobs if job._stopped_due_to_error]
+        if failed:
+            raise CronJobExecutionError(
+                f"{len(failed)} of {len(jobs)} job(s) stopped after "
+                "repeated failures: "
+                + "; ".join(
+                    f"{job.job_id} ({job.consecutive_errors} consecutive, "
+                    f"last error: {job.last_error})"
+                    for job in failed
+                )
+            )
+
+        return jobs
+
+    @staticmethod
+    def stop_many(jobs: List["CronJob"]) -> None:
+        """Stop every job in ``jobs``, continuing past any that fail to stop.
+
+        Args:
+            jobs: The jobs to stop, typically the return value of
+                :meth:`run_many` called with ``block=False``.
+        """
+        for job in jobs:
+            try:
+                job.stop()
+            except Exception as e:
+                # One job refusing to stop must not strand the rest.
+                logger.error(f"Failed to stop job {job.job_id}: {e}")
 
 
 # # Example usage

--- a/tests/structs/test_cron_job.py
+++ b/tests/structs/test_cron_job.py
@@ -1,9 +1,23 @@
 import threading
 import time
-from swarms.structs.cron_job import CronJob
+
+import pytest
+
+from swarms.structs.cron_job import (
+    CronJob,
+    CronJobConfigError,
+    CronJobExecutionError,
+)
 
 
 class MockAgent:
+    """An agent-shaped object: exposes run(), like a real Agent.
+
+    It deliberately does *not* define __call__. CronJob dispatches on having a
+    run() method, so this is the shape that used to fail before the check was
+    corrected.
+    """
+
     def __init__(self, calls_list=None):
         self.calls_list = calls_list if calls_list is not None else []
 
@@ -11,44 +25,59 @@ class MockAgent:
         self.calls_list.append(task)
         return f"result-{task}"
 
-    def __call__(self, task: str = None, **kwargs):
-        return self.run(task=task, **kwargs)
+
+class FailingAgent:
+    """Fails its first ``fail_times`` calls, then succeeds."""
+
+    def __init__(self, fail_times: int = 1):
+        self.fail_times = fail_times
+        self.attempts = 0
+        self.successes = 0
+
+    def run(self, task: str = None, **kwargs):
+        self.attempts += 1
+        if self.attempts <= self.fail_times:
+            raise ValueError("transient failure")
+        self.successes += 1
+        return f"result-{task}"
 
 
-def test_cron_job_batched_run_schedules_all_tasks():
+def run_in_thread(fn):
+    """Start ``fn`` on a daemon thread and hand back the thread."""
+    thread = threading.Thread(target=fn, daemon=True)
+    thread.start()
+    return thread
+
+
+# ---------------------------------------------------------------------------
+# Scheduling
+# ---------------------------------------------------------------------------
+
+
+def test_batched_run_schedules_every_task():
+    """batched_run used to block on the first task, leaving the rest unscheduled."""
     calls = []
-    agent = MockAgent(calls)
-    job = CronJob(agent=agent, interval="1second")
+    job = CronJob(agent=MockAgent(calls), interval="1second")
 
-    t = threading.Thread(
-        target=lambda: job.batched_run(
-            ["task-A", "task-B", "task-C"]
-        ),
-        daemon=True,
+    t = run_in_thread(
+        lambda: job.batched_run(["task-A", "task-B", "task-C"])
     )
-    t.start()
     time.sleep(2.5)
     job.stop()
     t.join(timeout=2)
 
-    assert "task-A" in calls
-    assert "task-B" in calls
-    assert "task-C" in calls
+    assert {"task-A", "task-B", "task-C"} <= set(calls)
 
 
-def test_cron_job_batched_run_returns_list_of_jobs():
-    calls = []
-    agent = MockAgent(calls)
-    job = CronJob(agent=agent, interval="1second")
-
+def test_batched_run_returns_one_job_per_task():
+    job = CronJob(agent=MockAgent(), interval="1second")
     results = []
 
-    def runner():
-        res = job.batched_run(["task-1", "task-2", "task-3"])
-        results.append(res)
-
-    t = threading.Thread(target=runner, daemon=True)
-    t.start()
+    t = run_in_thread(
+        lambda: results.append(
+            job.batched_run(["task-1", "task-2", "task-3"])
+        )
+    )
     time.sleep(0.5)
     job.stop()
     t.join(timeout=2)
@@ -57,22 +86,371 @@ def test_cron_job_batched_run_returns_list_of_jobs():
     assert len(results[0]) == 3
 
 
-def test_cron_job_single_run_blocks_and_returns_job():
-    calls = []
-    agent = MockAgent(calls)
-    job = CronJob(agent=agent, interval="1second")
-
+def test_run_blocks_and_returns_the_scheduled_job():
+    job = CronJob(agent=MockAgent(), interval="1second")
     results = []
 
-    def runner():
-        res = job.run("task-single")
-        results.append(res)
-
-    t = threading.Thread(target=runner, daemon=True)
-    t.start()
+    t = run_in_thread(lambda: results.append(job.run("task-single")))
     time.sleep(0.5)
     job.stop()
     t.join(timeout=2)
 
     assert len(results) == 1
     assert results[0] is not None
+
+
+def test_task_fires_repeatedly_on_its_interval():
+    calls = []
+    job = CronJob(agent=MockAgent(calls), interval="1second")
+
+    t = run_in_thread(lambda: job.run("tick"))
+    time.sleep(3.2)
+    job.stop()
+    t.join(timeout=2)
+
+    # ~3 firings in 3.2s at a 1s interval; allow slack for a loaded machine.
+    assert 2 <= len(calls) <= 4
+
+
+# ---------------------------------------------------------------------------
+# Agent dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_prefers_run_over_calling_the_agent():
+    """An object with run() and no __call__ must go through run()."""
+    calls = []
+    job = CronJob(agent=MockAgent(calls), interval="1second")
+    assert job._run_job("t") == "result-t"
+    assert calls == ["t"]
+
+
+def test_dispatch_falls_back_to_calling_a_plain_function():
+    """isinstance(x, Callable) is true for functions, so this used to take the
+    run() branch and raise AttributeError."""
+    seen = []
+
+    def plain_function(task, **kwargs):
+        seen.append(task)
+        return f"fn-{task}"
+
+    job = CronJob(agent=plain_function, interval="1second")
+    assert job._run_job("t") == "fn-t"
+    assert seen == ["t"]
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_execution_does_not_kill_the_schedule():
+    """The loop used to set is_running=False and re-raise on the first error,
+    so one transient failure stopped the job permanently."""
+    agent = FailingAgent(fail_times=1)
+    job = CronJob(agent=agent, interval="1second")
+
+    t = run_in_thread(lambda: job.run("t"))
+    time.sleep(3.5)
+    still_running = job.is_running
+    job.stop()
+    t.join(timeout=3)
+
+    assert (
+        agent.successes >= 1
+    ), "job never recovered from one failure"
+    assert still_running, "schedule died on a transient error"
+    assert job.error_count == 1
+    assert job.consecutive_errors == 0, "counter not reset on success"
+
+
+def test_consecutive_errors_stop_the_job_when_a_budget_is_set():
+    agent = FailingAgent(fail_times=99)
+    job = CronJob(
+        agent=agent, interval="1second", max_consecutive_errors=2
+    )
+
+    with pytest.raises(CronJobExecutionError, match="consecutive"):
+        job.run("t")
+
+    assert job._stopped_due_to_error is True
+    assert job.is_running is False
+
+
+def test_without_a_budget_the_job_retries_indefinitely():
+    agent = FailingAgent(fail_times=99)
+    job = CronJob(agent=agent, interval="1second")
+
+    t = run_in_thread(lambda: job.run("t"))
+    time.sleep(3.5)
+    alive = job.thread.is_alive()
+    job.stop()
+    t.join(timeout=3)
+
+    assert agent.attempts > 1, "gave up after the first failure"
+    assert alive, "scheduler thread died"
+
+
+def test_stats_expose_the_failure_picture():
+    agent = FailingAgent(fail_times=99)
+    job = CronJob(agent=agent, interval="1second")
+
+    t = run_in_thread(lambda: job.run("t"))
+    time.sleep(2.5)
+    stats = job.get_execution_stats()
+    job.stop()
+    t.join(timeout=3)
+
+    assert stats["error_count"] >= 1
+    assert stats["consecutive_errors"] >= 1
+    assert "transient failure" in stats["last_error"]
+    assert stats["stopped_due_to_error"] is False
+
+
+# ---------------------------------------------------------------------------
+# Configuration validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "interval",
+    [
+        "1second",
+        "5seconds",
+        "1minute",
+        "10minutes",
+        "1hour",
+        "2hours",
+    ],
+)
+def test_valid_intervals_are_accepted(interval):
+    CronJob(agent=MockAgent(), interval=interval)
+
+
+@pytest.mark.parametrize(
+    "interval",
+    [
+        "0second",
+        "0minutes",
+        "",
+        "   ",
+        "-1second",
+        "1day",
+        "second",
+        "1 second",
+    ],
+)
+def test_invalid_intervals_are_rejected_at_construction(interval):
+    """'0second' scheduled a job that silently never fired, and '' failed much
+    later with a message claiming no interval had been provided."""
+    with pytest.raises(CronJobConfigError):
+        CronJob(agent=MockAgent(), interval=interval)
+
+
+def test_missing_agent_is_rejected():
+    with pytest.raises(CronJobConfigError, match="Agent"):
+        CronJob(agent=None, interval="1second")
+
+
+def test_hourly_interval_schedules_without_error():
+    """The hour/hours lambdas took one argument while the caller passed two."""
+    job = CronJob(agent=MockAgent(), interval="1hour")
+    assert job._run("task-hourly") is not None
+    job.stop()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_stop_joins_the_scheduler_thread():
+    job = CronJob(agent=MockAgent(), interval="1second")
+
+    t = run_in_thread(lambda: job.run("t"))
+    time.sleep(1.2)
+    job.stop()
+    t.join(timeout=3)
+
+    assert job.is_running is False
+    leftover = [
+        thread.name
+        for thread in threading.enumerate()
+        if thread.name.startswith(f"cronjob_{job.job_id}")
+    ]
+    assert leftover == []
+
+
+def test_callback_customizes_output_and_a_broken_one_is_survivable():
+    job = CronJob(
+        agent=MockAgent(),
+        interval="1second",
+        callback=lambda output, task, metadata: f"wrapped({output})",
+    )
+    assert job._run_job("t") == "wrapped(result-t)"
+
+    def broken_callback(output, task, metadata):
+        raise RuntimeError("callback exploded")
+
+    job.set_callback(broken_callback)
+    # The original output survives a callback that raises.
+    assert job._run_job("t") == "result-t"
+
+
+# ---------------------------------------------------------------------------
+# run_many: several agents, several cadences
+# ---------------------------------------------------------------------------
+
+
+def test_run_many_runs_each_agent_on_its_own_cadence():
+    fast, slow = MockAgent(), MockAgent()
+    jobs = CronJob.run_many(
+        [
+            {"agent": fast, "interval": "1second", "task": "fast"},
+            {"agent": slow, "interval": "3seconds", "task": "slow"},
+        ],
+        block=False,
+    )
+    time.sleep(6.2)
+    CronJob.stop_many(jobs)
+
+    assert len(fast.calls_list) > len(slow.calls_list)
+    assert len(slow.calls_list) >= 1
+    assert len({job.job_id for job in jobs}) == 2
+
+
+def test_run_many_isolates_a_failing_agent_from_the_others():
+    healthy = MockAgent()
+    broken = FailingAgent(fail_times=99)
+    jobs = CronJob.run_many(
+        [
+            {"agent": healthy, "interval": "1second", "task": "ok"},
+            {"agent": broken, "interval": "1second", "task": "bad"},
+        ],
+        block=False,
+    )
+    time.sleep(3.5)
+    healthy_job, broken_job = jobs
+    CronJob.stop_many(jobs)
+
+    assert len(healthy.calls_list) >= 2, "healthy agent was held back"
+    assert healthy_job.error_count == 0
+    assert broken_job.error_count >= 1
+
+
+def test_run_many_applies_error_budgets_per_job():
+    healthy = MockAgent()
+    broken = FailingAgent(fail_times=99)
+    jobs = CronJob.run_many(
+        [
+            {"agent": healthy, "interval": "1second", "task": "ok"},
+            {
+                "agent": broken,
+                "interval": "1second",
+                "task": "bad",
+                "max_consecutive_errors": 2,
+            },
+        ],
+        block=False,
+    )
+    time.sleep(4.5)
+    healthy_job, broken_job = jobs
+    still_up = healthy_job.is_running
+    CronJob.stop_many(jobs)
+
+    assert broken_job._stopped_due_to_error is True
+    assert still_up, "a sibling giving up stopped the healthy job"
+
+
+def test_run_many_blocking_form_raises_when_a_job_gives_up():
+    with pytest.raises(
+        CronJobExecutionError, match="repeated failures"
+    ):
+        CronJob.run_many(
+            [
+                {
+                    "agent": FailingAgent(fail_times=99),
+                    "interval": "1second",
+                    "task": "bad",
+                    "max_consecutive_errors": 2,
+                }
+            ],
+            block=True,
+        )
+
+
+def test_run_many_stop_many_leaves_no_threads_behind():
+    jobs = CronJob.run_many(
+        [
+            {
+                "agent": MockAgent(),
+                "interval": "1second",
+                "task": "a",
+            },
+            {
+                "agent": MockAgent(),
+                "interval": "1second",
+                "task": "b",
+            },
+        ],
+        block=False,
+    )
+    time.sleep(1.2)
+    CronJob.stop_many(jobs)
+    time.sleep(0.3)
+
+    assert all(not job.is_running for job in jobs)
+    ids = {job.job_id for job in jobs}
+    leftover = [
+        thread.name
+        for thread in threading.enumerate()
+        if any(thread.name == f"cronjob_{jid}" for jid in ids)
+    ]
+    assert leftover == []
+
+
+def test_run_many_forwards_per_job_kwargs():
+    received = {}
+
+    class KwargAgent:
+        def run(self, task=None, **kwargs):
+            received.update(kwargs)
+            return "ok"
+
+    jobs = CronJob.run_many(
+        [
+            {
+                "agent": KwargAgent(),
+                "interval": "1second",
+                "task": "t",
+                "kwargs": {"img": "chart.png"},
+            }
+        ],
+        block=False,
+    )
+    time.sleep(1.5)
+    CronJob.stop_many(jobs)
+
+    assert received.get("img") == "chart.png"
+
+
+def test_run_many_rejects_an_empty_schedule_list():
+    with pytest.raises(CronJobConfigError, match="at least one"):
+        CronJob.run_many([], block=False)
+
+
+@pytest.mark.parametrize(
+    "spec,missing",
+    [
+        ({"interval": "1second", "task": "t"}, "agent"),
+        ({"agent": "x", "task": "t"}, "interval"),
+        ({"agent": "x", "interval": "1second"}, "task"),
+    ],
+)
+def test_run_many_names_the_missing_key(spec, missing):
+    with pytest.raises(CronJobConfigError, match=missing):
+        CronJob.run_many([spec], block=False)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## The bug

A task that raised killed the schedule permanently, and the caller was never told.

`_run_schedule` set `is_running = False` and re-raised on any exception. That ends the scheduler thread. `_block_forever` also loops on `is_running`, so `run()` then returned a `Job` object as though the schedule were healthy.

Reproduced on `master` with an agent that fails **once** and then succeeds, which is the ordinary transient case:

```
agent invoked        : 1x over 4s   (interval=1s, so ~4 expected)
caller run() outcome : returned "Every 1 second do _run_job('t') ..."
is_running           : False
scheduler thread     : DEAD
```

One rate limit or dropped connection and the job is over, looking fine.

## The fix

| | before | after |
|---|---|---|
| agent fails once, then recovers | invoked **1x**, thread dead | invoked **3x**, 2 succeeded, `consecutive_errors` back to 0 |
| agent fails every time | dies after the 1st, `run()` returns quietly | keeps retrying, scheduler alive |
| job exhausts its error budget | n/a | stops **and** `run()` raises, naming the count and last error |

- A failed execution is logged with traceback and retried on the next tick, which is what cron does.
- `max_consecutive_errors` (default `None`, never give up) stops a job that is failing every time. Default is deliberately "never" since the whole bug was giving up too eagerly.
- `error_count`, `consecutive_errors` and `last_error` are tracked and exposed through `get_execution_stats()`.

Two validation gaps closed alongside it, both found while probing:

- `interval="0second"` was accepted and then **silently never fired**. Now rejected.
- `interval=""` was accepted at construction and failed much later with *"Interval must be provided during initialization"*, which is confusing because it was provided. Now rejected up front.

## New: `CronJob.run_many()`

A `CronJob` binds one agent to one interval, so a fleet on mixed cadences needs one job per agent. `run_many` builds them, starts each on its own scheduler thread, and blocks once. `stop_many` is the companion.

```python
CronJob.run_many([
    {"agent": price_agent,  "interval": "30seconds", "task": "Check BTC price"},
    {"agent": anomaly_agent,"interval": "10minutes", "task": "Scan for anomalies",
     "max_consecutive_errors": 5},
    {"agent": digest_agent, "interval": "1hour",     "task": "Summarise the hour"},
])
```

Per-job threads mean the agents are **isolated**. Measured: with one healthy and one permanently failing agent at the same interval, the healthy one ran 4x with `error_count=0` while the broken one retried independently. With a budget set on only the broken one, it gave up and the healthy one kept running.

`block=False` starts the fleet and hands back the jobs for a caller that has its own main loop.

Note this isolation only works *because* of the fix above. Before it, one agent raising once would have silently killed its own scheduler thread.

## Verification

Measured, not asserted:

- Cadence is exact: three agents at 1s / 2s / 3s produced **6 / 3 / 2** firings over ~6s.
- Thread cleanup: 0 leftover `cronjob_*` threads after `stop` and `stop_many`.
- No regressions: the pre-existing dispatch behaviour from #1904 and `batched_run` / hourly-interval behaviour from #1920 all still hold.

Tests go from **3 to 38**, covering cadence, agent dispatch (both shapes), failure and recovery, error budgets, interval validation, lifecycle, callbacks, and `run_many`.

## Examples

Five new files in `examples/guides/deployment/cron_job_examples/`, with the README reorganised into a "start here" section:

| File | Shows |
|---|---|
| `single_agent_cron.py` | one agent, one interval |
| `one_agent_many_tasks_cron.py` | one agent, several tasks, shared cadence (`batched_run`) |
| `multi_agent_schedules_cron.py` | several agents on different cadences (`run_many`) |
| `non_blocking_cron.py` | `block=False`, inspect mid-flight, stop |
| `resilient_cron.py` | failure handling, error budgets, live monitoring |

`non_blocking_cron.py` and `resilient_cron.py` run without API keys and I ran both end to end. The resilience one recovered through 21 failures while completing 19 successful runs.

## Not included

`tests/structs/test_agent.py` has an unrelated black reformat in the working tree; I left it out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
