### PR TITLE
[Bug] Agent.max_tokens is overwritten in __init__, so setting it does nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ print(result)
 | `context_compression` | bool | `True` | Auto-summarise when near context limit (v12) |
 | `persistent_memory` | bool | `False` | Read/write MEMORY.md across restarts (v12); opt in explicitly |
 | `temperature` | float | `0.5` | Sampling temperature |
-| `max_tokens` | int | `16000` | Max tokens per LLM call. Note: currently overwritten during setup by the model's own limit, so passing it has no effect |
+| `max_tokens` | int | model's max output | Max tokens per LLM call. Unset resolves to the model's own output limit |
 | `reasoning_effort` | str | `None` | `"low"`, `"medium"`, `"high"` for reasoning models |
 | `thinking_tokens` | int | `None` | Extended thinking budget (Claude) |
 | `output_type` | str | `"str-all-except-first"` | How to format returned output |

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -345,7 +345,7 @@ class Agent:
         list_base_models: Optional[List[BaseModel]] = None,
         rules: str = None,  # type: ignore
         planning_prompt: Optional[str] = None,
-        max_tokens: int = 16000,
+        max_tokens: Optional[int] = None,
         temperature: float = 0.5,
         tags: Optional[List[str]] = None,
         auto_generate_prompt: bool = False,
@@ -526,7 +526,8 @@ class Agent:
         if self.context_length is None:
             self.context_length = self._default_context_length()
 
-        self.max_tokens = self._default_max_tokens() or 16000
+        if self.max_tokens is None or self.max_tokens <= 0:
+            self.max_tokens = self._default_max_tokens() or 16000
 
         if self.max_loops == "auto":
             self.system_prompt += (

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2515,6 +2515,43 @@ class TestContextLength:
         assert agent.context_length == 16000
 
 
+class TestMaxTokens:
+    """max_tokens must survive __init__, the way context_length already does."""
+
+    @staticmethod
+    def _agent(**kwargs):
+        with patch("swarms.structs.agent.LiteLLM"):
+            return Agent(
+                agent_name="tok_agent",
+                max_loops=1,
+                print_on=False,
+                verbose=False,
+                persistent_memory=False,
+                **kwargs,
+            )
+
+    def test_explicit_value_is_honoured(self):
+        """A caller capping output was overwritten with the model's own limit."""
+        agent = self._agent(model_name="gpt-4o-mini", max_tokens=500)
+
+        assert agent.max_tokens == 500
+
+    def test_default_uses_the_model_output_window(self):
+        agent = self._agent(model_name="gpt-4o-mini")
+
+        assert agent.max_tokens > 500
+
+    def test_non_positive_falls_back_to_the_model(self):
+        for bad in (0, -1, None):
+            agent = self._agent(model_name="gpt-4o-mini", max_tokens=bad)
+            assert agent.max_tokens > 0
+
+    def test_unknown_model_falls_back(self):
+        agent = self._agent(model_name="totally-made-up-model-xyz")
+
+        assert agent.max_tokens == 16000
+
+
 # ============================================================================
 # RELIABILITY CHECK WARNINGS
 # ============================================================================


### PR DESCRIPTION
## Problem

`Agent.__init__` stores the caller's value and then, about eighty lines later, throws it away:

```python
self.max_tokens = max_tokens            # line 450
...
self.max_tokens = self._default_max_tokens() or 16000   # line 529, unconditional
```

So the parameter has no effect:

```
asked for 500 -> 16384
unset         -> 16384
```

Anyone capping output for cost, latency, or a downstream length limit gets the model's full output window instead, with no warning. `CLAUDE.md` currently documents the symptom — *"currently overwritten during setup by the model's own limit, so passing it has no effect"* — which is how I found it.

`context_length` had exactly this bug and was fixed; `max_tokens` is the same line pattern two statements down and was missed.

## Fix

The model default applies only when nothing usable was supplied:

```python
if self.max_tokens is None or self.max_tokens <= 0:
    self.max_tokens = self._default_max_tokens() or 16000
```

The parameter default moves from `16000` to `None` so "unset" is distinguishable from a deliberate `16000`. Nothing else needed to change: `reliability_check` already treats `None`/non-positive as "resolve from the model", and `self.max_tokens` is still always an int by the end of `__init__`.

After:

```
asked for 500 -> 500
unset         -> 16384
zero          -> 16384
explicit None -> 16384
```

An agent that never touched `max_tokens` resolves to the same value it does today, so the default path is unchanged.

## Tests

`TestMaxTokens` sits beside the existing `TestContextLength` in `tests/structs/test_agent.py` and mirrors it: explicit value honoured, unset sizes to the model, non-positive and `None` fall back, unknown model falls back to 16000 without raising.

The first fails on master:

```
FAILED tests/structs/test_agent.py::TestMaxTokens::test_explicit_value_is_honoured
```

File goes from `19 failed, 74 passed, 8 errors` on master to `19 failed, 78 passed, 8 errors` here — same failures, plus the four new tests. Those 19 need provider credentials.

`CLAUDE.md`'s parameter table is updated, since the note there described the bug as intended behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)