### PR TITLE
[Bug] Agent.saved_state_path is discarded, so state lands in a random file

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -434,10 +434,10 @@ class Agent:
         self.system_prompt = system_prompt or ""
         self.agent_name = agent_name
         self.agent_description = agent_description
-        # self.saved_state_path = f"{self.agent_name}_{generate_api_key(prefix='agent-')}_state.json"
-        self.saved_state_path = (
-            f"{generate_api_key(prefix='agent-')}_state.json"
-        )
+        if not self.saved_state_path:
+            self.saved_state_path = (
+                f"{generate_api_key(prefix='agent-')}_state.json"
+            )
         self.autosave = autosave
         self.multi_modal = multi_modal
         self.tokenizer = tokenizer

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -2557,6 +2557,41 @@ class TestMaxTokens:
         assert agent.max_tokens == 16000
 
 
+class TestSavedStatePath:
+    """saved_state_path must survive __init__ instead of being overwritten."""
+
+    @staticmethod
+    def _agent(**kwargs):
+        with patch("swarms.structs.agent.LiteLLM"):
+            return Agent(
+                agent_name="state_agent",
+                model_name="gpt-4o-mini",
+                max_loops=1,
+                print_on=False,
+                verbose=False,
+                persistent_memory=False,
+                **kwargs,
+            )
+
+    def test_explicit_path_is_honoured(self):
+        """The constructor argument was replaced with a generated filename."""
+        agent = self._agent(saved_state_path="my_agent_state.json")
+
+        assert agent.saved_state_path == "my_agent_state.json"
+
+    def test_unset_path_still_gets_a_generated_one(self):
+        agent = self._agent()
+
+        assert agent.saved_state_path.startswith("agent-")
+        assert agent.saved_state_path.endswith("_state.json")
+
+    def test_two_agents_without_a_path_do_not_collide(self):
+        first = self._agent().saved_state_path
+        second = self._agent().saved_state_path
+
+        assert first != second
+
+
 # ============================================================================
 # RELIABILITY CHECK WARNINGS
 # ============================================================================


### PR DESCRIPTION
## Problem

`__init__` accepts `saved_state_path`, assigns it, and twelve lines later overwrites it unconditionally:

```python
self.saved_state_path = saved_state_path          # line 418
...
self.saved_state_path = (                          # line 430
    f"{generate_api_key(prefix='agent-')}_state.json"
)
```

```
asked for 'my_agent_state.json' -> agent-YEkRWEc0j03dYmtPZFRKAO6HBLMreYyV_state.json
```

`save()` reads that attribute:

```python
resolved_path = file_path or self.saved_state_path or f"{self.agent_name}_state.json"
```

so an agent configured with a specific state file autosaves somewhere else entirely, and every construction generates a fresh name, leaving another orphan `agent-<random>_state.json` in the workspace on each run.

Same shape as the `max_tokens` overwrite in #1957; this is a different attribute twenty lines up, so it is a separate fix.

## Fix

Generate only when the caller supplied nothing.

```
explicit -> my_agent_state.json
unset    -> agent-6CzeWOuLOS1u…
```

## Scope — what this does *not* fix

An earlier version of this description claimed the save/load round trip works after this change. It does not, and @kyegomez was right to call that out. Two further defects sit in `load()` and are **pre-existing and independent of this diff**:

- `load()` (`agent.py:2452`) builds `f"{self.saved_state_path}.json"` unconditionally, so a path that already ends in `.json` becomes `my_agent_state.json.json`; and it never joins the agent workspace directory, while `save()` does. So `save()` writes `agent_workspace/agents/<agent>/my_agent_state.json` and `load()` looks for `my_agent_state.json.json` in the process cwd.
- `_get_agent_workspace_dir()` keys the directory on `self.id`, which is random per construction unless the caller passes `id=`, so a restarted agent lands in a new directory regardless of the filename.

Both are filed separately as #1994 rather than folded in here — they are a different bug (path construction), they need `save()` and `load()` to share one resolver, and this PR is a one-line guard that stands on its own.

What this PR fixes is exactly: the attribute the caller passed survives `__init__`, so `save()` writes where they asked.

## Tests

`TestSavedStatePath` in `tests/structs/test_agent.py`: explicit path honoured, unset still gets a generated name in the existing format, and two agents without a path still get distinct names — that last one is why the generated fallback cannot simply be keyed on `agent_name`.

The first fails on master:

```
FAILED tests/structs/test_agent.py::TestSavedStatePath::test_explicit_path_is_honoured
```

Rebased on `07f3bd39`. Failure set in `tests/structs/test_agent.py` is byte-identical to master (27 pre-existing failures/errors, diffed), plus the three new tests passing. `black==24.2.0 --check` clean.

The dead commented-out line above the assignment (an older `agent_name`-prefixed variant) is removed with it.