### PR TITLE
[Bug] PlannerWorkerSwarm.run accepts img and never passes it to a single agent

### DIFF
--- a/swarms/structs/planner_worker_swarm.py
+++ b/swarms/structs/planner_worker_swarm.py
@@ -361,10 +361,12 @@ class WorkerPool:
         max_workers: Optional[int] = None,
         poll_interval: float = 0.1,
         task_timeout: Optional[float] = None,
+        img: Optional[str] = None,
     ):
         self.agents = agents
         self.task_queue = task_queue
         self.conversation = conversation
+        self.img = img
         self.max_workers = max_workers or min(
             len(agents), os.cpu_count() or 4
         )
@@ -462,7 +464,7 @@ class WorkerPool:
                         max_workers=1
                     ) as task_executor:
                         future = task_executor.submit(
-                            agent.run, task=context
+                            agent.run, task=context, img=self.img
                         )
                         try:
                             result = future.result(
@@ -473,7 +475,7 @@ class WorkerPool:
                                 f"Task execution exceeded {self.task_timeout}s timeout"
                             )
                 else:
-                    result = agent.run(task=context)
+                    result = agent.run(task=context, img=self.img)
 
                 current = self.task_queue.get_task(task.id)
                 if current and self.task_queue.complete(
@@ -691,6 +693,7 @@ class PlannerWorkerSwarm:
         task: str,
         depth: int = 0,
         parent_task_id: Optional[str] = None,
+        img: Optional[str] = None,
     ) -> List[PlannerTask]:
         """Run a planner and add produced tasks to the queue.
 
@@ -711,7 +714,7 @@ class PlannerWorkerSwarm:
             f"[PlannerWorkerSwarm] Running {planner_name} (depth={depth})"
         )
 
-        raw_output = planner.run(task=task)
+        raw_output = planner.run(task=task, img=img)
 
         spec = self._parse_structured_output(
             raw_output, PlannerTaskSpec
@@ -759,12 +762,13 @@ class PlannerWorkerSwarm:
                         task=f"Decompose this task into smaller subtasks:\n\n{ptask.description}",
                         depth=depth + 1,
                         parent_task_id=ptask.id,
+                        img=img,
                     )
                     added_tasks.extend(sub_tasks)
 
         return added_tasks
 
-    def _run_judge(self) -> CycleVerdict:
+    def _run_judge(self, img: Optional[str] = None) -> CycleVerdict:
         """Run the judge agent to evaluate cycle results."""
         schema = BaseTool().base_model_to_dict(CycleVerdict)
 
@@ -795,7 +799,7 @@ class PlannerWorkerSwarm:
             "If not, identify specific gaps and provide instructions for the next planning cycle."
         )
 
-        raw_output = judge.run(task=eval_task)
+        raw_output = judge.run(task=eval_task, img=img)
 
         try:
             verdict = self._parse_structured_output(
@@ -889,7 +893,7 @@ class PlannerWorkerSwarm:
                     "Create new tasks to address these gaps."
                 )
 
-            self._run_planner(planner_task)
+            self._run_planner(planner_task, img=img)
 
             # Phase 2: Worker execution
             worker_pool = WorkerPool(
@@ -898,6 +902,7 @@ class PlannerWorkerSwarm:
                 conversation=self.conversation,
                 max_workers=self.max_workers,
                 task_timeout=self.task_timeout,
+                img=img,
             )
             worker_pool.run(timeout=self.worker_timeout)
 
@@ -910,7 +915,7 @@ class PlannerWorkerSwarm:
             )
 
             # Phase 3: Judge evaluation
-            verdict = self._run_judge()
+            verdict = self._run_judge(img=img)
 
             logger.info(
                 f"[PlannerWorkerSwarm] Cycle {cycle + 1} done. "

--- a/tests/structs/test_planner_worker_swarm.py
+++ b/tests/structs/test_planner_worker_swarm.py
@@ -492,6 +492,38 @@ class TestWorkerPoolMocked:
         ).run(timeout=10)
         assert q.is_all_done() and a.run.call_count == 3
 
+    def test_img_reaches_every_worker(self):
+        q = TaskQueue()
+        q.add_tasks(
+            [
+                PlannerTask(title=f"T{i}", description=f"D{i}")
+                for i in range(2)
+            ]
+        )
+        a = _mock_agent("W1")
+        WorkerPool(
+            agents=[a],
+            task_queue=q,
+            conversation=Conversation(time_enabled=False),
+            max_workers=1,
+            img="chart.png",
+        ).run(timeout=10)
+        assert a.run.call_count == 2
+        for call in a.run.call_args_list:
+            assert call.kwargs["img"] == "chart.png"
+
+    def test_no_img_still_passes_none(self):
+        q = TaskQueue()
+        q.add_task(PlannerTask(title="T", description="D"))
+        a = _mock_agent("W1")
+        WorkerPool(
+            agents=[a],
+            task_queue=q,
+            conversation=Conversation(time_enabled=False),
+            max_workers=1,
+        ).run(timeout=10)
+        assert a.run.call_args.kwargs["img"] is None
+
     def test_worker_prompt_injected(self):
         q = TaskQueue()
         q.add_task(PlannerTask(title="MyTask", description="Do it"))


### PR DESCRIPTION
## Problem

`PlannerWorkerSwarm.run` takes `img`, documents it, and declares it to the tracer:

```python
@trace_run("PlannerWorkerSwarm.run", input_params=("task", "img"))
def run(self, task=None, img=None, *args, **kwargs):
    """
    Args:
        task: The goal to accomplish.
        img: Optional image input.
    """
```

Before this change, those three lines are the only places `img` appears in the entire class. Every agent is invoked with the task alone:

```python
raw_output = planner.run(task=task)          # planner
result = agent.run(task=context)             # each worker
raw_output = judge.run(task=eval_task)       # judge
```

So a caller who passes an image gets a full planner/worker/judge cycle that never sees it — a confident answer about a chart nobody looked at, with no error and nothing in the logs. Same shape as #1906 (SkillOrchestra) and #1903 (HeavySwarm's decomposer).

Found by walking every `run`-like method in `swarms/structs` that declares `img`/`imgs` and checking whether the body references the parameter at all.

## Change

`img` reaches the three places that actually call an agent:

- the planner, and the sub-planners it spawns for `CRITICAL` tasks
- the worker pool
- the judge

`WorkerPool` needed a field rather than an argument because workers claim tasks off a shared queue instead of being called with a task, so there is no per-call site to thread it through.

## Verification

`tests/structs/test_planner_worker_swarm.py`: `52 passed`, 1 failed — `TestLive::test_end_to_end`, which pre-exists on master and needs provider credentials.

Two tests added to the existing `TestWorkerPoolMocked` class: every worker call carries the image, and the no-image case still passes `img=None` rather than dropping the keyword. Both fail without the fix:

```
FAILED TestWorkerPoolMocked::test_img_reaches_every_worker
FAILED TestWorkerPoolMocked::test_no_img_still_passes_none
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)