### PR TITLE
fix(majority-voting): validate agents and loop count

### DIFF
--- a/swarms/structs/majority_voting.py
+++ b/swarms/structs/majority_voting.py
@@ -152,8 +152,11 @@ class MajorityVoting:
 
     def reliability_check(self):
 
-        if self.agents is None:
-            raise ValueError("Agents list is empty")
+        if not self.agents:
+            raise ValueError("Agents list cannot be None or empty")
+
+        if self.max_loops <= 0:
+            raise ValueError("max_loops must be greater than 0")
 
         # Log the agents in a more formatted, readable way
         agent_list = "\n".join(

--- a/tests/structs/test_majority_voting.py
+++ b/tests/structs/test_majority_voting.py
@@ -174,6 +174,14 @@ def test_majority_voting_error_handling():
     except ValueError as e:
         assert "max_loops" in str(e).lower() or "0" in str(e)
 
+    try:
+        MajorityVoting(agents=[analyst], max_loops=-1)
+        assert (
+            False
+        ), "Should have raised ValueError for negative max_loops"
+    except ValueError as e:
+        assert "max_loops" in str(e).lower()
+
 
 def test_majority_voting_different_output_types():
     """Test MajorityVoting with different output types"""


### PR DESCRIPTION
## Description

Tightens `MajorityVoting.reliability_check()` validation so empty agent lists and non-positive `max_loops` values are rejected before voting begins.

Non-positive loop counts produce no voting iterations, so they are treated as invalid configuration.

## Issue

Fixes #1952

## Validation

- `pytest tests/structs/test_majority_voting.py -q --tb=short -ra` -> `6 passed`
- Black passed
- Ruff passed
- `git diff --check` passed

Dependencies: none