### PR TITLE
Cleanup/tool schema 1848

### DIFF
--- a/swarms/tools/base_tool.py
+++ b/swarms/tools/base_tool.py
@@ -232,8 +232,6 @@ class BaseTool(BaseModel):
         self,
         pydantic_type: type[BaseModel],
         output_str: bool = False,
-        *args: Any,
-        **kwargs: Any,
     ) -> Union[dict[str, Any], str]:
         """
         Convert a Pydantic BaseModel to OpenAI function calling schema dictionary.
@@ -245,8 +243,6 @@ class BaseTool(BaseModel):
         Args:
             pydantic_type (type[BaseModel]): The Pydantic model class to convert
             output_str (bool): Whether to return string output format
-            *args: Additional positional arguments (unused; kept for API compat)
-            **kwargs: Additional keyword arguments (unused; kept for API compat)
 
         Returns:
             Union[dict[str, Any], str]: OpenAI function calling schema dictionary or JSON string

--- a/swarms/tools/base_tool.py
+++ b/swarms/tools/base_tool.py
@@ -238,14 +238,15 @@ class BaseTool(BaseModel):
         """
         Convert a Pydantic BaseModel to OpenAI function calling schema dictionary.
 
-        This method transforms a Pydantic model into a dictionary format compatible
-        with OpenAI's function calling API. Results are cached for performance.
+        Thin validated wrapper around ``base_model_to_openai_function``, which
+        already emits the modern ``{"type": "function", "function": …}`` shape.
+        No legacy envelope unwrap/rewrap.
 
         Args:
             pydantic_type (type[BaseModel]): The Pydantic model class to convert
             output_str (bool): Whether to return string output format
-            *args: Additional positional arguments
-            **kwargs: Additional keyword arguments
+            *args: Additional positional arguments (unused; kept for API compat)
+            **kwargs: Additional keyword arguments (unused; kept for API compat)
 
         Returns:
             Union[dict[str, Any], str]: OpenAI function calling schema dictionary or JSON string
@@ -277,31 +278,9 @@ class BaseTool(BaseModel):
                 f"Converting Pydantic model {pydantic_type.__name__} to schema",
             )
 
