### PR TITLE
fix: preserve metadata in Conversation.add

### DIFF
--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -450,6 +450,7 @@ class Conversation:
         self,
         role: str,
         content: Union[str, dict, list, Any],
+        metadata: Optional[dict] = None,
         category: Optional[str] = None,
     ):
         """Add a message to the conversation history.
@@ -457,6 +458,7 @@ class Conversation:
         Args:
             role (str): The role of the speaker (e.g., 'User', 'System').
             content (Union[str, dict, list]): The content of the message to be added.
+            metadata (Optional[dict]): Optional metadata for the message.
             category (Optional[str]): Optional category for the message.
         """
         # Base message with role and timestamp
@@ -473,6 +475,9 @@ class Conversation:
 
         if category:
             message["category"] = category
+
+        if metadata:
+            message["metadata"] = metadata
 
         # Add message to conversation history
         self.conversation_history.append(message)
@@ -585,7 +590,10 @@ class Conversation:
             category (Optional[str]): Optional category for the message.
         """
         result = self.add_in_memory(
-            role=role, content=content, category=category
+            role=role,
+            content=content,
+            metadata=metadata,
+            category=category,
         )
 
         # Ensure autosave happens after the message is added

--- a/tests/structs/test_conversation.py
+++ b/tests/structs/test_conversation.py
@@ -859,6 +859,7 @@ def test_timestamp_format_in_history_string(tmp_path):
     conv = Conversation(
         time_enabled=True,
         dynamic_context_window=False,
+        save_filepath=str(tmp_path / "timestamp_1.json"),
         conversations_dir=str(tmp_path / "convs"),
     )
     conv.add("user", "Hello")
@@ -872,6 +873,7 @@ def test_no_timestamp_fallback(tmp_path):
     conv = Conversation(
         time_enabled=False,
         dynamic_context_window=False,
+        save_filepath=str(tmp_path / "timestamp_2.json"),
         conversations_dir=str(tmp_path / "convs"),
     )
     conv.add("user", "Hello")
@@ -884,6 +886,7 @@ def test_time_enabled_end_to_end(tmp_path):
     conv = Conversation(
         time_enabled=True,
         dynamic_context_window=False,
+        save_filepath=str(tmp_path / "timestamp_3.json"),
         conversations_dir=str(tmp_path / "convs"),
     )
     conv.add("user", "First")
@@ -898,6 +901,88 @@ def test_time_enabled_end_to_end(tmp_path):
         datetime.fromisoformat(ts)
 
 
+# ── Message Metadata Tests (Issue #1926) ──
+
+
+def test_add_message_with_metadata(tmp_path):
+    """Test that Conversation.add preserves message metadata."""
+    conv = Conversation(
+        name="test_add_metadata",
+        save_filepath=str(tmp_path / "metadata_1.json"),
+        conversations_dir=str(tmp_path / "convs"),
+    )
+    metadata = {"trace_id": "abc123", "cost": 0.01}
+    msg = conv.add("user", "Hello with metadata", metadata=metadata)
+    assert len(conv.conversation_history) == 1
+    assert conv.conversation_history[0]["metadata"] == metadata
+    assert msg["metadata"] == metadata
+    return True
+
+
+def test_add_message_with_metadata_and_category(tmp_path):
+    """Test that metadata and category coexist on stored message."""
+    conv = Conversation(
+        name="test_add_metadata_cat",
+        save_filepath=str(tmp_path / "metadata_2.json"),
+        conversations_dir=str(tmp_path / "convs"),
+    )
+    metadata = {"trace_id": "xyz789"}
+    msg = conv.add(
+        "user",
+        "Hello",
+        category="input",
+        metadata=metadata,
+    )
+    assert conv.conversation_history[0]["category"] == "input"
+    assert conv.conversation_history[0]["metadata"] == metadata
+    assert msg["category"] == "input"
+    assert msg["metadata"] == metadata
+    return True
+
+
+def test_add_message_metadata_serialization(tmp_path):
+    """Test that metadata is preserved across to_dict, to_json, and to_yaml."""
+    conv = Conversation(
+        name="test_add_metadata_ser",
+        save_filepath=str(tmp_path / "metadata_3.json"),
+        conversations_dir=str(tmp_path / "convs"),
+    )
+    metadata = {"source": "unit_test", "run_id": 42}
+    conv.add("user", "Test metadata serialization", metadata=metadata)
+
+    # to_dict
+    dict_res = conv.to_dict()
+    assert dict_res[0]["metadata"] == metadata
+
+    # to_json
+    json_res = conv.to_json()
+    assert '"metadata":' in json_res
+    assert '"source": "unit_test"' in json_res
+
+    # to_yaml
+    yaml_res = conv.to_yaml()
+    assert "metadata:" in yaml_res
+    assert "source: unit_test" in yaml_res
+    return True
+
+
+def test_add_message_empty_and_none_metadata(tmp_path):
+    """Test that empty or None metadata does not pollute message dict."""
+    conv = Conversation(
+        name="test_add_metadata_empty",
+        save_filepath=str(tmp_path / "metadata_4.json"),
+        conversations_dir=str(tmp_path / "convs"),
+    )
+    msg_none = conv.add("user", "None metadata", metadata=None)
+    assert "metadata" not in conv.conversation_history[0]
+    assert "metadata" not in msg_none
+
+    msg_empty = conv.add("user", "Empty metadata", metadata={})
+    assert "metadata" not in conv.conversation_history[1]
+    assert "metadata" not in msg_empty
+    return True
+
+
 def run_all_tests():
     """Run all test functions and return results."""
     logger.info("Starting test suite execution")
@@ -905,6 +990,10 @@ def run_all_tests():
     test_functions = [
         test_add_message,
         test_add_message_with_time,
+        test_add_message_with_metadata,
+        test_add_message_with_metadata_and_category,
+        test_add_message_metadata_serialization,
+        test_add_message_empty_and_none_metadata,
         test_delete_message,
         test_delete_message_out_of_bounds,
         test_update_message,


### PR DESCRIPTION
## What changed

Fixes #1926.

`Conversation.add()` accepted a `metadata` argument but silently discarded it because it was not forwarded to `add_in_memory()`.

This change:

- Adds optional `metadata` support to `add_in_memory()`
- Forwards metadata from `Conversation.add()`
- Persists metadata on the stored message
- Preserves existing category behavior
- Adds regression tests for metadata storage and serialization

## Tests

- `tests/structs/test_conversation.py`
- 55 tests passing

```bash
.venv/bin/pytest tests/structs/test_conversation.py -q
```

Result:
`55 passed`

## CI Note

The failing `Test Main Features`, `Python package`, and `Pyre` checks appear to be pre-existing repository CI issues and are also present on the upstream master branch.

The targeted Conversation test suite passes locally:
`55 passed`

Lint/formatting checks are also passing.