### PR TITLE
fix(social-algorithms): remove agents by name

### DIFF
--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -358,7 +358,14 @@ class SocialAlgorithms:
         Raises:
             AgentNotFoundError: If no agent with the given name is found.
         """
-        del self.agents[agent_name]
+        for index, agent in enumerate(self.agents):
+            if agent.agent_name == agent_name:
+                del self.agents[index]
+                break
+        else:
+            raise AgentNotFoundError(
+                f"No agent found with name: {agent_name}"
+            )
 
         if self.verbose:
             logger.info(f"Removed agent: {agent_name}")

--- a/tests/structs/test_social_algorithms.py
+++ b/tests/structs/test_social_algorithms.py
@@ -1,0 +1,58 @@
+import pytest
+
+from swarms.structs.agent import Agent
+from swarms.structs.social_algorithms import (
+    AgentNotFoundError,
+    SocialAlgorithms,
+)
+
+
+def _agent(name):
+    agent = Agent.__new__(Agent)
+    agent.agent_name = name
+    return agent
+
+
+def _social_algorithm_with_agents(agent_names):
+    social_algorithm = SocialAlgorithms.__new__(SocialAlgorithms)
+    social_algorithm.agents = [_agent(name) for name in agent_names]
+    social_algorithm.verbose = False
+    return social_algorithm
+
+
+def test_remove_agent_removes_matching_agent_by_name():
+    social_algorithm = _social_algorithm_with_agents(
+        ["researcher", "critic"]
+    )
+
+    social_algorithm.remove_agent("researcher")
+
+    assert [
+        agent.agent_name for agent in social_algorithm.agents
+    ] == ["critic"]
+
+
+def test_remove_agent_preserves_remaining_agent_order():
+    social_algorithm = _social_algorithm_with_agents(
+        ["planner", "researcher", "critic", "writer"]
+    )
+
+    social_algorithm.remove_agent("critic")
+
+    assert [
+        agent.agent_name for agent in social_algorithm.agents
+    ] == ["planner", "researcher", "writer"]
+
+
+def test_remove_agent_raises_agent_not_found_for_unknown_name():
+    social_algorithm = _social_algorithm_with_agents(["researcher"])
+
+    with pytest.raises(AgentNotFoundError):
+        social_algorithm.remove_agent("critic")
+
+
+def test_remove_agent_raises_agent_not_found_for_empty_agent_list():
+    social_algorithm = _social_algorithm_with_agents([])
+
+    with pytest.raises(AgentNotFoundError):
+        social_algorithm.remove_agent("researcher")


### PR DESCRIPTION
## Description

Fixes `SocialAlgorithms.remove_agent()` to search the agent list by `agent.agent_name`, remove the matching agent while preserving remaining order, and raise the existing `AgentNotFoundError` when no match exists.

## Issue

Fixes #1953

## Validation

- `pytest tests/structs/test_social_algorithms.py -q -vv --tb=short -ra` -> `4 passed`
- Black passed
- Ruff passed
- `git diff --check` passed

Dependencies: none