### PR TITLE
fix(agent-rearrange): isolate concurrent_run tasks

### DIFF
--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -944,7 +944,7 @@ class AgentRearrange(SerializableMixin):
         return self.run(task=task, *args, **kwargs)
 
     def _clone_for_task(self) -> "AgentRearrange":
-        """Build an isolated clone of this orchestrator for one batch_run task.
+        """Build an isolated clone of this orchestrator for one task.
 
         Each clone gets:
         - A fresh ``Conversation`` so per-task history does not bleed across
@@ -1088,8 +1088,14 @@ class AgentRearrange(SerializableMixin):
             The number of concurrent executions is limited by max_workers parameter.
             Each task runs independently through the full agent workflow.
         """
+
+        def run_isolated(task, *run_args, **run_kwargs):
+            return self._clone_for_task().run(
+                task, *run_args, **run_kwargs
+            )
+
         return run_concurrently(
-            self.run,
+            run_isolated,
             tasks,
             *args,
             img=img,

--- a/tests/structs/test_agent_rearrange.py
+++ b/tests/structs/test_agent_rearrange.py
@@ -1371,5 +1371,45 @@ class TestAgentContextManagement:
         ), f"the second task never reached the agent: {messages}"
 
 
+# ============================================================================
+# concurrent_run — task isolation
+# ============================================================================
+
+
+class TestConcurrentRunIsolation:
+    def test_each_task_gets_own_clone_conversation(self):
+        """concurrent_run tasks should not share the parent conversation."""
+        pipeline = _make_pipeline("AgentA", "AgentB")
+        tasks = ["alpha", "beta", "gamma"]
+        original_conversation = pipeline.conversation
+        original_msg_count = len(
+            original_conversation.conversation_history
+        )
+        seen_conversations: List[object] = []
+
+        def _mock_run(self_inner, task=None, img=None, *a, **kw):
+            seen_conversations.append(self_inner.conversation)
+            self_inner.conversation.add("user", task)
+            return f"result:{task}"
+
+        with patch.object(AgentRearrange, "_run", _mock_run):
+            results = pipeline.concurrent_run(
+                tasks=tasks,
+                max_workers=1,
+            )
+
+        assert results == [f"result:{task}" for task in tasks]
+        assert len(seen_conversations) == len(tasks)
+        assert all(
+            conversation is not original_conversation
+            for conversation in seen_conversations
+        )
+        assert len(set(map(id, seen_conversations))) == len(tasks)
+        assert (
+            len(original_conversation.conversation_history)
+            == original_msg_count
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Rebases this fix on top of the `execution_utils` refactor from #2012. `AgentRearrange.concurrent_run()` keeps using the shared `run_concurrently(...)` abstraction for task/image pairing, image-length validation, string-image handling, ordered result collection, `max_workers`, and argument forwarding.

This PR preserves the remaining AgentRearrange-specific invariant: each concurrent task invokes `run()` on a fresh `_clone_for_task()` orchestrator, so every task gets its own fresh orchestrator `Conversation` and the parent conversation is not reused as worker state.

The clone helper always creates a fresh `Conversation` and deep-copies agents where possible, with its existing fallback behavior unchanged.

## Issue

Fixes #1951

## Validation

- `pytest tests/structs/test_agent_rearrange.py::TestConcurrentRunIsolation -q` -> `1 passed`
- `pytest tests/structs/test_agent_rearrange.py -q --tb=short -ra` -> `62 passed, 9 failed`; the failure set matches clean upstream/master, which reports `61 passed, 9 failed`
- `pytest tests/structs/test_execution_utils.py -q --tb=short -ra` -> `43 passed`
- Black passed
- Ruff passed
- `git diff --check` passed
- `git show --check` passed

## Scope

This PR does not restore the pre-#2012 hand-written executor and does not duplicate image validation/order logic now owned by `execution_utils`.

This PR does not change the existing `*args` API behavior. That separate behavior is being addressed by #1891.

Dependencies: #2012