### PR TITLE
[Bug] AOPCluster.get_tools ignores the output_type it documents

### DIFF
--- a/swarms/structs/aop.py
+++ b/swarms/structs/aop.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from contextlib import AbstractAsyncContextManager
 import socket
 import sys
@@ -8,7 +9,7 @@ import traceback
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 from uuid import uuid4
 
 from loguru import logger
@@ -2931,22 +2932,30 @@ class AOPCluster:
 
     def get_tools(
         self, output_type: Literal["json", "dict", "str"] = "dict"
-    ) -> List[Dict[str, Any]]:
+    ) -> Union[List[Dict[str, Any]], str]:
         """
         Retrieve the list of tools (agents) from all MCP servers in the cluster.
 
         Args:
             output_type (Literal["json", "dict", "str"], optional): The format of the output.
-                Can be "json", "dict", or "str". Defaults to "dict".
+                "dict" returns the tool dictionaries, "json" returns them as a
+                JSON string, and "str" returns their string representation.
+                Defaults to "dict".
 
         Returns:
-            List[Dict[str, Any]]: A list of tool information dictionaries.
+            Union[List[Dict[str, Any]], str]: The tools, in the requested format.
         """
-        return MCPManager(
+        tools = MCPManager(
             mcp_urls=self.urls,
             transport=self.transport,
             agent_name="AOPCluster",
         ).get_tools(format="openai")
+
+        if output_type == "json":
+            return json.dumps(tools, indent=2)
+        if output_type == "str":
+            return str(tools)
+        return tools
 
     def find_tool_by_server_name(
         self, server_name: str

--- a/tests/structs/test_aop.py
+++ b/tests/structs/test_aop.py
@@ -1,3 +1,4 @@
+import json
 import socket
 import time
 from unittest.mock import Mock, patch
@@ -1216,6 +1217,25 @@ def test_aop_cluster_get_tools():
         mock_manager_cls.return_value.get_tools.assert_called_once_with(
             format="openai"
         )
+
+
+def test_aop_cluster_get_tools_output_types():
+    """json and str were documented but the dict list came back regardless."""
+    urls = ["http://localhost:8000"]
+    tools = [{"function": {"name": "agent-a"}}]
+
+    with patch("swarms.structs.aop.MCPManager") as mock_manager_cls:
+        mock_manager_cls.return_value.get_tools.return_value = tools
+        cluster = AOPCluster(urls)
+
+        assert cluster.get_tools() == tools
+        assert cluster.get_tools(output_type="dict") == tools
+
+        as_json = cluster.get_tools(output_type="json")
+        assert isinstance(as_json, str)
+        assert json.loads(as_json) == tools
+
+        assert cluster.get_tools(output_type="str") == str(tools)
 
 
 def test_aop_cluster_find_tool_by_server_name():


### PR DESCRIPTION
## Problem

`AOPCluster.get_tools` advertises three output formats and implements none of them:

```python
def get_tools(
    self, output_type: Literal["json", "dict", "str"] = "dict"
) -> List[Dict[str, Any]]:
    """
    Args:
        output_type: The format of the output. Can be "json", "dict", or "str".
    """
    return MCPManager(...).get_tools(format="openai")
```

`output_type` appears in the signature and the docstring and nowhere in the body. `get_tools(output_type="json")` returns a list of dicts, so a caller doing `json.loads(cluster.get_tools(output_type="json"))` gets a `TypeError` from an API that documents exactly that call.

The inner `format="openai"` is a different axis — `MCPManager.get_tools` takes `Literal["openai", "mcp"]`, which selects the *schema*, not the serialization. So there is no chain by which the outer parameter could ever have had an effect.

Same class as #1922, which you merged.

## Fix: honour it, don't delete it

#1922 removed the dead parameter, and I checked whether the same applied here. It does not — three call sites already pass it:

```
swarms/structs/aop.py:2963                                    self.get_tools(output_type="dict")
examples/guides/aop_examples/discovery/simple_discovery_example.py:105
examples/guides/aop_examples/medical_aop/client.py:61
tests/structs/test_aop.py:1208
```

Removing it would turn each of those into a `TypeError`. Implementing it leaves every existing caller on exactly the path it already takes, since they all pass `"dict"`, which is also the default.

The return annotation widens to `Union[List[Dict[str, Any]], str]`, which is what the docstring described all along.

## Verification

```
dict -> list [{'function': {'name': 'a'}}]
json -> str  '[\n  {\n    "function": {\n      "name": "a…'
str  -> str  [{'function': {'name': 'a'}}]
```

Test added next to the existing `test_aop_cluster_get_tools` in `tests/structs/test_aop.py`, asserting the default and `"dict"` are unchanged, `"json"` round-trips through `json.loads`, and `"str"` matches `str(tools)`. It fails on the unfixed body:

```
FAILED tests/structs/test_aop.py::test_aop_cluster_get_tools_output_types
```

File baseline is `12 failed, 68 passed` on master and `12 failed, 69 passed` here — same failures, plus the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)