-            # Get the base function schema
-            base_result = base_model_to_openai_function(
-                pydantic_type, output_str=output_str, *args, **kwargs
+            result = base_model_to_openai_function(
+                pydantic_type, output_str=output_str
             )
-
-            # If output_str is True, return the string directly
-            if output_str and isinstance(base_result, str):
-                return base_result
-
-            # Extract the function definition from the functions array
-            if (
-                "functions" in base_result
-                and len(base_result["functions"]) > 0
-            ):
-                function_def = base_result["functions"][0]
-
-                # Return in proper OpenAI function calling format
-                result = {
-                    "type": "function",
-                    "function": function_def,
-                }
-            else:
-                raise FunctionSchemaError(
-                    "Failed to extract function definition from base_model_to_openai_function result"
-                )
 
             self._log_if_verbose(
                 "info",

--- a/swarms/tools/pydantic_to_json.py
+++ b/swarms/tools/pydantic_to_json.py
@@ -28,18 +28,19 @@ def base_model_to_openai_function(
     output_str: bool = False,
 ) -> dict[str, Any]:
     """
-    Convert a Pydantic model class to an OpenAI-compatible function specification dictionary.
+    Convert a Pydantic model class to an OpenAI tool/function schema.
 
-    This function takes a Pydantic model type, extracts its schema, properties, and docstring,
-    and returns a dictionary representation suitable for use with OpenAI's function-calling API.
-    Optionally, it can output the result as a formatted JSON string.
+    Emits the modern tools format directly:
+    ``{"type": "function", "function": {"name", "description", "parameters"}}``.
 
     Args:
         pydantic_type (type[BaseModel]): The Pydantic model class to convert.
-        output_str (bool, optional): If True, returns a pretty-printed JSON string. Defaults to False.
+        output_str (bool, optional): If True, returns a pretty-printed JSON
+            string. Defaults to False.
 
     Returns:
-        dict[str, Any]: The OpenAI-compatible function specification, or a JSON string if output_str is True.
+        dict[str, Any]: The OpenAI tool schema, or a JSON string if
+            output_str is True.
     """
     schema = pydantic_type.model_json_schema()
 
@@ -84,19 +85,14 @@ def base_model_to_openai_function(
     _remove_a_key(parameters, "additionalProperties")
 
     result = {
-        "function_call": {
+        "type": "function",
+        "function": {
             "name": name,
+            "description": schema["description"],
+            "parameters": parameters,
         },
-        "functions": [
-            {
-                "name": name,
-                "description": schema["description"],
-                "parameters": parameters,
-            },
-        ],
     }
 
-    # Handle output_str parameter
     if output_str:
         import json
 
@@ -108,38 +104,32 @@ def base_model_to_openai_function(
 def multi_base_model_to_openai_function(
     pydantic_types: List[BaseModel] = None,
     output_str: bool = False,
-) -> dict[str, Any]:
+) -> list[dict[str, Any]]:
     """
-    Convert multiple Pydantic model classes to a combined OpenAI function specification.
+    Convert multiple Pydantic model classes to OpenAI tool schemas.
 
-    This function takes a list of Pydantic types and returns a dictionary containing
-    all their OpenAI-compatible function specifications, with a default "auto" function_call.
-    Optionally returns the output as a pretty-printed JSON string.
+    Returns a list of modern ``{"type": "function", "function": …}``
+    entries — the same shape as a single ``base_model_to_openai_function``
+    call, with no legacy ``function_call`` / ``functions`` envelope.
 
     Args:
-        pydantic_types (List[BaseModel]): A list of Pydantic model classes to convert.
-        output_str (bool, optional): If True, outputs a formatted JSON string. Defaults to False.
+        pydantic_types (List[BaseModel]): A list of Pydantic model classes
+            to convert.
+        output_str (bool, optional): If True, outputs a formatted JSON
+            string. Defaults to False.
 
     Returns:
-        dict[str, Any]: Dictionary with combined OpenAI function specifications,
-            or a JSON string if output_str is True.
+        list[dict[str, Any]]: OpenAI tool schemas, or a JSON string if
+            output_str is True.
     """
-    functions: list[dict[str, Any]] = [
-        base_model_to_openai_function(
-            pydantic_type, output_str=False
-        )["functions"][0]
+    results: list[dict[str, Any]] = [
+        base_model_to_openai_function(pydantic_type, output_str=False)
         for pydantic_type in pydantic_types
     ]
 
-    result = {
-        "function_call": "auto",
-        "functions": functions,
-    }
-
-    # Handle output_str parameter
     if output_str:
         import json
 
-        return json.dumps(result, indent=2)
+        return json.dumps(results, indent=2)
 
-    return result
+    return results

--- a/swarms/tools/pydantic_to_json.py
+++ b/swarms/tools/pydantic_to_json.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, List, Union
 
 from swarms.utils.docstring_parser import parse
 from pydantic import BaseModel
@@ -26,7 +26,7 @@ def _remove_a_key(d: dict, remove_key: str) -> None:
 def base_model_to_openai_function(
     pydantic_type: type[BaseModel],
     output_str: bool = False,
-) -> dict[str, Any]:
+) -> Union[dict[str, Any], str]:
     """
     Convert a Pydantic model class to an OpenAI tool/function schema.
 
@@ -39,7 +39,7 @@ def base_model_to_openai_function(
             string. Defaults to False.
 
     Returns:
-        dict[str, Any]: The OpenAI tool schema, or a JSON string if
+        dict[str, Any] | str: The OpenAI tool schema, or a JSON string if
             output_str is True.
     """
     schema = pydantic_type.model_json_schema()
@@ -104,7 +104,7 @@ def base_model_to_openai_function(
 def multi_base_model_to_openai_function(
     pydantic_types: List[BaseModel] = None,
     output_str: bool = False,
-) -> list[dict[str, Any]]:
+) -> Union[list[dict[str, Any]], str]:
     """
     Convert multiple Pydantic model classes to OpenAI tool schemas.
 
@@ -119,7 +119,7 @@ def multi_base_model_to_openai_function(
             string. Defaults to False.
 
     Returns:
-        list[dict[str, Any]]: OpenAI tool schemas, or a JSON string if
+        list[dict[str, Any]] | str: OpenAI tool schemas, or a JSON string if
             output_str is True.
     """
     results: list[dict[str, Any]] = [

--- a/tests/tools/test_base_tool.py
+++ b/tests/tools/test_base_tool.py
@@ -39,9 +39,10 @@ def test_base_model_to_dict():
 
     result = tool.base_model_to_dict(TestModel)
 
-    assert "type" in result
-    assert "properties" in result["properties"]
-    assert "name" in result["properties"]["properties"]
+    assert result["type"] == "function"
+    assert result["function"]["name"] == "TestModel"
+    assert "name" in result["function"]["parameters"]["properties"]
+    assert "age" in result["function"]["parameters"]["properties"]
     print("base_model_to_dict test passed")
 
 

--- a/tests/tools/test_output_str_fix.py
+++ b/tests/tools/test_output_str_fix.py
@@ -41,11 +41,12 @@ def test_multi_base_model_to_openai_function():
     print(
         "\nTesting multi_base_model_to_openai_function with output_str=False..."
     )
-    result_dict = multi_base_model_to_openai_function(
+    result_list = multi_base_model_to_openai_function(
         [TestModel], output_str=False
     )
-    print(f"✓ Dict result type: {type(result_dict)}")
-    print(f"✓ Dict result keys: {list(result_dict.keys())}")
+    print(f"✓ List result type: {type(result_list)}")
+    print(f"✓ List result length: {len(result_list)}")
+    print(f"✓ First schema keys: {list(result_list[0].keys())}")
 
     print(
         "\nTesting multi_base_model_to_openai_function with output_str=True..."
@@ -179,11 +180,37 @@ def test_function_name_is_the_model_name():
 
     result = base_model_to_openai_function(WeatherQuery)
 
-    assert result["function_call"]["name"] == "WeatherQuery"
-    assert result["functions"][0]["name"] == "WeatherQuery"
+    assert result["type"] == "function"
+    assert result["function"]["name"] == "WeatherQuery"
 
     # The rename must not cost the per-parameter descriptions the loop
     # exists to attach.
-    props = result["functions"][0]["parameters"]["properties"]
+    props = result["function"]["parameters"]["properties"]
     assert props["city"]["description"] == "The city to look up."
     assert props["units"]["description"] == "Temperature units."
+
+
+def test_no_legacy_envelope_round_trip():
+    """Emit modern tools shape directly; BaseTool must not unwrap/rewrap.
+
+    #1848: base_model_to_openai_function used to build
+    {function_call, functions:[…]} only for base_model_to_dict to peel
+    functions[0] and re-wrap as {type, function}. Both paths must now
+    share one modern schema with no envelope keys.
+    """
+    from swarms.tools.base_tool import BaseTool
+
+    helper = base_model_to_openai_function(TestModel)
+    via_tool = BaseTool().base_model_to_dict(TestModel)
+
+    assert helper == via_tool
+    assert "function_call" not in helper
+    assert "functions" not in helper
+    assert helper["type"] == "function"
+    assert helper["function"]["name"] == "TestModel"
+
+    multi = multi_base_model_to_openai_function([TestModel])
+    assert isinstance(multi, list)
+    assert multi[0] == helper
+    assert "function_call" not in multi[0]
+    assert "functions" not in multi[0]


### PR DESCRIPTION
## Problem

`base_model_to_openai_function` emitted the legacy `{"function_call", "functions"}` envelope, and `base_model_to_dict` immediately unpacked `functions[0]` and rewrapped it as `{"type": "function", "function": ...}`. Same peel happened again in `multi_base_model_to_openai_function`.

## Changes
- `base_model_to_openai_function` now returns `{"type": "function", "function": {"name", "description", "parameters"}}` directly
- `base_model_to_dict` is a thin wrapper around that (validation only)
- `multi_base_model_to_openai_function` returns a `list` of those schemas (was a `{function_call, functions}` dict — no in-tree callers)
- remove dead `*args`/`**kwargs` from `base_model_to_dict` (forwarding always raised; `B026`)

## Tests
- updated name assertion for the modern shape
- added `test_no_legacy_envelope_round_trip` (both paths return the same dict, no envelope keys)
- updated `test_base_model_to_dict` for the modern shape

Closes #1848