### PR TITLE
[Bug][Feat] Autonomous loop: structured transcript, mutable plan, and five correctness fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contribution Guidelines
+# Contributing to Swarms
 
 <div align="left">
   <a href="https://swarms.world">
@@ -10,363 +10,153 @@
   <em>The Enterprise-Grade Production-Ready Multi-Agent Orchestration Framework</em>
 </p>
 
+Swarms makes it simple to orchestrate agents to automate real-world work. Contributions of every size are welcome — the fastest way in is a `good first issue`.
 
-## Project Overview
+| Where to help | What it looks like |
+|---|---|
+| Tests | Cover existing code in `swarms/`, add edge cases and integration tests |
+| Docs | Fix docstrings, add examples to `examples/`, expand `docs/` |
+| Swarm architectures | New multi-agent orchestration methods in `swarms/structs/` |
+| Agents | New or improved specialized agents (finance, medical, code, research) |
+| Cleanup | Delete dead code, remove duplicate implementations, simplify functions |
+| Performance | Faster, cheaper swarm execution |
 
-**Swarms** is an enterprise-grade, production-ready multi-agent orchestration framework focused on making it simple to orchestrate agents to automate real-world activities. The goal is to automate the world economy with these swarms of agents.
-
-### Key Features
-
-| Category | Features | Benefits |
-|----------|----------|-----------|
-| 🏢 Enterprise Architecture | • Production-Ready Infrastructure<br>• High Reliability Systems<br>• Modular Design<br>• Comprehensive Logging | • Reduced downtime<br>• Easier maintenance<br>• Better debugging<br>• Enhanced monitoring |
-| 🤖 Agent Orchestration | • Hierarchical Swarms<br>• Parallel Processing<br>• Sequential Workflows<br>• Graph-based Workflows<br>• Dynamic Agent Rearrangement | • Complex task handling<br>• Improved performance<br>• Flexible workflows<br>• Optimized execution |
-| 🔄 Integration Capabilities | • Multi-Model Support<br>• Custom Agent Creation<br>• Extensive Tool Library<br>• Multiple Memory Systems | • Provider flexibility<br>• Custom solutions<br>• Extended functionality<br>• Enhanced memory management |
-
-### We Need Your Help To:
-
-- **Write Tests**: Ensure the reliability and correctness of the codebase
-- **Improve Documentation**: Maintain clear and comprehensive documentation
-- **Add New Orchestration Methods**: Add multi-agent orchestration methods
-- **Remove Defunct Code**: Clean up and remove bad code
-- **Enhance Agent Capabilities**: Improve existing agents and add new ones
-- **Optimize Performance**: Improve speed and efficiency of swarm operations
-
-Your contributions will help us push the boundaries of AI and make this library a valuable resource for the community.
+- [Good First Issues](https://github.com/kyegomez/swarms/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) · [Contributing Board](https://github.com/users/kyegomez/projects/1)
 
 ---
 
-## Getting Started
-
-### Installation
-
-#### Using pip
-```bash
-pip3 install -U swarms
-```
-
-#### Using uv (Recommended)
-[uv](https://github.com/astral-sh/uv) is a fast Python package installer and resolver, written in Rust.
+## Setup
 
 ```bash
-# Install uv
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Install swarms using uv
-uv pip install swarms
-```
-
-#### Using poetry
-```bash
-# Install poetry if you haven't already
-curl -sSL https://install.python-poetry.org | python3 -
-
-# Add swarms to your project
-poetry add swarms
-```
-
-#### From source
-```bash
-# Clone the repository
 git clone https://github.com/kyegomez/swarms.git
 cd swarms
-
-# Install with pip
-pip install -e .
+pip install -e .          # or: uv pip install -e .
 ```
 
-### Environment Configuration
-
-Create a `.env` file in your project root with the following variables:
+Create a `.env` in the project root:
 
 ```bash
 OPENAI_API_KEY=""
-WORKSPACE_DIR="agent_workspace"
 ANTHROPIC_API_KEY=""
 GROQ_API_KEY=""
+WORKSPACE_DIR="agent_workspace"
 ```
 
-- [Learn more about environment configuration here](https://docs.swarms.world/environment-setup)
+[Environment setup docs →](https://docs.swarms.world/environment-setup)
 
-### Project Structure
-
-- **`swarms/`**: Contains all the source code for the library
-  - **`agents/`**: Agent implementations and base classes
-  - **`structs/`**: Swarm orchestration structures (SequentialWorkflow, AgentRearrange, etc.)
-  - **`tools/`**: Tool implementations and base classes
-  - **`prompts/`**: System prompts and prompt templates
-  - **`utils/`**: Utility functions and helpers
-- **`examples/`**: Includes example scripts and notebooks demonstrating how to use the library
-- **`tests/`**: Unit tests for the library
-- **`docs/`**: Documentation files and guides
+**Layout**: `swarms/agents/` (agents) · `swarms/structs/` (swarms + workflows) · `swarms/tools/` · `swarms/prompts/` · `swarms/utils/` · `examples/` · `tests/` (mirrors `swarms/`) · `docs/`
 
 ---
 
-## How to Contribute
+## Reporting Issues
 
-### Reporting Issues
+Search existing issues first. If it's new, open a [Bug Report](https://github.com/kyegomez/swarms/issues/new?template=bug_report.md) or [Feature Request](https://github.com/kyegomez/swarms/issues/new?template=feature_request.md) with a concise title, steps to reproduce, expected vs. actual behavior, and logs. Label it appropriately.
 
-If you find any bugs, inconsistencies, or have suggestions for enhancements, please open an issue on GitHub:
+---
 
-1. **Search Existing Issues**: Before opening a new issue, check if it has already been reported.
-2. **Open a New Issue**: If it hasn't been reported, create a new issue and provide detailed information.
-   - **Title**: A concise summary of the issue.
-   - **Description**: Detailed description, steps to reproduce, expected behavior, and any relevant logs or screenshots.
-3. **Label Appropriately**: Use labels to categorize the issue (e.g., bug, enhancement, documentation).
+## Pull Requests
 
-**Issue Templates**: Use our issue templates for bug reports and feature requests:
-- [Bug Report](https://github.com/kyegomez/swarms/issues/new?template=bug_report.md)
-- [Feature Request](https://github.com/kyegomez/swarms/issues/new?template=feature_request.md)
+```bash
+git checkout -b fix/short-description
+# make the change, add a test
+pytest tests/
+git commit -am "Fix X in Y"
+git push origin fix/short-description
+```
 
-### Submitting Pull Requests
+Then open the PR against `master`, describe the problem it solves, and link the issue (`Fixes #1234`).
 
-We welcome pull requests (PRs) for bug fixes, improvements, and new features. Please follow these guidelines:
+### Keep PRs short and simple
 
-1. **Fork the Repository**: Create a personal fork of the repository on GitHub.
-2. **Clone Your Fork**: Clone your forked repository to your local machine.
+Review capacity is the bottleneck. PR size is the biggest factor in how fast your work merges — a small, obvious PR merges in hours; a large one can sit for weeks.
 
-   ```bash
-   git clone https://github.com/kyegomez/swarms.git
-   cd swarms
-   ```
+**Scope**
 
-3. **Create a New Branch**: Use a descriptive branch name.
+- One PR, one change: one bug fix, one feature, or one refactor. Find a second problem? Open a second PR.
+- Fewer files is better. **Multi-file PRs take significantly longer to review** — the reviewer has to hold the whole change at once.
+- Split large work into a sequence of small PRs that each stand alone and each leave the codebase working.
+- No drive-by changes: don't mix reformatting, renames, dependency bumps, or unrelated cleanups into a functional PR.
+- Don't reformat files you're editing. Change only the lines you need to; whitespace churn hides the real fix.
 
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+**Size**
 
-4. **Make Your Changes**: Implement your code, ensuring it adheres to the coding standards.
-5. **Add Tests**: Write tests to cover your changes.
-6. **Commit Your Changes**: Write clear and concise commit messages.
+| Diff | Expectation |
+|---|---|
+| < ~100 lines | Ideal — reviewed quickly |
+| 100–300 lines | Fine if it's one coherent change |
+| > ~300 lines | Slow review, or a request to split |
+| Many unrelated files | Likely asked to split before review |
 
-   ```bash
-   git commit -am "Add feature X"
-   ```
+**Code**
 
-7. **Push to Your Fork**:
+- Smallest change that fixes the problem. Don't rewrite code you happen to be near.
+- Reuse what exists instead of adding a parallel implementation.
+- No speculative abstraction — no options or hooks for cases nobody asked for.
+- No new dependencies unless unavoidable; justify them in the description.
+- Delete dead code rather than deprecating it, in its own PR.
 
-   ```bash
-   git push origin feature/your-feature-name
-   ```
+**Before opening**
 
-8. **Create a Pull Request**:
+- [ ] Diff contains only changes related to the stated purpose
+- [ ] No large comment blocks or commented-out code
+- [ ] Test added; `pytest tests/` passes
+- [ ] `black` / `flake8` clean, no unrelated reformatting
+- [ ] Description explains the problem and links the issue
 
-   - Go to the original repository on GitHub.
-   - Click on "New Pull Request".
-   - Select your branch and create the PR.
-   - Provide a clear description of your changes and reference any related issues.
-
-9. **Respond to Feedback**: Be prepared to make changes based on code reviews.
-
-**Note**: It's recommended to create small and focused PRs for easier review and faster integration.
-
-### Good First Issues
-
-The easiest way to contribute is to pick any issue with the `good first issue` tag 💪. These are specifically designed for new contributors:
-
-- [Good First Issues](https://github.com/kyegomez/swarms/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-- [Contributing Board](https://github.com/users/kyegomez/projects/1) - Participate in Roadmap discussions!
+A small, focused PR merges faster than a large one — even when the large one is better work.
 
 ---
 
 ## Coding Standards
 
-To maintain code quality and consistency, please adhere to the following standards.
+- **Type annotations** on every function and method.
+- **Docstrings** on every public class, function, and method ([Google style](http://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) or [NumPy](https://numpydoc.readthedocs.io/en/latest/format.html)): description, `Args`, `Returns`, `Raises`.
+- **Tests** for every feature and bug fix, in `tests/` mirroring `swarms/`. Run with `pytest tests/`.
+- **Style**: PEP 8, enforced with `black` and `flake8`. Match the surrounding code.
+- **Docs**: update `docs/` when you change the public API.
 
-### Type Annotations
+### Comments
 
-- **Mandatory**: All functions and methods must have type annotations.
-- **Example**:
+Write code that explains itself; comment only what it can't.
 
-  ```python
-  def add_numbers(a: int, b: int) -> int:
-      return a + b
-  ```
+- **No multi-line comment blocks** — no banners, section dividers, ASCII art, or multi-paragraph explanations. Explanation belongs in the docstring.
+- One short line for a non-obvious decision is the right size.
+- No commented-out code — git history keeps it.
+- Don't restate the code (`# loop over agents` above a `for` loop).
 
-- **Benefits**:
-  - Improves code readability.
-  - Helps with static type checking tools.
+```python
+# Bad — a block that restates the code and goes stale
+# ------------------------------------------------------------
+# This function takes a list of agents and runs each of them
+# against the provided task, collecting the results into a
+# list which is then returned to the caller.
+# ------------------------------------------------------------
+def run_all(agents: List[Agent], task: str) -> List[str]:
+    return [agent.run(task) for agent in agents]
 
-### Docstrings and Documentation
-
-- **Docstrings**: Every public class, function, and method must have a docstring following the [Google Python Style Guide](http://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) or [NumPy Docstring Standard](https://numpydoc.readthedocs.io/en/latest/format.html).
-- **Content**:
-  - **Description**: Briefly describe what the function or class does.
-  - **Args**: List and describe each parameter.
-  - **Returns**: Describe the return value(s).
-  - **Raises**: List any exceptions that are raised.
-
-- **Example**:
-
-  ```python
-  def calculate_mean(values: List[float]) -> float:
-      """
-      Calculates the mean of a list of numbers.
-
-      Args:
-          values (List[float]): A list of numerical values.
-
-      Returns:
-          float: The mean of the input values.
-
-      Raises:
-          ValueError: If the input list is empty.
-      """
-      if not values:
-          raise ValueError("The input list is empty.")
-      return sum(values) / len(values)
-  ```
-
-- **Documentation**: Update or create documentation pages if your changes affect the public API.
-
-### Testing
-
-- **Required**: All new features and bug fixes must include appropriate unit tests.
-- **Framework**: Use `unittest`, `pytest`, or a similar testing framework.
-- **Test Location**: Place tests in the `tests/` directory, mirroring the structure of `swarms/`.
-- **Test Coverage**: Aim for high test coverage to ensure code reliability.
-- **Running Tests**: Provide instructions for running tests.
-
-  ```bash
-  pytest tests/
-  ```
-
-### Code Style
-
-- **PEP 8 Compliance**: Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guidelines.
-- **Linting Tools**: Use `flake8`, `black`, or `pylint` to check code style.
-- **Consistency**: Maintain consistency with the existing codebase.
+# Good — docstring for the contract, a comment only for the surprise
+def run_all(agents: List[Agent], task: str) -> List[str]:
+    """Run ``task`` on each agent and return their outputs in order."""
+    # Sequential on purpose: agents share a rate-limited client.
+    return [agent.run(task) for agent in agents]
+```
 
 ---
 
-## Areas Needing Contributions
+## Resources
 
-We have several areas where contributions are particularly welcome.
+| | |
+|---|---|
+| Docs | [docs.swarms.world](https://docs.swarms.world) · [Quickstart](https://docs.swarms.world/quickstart) · [Agent API](https://docs.swarms.world/api/agent) |
+| Examples | [examples/](https://github.com/kyegomez/swarms/tree/master/examples) — [single_agent](https://github.com/kyegomez/swarms/tree/master/examples/single_agent), [multi_agent](https://github.com/kyegomez/swarms/tree/master/examples/multi_agent), [tools](https://github.com/kyegomez/swarms/tree/master/examples/tools) |
+| Architectures | [SequentialWorkflow](https://docs.swarms.world/api/sequential-workflow) · [AgentRearrange](https://docs.swarms.world/api/agent-rearrange) · [MixtureOfAgents](https://docs.swarms.world/api/mixture-of-agents) · [GraphWorkflow](https://docs.swarms.world/api/graph-workflow) · [GroupChat](https://docs.swarms.world/api/group-chat) · [SwarmRouter](https://docs.swarms.world/api/swarm-router) |
+| Community | [Discord](https://discord.gg/EamjgSaEQf) · [Twitter](https://twitter.com/kyegomez) · [LinkedIn](https://www.linkedin.com/company/the-swarm-corporation) · [YouTube](https://www.youtube.com/channel/UC9yXyitkbU_WSy7bd_41SqQ) · [Events](https://lu.ma/swarms_calendar) · [Blog](https://medium.com/@kyeg) |
+| Onboarding | [Book a session with the maintainer](https://cal.com/swarms/swarms-onboarding-session) |
 
-### Writing Tests
-
-- **Goal**: Increase test coverage to ensure the library's robustness.
-- **Tasks**:
-  - Write unit tests for existing code in `swarms/`.
-  - Identify edge cases and potential failure points.
-  - Ensure tests are repeatable and independent.
-  - Add integration tests for swarm orchestration methods.
-
-### Improving Documentation
-
-- **Goal**: Maintain clear and comprehensive documentation for users and developers.
-- **Tasks**:
-  - Update docstrings to reflect any changes.
-  - Add examples and tutorials in the `examples/` directory.
-  - Improve or expand the content in the `docs/` directory.
-  - Create video tutorials and walkthroughs.
-
-### Adding New Swarm Architectures
-
-- **Goal**: Provide new multi-agent orchestration methods.
-- **Current Architectures**:
-  - [SequentialWorkflow](https://docs.swarms.world/api/sequential-workflow)
-  - [AgentRearrange](https://docs.swarms.world/api/agent-rearrange)
-  - [MixtureOfAgents](https://docs.swarms.world/api/mixture-of-agents)
-  - [SpreadSheetSwarm](https://docs.swarms.world/api/spreadsheet-swarm)
-  - [ForestSwarm](https://docs.swarms.world/api/forest-swarm)
-  - [GraphWorkflow](https://docs.swarms.world/api/graph-workflow)
-  - [GroupChat](https://docs.swarms.world/api/group-chat)
-  - [SwarmRouter](https://docs.swarms.world/api/swarm-router)
-
-### Enhancing Agent Capabilities
-
-- **Goal**: Improve existing agents and add new specialized agents.
-- **Areas of Focus**:
-  - Financial analysis agents
-  - Medical diagnosis agents
-  - Code generation and review agents
-  - Research and analysis agents
-  - Creative content generation agents
-
-### Removing Defunct Code
-
-- **Goal**: Clean up and remove bad code to improve maintainability.
-- **Tasks**:
-  - Identify unused or deprecated code.
-  - Remove duplicate implementations.
-  - Simplify complex functions.
-  - Update outdated dependencies.
+Be respectful, give and take feedback openly, and collaborate. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ---
 
-## Development Resources
-
-### Documentation
-
-- **Official Documentation**: [docs.swarms.world](https://docs.swarms.world)
-- **Installation Guide**: [Installation](https://docs.swarms.world/installation)
-- **Quickstart Guide**: [Get Started](https://docs.swarms.world/quickstart)
-- **Agent Architecture**: [Agent Internal Mechanisms](https://docs.swarms.world/concepts/agents)
-- **Agent API**: [Agent API](https://docs.swarms.world/api/agent)
-
-### Examples and Tutorials
-
-- **Basic Examples**: [examples/](https://github.com/kyegomez/swarms/tree/master/examples)
-- **Agent Examples**: [examples/single_agent/](https://github.com/kyegomez/swarms/tree/master/examples/single_agent)
-- **Multi-Agent Examples**: [examples/multi_agent/](https://github.com/kyegomez/swarms/tree/master/examples/multi_agent)
-- **Tool Examples**: [examples/tools/](https://github.com/kyegomez/swarms/tree/master/examples/tools)
-
-### API Reference
-
-- **Core Classes**: [swarms/structs/](https://github.com/kyegomez/swarms/tree/master/swarms/structs)
-- **Agent Implementations**: [swarms/agents/](https://github.com/kyegomez/swarms/tree/master/swarms/agents)
-- **Tool Implementations**: [swarms/tools/](https://github.com/kyegomez/swarms/tree/master/swarms/tools)
-- **Utility Functions**: [swarms/utils/](https://github.com/kyegomez/swarms/tree/master/swarms/utils)
-
----
-
-## Community and Support
-
-### Connect With Us
-
-| Platform | Link | Description |
-|----------|------|-------------|
-| 📚 Documentation | [docs.swarms.world](https://docs.swarms.world) | Official documentation and guides |
-| 📝 Blog | [Medium](https://medium.com/@kyeg) | Latest updates and technical articles |
-| 💬 Discord | [Join Discord](https://discord.gg/EamjgSaEQf) | Live chat and community support |
-| 🐦 Twitter | [@kyegomez](https://twitter.com/kyegomez) | Latest news and announcements |
-| 👥 LinkedIn | [The Swarm Corporation](https://www.linkedin.com/company/the-swarm-corporation) | Professional network and updates |
-| 📺 YouTube | [Swarms Channel](https://www.youtube.com/channel/UC9yXyitkbU_WSy7bd_41SqQ) | Tutorials and demos |
-| 🎫 Events | [Sign up here](https://lu.ma/swarms_calendar) | Join our community events |
-
-### Onboarding Session
-
-Get onboarded with the creator and lead maintainer of Swarms, Kye Gomez, who will show you how to get started with the installation, usage examples, and starting to build your custom use case! [CLICK HERE](https://cal.com/swarms/swarms-onboarding-session)
-
-### Community Guidelines
-
-- **Communication**: Engage with the community by participating in discussions on issues and pull requests.
-- **Respect**: Maintain a respectful and inclusive environment.
-- **Feedback**: Be open to receiving and providing constructive feedback.
-- **Collaboration**: Work together to improve the project for everyone.
-
----
-
-## License
-
-By contributing to swarms, you agree that your contributions will be licensed under the [Apache License](LICENSE).
-
----
-
-## Citation
-
-If you use **swarms** in your research, please cite the project by referencing the metadata in [CITATION.cff](./CITATION.cff).
-
----
-
-Thank you for contributing to swarms! Your efforts help make this project better for everyone.
-
-If you have any questions or need assistance, please feel free to:
-- Open an issue on GitHub
-- Join our Discord community
-- Reach out to the maintainers
-- Schedule an onboarding session
+Contributions are licensed under the [Apache License](LICENSE). If you use Swarms in research, cite it via [CITATION.cff](./CITATION.cff).
 
 **Happy contributing! 🚀**

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,638 @@
+---
+name: swarms
+description: Build agents and multi-agent systems with the Swarms framework — the Agent class, tools, autonomous loops, memory, and the 15+ multi-agent architectures (SequentialWorkflow, ConcurrentWorkflow, GraphWorkflow, HierarchicalSwarm, SwarmRouter, and more). Use whenever writing, reviewing, or debugging code that imports `swarms`.
+---
+
+# Swarms
+
+Swarms is a multi-agent orchestration framework. Everything is built from one primitive — `Agent` — which multi-agent structures compose. This document is verified against **swarms v14.0.0**.
+
+## Golden rules
+
+1. **Import from the top level**: `from swarms import Agent`, never `from swarms.structs.agent import Agent`. The one common exception is `PlannerWorkerSwarm` (see below).
+2. **Every agent needs a unique `agent_name`** — memory files and swarm routing key on it.
+3. **Default to `max_loops=1`.** Use a specific integer for production. Use `"auto"` only for genuinely open-ended work.
+4. **Pass `tools=None`, not `tools=[]`.** An empty list breaks schema generation.
+5. **Check `examples/`** — 586 runnable examples live there. One is probably close to what you need.
+6. **Never set `streaming_on=True` and `streaming_callback` together.** Pick one.
+
+## Setup
+
+```bash
+pip install -U swarms
+```
+
+Set the key for whichever provider you use — any [LiteLLM](https://docs.litellm.ai/docs/providers) model string works:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export ANTHROPIC_API_KEY="sk-ant-..."
+export GROQ_API_KEY="..."
+export WORKSPACE_DIR="agent_workspace"   # where agent state and memory land
+```
+
+---
+
+# Part 1 — The Agent
+
+```python
+from swarms import Agent
+
+agent = Agent(
+    agent_name="Analyst",
+    agent_description="Analyzes market data and produces summaries.",
+    system_prompt="You are a precise financial analyst.",
+    model_name="gpt-5.4",
+    max_loops=1,
+)
+
+result = agent.run("Summarize the state of the semiconductor market.")
+```
+
+`Agent.__init__` accepts 90+ parameters. These are the ones that matter:
+
+| Parameter | Type | Default | Purpose |
+|---|---|---|---|
+| `agent_name` | `str` | `"swarm-worker-01"` | Unique identity; keys memory + routing |
+| `agent_description` | `str` | generic | How orchestrators decide to route to it |
+| `system_prompt` | `str` | built-in | Persona and instructions |
+| `model_name` | `str` | `"gpt-5.4"` | Any LiteLLM model string |
+| `max_loops` | `int \| "auto"` | `1` | Iterations, or autonomous mode |
+| `tools` | `list[Callable]` | `None` | Python functions the agent may call |
+| `temperature` | `float` | `0.5` | Sampling temperature |
+| `max_tokens` | `int` | model max | Output cap per call |
+| `top_p` | `float` | `None` | Nucleus sampling |
+| `context_length` | `int` | `None` | Token budget; triggers compression at 90% |
+| `output_type` | `str` | `"str-all-except-first"` | Return shape — see below |
+| `streaming_on` | `bool` | `False` | Stream tokens to stdout |
+| `streaming_callback` | `Callable` | `None` | Stream tokens to your function |
+| `interactive` | `bool` | `False` | REPL — prompts the user each loop |
+| `verbose` | `bool` | `False` | Debug logging |
+| `print_on` | `bool` | `True` | Print the final output |
+| `autosave` | `bool` | `False` | Persist agent state after each run |
+| `retry_attempts` | `int` | `3` | LLM call retries |
+| `reasoning_effort` | `str` | `"medium"` | `minimal`/`low`/`medium`/`high`/`xhigh`/`ultra`/`max`/`none` |
+| `thinking_tokens` | `int` | `1024` | Extended thinking budget (Claude) |
+| `mcp_url` / `mcp_urls` | `str` / `list[str]` | `None` | MCP servers to load tools from |
+| `handoffs` | `list[Agent]` | `None` | Agents this one may delegate to |
+| `persistent_memory` | `bool` | `False` | Read/write `MEMORY.md` across restarts |
+| `context_compression` | `bool` | `True` | Auto-summarize near the context limit |
+| `plan_enabled` | `bool` | `False` | Plan before executing |
+| `mode` | `str` | `"standard"` | `"standard"`, `"fast"`, `"interactive"` |
+| `fallback_models` | `list[str]` | `None` | Models to try if the primary fails |
+
+**`output_type` options**: `"str"`, `"list"`, `"dict"`, `"json"`, `"yaml"`, `"xml"`, `"final"`, `"last"`, `"all"`, `"basemodel"`, `"str-all-except-first"`, `"dict-all-except-first"`, `"dict-final"`, `"list-final"`.
+
+### Running
+
+```python
+agent.run(task="...")                          # standard
+agent.run(task="...", img="chart.png")         # one image
+agent.run(task="...", imgs=["a.png", "b.png"]) # several images
+agent.run(task="...", n=3)                     # 3 independent samples
+await agent.arun("...")                        # async
+```
+
+`Agent.run` signature: `run(task=None, img=None, imgs=None, correct_answer=None, streaming_callback=None, n=1)`.
+
+### Streaming
+
+```python
+# To stdout
+agent = Agent(agent_name="Writer", model_name="gpt-5.4", streaming_on=True)
+agent.run("Write a haiku about distributed systems.")
+
+# To a callback (do NOT combine with streaming_on)
+def on_token(token: str) -> None:
+    print(token, end="", flush=True)
+
+agent = Agent(agent_name="Writer", model_name="gpt-5.4", streaming_callback=on_token)
+agent.run("Write a haiku.")
+
+# Async streaming
+async for token in agent.arun_stream("Explain async/await."):
+    print(token, end="", flush=True)
+```
+
+---
+
+# Part 2 — Tools
+
+Any Python function with type hints and a docstring becomes a tool. The framework generates the OpenAI function schema automatically — **the docstring is the tool description the model reads, so write it for the model.**
+
+```python
+from swarms import Agent
+
+def get_stock_price(ticker: str) -> str:
+    """Fetch the current stock price for a ticker symbol.
+
+    Args:
+        ticker: Stock ticker symbol, e.g. 'AAPL'.
+
+    Returns:
+        The current price as a formatted string.
+    """
+    import yfinance as yf
+    return f"{ticker}: ${yf.Ticker(ticker).fast_info['last_price']:.2f}"
+
+agent = Agent(
+    agent_name="StockAnalyst",
+    model_name="gpt-5.4",
+    tools=[get_stock_price],
+    max_loops=3,          # needs > 1 so it can act on the tool result
+)
+agent.run("What are Apple and Microsoft trading at?")
+```
+
+**`max_loops` must exceed 1 for tool use** — loop 1 calls the tool, loop 2 uses the result.
+
+Related knobs: `tool_call_summary=True` (summarize tool output), `show_tool_execution_output=True` (print raw returns), `tool_retry_attempts` (retries on tool failure).
+
+### MCP servers
+
+```python
+agent = Agent(
+    agent_name="MCPAgent",
+    model_name="gpt-5.4",
+    mcp_url="http://localhost:8000/sse",
+    # or: mcp_urls=["http://localhost:8000/sse", "http://localhost:8001/sse"]
+    max_loops=3,
+)
+```
+
+Inspect what a server exposes before wiring it up:
+
+```python
+from swarms.tools.mcp_manager import MCPManager
+
+mgr = MCPManager(mcp_url="http://localhost:8000/sse")
+print(mgr.list_tool_names())
+schemas = mgr.get_tools()          # aget_tools() for the async form
+```
+
+### Handoffs
+
+Give an agent a roster it can delegate to. It receives a `handoff_task` tool automatically.
+
+```python
+triage = Agent(
+    agent_name="Triage",
+    model_name="gpt-5.4",
+    handoffs=[billing_agent, technical_agent, refunds_agent],
+    max_loops=3,
+)
+triage.run("My invoice is wrong and the app won't load.")
+```
+
+---
+
+# Part 3 — Autonomous mode (`max_loops="auto"`)
+
+The agent runs plan → execute → reflect until it decides it is finished, with **16 built-in tools** available:
+
+| Group | Tools |
+|---|---|
+| Planning | `create_plan`, `think`, `subtask_done`, `complete_task`, `respond_to_user` |
+| Files | `create_file`, `update_file`, `read_file`, `list_directory`, `delete_file` |
+| System | `run_bash`, `grep` |
+| Delegation | `create_sub_agent`, `assign_task`, `check_sub_agent_status`, `cancel_sub_agent_tasks` |
+
+```python
+agent = Agent(
+    agent_name="Researcher",
+    model_name="gpt-5.4",
+    max_loops="auto",
+    tools=[search_web],           # your tools stack on top of the built-ins
+    persistent_memory=True,
+    context_compression=True,
+    context_length=32000,
+)
+agent.run("Research the top 5 vector databases and write compare.md")
+```
+
+Restrict the built-in set with `selected_tools` (default `"all"`):
+
+```python
+agent = Agent(
+    agent_name="ReadOnly",
+    max_loops="auto",
+    selected_tools=["create_plan", "think", "read_file", "grep", "complete_task"],
+)
+```
+
+Inspect the full list at runtime with `agent.get_all_selected_tools()`.
+
+⚠️ **`run_bash` and `delete_file` are real.** In autonomous mode the agent can modify and delete files and execute shell commands. Scope `selected_tools` and set `WORKSPACE_DIR` deliberately.
+
+---
+
+# Part 4 — Memory and conversation
+
+### Persistent memory
+
+`persistent_memory=True` reads `{WORKSPACE_DIR}/agents/{agent_name}/MEMORY.md` on startup and appends to it each response. It is **off by default** — set it in every process that should share the memory.
+
+```python
+agent = Agent(agent_name="ProjectAssistant", model_name="gpt-5.4", persistent_memory=True)
+agent.run("My project is called Helios. Remember that.")
+
+# Later process, same agent_name and the flag set again → it remembers.
+```
+
+### Context compression
+
+`context_compression=True` (default) fires at 90% of `context_length`, summarizing history in place so long sessions never hit the wall. Leave it on for anything long-running.
+
+### Conversation
+
+```python
+from swarms import Conversation
+
+conv = Conversation(
+    name="my-conversation",     # note: `name`, not `agent_name`
+    system_prompt="You are helpful.",
+    time_enabled=True,
+    token_count=True,
+)
+conv.add("user", "What is 2+2?")
+conv.add("assistant", "4.")
+
+conv.return_history_as_string()
+conv.search("2+2")
+conv.compact(summary="User asked arithmetic. Answer: 4.")   # archives, then collapses
+conv.save_as_json("conv.json")
+```
+
+---
+
+# Part 5 — Multi-agent architectures
+
+## Choosing one
+
+| Situation | Use |
+|---|---|
+| Single task | `Agent` |
+| Linear A→B→C | `SequentialWorkflow` |
+| Same task, many agents at once | `ConcurrentWorkflow` |
+| Custom mix of sequential + parallel | `AgentRearrange` |
+| Dependency graph / fan-out-fan-in | `GraphWorkflow` |
+| Many models, one synthesized answer | `MixtureOfAgents` |
+| Manager delegates to specialists | `HierarchicalSwarm` |
+| Open discussion | `GroupChat` |
+| Discrete decision by consensus | `MajorityVoting` |
+| Quality-critical evaluation | `CouncilAsAJudge` |
+| Structured adversarial debate | `DebateWithJudge` |
+| Deep multi-stage research | `HeavySwarm` |
+| Route each task to the best agent | `MultiAgentRouter` |
+| Plan then execute with workers | `PlannerWorkerSwarm` |
+| Don't know yet | `SwarmRouter(swarm_type="auto")` or `AutoSwarmBuilder` |
+
+## SequentialWorkflow
+
+Each agent's output becomes the next agent's context.
+
+```python
+from swarms import Agent, SequentialWorkflow
+
+pipeline = SequentialWorkflow(
+    agents=[researcher, analyst, writer],
+    max_loops=1,
+    output_type="dict",
+)
+pipeline.run("Analyze how rate hikes affect tech stocks.")
+```
+
+Options: `team_awareness=True` (agents see the roster), `multi_agent_collab_prompt=True`, `drift_detection=True`.
+
+## ConcurrentWorkflow
+
+All agents run the same task in parallel.
+
+```python
+from swarms import Agent, ConcurrentWorkflow
+
+workflow = ConcurrentWorkflow(
+    agents=agents,
+    max_workers=5,
+    show_dashboard=True,
+    on_error="store",          # or "raise"
+)
+workflow.run("List 10 use cases for multi-agent AI.")
+```
+
+## AgentRearrange — flow DSL
+
+```python
+from swarms import Agent, AgentRearrange
+
+pipeline = AgentRearrange(
+    agents=[planner, coder, reviewer, tester],
+    flow="Planner -> Coder -> Reviewer, Tester",
+    max_loops=1,
+)
+pipeline.run("Build an email validator.")
+```
+
+- `A -> B` — sequential, B receives A's output
+- `A, B` — concurrent, same input
+- `A -> B, C -> D` — A, then B and C in parallel, then D on their combined output
+
+**Every name in `flow` must match an `agent_name` in `agents`**, or it fails at run time. There is no human-in-the-loop step — split into separate `.run()` calls and insert your own `input()` between them.
+
+## GraphWorkflow — DAG
+
+Pass agents directly to `add_node`/`add_edge`; there is no need to wrap them in `Node` objects.
+
+```python
+from swarms import Agent, GraphWorkflow
+
+wf = GraphWorkflow(name="research-dag", max_loops=1)
+
+for a in (ingestion, branch_a, branch_b, merger):
+    wf.add_node(a)
+
+wf.add_edge(ingestion, branch_a)      # fan out
+wf.add_edge(ingestion, branch_b)
+wf.add_edge(branch_a, merger)         # fan in
+wf.add_edge(branch_b, merger)
+
+wf.set_entry_points(["Ingestion"])
+wf.set_end_points(["Merger"])
+
+def on_done(node: str, result) -> None:
+    print(f"[{node}] {len(str(result))} chars")
+
+results = wf.run(task="Analyze this dataset two ways and merge.", on_node_complete=on_done)
+```
+
+`add_node` also accepts a nested `GraphWorkflow`. Other options: `backend="networkx"|"rustworkx"`, `max_parallel_nodes`, `checkpoint_dir`, `streaming_callback`.
+
+## SwarmRouter — one entry point
+
+Swap architectures without rewriting orchestration.
+
+```python
+from swarms import Agent, SwarmRouter
+
+router = SwarmRouter(agents=agents, swarm_type="SequentialWorkflow", max_loops=1)
+router.run("Write a post about transformers.")
+```
+
+Valid `swarm_type` values — **exactly these 16**:
+
+`"AgentRearrange"`, `"MixtureOfAgents"`, `"SequentialWorkflow"`, `"ConcurrentWorkflow"`, `"GroupChat"`, `"MultiAgentRouter"`, `"HierarchicalSwarm"`, `"MajorityVoting"`, `"CouncilAsAJudge"`, `"HeavySwarm"`, `"BatchedGridWorkflow"`, `"LLMCouncil"`, `"DebateWithJudge"`, `"RoundRobin"`, `"PlannerWorkerSwarm"`, `"auto"`.
+
+`"AutoSwarmBuilder"` and `"SpreadSheetSwarm"` are **not** router types — use those classes directly. With `swarm_type="AgentRearrange"` you must also pass `rearrange_flow`.
+
+## MixtureOfAgents
+
+Workers answer independently; an aggregator synthesizes. Best with diverse providers.
+
+```python
+from swarms import Agent, MixtureOfAgents
+
+moa = MixtureOfAgents(
+    agents=[worker_gpt, worker_claude, worker_llama],
+    aggregator_agent=aggregator,       # optional; falls back to aggregator_model_name
+    layers=3,
+    max_loops=1,
+)
+moa.run("Best practices for securing a Kubernetes cluster?")
+```
+
+## HierarchicalSwarm
+
+A director decomposes the task, delegates, and synthesizes results.
+
+```python
+from swarms import Agent, HierarchicalSwarm
+
+swarm = HierarchicalSwarm(
+    agents=[data_worker, writing_worker, review_worker],
+    director=director,            # optional; else built from director_model_name
+    max_loops=2,
+    planning_enabled=True,
+    parallel_execution=True,
+    director_feedback_on=True,
+)
+swarm.run("Produce a competitive analysis of the AI chip market.")
+```
+
+Also: `agent_as_judge=True`, `max_agent_retries`, `max_reassignment_attempts`, `interactive=True`.
+
+## GroupChat
+
+Asynchronous and self-selecting — no rounds, no speaker-selection function. Every agent scores how much it wants to speak (0–1); replies above `threshold` are broadcast. Ends at `max_loops` messages or after `idle_timeout` seconds of silence.
+
+```python
+from swarms import Agent, GroupChat
+
+chat = GroupChat(
+    agents=[optimist, pessimist, realist],   # at least 2 required
+    max_loops=10,
+    threshold=0.5,           # raise for a more selective room
+    recency_penalty=0.3,     # discourages one agent dominating
+    idle_timeout=8.0,
+)
+chat.run("Should we adopt AI for medical diagnosis?")
+```
+
+`auto_equip=True` (default) injects the required `RESPOND_TOOL` into every agent — **you do not need to pass it yourself**. Set `auto_equip=False` only if you attach `RESPOND_TOOL` manually via `tools_list_dictionary`.
+
+## MajorityVoting
+
+Agents answer independently; a consensus agent picks the winner.
+
+```python
+from swarms import Agent, MajorityVoting
+
+mv = MajorityVoting(
+    agents=voters,
+    consensus_agent_model_name="gpt-5.4",
+    max_loops=1,
+)
+mv.run("Python or Rust for a high-performance web server?")
+```
+
+## CouncilAsAJudge
+
+Evaluates a response across dimensions. **It builds its own council from model names — it does not take an `agents` list or a `judge` agent.**
+
+```python
+from swarms import CouncilAsAJudge
+
+council = CouncilAsAJudge(
+    model_name="gpt-5.4",
+    aggregation_model_name="gpt-5.4",
+    random_model_name=True,
+    max_loops=1,
+)
+council.run("Should we store biometric data on-device only?")
+```
+
+## DebateWithJudge
+
+```python
+from swarms import Agent, DebateWithJudge
+
+debate = DebateWithJudge(
+    pro_agent=pro,
+    con_agent=con,
+    judge_agent=judge,
+    max_loops=3,          # rounds
+)
+debate.run("Motion: open-source LLMs will surpass closed-source by 2027.")
+```
+
+`preset_agents=True` generates pro/con/judge for you from `model_name`. The kwargs are `pro_agent`/`con_agent`/`judge_agent` — **not** `agents=[...]` plus `judge=`.
+
+## HeavySwarm
+
+Deep multi-stage analysis. **Configured by model names, not by an `agents` list.**
+
+```python
+from swarms import HeavySwarm
+
+swarm = HeavySwarm(
+    question_agent_model_name="gpt-5.4",
+    worker_model_name="gpt-5.4",
+    max_loops=1,
+    timeout=900,
+    show_dashboard=True,
+    worker_tools=[search_web],
+)
+swarm.run("Analyze the implications of AGI on global labour markets.")
+```
+
+## PlannerWorkerSwarm
+
+A planner decomposes the task and workers execute; a judge checks completion each cycle. **Not exported at the top level:**
+
+```python
+from swarms.structs.planner_worker_swarm import PlannerWorkerSwarm
+
+swarm = PlannerWorkerSwarm(
+    agents=workers,                    # workers only — the planner is built internally
+    planner_model_name="gpt-5.4",
+    judge_model_name="gpt-5.4",
+    max_planner_depth=1,
+    max_loops=1,
+)
+swarm.run("Build a go-to-market strategy for a B2B SaaS product.")
+```
+
+## Others
+
+```python
+from swarms import (
+    MultiAgentRouter,      # routes each task to the best-fit agent
+    RoundRobinSwarm,       # fixed rotation
+    LLMCouncil,            # members answer, rank peers anonymously, chairman synthesizes
+    BatchedGridWorkflow,   # agent i runs task i
+    AutoSwarmBuilder,      # generates the agents and architecture from a description
+    SpreadSheetSwarm,      # structured tabular processing
+    AdvisorSwarm, SelfMoASeq, HybridHierarchicalClusterSwarm,
+)
+
+builder = AutoSwarmBuilder(name="MarketResearch", description="...", max_loops=1)
+builder.run("Research the EV market and find growth opportunities.")
+```
+
+---
+
+# Part 6 — Execution helpers
+
+```python
+from swarms import (
+    run_agents_concurrently,
+    run_agents_with_different_tasks,
+    run_agents_concurrently_async,
+    batch_agent_execution,
+    run_single_agent,
+    aggregate,
+)
+
+run_agents_concurrently(agents=agents, task="Summarize today's news.", max_workers=8)
+run_agents_with_different_tasks([(agent_a, "task A"), (agent_b, "task B")])  # list of tuples
+batch_agent_execution(agents=agents, tasks=tasks, max_workers=10)
+aggregate(workers=agents, task="...", aggregator_model_name="gpt-5.4")
+```
+
+Note `run_agents_with_different_tasks` takes a **list of `(agent, task)` tuples**, not a dict.
+
+## Scheduling
+
+```python
+from swarms import CronJob
+
+job = CronJob(agent=agent, interval="10minutes", job_id="market-check")
+job.run(task="Check for unusual market activity.")
+```
+
+`interval` is `"<number><unit>"`, and the unit must be one of `second`, `seconds`, `minute`, `minutes`, `hour`, `hours`. Abbreviations like `"30s"` raise `CronJobConfigError`, as does a zero interval.
+
+## Loading agents from files
+
+```python
+from swarms import AgentLoader
+
+loader = AgentLoader(concurrent=True)
+agents = loader.load_agents_from_markdown("agents/")   # also: _from_yaml, _from_csv
+agent = loader.load_agent_from_markdown("agents/researcher.md")
+```
+
+---
+
+# Part 7 — Pitfalls
+
+| Don't | Do | Why |
+|---|---|---|
+| `from swarms.structs.agent import Agent` | `from swarms import Agent` | Submodule paths move between versions |
+| `tools=[]` | `tools=None` | Empty list breaks schema generation |
+| `tools=[f]` with `max_loops=1` | `max_loops=3` | Loop 1 calls the tool; it needs loop 2 to use the result |
+| Same `agent_name` on several agents | Unique names | `MEMORY.md` is keyed on it — they corrupt each other |
+| `streaming_on=True` + `streaming_callback` | Pick one | They conflict |
+| `CouncilAsAJudge(agents=..., judge=...)` | Model-name kwargs | It takes no `agents` or `judge` argument |
+| `DebateWithJudge(agents=[p, c], judge=j)` | `pro_agent=`, `con_agent=`, `judge_agent=` | Those kwarg names don't exist |
+| `HeavySwarm(num_agents=4, model_name=...)` | `question_agent_model_name=`, `worker_model_name=` | Those kwarg names don't exist |
+| `from swarms import PlannerWorkerSwarm` | `from swarms.structs.planner_worker_swarm import ...` | Not exported at the top level |
+| `swarm_type="AutoSwarmBuilder"` | Use the class directly | Not one of the 16 router types |
+| `GraphWorkflow.add_node(Node(...))` | `add_node(agent)` | It takes the agent itself |
+| Building agents inside a loop | Build once, reuse | Construction is expensive |
+| `context_compression=False` on long runs | Leave it `True` | The run will hit the context wall |
+| Bare `max_loops="auto"` in production | Integer `max_loops` | Autonomous runs have no natural stopping point |
+
+## Production configuration
+
+```python
+agent = Agent(
+    agent_name="ProductionAgent",
+    agent_description="...",
+    model_name="gpt-5.4",
+    max_loops=3,
+    context_length=32000,
+    context_compression=True,
+    persistent_memory=True,
+    autosave=True,
+    retry_attempts=3,
+    fallback_models=["claude-sonnet-4-6"],
+    verbose=False,
+)
+```
+
+## Debugging
+
+- `verbose=True` — full internal logging
+- `show_tool_execution_output=True` — raw tool returns
+- `output_type="all"` — the complete conversation instead of just the final message
+- `agent.get_all_selected_tools()` — the autonomous tool roster
+- `agent.short_memory.return_history_as_string()` — dump the conversation
+
+---
+
+## Reference
+
+- Docs: [docs.swarms.world](https://docs.swarms.world) · [Agent API](https://docs.swarms.world/api/agent)
+- Examples: [`examples/`](examples/) — `single_agent/`, `multi_agent/`, `tools/`, `guides/`
+- Source: `swarms/structs/` (agents + swarms), `swarms/agents/` (loops, judges, routers), `swarms/tools/`
+- Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/max_loops_agent.py
+++ b/max_loops_agent.py
@@ -1,0 +1,39 @@
+from dotenv import load_dotenv
+
+from swarms import Agent
+
+load_dotenv()
+
+# Define an expanded system prompt
+system_prompt = (
+    "You are Medical-Research-Agent, a highly advanced and helpful assistant specializing "
+    "in medical research, clinical analysis, and evidence-based healthcare recommendations. "
+    "You assist users with intricate medical research questions, providing comprehensive literature analysis, "
+    "insightful data synthesis, and critical evaluation of clinical studies. "
+    "When comparing treatments or interventions, you evaluate metrics such as efficacy, safety profile, "
+    "sample size, statistical significance, potential side effects, and study limitations. "
+    "Deliver recommendations that are rooted in current scientific evidence, explain your reasoning in clear, "
+    "accessible language tailored for both clinicians and lay audiences as appropriate. "
+    "Maintain a professional and objective tone, cite reputable medical sources or clinical guidelines where helpful, "
+    "and always clarify any uncertainties or research gaps in your analysis."
+)
+
+# Initialize the agent
+agent = Agent(
+    agent_name="Medical-Research-Agent",
+    agent_description="Advanced medical research and clinical analysis agent",
+    system_prompt=system_prompt,
+    model_name="gpt-5.4",
+    max_loops="auto",
+    top_p=None,
+    temperature=None,
+    reasoning_effort=None,
+    persistent_memory=False,
+    output_type="list",
+)
+
+out = agent.run(
+    task="Analyze the comparative effectiveness and safety of current treatments for type 2 diabetes. Provide a detailed comparison including metrics such as efficacy, safety, major clinical trial outcomes, and guideline recommendations.",
+)
+
+print(out)

--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -51,8 +51,26 @@ from swarms.tools.handoffs_tool_schema import get_handoff_tool_schema
 from swarms.tools.py_func_to_openai_func_str import (
     convert_multiple_functions_to_openai_function_schema,
 )
+from swarms.structs.transcript import Transcript
 from swarms.utils.formatter import formatter
 from swarms.utils.index import exists, format_data_structure
+
+
+def _format_tool_error(function_name: str, error: Exception) -> str:
+    """
+    Render a tool failure as text the model can act on.
+
+    Tool errors are fed back into the conversation as the tool's result so the
+    model can correct itself on the next turn. Swallowing them means the next
+    iteration rebuilds an identical prompt and the model re-emits the identical
+    failing call until the iteration budget is gone.
+    """
+    return (
+        f"ERROR: {function_name} failed with "
+        f"{type(error).__name__}: {error}. "
+        "Review the arguments and either retry with a correction or take a "
+        "different approach. Do not repeat the same call unchanged."
+    )
 
 
 class AutonomousAgentLoop:
@@ -71,6 +89,43 @@ class AutonomousAgentLoop:
 
     def __init__(self, agent: Any):
         self.agent = agent
+        # The real conversation body sent to the model: user turns, assistant
+        # turns carrying `tool_calls`, and `{"role": "tool", ...}` results.
+        # `short_memory` is kept in sync alongside it because persistence,
+        # output formatting and the final summary all read from there.
+        self._transcript = Transcript()
+
+    def _say_user(self, content: str, mirror: bool = True) -> None:
+        """Add a user turn to the transcript (and to short_memory)."""
+        self._transcript.append_user(content)
+        if mirror:
+            self.agent.short_memory.add(
+                role=self.agent.user_name, content=content
+            )
+
+    def _record_assistant(self, parsed: Any) -> List[Dict[str, Any]]:
+        """Add the model's turn; return the tool calls it made."""
+        return self._transcript.record_assistant(parsed)
+
+    def _flush_tool_results(
+        self, calls: List[Dict[str, Any]], results: Dict[str, Any]
+    ) -> None:
+        """Answer every tool call in the preceding assistant turn."""
+        self._transcript.flush_tool_results(calls, results)
+
+    def _map_batch_results(
+        self,
+        tool_calls: List[Dict[str, Any]],
+        output: Any,
+        results: Dict[str, Any],
+    ) -> None:
+        """Attribute a batched tool execution back to individual call ids."""
+        self._transcript.map_batch_results(
+            tool_calls,
+            output,
+            results,
+            formatter=format_data_structure,
+        )
 
     def _run_autonomous_loop(
         self,
@@ -145,16 +200,16 @@ class AutonomousAgentLoop:
         """
         try:
 
-            self.agent.short_memory.add(
-                role=self.agent.user_name, content=task
-            )
-
-            # Reset autonomous loop state
+            # Reset autonomous loop state. The transcript is cleared before
+            # the task is seeded, or the opening turn would be discarded.
+            self._transcript = Transcript()
             self.agent.autonomous_subtasks = []
             self.agent.current_subtask_index = 0
             self.agent.subtask_status = {}
             self.agent.plan_created = False
             self.agent.think_call_count = 0
+
+            self._say_user(task)
 
             # Add planning tools to tools_list_dictionary
             planning_tools = get_autonomous_planning_tools()
@@ -179,15 +234,27 @@ class AutonomousAgentLoop:
                     f"Filtered to {len(planning_tools)} tools: {[t.get('function', {}).get('name', '') for t in planning_tools]}"
                 )
 
-            # The `think` tool is redundant when the model already reasons natively
-            # via extended thinking (thinking_tokens). Drop it to avoid unnecessary
-            # tool-call round-trips and a cluttered tool list.
-            if self.agent.thinking_tokens is not None:
+            # The `think` tool is opt-in via Agent(think_tool=True). It costs a
+            # full round-trip to produce reasoning the model could emit inline
+            # alongside its actions, so it is off unless asked for.
+            #
+            # This replaces an earlier `thinking_tokens is not None` check.
+            # `thinking_tokens` defaults to 1024 rather than None, so that test
+            # was always true and silently stripped `think` for every agent -
+            # the intent was to drop it only when extended thinking was on.
+            if not getattr(self.agent, "think_tool", False):
                 planning_tools = [
                     t
                     for t in planning_tools
                     if t.get("function", {}).get("name") != "think"
                 ]
+            elif self.agent.thinking_tokens:
+                logger.info(
+                    "think_tool=True alongside thinking_tokens="
+                    f"{self.agent.thinking_tokens}: the model reasons natively, "
+                    "so the think tool adds a round-trip without adding "
+                    "information. Consider think_tool=False."
+                )
 
             if self.agent.tools_list_dictionary is None:
                 self.agent.tools_list_dictionary = []
@@ -304,9 +371,7 @@ class AutonomousAgentLoop:
                 )
 
             planning_prompt = get_planning_prompt(task)
-            self.agent.short_memory.add(
-                role=self.agent.user_name, content=planning_prompt
-            )
+            self._say_user(planning_prompt)
 
             plan_created = False
             planning_attempts = 0
@@ -318,14 +383,12 @@ class AutonomousAgentLoop:
             ):
                 planning_attempts += 1
                 try:
-                    task_prompt = (
-                        self.agent.short_memory.return_history_as_string()
-                    )
                     response = self.agent.call_llm(
-                        task=task_prompt,
+                        task=None,
                         img=img,
                         current_loop=0,
                         streaming_callback=streaming_callback,
+                        messages=self._transcript.messages,
                         *args,
                         **kwargs,
                     )
@@ -334,6 +397,8 @@ class AutonomousAgentLoop:
                     self.agent.short_memory.add(
                         role=self.agent.agent_name, content=response
                     )
+                    planning_calls = self._record_assistant(response)
+                    planning_results: Dict[str, Any] = {}
 
                     # Check if response contains create_plan or handoff_task tool call
                     if isinstance(response, list):
@@ -365,6 +430,9 @@ class AutonomousAgentLoop:
                                         role="Tool Executor",
                                         content=f"create_plan result: {result}",
                                     )
+                                    planning_results[
+                                        tool_call.get("id", "")
+                                    ] = result
 
                                 elif (
                                     function_name == "handoff_task"
@@ -397,6 +465,9 @@ class AutonomousAgentLoop:
                                         role="Tool Executor",
                                         content=f"handoff_task result: {result}",
                                     )
+                                    planning_results[
+                                        tool_call.get("id", "")
+                                    ] = result
 
                                 # Show plan creation result
                                 if self.agent.print_on:
@@ -419,6 +490,12 @@ class AutonomousAgentLoop:
 
                                 plan_created = True
                                 break
+
+                    # Every tool_call in the assistant turn must be answered
+                    # before the next request, whether or not the plan landed.
+                    self._flush_tool_results(
+                        planning_calls, planning_results
+                    )
 
                     # Also check if plan was created via tool execution
                     if self.agent.plan_created:
@@ -526,7 +603,7 @@ class AutonomousAgentLoop:
 
                 # Show subtask start
                 if self.agent.print_on:
-                    progress = f"{sum(1 for s in self.agent.autonomous_subtasks if s['status'] in ['completed', 'failed'])}/{len(self.agent.autonomous_subtasks)}"
+                    progress = f"{sum(1 for s in self.agent.autonomous_subtasks if s['status'] in ['completed', 'failed', 'skipped'])}/{len(self.agent.autonomous_subtasks)}"
                     formatter.print_panel(
                         f"Subtask: {subtask_id}\nDescription: {subtask_desc}\nPriority: {subtask_priority}\nProgress: {progress} subtasks completed",
                         title=f"Executing Subtask: {subtask_id}",
@@ -537,6 +614,12 @@ class AutonomousAgentLoop:
                 max_subtask_loops = MAX_SUBTASK_LOOPS
                 subtask_done = False
 
+                # Counts CONSECUTIVE think calls across this subtask's
+                # iterations. It is reset here, once per subtask, and again by
+                # any non-think tool call below - not once per iteration, which
+                # would only ever catch repeats inside a single response.
+                self.agent.think_call_count = 0
+
                 # Add the execution prompt ONCE before the inner loop so the model
                 # doesn't see duplicate copies of it on subsequent iterations and
                 # mistakenly conclude "this task has been run before."
@@ -545,29 +628,21 @@ class AutonomousAgentLoop:
                     subtask_desc,
                     self.agent.autonomous_subtasks,
                 )
-                self.agent.short_memory.add(
-                    role=self.agent.user_name,
-                    content=execution_prompt,
-                )
+                self._say_user(execution_prompt)
 
                 while (
                     not subtask_done
                     and subtask_iterations < max_subtask_loops
                 ):
                     subtask_iterations += 1
-                    self.agent.think_call_count = (
-                        0  # Reset for each subtask
-                    )
 
                     try:
-                        task_prompt = (
-                            self.agent.short_memory.return_history_as_string()
-                        )
                         response = self.agent.call_llm(
-                            task=task_prompt,
+                            task=None,
                             img=img,
                             current_loop=subtask_iterations,
                             streaming_callback=streaming_callback,
+                            messages=self._transcript.messages,
                             *args,
                             **kwargs,
                         )
@@ -580,9 +655,18 @@ class AutonomousAgentLoop:
                             content=response,
                         )
 
+                        # Record the model's turn, then answer every tool call
+                        # it made before the next request goes out.
+                        turn_calls = self._record_assistant(response)
+                        turn_results: Dict[str, Any] = {}
+
                         # Handle tool calls
                         if isinstance(response, list):
                             regular_tool_calls = []
+                            # complete_task sets this instead of returning
+                            # mid-loop, so tool calls batched after it are not
+                            # dropped.
+                            task_complete = False
 
                             for tool_call in response:
                                 if isinstance(
@@ -595,17 +679,42 @@ class AutonomousAgentLoop:
                                     function_name = tool_call[
                                         "function"
                                     ]["name"]
-                                    arguments = json.loads(
-                                        tool_call["function"][
-                                            "arguments"
-                                        ]
-                                    )
+                                    try:
+                                        arguments = json.loads(
+                                            tool_call["function"][
+                                                "arguments"
+                                            ]
+                                        )
+                                    except (
+                                        json.JSONDecodeError,
+                                        TypeError,
+                                    ) as parse_error:
+                                        # Report the malformed payload back to
+                                        # the model instead of aborting the
+                                        # whole iteration on one bad call.
+                                        self.agent.short_memory.add(
+                                            role="Tool Executor",
+                                            content=_format_tool_error(
+                                                function_name,
+                                                parse_error,
+                                            ),
+                                        )
+                                        if self.agent.verbose:
+                                            logger.warning(
+                                                f"Could not parse arguments for {function_name}: {parse_error}"
+                                            )
+                                        continue
 
                                     # Handle planning tools and handoff tool
                                     if (
                                         function_name
                                         in planning_tool_handlers
                                     ):
+                                        # Set when the handler raises, so a
+                                        # failed call is not mistaken for a
+                                        # completed subtask or a finished task.
+                                        tool_failed = False
+
                                         # Special handling for handoff_task tool
                                         if (
                                             function_name
@@ -623,9 +732,18 @@ class AutonomousAgentLoop:
                                                     tool_call,
                                                 )
 
-                                            result = self.agent._handoff_task_tool(
-                                                handoffs=handoffs_list
-                                            )
+                                            try:
+                                                result = self.agent._handoff_task_tool(
+                                                    handoffs=handoffs_list
+                                                )
+                                            except (
+                                                Exception
+                                            ) as tool_error:
+                                                tool_failed = True
+                                                result = _format_tool_error(
+                                                    function_name,
+                                                    tool_error,
+                                                )
                                         else:
                                             # Only pre-visualize tools that won't be shown again
                                             # with their result (subtask_done / complete_task are
@@ -639,17 +757,46 @@ class AutonomousAgentLoop:
                                                     arguments,
                                                 )
 
-                                            result = planning_tool_handlers[
-                                                function_name
-                                            ](
-                                                **arguments
-                                            )
+                                            try:
+                                                result = planning_tool_handlers[
+                                                    function_name
+                                                ](
+                                                    **arguments
+                                                )
+                                            except (
+                                                Exception
+                                            ) as tool_error:
+                                                tool_failed = True
+                                                result = _format_tool_error(
+                                                    function_name,
+                                                    tool_error,
+                                                )
 
                                         # Add result to memory
                                         self.agent.short_memory.add(
                                             role="Tool Executor",
                                             content=f"{function_name} result: {result}",
                                         )
+                                        turn_results[
+                                            tool_call.get("id", "")
+                                        ] = result
+
+                                        # Any tool that is not `think` breaks
+                                        # the streak, which is what makes the
+                                        # limit a *consecutive* one.
+                                        if function_name != "think":
+                                            self.agent.think_call_count = (
+                                                0
+                                            )
+
+                                        if tool_failed:
+                                            if self.agent.print_on:
+                                                formatter.print_panel(
+                                                    result,
+                                                    title=f"Tool Error: {function_name}",
+                                                )
+                                            if self.agent.verbose:
+                                                logger.warning(result)
 
                                         # Visualize result for important tools
                                         if function_name in [
@@ -662,10 +809,12 @@ class AutonomousAgentLoop:
                                                 result,
                                             )
 
-                                        # Check if subtask is done
+                                        # Check if subtask is done. A failed
+                                        # handler does not complete anything.
                                         if (
                                             function_name
                                             == "subtask_done"
+                                            and not tool_failed
                                         ):
                                             if (
                                                 arguments.get(
@@ -689,17 +838,16 @@ class AutonomousAgentLoop:
                                                         f"Subtask {subtask_id} marked as {status}\n\nSummary: {arguments.get('summary', 'N/A')}",
                                                         title=f"Subtask {status.title()}: {subtask_id}",
                                                     )
-                                                break
 
-                                        # Check if main task is complete
+                                        # Check if main task is complete. The
+                                        # return is deferred until every tool
+                                        # call in this response has run.
                                         if (
                                             function_name
                                             == "complete_task"
+                                            and not tool_failed
                                         ):
-                                            # Task is complete, exit all loops
-                                            return self.agent._generate_final_summary(
-                                                streaming_callback=streaming_callback
-                                            )
+                                            task_complete = True
                                     else:
                                         # Collect regular tool calls for batch visualization and execution
                                         regular_tool_calls.append(
@@ -748,6 +896,11 @@ class AutonomousAgentLoop:
                                         content=format_data_structure(
                                             tool_output
                                         ),
+                                    )
+                                    self._map_batch_results(
+                                        regular_tool_calls,
+                                        tool_output,
+                                        turn_results,
                                     )
 
                                     # Display tool execution results using formatter
@@ -799,6 +952,21 @@ class AutonomousAgentLoop:
                                         regular_tool_calls,
                                         subtask_iterations,
                                     )
+                                    self._map_batch_results(
+                                        regular_tool_calls,
+                                        f"tool execution failed: {e}",
+                                        turn_results,
+                                    )
+
+                            self._flush_tool_results(
+                                turn_calls, turn_results
+                            )
+
+                            if task_complete:
+                                return self.agent._generate_final_summary(
+                                    streaming_callback=streaming_callback,
+                                    messages=self._transcript.messages,
+                                )
                         else:
                             # Handle regular tool execution
                             if exists(self.agent.tools):
@@ -895,6 +1063,10 @@ class AutonomousAgentLoop:
                                         response, subtask_iterations
                                     )
 
+                            self._flush_tool_results(
+                                turn_calls, turn_results
+                            )
+
                         # Check if subtask status changed
                         if (
                             subtask_id in self.agent.subtask_status
@@ -917,28 +1089,71 @@ class AutonomousAgentLoop:
                                 logger.warning(
                                     f"Too many consecutive think calls ({self.agent.think_call_count}). Forcing action."
                                 )
-                            # Force action by adding a prompt
-                            self.agent.short_memory.add(
-                                role="system",
-                                content="You have been thinking too much. Take action now using available tools.",
+                            # Force action. The nudge goes into the real
+                            # transcript, not just short_memory, or the model
+                            # never sees it on the next request.
+                            nudge = (
+                                "You have called `think` "
+                                f"{self.agent.think_call_count} times in a row "
+                                "without acting. Stop analysing. Take concrete "
+                                "action now using the available tools, and call "
+                                "subtask_done when the work is finished."
                             )
+                            self.agent.short_memory.add(
+                                role="system", content=nudge
+                            )
+                            self._transcript.append_user(nudge)
+
+                            # Reset so the nudge gets a fair chance to work
+                            # before firing again on the very next iteration.
+                            self.agent.think_call_count = 0
 
                     except Exception as e:
                         if self.agent.verbose:
                             logger.error(
                                 f"Error in subtask execution loop: {e}"
                             )
-                        # Continue to next iteration
+                        # Record the failure in the conversation. Without this
+                        # the next iteration rebuilds an identical prompt and
+                        # the model repeats whatever just failed.
+                        self.agent.short_memory.add(
+                            role="Tool Executor",
+                            content=(
+                                f"ERROR: the previous step failed with "
+                                f"{type(e).__name__}: {e}. Adjust your "
+                                "approach before retrying."
+                            ),
+                        )
 
                 if not subtask_done:
+                    # A subtask that burned its whole iteration budget without
+                    # finishing is recorded as failed, not left pending. Left
+                    # pending it stays eligible, so the outer loop re-selects it
+                    # and re-runs the same doomed budget up to
+                    # MAX_SUBTASK_ITERATIONS times - 100 x 20 = 2000 LLM calls
+                    # for one stuck subtask. Failing it terminates the run,
+                    # cascades `skipped` to its dependents, and reports honestly.
+                    reason = (
+                        f"Exhausted its {max_subtask_loops}-iteration budget "
+                        "without completing."
+                    )
+                    self.agent.subtask_status[subtask_id] = "failed"
+                    for subtask in self.agent.autonomous_subtasks:
+                        if subtask["step_id"] == subtask_id:
+                            subtask["status"] = "failed"
+                            subtask.setdefault("summary", reason)
+                            break
+
                     if self.agent.print_on:
                         formatter.print_panel(
-                            f"Subtask {subtask_id} not completed after {max_subtask_loops} iterations",
+                            f"Subtask {subtask_id} not completed after "
+                            f"{max_subtask_loops} iterations - marking failed.",
                             title="Subtask Timeout",
                         )
                     if self.agent.verbose:
                         logger.warning(
-                            f"Subtask {subtask_id} not completed after {max_subtask_loops} iterations"
+                            f"Subtask {subtask_id} not completed after "
+                            f"{max_subtask_loops} iterations - marking failed."
                         )
 
             # Phase 3: Final Summary
@@ -998,10 +1213,14 @@ class AutonomousAgentLoop:
                 of subtasks created. Format: "Plan created successfully with {n} subtasks"
 
         Note:
-            - This method is called automatically by the autonomous loop during planning phase
-            - The plan replaces any existing autonomous_subtasks
-            - All subtasks start with status "pending"
-            - current_subtask_index is reset to 0
+            - Called during the planning phase, and again at any point during
+              execution when the model revises the plan.
+            - The call is idempotent, not destructive. Steps are merged by
+              ``step_id``: work that already finished keeps its status and
+              summary, still-pending steps are updated in place, unmentioned
+              steps that already finished are retained as history, and
+              unmentioned steps that are still pending are dropped. Only a
+              first call on an empty plan starts from scratch.
             - If verbose=True, plan creation is logged with step details
 
         Examples:
@@ -1028,27 +1247,128 @@ class AutonomousAgentLoop:
         if self.agent.verbose:
             logger.info(f"Creating plan for task: {task_description}")
 
-        # Store the plan
-        self.agent.autonomous_subtasks = []
+        existing = {
+            subtask["step_id"]: subtask
+            for subtask in self.agent.autonomous_subtasks
+        }
+        is_revision = bool(existing)
+
+        incoming: Dict[str, Dict[str, Any]] = {}
+        incoming_order: List[str] = []
+        known_step_ids = {step.get("step_id", "") for step in steps}
+        # A revision may reference work that already finished but is not being
+        # restated, so those ids stay valid dependency targets.
+        known_step_ids |= set(existing)
+
         for step in steps:
-            subtask = {
-                "step_id": step.get("step_id", ""),
+            step_id = step.get("step_id", "")
+
+            # step_id values in `dependencies` are model-generated free text.
+            # A typo or hallucinated id used to satisfy the dependency check
+            # silently; now it is dropped, with a warning, so the plan stays
+            # runnable instead of deadlocking on a reference to nothing.
+            declared = step.get("dependencies", []) or []
+            dependencies = [
+                dep
+                for dep in declared
+                if dep in known_step_ids and dep != step_id
+            ]
+            dangling = [
+                dep for dep in declared if dep not in dependencies
+            ]
+            if dangling:
+                logger.warning(
+                    f"Subtask {step_id!r} declares unknown or self-referential "
+                    f"dependencies {dangling} - dropping them. Known step ids: "
+                    f"{sorted(known_step_ids)}"
+                )
+
+            incoming[step_id] = {
+                "step_id": step_id,
                 "description": step.get("description", ""),
                 "priority": step.get("priority", "medium"),
-                "dependencies": step.get("dependencies", []),
+                "dependencies": dependencies,
                 "status": "pending",
             }
-            self.agent.autonomous_subtasks.append(subtask)
-            self.agent.subtask_status[subtask["step_id"]] = "pending"
+            incoming_order.append(step_id)
+
+        # Merge, preserving the order the plan already had and appending
+        # genuinely new work at the end.
+        merged: List[Dict[str, Any]] = []
+        added, updated, removed, retained = [], [], [], []
+
+        for subtask in self.agent.autonomous_subtasks:
+            step_id = subtask["step_id"]
+            terminal = subtask["status"] in (
+                "completed",
+                "failed",
+                "skipped",
+            )
+            if step_id in incoming:
+                if terminal:
+                    # Finished work is not re-opened by a revision.
+                    merged.append(subtask)
+                    retained.append(step_id)
+                else:
+                    merged.append(incoming[step_id])
+                    updated.append(step_id)
+            elif terminal:
+                # Not restated, but it happened - keep it as history.
+                merged.append(subtask)
+                retained.append(step_id)
+            else:
+                removed.append(step_id)
+                self.agent.subtask_status.pop(step_id, None)
+
+        for step_id in incoming_order:
+            if step_id not in existing:
+                merged.append(incoming[step_id])
+                added.append(step_id)
+
+        self.agent.autonomous_subtasks = merged
+        for subtask in merged:
+            self.agent.subtask_status.setdefault(
+                subtask["step_id"], subtask["status"]
+            )
+            if subtask["status"] == "pending":
+                self.agent.subtask_status[subtask["step_id"]] = (
+                    "pending"
+                )
 
         self.agent.plan_created = True
-        self.agent.current_subtask_index = 0
+        if not is_revision:
+            self.agent.current_subtask_index = 0
 
+        if not is_revision:
+            if self.agent.verbose:
+                logger.info(
+                    f"Plan created with {len(merged)} steps: "
+                    f"{[s['step_id'] for s in merged]}"
+                )
+            return f"Plan created successfully with {len(merged)} subtasks"
+
+        # A revision reports what changed, not the whole plan, so the model
+        # can see the effect of its edit.
+        diff_parts = []
+        if added:
+            diff_parts.append(f"added {added}")
+        if updated:
+            diff_parts.append(f"updated {updated}")
+        if removed:
+            diff_parts.append(f"removed {removed}")
+        if retained:
+            diff_parts.append(f"kept finished {retained}")
+        summary = "; ".join(diff_parts) or "no changes"
+
+        if self.agent.print_on:
+            formatter.print_panel(summary, title="Plan Revised")
         if self.agent.verbose:
-            logger.info(
-                f"Plan created with {len(steps)} steps: {[s['step_id'] for s in self.agent.autonomous_subtasks]}"
-            )
-        return f"Plan created successfully with {len(steps)} subtasks"
+            logger.info(f"Plan revised: {summary}")
+
+        return (
+            f"Plan updated ({summary}). The plan now has "
+            f"{len(merged)} subtasks."
+        )
 
     def _think_tool(
         self,
@@ -1235,17 +1555,65 @@ class AutonomousAgentLoop:
 
         # Find subtasks that are pending and have all dependencies completed
         for subtask in self.agent.autonomous_subtasks:
-            if subtask["status"] == "pending":
-                # Check if all dependencies are completed
-                dependencies = subtask.get("dependencies", [])
-                if not dependencies or all(
-                    self.agent.subtask_status.get(dep, "completed")
-                    in ["completed", "failed"]
-                    for dep in dependencies
-                ):
-                    return subtask
+            if subtask["status"] != "pending":
+                continue
+
+            dependencies = subtask.get("dependencies", [])
+            if not dependencies:
+                return subtask
+
+            statuses = [
+                self.agent.subtask_status.get(dep)
+                for dep in dependencies
+            ]
+
+            # Only an actually completed dependency satisfies. A failed one
+            # cannot produce the output its dependents were planned around,
+            # and an unknown id (None) means the reference is unresolvable --
+            # neither should unblock execution.
+            if all(status == "completed" for status in statuses):
+                return subtask
+
+            # Dependencies that failed or were skipped can never complete, so
+            # this subtask is unreachable. Mark it skipped rather than leaving
+            # it pending forever, so the run terminates and the final summary
+            # can report what was not attempted.
+            blockers = [
+                dep
+                for dep, status in zip(dependencies, statuses)
+                if status in ("failed", "skipped")
+            ]
+            if blockers:
+                self._skip_subtask(subtask, blockers)
 
         return None
+
+    def _skip_subtask(
+        self, subtask: Dict[str, Any], blockers: List[str]
+    ) -> None:
+        """
+        Mark a subtask as skipped because a dependency it needs cannot complete.
+
+        Args:
+            subtask: The subtask being skipped.
+            blockers: The dependency step_ids that failed or were skipped.
+        """
+        step_id = subtask["step_id"]
+        reason = (
+            f"Skipped: depends on {', '.join(blockers)}, which did not "
+            "complete successfully."
+        )
+
+        subtask["status"] = "skipped"
+        subtask["summary"] = reason
+        self.agent.subtask_status[step_id] = "skipped"
+
+        if self.agent.print_on:
+            formatter.print_panel(
+                reason, title=f"Subtask Skipped: {step_id}"
+            )
+        if self.agent.verbose:
+            logger.warning(f"Subtask {step_id} skipped. {reason}")
 
     def _all_subtasks_complete(self) -> bool:
         """
@@ -1258,6 +1626,6 @@ class AutonomousAgentLoop:
             return False
 
         return all(
-            subtask["status"] in ["completed", "failed"]
+            subtask["status"] in ["completed", "failed", "skipped"]
             for subtask in self.agent.autonomous_subtasks
         )

--- a/swarms/prompts/autonomous_agent_prompt.py
+++ b/swarms/prompts/autonomous_agent_prompt.py
@@ -52,6 +52,13 @@ You operate in a structured three-phase cycle:
 - Critical priority tasks are foundational and must be completed first
 - Dependencies ensure logical execution order
 - The plan should be comprehensive but not overly granular
+- The plan is not frozen. Call `create_plan` again whenever execution teaches
+  you something the plan did not anticipate: work you discovered, a step that
+  should be split, a step that is no longer needed, or a dependency you got
+  wrong. Pass the full step list you now believe in. Completed steps keep
+  their results, so revising never loses finished work. Revise instead of
+  forcing unplanned work into an unrelated subtask, and instead of failing a
+  subtask you could re-scope.
 
 **Example Plan Structure**:
 Task: Research and write a report on renewable energy
@@ -250,14 +257,43 @@ Now, begin your mission with excellence.
 """
 
 
-def get_autonomous_agent_prompt() -> str:
+NO_THINK_TOOL_OVERRIDE = """
+
+## TOOL AVAILABILITY OVERRIDE
+
+The `think` tool is NOT available in this run. Disregard every instruction
+above that tells you to call it, along with the limits described for it.
+
+Reason inline instead: state your brief analysis in your own message text, then
+call the tools that do the actual work in that same response. Do not spend a
+turn on analysis alone - it costs a full round-trip and produces no progress.
+"""
+
+
+def get_autonomous_agent_prompt(
+    include_think_tool: bool = False,
+) -> str:
     """
     Get the comprehensive autonomous agent system prompt.
 
+    Args:
+        include_think_tool: Whether the `think` tool is available to the agent.
+            When False, an override is appended telling the model to ignore the
+            think-tool instructions and reason inline instead. This mirrors
+            ``Agent(think_tool=...)``; the prompt must agree with the tool list
+            or the model is told to call a tool it has not been given.
+
     Returns:
-        str: The full autonomous agent system prompt
+        str: The autonomous agent system prompt.
     """
-    return AUTONOMOUS_AGENT_SYSTEM_PROMPT
+    if include_think_tool:
+        return AUTONOMOUS_AGENT_SYSTEM_PROMPT
+
+    # The think guidance is woven through the prompt in a dozen places, so it
+    # is overridden at the end rather than excised - a late, explicit
+    # instruction is unambiguous, where a partial edit risks mangling the text.
+    # Restructuring the prompt into composable sections is the proper fix.
+    return AUTONOMOUS_AGENT_SYSTEM_PROMPT + NO_THINK_TOOL_OVERRIDE
 
 
 def get_autonomous_agent_prompt_with_context(

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -71,6 +71,7 @@ from swarms.structs.autonomous_loop_utils import (
 )
 from swarms.structs.conversation import Conversation
 from swarms.structs.ma_utils import set_random_models_for_agents
+from swarms.structs.transcript import Transcript
 from swarms.structs.safe_loading import (
     SafeLoaderUtils,
     SafeStateManager,
@@ -193,6 +194,12 @@ class Agent:
             Each subdirectory should contain a SKILL.md file with YAML frontmatter (name, description)
             and markdown instructions. Skills are auto-loaded into system prompt for context-aware activation.
             Example: skills_dir="./skills" loads from ./skills/*/SKILL.md
+        think_tool (bool): Whether the autonomous looper (max_loops="auto") offers the
+            `think` tool. Defaults to False. A `think` call spends a full round-trip to
+            produce reasoning the model could emit inline alongside its actions, so it is
+            off unless asked for. Enable it for models that do not reason natively, or
+            when an explicit analysis step is worth the extra turn. When False, the system
+            prompt is adjusted to match so the model is not told to call a tool it lacks.
         selected_tools (Union[str, List[str]]): Tools to enable for the autonomous looper when max_loops="auto".
             Available tools: "create_plan", "think", "subtask_done", "complete_task", "respond_to_user",
             "create_file", "update_file", "read_file", "list_directory", "delete_file", "run_bash",
@@ -387,6 +394,7 @@ class Agent:
         show_tool_execution_output: bool = True,
         reasoning_effort: Literal[get_reasoning_efforts()] = "medium",
         thinking_tokens: int = 1024,
+        think_tool: bool = False,
         reasoning_enabled: bool = False,
         handoffs: Optional[Union[Sequence[Callable], Any]] = None,
         capabilities: Optional[List[str]] = None,
@@ -496,6 +504,13 @@ class Agent:
         self.show_tool_execution_output = show_tool_execution_output
         self.reasoning_effort = reasoning_effort
         self.thinking_tokens = thinking_tokens
+
+        # Whether the autonomous loop offers the `think` tool. Off by default:
+        # a think call costs a full round-trip to produce reasoning the model
+        # could have emitted alongside its actions in the same response. Turn
+        # it on for models that do not reason natively, or when an explicit
+        # analysis step is worth the extra turn.
+        self.think_tool = think_tool
         self.reasoning_enabled = reasoning_enabled
         self.fallback_model_name = fallback_model_name
         self.handoffs = handoffs
@@ -530,8 +545,13 @@ class Agent:
             self.max_tokens = self._default_max_tokens() or 16000
 
         if self.max_loops == "auto":
+            # The prompt must agree with the tool list: without this the model
+            # is instructed to call a `think` tool it was never given.
             self.system_prompt += (
-                "\n\n" + get_autonomous_agent_prompt()
+                "\n\n"
+                + get_autonomous_agent_prompt(
+                    include_think_tool=self.think_tool
+                )
             )
 
         # When False the agent does not read or write MEMORY.md across sessions.
@@ -1366,6 +1386,10 @@ class Agent:
             # Set the loop count
             loop_count = 0
 
+            # Structured conversation for this run. Built lazily below so the
+            # transforms path can keep its flattened prompt.
+            transcript: Optional[Transcript] = None
+
             # Clear the short memory
             response = None
 
@@ -1416,24 +1440,35 @@ class Agent:
                 if self.dynamic_temperature_enabled is True:
                     self.dynamic_temperature()
 
-                # Task prompt with optional transforms
+                # Task prompt with optional transforms.
+                #
+                # `transforms` rewrites the whole history into a single string
+                # by design, so that path keeps the legacy flattened prompt.
+                # Everything else sends a real message list, which preserves
+                # assistant `tool_calls` turns and `tool` results instead of
+                # collapsing them into prose.
+                task_prompt = None
+                use_transcript = self.transforms is None
+
                 if self.transforms is not None:
                     task_prompt = handle_transforms(
                         transforms=self.transforms,
                         short_memory=self.short_memory,
                         model_name=self.model_name,
                     )
-
-                else:
-                    # Use original method if no transforms
-                    task_prompt = (
-                        self.short_memory.return_history_as_string()
-                    )
+                elif transcript is None:
+                    transcript = self._transcript_from_memory()
 
                 # Parameters
                 attempt = 0
                 success = False
                 while attempt < self.retry_attempts and not success:
+                    # Hoisted out of the try: if an attempt fails after the
+                    # assistant turn is recorded, the except below still has to
+                    # answer its tool calls, or the retry would send a dangling
+                    # `tool_calls` turn and be rejected.
+                    turn_calls = []
+                    turn_results = {}
                     try:
 
                         show_loading = (
@@ -1450,6 +1485,12 @@ class Agent:
                         )
 
                         with loading_ctx:
+                            llm_kwargs = dict(kwargs)
+                            if use_transcript:
+                                llm_kwargs["messages"] = (
+                                    transcript.messages
+                                )
+
                             response = self.call_llm(
                                 task=task_prompt,
                                 img=img,
@@ -1457,7 +1498,7 @@ class Agent:
                                 current_loop=loop_count,
                                 streaming_callback=streaming_callback,
                                 *args,
-                                **kwargs,
+                                **llm_kwargs,
                             )
 
                         # If streaming is enabled, then don't print the response
@@ -1474,6 +1515,14 @@ class Agent:
                             role=self.agent_name,
                             content=response,
                         )
+
+                        # Record the model's turn. Any tool calls it made must
+                        # each receive a matching tool result before the next
+                        # request, which `flush_tool_results` guarantees below.
+                        if use_transcript:
+                            turn_calls = transcript.record_assistant(
+                                response
+                            )
 
                         # Print
                         if self.print_on is True:
@@ -1524,6 +1573,9 @@ class Agent:
                                         role="Tool Executor",
                                         content=f"Handoff Result:\n{result}",
                                     )
+                                    turn_results[
+                                        tool_call.get("id", "")
+                                    ] = result
                                     if self.print_on:
                                         delegated_agents = ", ".join(
                                             agent.get(
@@ -1539,9 +1591,19 @@ class Agent:
 
                         # Check and execute callable tools
                         if exists(self.tools):
-                            self.tool_execution_retry(
+                            tool_output = self.tool_execution_retry(
                                 response, loop_count
                             )
+                            if use_transcript and turn_calls:
+                                transcript.map_batch_results(
+                                    [
+                                        {"id": c["id"]}
+                                        for c in turn_calls
+                                    ],
+                                    tool_output,
+                                    turn_results,
+                                    formatter=format_data_structure,
+                                )
 
                         # Handle MCP tools
                         if self.mcp_enabled:
@@ -1555,6 +1617,14 @@ class Agent:
                                 logger.warning(
                                     f"LLM returned None response in loop {loop_count}, skipping MCP tool handling"
                                 )
+
+                        # Answer every tool call in the assistant turn just
+                        # recorded. A gap here makes the *next* request invalid,
+                        # so this runs on every path that reached this point.
+                        if use_transcript and turn_calls:
+                            transcript.flush_tool_results(
+                                turn_calls, turn_results
+                            )
 
                         success = True  # Mark as successful to exit the retry loop
 
@@ -1570,6 +1640,13 @@ class Agent:
                         AuthenticationError,
                         Exception,
                     ) as e:
+
+                        # Close out any tool calls recorded before the failure,
+                        # so the retried request is still well formed.
+                        if use_transcript and turn_calls:
+                            transcript.flush_tool_results(
+                                turn_calls, turn_results
+                            )
 
                         # Track the LLM/generation error via telemetry — the
                         # retry loop swallows it, so capture_run never sees it.
@@ -1894,12 +1971,54 @@ class Agent:
             **kwargs,
         )
 
+    def _transcript_from_memory(self) -> Transcript:
+        """
+        Seed a structured transcript from ``short_memory``.
+
+        Conversation roles are free-form strings ("User", the agent name,
+        "Tool Executor", ...), so they are mapped onto chat roles here. The
+        system prompt is skipped because the LLM wrapper supplies it. Turns
+        added *during* a run are appended structurally on top of this prefix,
+        which is what preserves tool-call fidelity where it matters most.
+        """
+        transcript = Transcript()
+        for message in self.short_memory.conversation_history:
+            if not isinstance(message, dict):
+                continue
+            role = message.get("role")
+            content = message.get("content")
+            if content is None or str(role).lower() == "system":
+                continue
+            if role == self.agent_name:
+                transcript.append_assistant_text(content)
+            else:
+                transcript.append_user(content)
+        return transcript
+
+    def _memory_and_transcript(
+        self, role: str, content: Any, transcript: Transcript
+    ) -> None:
+        """Record a turn in both ``short_memory`` and the live transcript."""
+        self.short_memory.add(role=role, content=content)
+        if role == self.agent_name:
+            transcript.append_assistant_text(content)
+        else:
+            transcript.append_user(content)
+
     def _generate_final_summary(
         self,
         streaming_callback: Optional[Callable[[str], None]] = None,
+        messages: Optional[List[dict]] = None,
     ) -> str:
         """
         Generate a comprehensive final summary of the autonomous task execution.
+
+        Args:
+            streaming_callback: Optional callback receiving streaming tokens.
+            messages: The autonomous loop's structured transcript. When given,
+                the summary is requested against the real conversation - with
+                its tool calls and tool results intact - rather than against a
+                flattened string rendering of it.
 
         Returns:
             str: Comprehensive summary
@@ -1910,11 +2029,21 @@ class Agent:
         )
 
         try:
-            task_prompt = self.short_memory.return_history_as_string()
+            if messages is not None:
+                call_kwargs = {
+                    "task": None,
+                    "messages": messages
+                    + [{"role": "user", "content": summary_prompt}],
+                }
+            else:
+                call_kwargs = {
+                    "task": self.short_memory.return_history_as_string()
+                }
+
             response = self.call_llm(
-                task=task_prompt,
                 current_loop=0,
                 streaming_callback=streaming_callback,
+                **call_kwargs,
             )
 
             response = self.parse_llm_output(response)
@@ -2255,9 +2384,12 @@ Subtask Breakdown:
                 "The agent name is not set. Please set an agent name to improve reliability."
             )
 
-        if self.max_loops is None or self.max_loops == 0:
+        if self.max_loops != "auto" and (
+            not isinstance(self.max_loops, int) or self.max_loops <= 0
+        ):
             raise AgentInitializationError(
-                "Max loops is not provided or is set to 0. Please set max loops to 1 or more."
+                "max_loops must be a positive integer or 'auto', "
+                f"got {self.max_loops!r}."
             )
 
         # Ensure max_tokens is set to a valid value based on the model, with a robust fallback.
@@ -3951,6 +4083,11 @@ Summary: {summary}
             content=format_data_structure(output),
         )
 
+        # Returned so a caller building a structured transcript can attribute
+        # this back to the individual tool_call ids. Callers that do not need
+        # it simply ignore the value.
+        self._last_tool_output = output
+
         if self.print_on is True:
             # Extract tool names and details from response for better display
             tool_names = []
@@ -4129,7 +4266,7 @@ Summary: {summary}
                     response=response,
                     loop_count=loop_count,
                 )
-                return
+                return getattr(self, "_last_tool_output", None)
             except Exception as e:
                 last_error = e
                 logger.error(

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -146,7 +146,17 @@ def get_autonomous_planning_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "create_plan",
-                "description": "Create a detailed plan for completing a task",
+                "description": (
+                    "Create or revise the plan for completing a task. Call it "
+                    "once up front, and again at any point during execution "
+                    "when what you have learned changes the plan - to add work "
+                    "you discovered, split a step that turned out to be "
+                    "several, drop a step that is no longer needed, or fix a "
+                    "dependency. Revising is cheap and expected: pass the full "
+                    "step list you now believe in. Steps are merged by "
+                    "step_id, and steps you already finished keep their "
+                    "results, so a revision never discards completed work."
+                ),
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/swarms/structs/transcript.py
+++ b/swarms/structs/transcript.py
@@ -1,0 +1,201 @@
+"""
+Structured conversation transcript for agent loops.
+
+Chat-completions APIs expect a conversation to be a sequence of *typed* turns:
+a user message, an assistant message that may carry ``tool_calls``, and one
+``{"role": "tool", "tool_call_id": ...}`` message per call the assistant made.
+Models are post-trained on that shape, and the API enforces part of it - an
+assistant message with ``tool_calls`` that is not answered by a tool message
+for every id causes the next request to be rejected.
+
+Flattening the conversation into a single user string loses all of it: the
+model can no longer tell its own prior actions from the user's input, tool
+results arrive as prose, and the stable prefix needed for prompt caching is
+rebuilt on every turn.
+
+This module owns that structure so the agent loops do not each reimplement it.
+``short_memory`` is still maintained alongside a ``Transcript`` by its callers,
+because persistence, output formatting and the final summary all read from
+there; see :class:`~swarms.structs.conversation.Conversation`.
+"""
+
+from typing import Any, Dict, List, Optional
+
+
+class Transcript:
+    """
+    An ordered list of chat-completions messages, built incrementally.
+
+    The class exists mainly to guarantee one invariant: every tool call
+    recorded by :meth:`record_assistant` receives a matching tool result before
+    the next request goes out. :meth:`flush_tool_results` enforces it, filling
+    in a placeholder for any call that was never dispatched so the model learns
+    why rather than the request failing.
+
+    Example:
+        >>> t = Transcript()
+        >>> t.append_user("read config.json")
+        >>> calls = t.record_assistant(parsed_response)
+        >>> results = {calls[0]["id"]: "{...}"} if calls else {}
+        >>> t.flush_tool_results(calls, results)
+        >>> messages = t.messages
+    """
+
+    def __init__(
+        self, messages: Optional[List[Dict[str, Any]]] = None
+    ):
+        self._messages: List[Dict[str, Any]] = list(messages or [])
+
+    # ------------------------------------------------------------------
+    # reading
+    # ------------------------------------------------------------------
+
+    @property
+    def messages(self) -> List[Dict[str, Any]]:
+        """A copy of the conversation, safe to hand to a request."""
+        return list(self._messages)
+
+    def __len__(self) -> int:
+        return len(self._messages)
+
+    def __iter__(self):
+        return iter(self._messages)
+
+    def __getitem__(self, index):
+        return self._messages[index]
+
+    def __bool__(self) -> bool:
+        return bool(self._messages)
+
+    def clear(self) -> None:
+        self._messages.clear()
+
+    # ------------------------------------------------------------------
+    # writing
+    # ------------------------------------------------------------------
+
+    def append_user(self, content: Any) -> None:
+        """Add a user turn."""
+        self._messages.append(
+            {"role": "user", "content": str(content)}
+        )
+
+    def append_assistant_text(self, content: Any) -> None:
+        """Add a plain assistant turn carrying no tool calls."""
+        self._messages.append(
+            {"role": "assistant", "content": str(content)}
+        )
+
+    def record_assistant(self, parsed: Any) -> List[Dict[str, Any]]:
+        """
+        Add the model's turn and return the tool calls it made.
+
+        Args:
+            parsed: The model's response after ``Agent.parse_llm_output`` -
+                either a list of tool-call dicts or plain text.
+
+        Returns:
+            The tool calls, normalised to ``{"id", "name", "arguments"}``.
+            Empty for a text-only turn. Every id returned must be passed to
+            :meth:`flush_tool_results` before the next request.
+        """
+        calls: List[Dict[str, Any]] = []
+
+        if isinstance(parsed, list):
+            tool_calls = []
+            for index, item in enumerate(parsed):
+                if not isinstance(item, dict):
+                    continue
+                function = item.get("function") or {}
+                name = function.get("name")
+                if not name:
+                    continue
+                # Providers normally supply an id; synthesise a stable one if
+                # not, since result pairing depends on it.
+                call_id = (
+                    item.get("id")
+                    or f"call_{len(self._messages)}_{index}"
+                )
+                arguments = function.get("arguments", "{}")
+                tool_calls.append(
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": name,
+                            "arguments": arguments,
+                        },
+                    }
+                )
+                calls.append(
+                    {
+                        "id": call_id,
+                        "name": name,
+                        "arguments": arguments,
+                    }
+                )
+
+            if tool_calls:
+                self._messages.append(
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": tool_calls,
+                    }
+                )
+                return calls
+
+        self.append_assistant_text(parsed)
+        return calls
+
+    def flush_tool_results(
+        self,
+        calls: List[Dict[str, Any]],
+        results: Dict[str, Any],
+    ) -> None:
+        """
+        Emit exactly one tool result per call in the preceding assistant turn.
+
+        Args:
+            calls: What :meth:`record_assistant` returned.
+            results: Results keyed by tool call id. Missing entries are filled
+                with a placeholder rather than skipped, because a gap makes the
+                next request invalid.
+        """
+        for call in calls:
+            result = results.get(
+                call["id"],
+                f"(no result recorded for {call['name']})",
+            )
+            self._messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call["id"],
+                    "content": str(result),
+                }
+            )
+
+    def map_batch_results(
+        self,
+        tool_calls: List[Dict[str, Any]],
+        output: Any,
+        results: Dict[str, Any],
+        formatter=str,
+    ) -> None:
+        """
+        Attribute a batched tool execution back to individual call ids.
+
+        Batch executors return one value per call when they can and a single
+        combined value otherwise. Either way every id needs an entry, so a
+        non-list output is recorded against all of them rather than leaving
+        gaps.
+        """
+        if isinstance(output, list) and len(output) == len(
+            tool_calls
+        ):
+            pairs = zip(tool_calls, output)
+        else:
+            pairs = ((call, output) for call in tool_calls)
+
+        for call, value in pairs:
+            results[call.get("id", "")] = formatter(value)

--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -573,6 +573,7 @@ class LiteLLM:
         task: Optional[str] = None,
         img: Optional[str] = None,
         imgs: Optional[List[str]] = None,
+        messages: Optional[List[dict]] = None,
     ):
         """
         Prepare the messages list for the LLM API call.
@@ -587,6 +588,13 @@ class LiteLLM:
             img (Optional[str]): Image input (file path, URL, data URI, or base64 string).
                 If provided, the task and image are combined into a vision message.
                 Defaults to None.
+            messages (Optional[List[dict]]): A prebuilt conversation body in
+                OpenAI chat format - user/assistant turns, ``tool_calls`` on
+                assistant messages, and ``{"role": "tool", "tool_call_id": ...}``
+                results. When given, it is appended after the system prompt and
+                ``task`` is ignored. This is the path an agentic loop uses to
+                preserve real tool-call structure instead of flattening the
+                conversation into a single user string.
 
         Returns:
             list: A list of messages formatted for the LLM API. Includes the system
@@ -630,21 +638,34 @@ class LiteLLM:
                     # If splitting fails for any reason, fall back to original task
                     pass
 
-        # Start with a fresh copy of messages to avoid duplication.
-        # Also drop any empty system blocks to satisfy Anthropic validation.
-        messages = []
+        # Start with a fresh copy of this instance's own turns (the system
+        # prompt) to avoid duplication. Also drop any empty system blocks to
+        # satisfy Anthropic validation. Named `base` rather than `messages` so
+        # it cannot shadow the `messages` parameter below.
+        base = []
         for m in self.messages:
             if not isinstance(m, dict):
                 continue
             if m.get("role") != "system":
-                messages.append(m)
+                base.append(m)
                 continue
             content = m.get("content")
             if content is None:
                 continue
             if isinstance(content, str) and not content.strip():
                 continue
-            messages.append(m)
+            base.append(m)
+
+        # A prebuilt conversation body replaces the single-user-turn path
+        # entirely: the caller has already structured the turns, so the only
+        # thing to add is this instance's system prompt.
+        if messages is not None:
+            prepared = base + list(messages)
+            if self.prompt_caching and prepared:
+                self._apply_prompt_caching(prepared)
+            return prepared
+
+        messages = base
 
         # Check if model supports vision if any image is provided
         images = [
@@ -1124,6 +1145,7 @@ class LiteLLM:
         imgs: Optional[List[str]] = None,
         runtime_args: tuple = (),
         runtime_kwargs: Optional[dict] = None,
+        messages: Optional[List[dict]] = None,
     ) -> dict:
         """
         Assemble the full parameter dict for a litellm completion call.
@@ -1141,7 +1163,7 @@ class LiteLLM:
         completion_params = {
             "model": self.model_name,
             "messages": self._prepare_messages(
-                task=task, img=img, imgs=imgs
+                task=task, img=img, imgs=imgs, messages=messages
             ),
             "stream": self.stream,
             "max_tokens": self.max_tokens,
@@ -1313,10 +1335,11 @@ class LiteLLM:
 
     def run(
         self,
-        task: str,
+        task: Optional[str] = None,
         audio: Optional[str] = None,
         img: Optional[str] = None,
         imgs: Optional[List[str]] = None,
+        messages: Optional[List[dict]] = None,
         *args,
         **kwargs,
     ):
@@ -1360,6 +1383,7 @@ class LiteLLM:
                 imgs=imgs,
                 runtime_args=args,
                 runtime_kwargs=kwargs,
+                messages=messages,
             )
             response = completion(**completion_params)
             return self._process_response(response)
@@ -1378,10 +1402,11 @@ class LiteLLM:
 
     async def arun(
         self,
-        task: str,
+        task: Optional[str] = None,
         audio: Optional[str] = None,
         img: Optional[str] = None,
         imgs: Optional[List[str]] = None,
+        messages: Optional[List[dict]] = None,
         *args,
         **kwargs,
     ):
@@ -1398,6 +1423,7 @@ class LiteLLM:
                 imgs=imgs,
                 runtime_args=args,
                 runtime_kwargs=kwargs,
+                messages=messages,
             )
             response = await acompletion(**completion_params)
             return self._process_response(response)

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -1,0 +1,859 @@
+"""
+Regression tests for the ``max_loops="auto"`` autonomous loop.
+
+Approach
+--------
+Fully offline. Constructing a real ``swarms.Agent`` performs no network I/O
+(the LLM is only contacted on ``.run()``), so every test below builds a real
+agent and a real :class:`AutonomousAgentLoop`. The single seam that would talk
+to a provider — ``Agent.call_llm`` — is monkeypatched per-test with a scripted
+sequence of canned responses, so the loop's real control flow, real tool
+dispatch, and real state transitions are exercised end to end.
+
+Covers three fixed defects:
+
+* #1963 — tool errors were logged and discarded, so the model never learned a
+  call had failed and re-emitted it until the iteration budget was gone.
+* #1964 — ``subtask_done`` broke out of the tool-call loop, silently dropping
+  every call the model batched after it, while still marking the subtask done.
+* #1966 — a *failed* dependency satisfied its dependents, and an unknown
+  ``step_id`` defaulted to satisfied.
+
+Run:
+    cd /Users/swarms_wd/Desktop/research/swarms
+    PYTHONPATH=. python3 -m pytest tests/agents/test_autonomous_loop.py -q -p no:randomly
+"""
+
+import json
+
+import pytest
+
+from swarms import Agent
+from swarms.agents.autonomous_loop import AutonomousAgentLoop
+from swarms.structs.autonomous_loop_utils import MAX_SUBTASK_LOOPS
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+def build_agent(**overrides):
+    """Build a real, offline agent configured for the autonomous loop."""
+    kwargs = dict(
+        agent_name="AutoLoopTestAgent",
+        model_name="gpt-4o-mini",
+        max_loops="auto",
+        persistent_memory=False,
+        context_compression=False,
+        print_on=False,
+        verbose=False,
+        autosave=False,
+    )
+    kwargs.update(overrides)
+    return Agent(**kwargs)
+
+
+def tool_call(name, **arguments):
+    """Build a tool call in the shape ``parse_llm_output`` yields."""
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(arguments),
+        },
+    }
+
+
+def plan(*steps):
+    """Build a ``create_plan`` response from ``(step_id, deps)`` pairs."""
+    return [
+        tool_call(
+            "create_plan",
+            task_description="test task",
+            steps=[
+                {
+                    "step_id": step_id,
+                    "description": f"do {step_id}",
+                    "priority": "high",
+                    "dependencies": list(deps),
+                }
+                for step_id, deps in steps
+            ],
+        )
+    ]
+
+
+def script_llm(agent, monkeypatch, responses):
+    """
+    Replace ``agent.call_llm`` with a scripted sequence.
+
+    Each call pops the next canned response. Running past the end returns a
+    plain string, which the loop treats as a no-op turn — that keeps a test
+    from hanging if the loop iterates more than expected.
+    """
+    queue = list(responses)
+    calls = []
+
+    def fake_call_llm(task=None, *args, **kwargs):
+        calls.append(task)
+        if queue:
+            return queue.pop(0)
+        return "no further action"
+
+    monkeypatch.setattr(agent, "call_llm", fake_call_llm)
+    return calls
+
+
+def history(agent):
+    """Full conversation text, for asserting what the model would next see."""
+    return agent.short_memory.return_history_as_string()
+
+
+def status_of(agent, step_id):
+    for subtask in agent.autonomous_subtasks:
+        if subtask["step_id"] == step_id:
+            return subtask["status"]
+    raise AssertionError(f"no subtask {step_id!r}")
+
+
+# --------------------------------------------------------------------------
+# #1966 — dependency resolution
+# --------------------------------------------------------------------------
+
+
+class TestDependencyResolution:
+    """A dependency only counts as satisfied when it actually completed."""
+
+    def test_failed_dependency_does_not_unblock_dependent(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t",
+            [
+                {"step_id": "a"},
+                {"step_id": "b", "dependencies": ["a"]},
+            ],
+        )
+
+        agent.subtask_status["a"] = "failed"
+        agent.autonomous_subtasks[0]["status"] = "failed"
+
+        assert loop._get_next_executable_subtask() is None
+        assert status_of(agent, "b") == "skipped"
+
+    def test_completed_dependency_unblocks_dependent(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t",
+            [
+                {"step_id": "a"},
+                {"step_id": "b", "dependencies": ["a"]},
+            ],
+        )
+
+        agent.subtask_status["a"] = "completed"
+        agent.autonomous_subtasks[0]["status"] = "completed"
+
+        nxt = loop._get_next_executable_subtask()
+        assert nxt is not None and nxt["step_id"] == "b"
+
+    def test_skip_cascades_through_a_dependency_chain(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t",
+            [
+                {"step_id": "a"},
+                {"step_id": "b", "dependencies": ["a"]},
+                {"step_id": "c", "dependencies": ["b"]},
+            ],
+        )
+
+        agent.subtask_status["a"] = "failed"
+        agent.autonomous_subtasks[0]["status"] = "failed"
+
+        # First pass skips b; second pass sees b skipped and skips c.
+        assert loop._get_next_executable_subtask() is None
+        assert loop._get_next_executable_subtask() is None
+        assert status_of(agent, "b") == "skipped"
+        assert status_of(agent, "c") == "skipped"
+
+    def test_unknown_dependency_is_dropped_at_plan_time(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t",
+            [{"step_id": "a", "dependencies": ["ghost_step", "a"]}],
+        )
+
+        # The hallucinated id and the self-reference are both removed, so the
+        # subtask is runnable rather than permanently blocked.
+        assert agent.autonomous_subtasks[0]["dependencies"] == []
+        nxt = loop._get_next_executable_subtask()
+        assert nxt is not None and nxt["step_id"] == "a"
+
+    def test_real_dependencies_survive_validation(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t",
+            [
+                {"step_id": "a"},
+                {"step_id": "b", "dependencies": ["a", "nope"]},
+            ],
+        )
+
+        assert agent.autonomous_subtasks[1]["dependencies"] == ["a"]
+
+    def test_skipped_counts_as_terminal(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool("t", [{"step_id": "a"}])
+
+        agent.autonomous_subtasks[0]["status"] = "skipped"
+        assert loop._all_subtasks_complete() is True
+
+
+# --------------------------------------------------------------------------
+# #1964 — tool calls batched after subtask_done
+# --------------------------------------------------------------------------
+
+
+class TestBatchedToolCalls:
+    """Every tool call in a response runs, whatever its position."""
+
+    def test_call_after_subtask_done_still_executes(
+        self, monkeypatch, tmp_path
+    ):
+        agent = build_agent()
+        target = tmp_path / "written.txt"
+
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                plan(("step1", [])),
+                # subtask_done deliberately precedes the real work, which is
+                # exactly what the execution prompt asks the model to batch.
+                [
+                    tool_call(
+                        "subtask_done",
+                        task_id="step1",
+                        summary="done",
+                        success=True,
+                    ),
+                    tool_call(
+                        "create_file",
+                        file_path=str(target),
+                        content="payload",
+                    ),
+                ],
+                [
+                    tool_call(
+                        "complete_task",
+                        task_id="main",
+                        summary="all done",
+                        success=True,
+                    )
+                ],
+            ],
+        )
+
+        agent.run("test task")
+
+        assert (
+            target.exists()
+        ), "file write batched after subtask_done was dropped"
+        assert target.read_text() == "payload"
+        assert status_of(agent, "step1") == "completed"
+
+    def test_call_after_complete_task_still_executes(
+        self, monkeypatch, tmp_path
+    ):
+        agent = build_agent()
+        target = tmp_path / "late.txt"
+
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                plan(("step1", [])),
+                [
+                    tool_call(
+                        "complete_task",
+                        task_id="main",
+                        summary="finished",
+                        success=True,
+                    ),
+                    tool_call(
+                        "create_file",
+                        file_path=str(target),
+                        content="payload",
+                    ),
+                ],
+            ],
+        )
+
+        agent.run("test task")
+
+        assert (
+            target.exists()
+        ), "file write batched after complete_task was dropped"
+
+
+# --------------------------------------------------------------------------
+# #1963 — tool errors reach the model
+# --------------------------------------------------------------------------
+
+
+class TestToolErrorFeedback:
+    """A failing tool call is reported back, not silently discarded."""
+
+    def test_handler_exception_is_added_to_the_conversation(
+        self, monkeypatch
+    ):
+        agent = build_agent()
+
+        def exploding_think(*args, **kwargs):
+            raise RuntimeError("handler blew up")
+
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                plan(("step1", [])),
+                [
+                    tool_call(
+                        "think",
+                        current_state="s",
+                        analysis="a",
+                        next_actions=["x"],
+                        confidence=0.9,
+                    )
+                ],
+                [
+                    tool_call(
+                        "subtask_done",
+                        task_id="step1",
+                        summary="done",
+                        success=True,
+                    )
+                ],
+                [
+                    tool_call(
+                        "complete_task",
+                        task_id="main",
+                        summary="done",
+                        success=True,
+                    )
+                ],
+            ],
+        )
+        monkeypatch.setattr(
+            AutonomousAgentLoop, "_think_tool", exploding_think
+        )
+
+        agent.run("test task")
+
+        text = history(agent)
+        assert "handler blew up" in text
+        assert "RuntimeError" in text
+
+    def test_malformed_arguments_do_not_abort_the_iteration(
+        self, monkeypatch, tmp_path
+    ):
+        agent = build_agent()
+        target = tmp_path / "after_bad_json.txt"
+
+        bad = {
+            "type": "function",
+            "function": {"name": "think", "arguments": "{not json"},
+        }
+
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                plan(("step1", [])),
+                [
+                    bad,
+                    tool_call(
+                        "create_file",
+                        file_path=str(target),
+                        content="payload",
+                    ),
+                    tool_call(
+                        "subtask_done",
+                        task_id="step1",
+                        summary="done",
+                        success=True,
+                    ),
+                ],
+                [
+                    tool_call(
+                        "complete_task",
+                        task_id="main",
+                        summary="done",
+                        success=True,
+                    )
+                ],
+            ],
+        )
+
+        agent.run("test task")
+
+        assert (
+            target.exists()
+        ), "a malformed call aborted the whole response"
+        assert "ERROR: think failed" in history(agent)
+
+    def test_failed_subtask_done_does_not_complete_the_subtask(
+        self, monkeypatch
+    ):
+        agent = build_agent()
+
+        def exploding_done(*args, **kwargs):
+            raise RuntimeError("could not record completion")
+
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                plan(("step1", [])),
+                [
+                    tool_call(
+                        "subtask_done",
+                        task_id="step1",
+                        summary="done",
+                        success=True,
+                    )
+                ],
+            ],
+        )
+        monkeypatch.setattr(
+            AutonomousAgentLoop, "_subtask_done_tool", exploding_done
+        )
+
+        agent.run("test task")
+
+        # The handler never recorded anything, so the subtask must not be
+        # reported as completed on the strength of the call alone.
+        assert status_of(agent, "step1") != "completed"
+
+
+# --------------------------------------------------------------------------
+# #1977 - structured transcript
+# --------------------------------------------------------------------------
+
+
+class TestStructuredTranscript:
+    """The loop sends a real conversation, not a flattened string."""
+
+    def _run_simple(self, monkeypatch, tmp_path):
+        agent = build_agent()
+        target = tmp_path / "t.txt"
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                plan(("step1", [])),
+                [
+                    tool_call(
+                        "create_file",
+                        file_path=str(target),
+                        content="x",
+                    )
+                ],
+                [
+                    tool_call(
+                        "subtask_done",
+                        task_id="step1",
+                        summary="d",
+                        success=True,
+                    )
+                ],
+                [
+                    tool_call(
+                        "complete_task",
+                        task_id="main",
+                        summary="d",
+                        success=True,
+                    )
+                ],
+            ],
+        )
+        agent.run("demo")
+        return agent
+
+    def test_transcript_uses_real_roles(self, monkeypatch, tmp_path):
+        agent = self._run_simple(monkeypatch, tmp_path)
+        roles = [
+            m["role"]
+            for m in agent.autonomous_loop._transcript.messages
+        ]
+
+        assert "assistant" in roles, "no assistant turn was recorded"
+        assert (
+            "tool" in roles
+        ), "tool results were not recorded as tool messages"
+        assert roles[0] == "user"
+
+    def test_assistant_turns_carry_tool_calls(
+        self, monkeypatch, tmp_path
+    ):
+        agent = self._run_simple(monkeypatch, tmp_path)
+        assistant = [
+            m
+            for m in agent.autonomous_loop._transcript.messages
+            if m["role"] == "assistant"
+        ]
+        assert assistant, "no assistant turns"
+        assert all("tool_calls" in m for m in assistant)
+        names = [
+            c["function"]["name"]
+            for m in assistant
+            for c in m["tool_calls"]
+        ]
+        assert "create_file" in names
+
+    def test_every_tool_call_has_a_matching_result(
+        self, monkeypatch, tmp_path
+    ):
+        """
+        The chat-completions contract: an assistant message with tool_calls
+        must be followed by one tool message per tool_call_id. A gap makes the
+        next request fail outright, so this is the invariant that matters most.
+        """
+        agent = self._run_simple(monkeypatch, tmp_path)
+        transcript = agent.autonomous_loop._transcript.messages
+
+        for index, message in enumerate(transcript):
+            if message["role"] != "assistant" or not message.get(
+                "tool_calls"
+            ):
+                continue
+            expected = [c["id"] for c in message["tool_calls"]]
+            following = [
+                transcript[j]["tool_call_id"]
+                for j in range(
+                    index + 1,
+                    min(index + 1 + len(expected), len(transcript)),
+                )
+                if transcript[j]["role"] == "tool"
+            ]
+            assert following == expected, (
+                f"assistant turn {index} has unanswered tool calls: "
+                f"expected {expected}, got {following}"
+            )
+
+    def test_llm_receives_messages_not_a_flattened_string(
+        self, monkeypatch, tmp_path
+    ):
+        agent = build_agent()
+        seen = {}
+
+        def capture(task=None, *args, **kwargs):
+            seen.setdefault("messages", kwargs.get("messages"))
+            seen.setdefault("task", task)
+            return [
+                tool_call(
+                    "complete_task",
+                    task_id="m",
+                    summary="d",
+                    success=True,
+                )
+            ]
+
+        monkeypatch.setattr(agent, "call_llm", capture)
+        agent.run("demo")
+
+        assert (
+            seen["task"] is None
+        ), "the loop still sends a task string"
+        assert isinstance(seen["messages"], list)
+        assert seen["messages"][0]["role"] == "user"
+
+
+# --------------------------------------------------------------------------
+# #1978 - the plan is mutable
+# --------------------------------------------------------------------------
+
+
+class TestMutablePlan:
+    """Re-planning merges rather than wiping."""
+
+    def test_revision_preserves_completed_work(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a"}, {"step_id": "b"}]
+        )
+
+        agent.autonomous_subtasks[0]["status"] = "completed"
+        agent.autonomous_subtasks[0]["summary"] = "did a"
+        agent.subtask_status["a"] = "completed"
+
+        loop._create_plan_tool(
+            "t",
+            [{"step_id": "a"}, {"step_id": "b"}, {"step_id": "c"}],
+        )
+
+        assert status_of(agent, "a") == "completed"
+        assert agent.autonomous_subtasks[0]["summary"] == "did a"
+        assert status_of(agent, "c") == "pending"
+
+    def test_revision_can_add_discovered_work(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool("t", [{"step_id": "a"}])
+        loop._create_plan_tool(
+            "t", [{"step_id": "a"}, {"step_id": "new"}]
+        )
+
+        ids = [s["step_id"] for s in agent.autonomous_subtasks]
+        assert ids == ["a", "new"]
+
+    def test_revision_drops_pending_steps_left_out(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a"}, {"step_id": "obsolete"}]
+        )
+        loop._create_plan_tool("t", [{"step_id": "a"}])
+
+        ids = [s["step_id"] for s in agent.autonomous_subtasks]
+        assert ids == ["a"]
+        assert "obsolete" not in agent.subtask_status
+
+    def test_finished_steps_left_out_are_kept_as_history(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "done"}, {"step_id": "b"}]
+        )
+        agent.autonomous_subtasks[0]["status"] = "completed"
+        agent.subtask_status["done"] = "completed"
+
+        loop._create_plan_tool("t", [{"step_id": "b"}])
+
+        ids = [s["step_id"] for s in agent.autonomous_subtasks]
+        assert "done" in ids, "finished work was erased by a revision"
+        assert status_of(agent, "done") == "completed"
+
+    def test_revision_can_update_a_pending_step(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a", "description": "old"}]
+        )
+        loop._create_plan_tool(
+            "t",
+            [
+                {
+                    "step_id": "a",
+                    "description": "new",
+                    "priority": "low",
+                }
+            ],
+        )
+
+        subtask = agent.autonomous_subtasks[0]
+        assert subtask["description"] == "new"
+        assert subtask["priority"] == "low"
+
+    def test_revision_reports_a_diff_not_the_whole_plan(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool("t", [{"step_id": "a"}])
+        result = loop._create_plan_tool(
+            "t", [{"step_id": "a"}, {"step_id": "b"}]
+        )
+
+        assert "added" in result and "'b'" in result
+        assert "Plan updated" in result
+
+    def test_first_call_still_reads_as_creation(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        result = loop._create_plan_tool("t", [{"step_id": "a"}])
+        assert "created successfully" in result
+
+    def test_revision_may_depend_on_finished_unmentioned_steps(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool("t", [{"step_id": "a"}])
+        agent.autonomous_subtasks[0]["status"] = "completed"
+        agent.subtask_status["a"] = "completed"
+
+        loop._create_plan_tool(
+            "t", [{"step_id": "b", "dependencies": ["a"]}]
+        )
+        b = [
+            s
+            for s in agent.autonomous_subtasks
+            if s["step_id"] == "b"
+        ][0]
+        assert b["dependencies"] == [
+            "a"
+        ], "a finished dependency was dropped"
+
+
+# --------------------------------------------------------------------------
+# think_tool parameter
+# --------------------------------------------------------------------------
+
+
+class TestThinkToolParameter:
+    """`think` is opt-in, and the prompt agrees with the tool list."""
+
+    def _tools_offered(self, agent, monkeypatch):
+        """Run the loop far enough to see the tool list it builds."""
+        offered = {}
+
+        def capture(task=None, *args, **kwargs):
+            offered.setdefault(
+                "names",
+                [
+                    t["function"]["name"]
+                    for t in (agent.tools_list_dictionary or [])
+                    if isinstance(t, dict) and "function" in t
+                ],
+            )
+            return [
+                tool_call(
+                    "complete_task",
+                    task_id="m",
+                    summary="d",
+                    success=True,
+                )
+            ]
+
+        monkeypatch.setattr(agent, "call_llm", capture)
+        agent.run("demo")
+        return offered.get("names", [])
+
+    def test_think_is_absent_by_default(self, monkeypatch):
+        agent = build_agent()
+        assert agent.think_tool is False
+        assert "think" not in self._tools_offered(agent, monkeypatch)
+
+    def test_think_is_offered_when_enabled(self, monkeypatch):
+        agent = build_agent(think_tool=True)
+        assert "think" in self._tools_offered(agent, monkeypatch)
+
+    def test_prompt_matches_the_tool_list(self):
+        """The model must not be told to call a tool it was not given."""
+        without = build_agent()
+        with_think = build_agent(think_tool=True)
+
+        assert "TOOL AVAILABILITY OVERRIDE" in without.system_prompt
+        assert (
+            "TOOL AVAILABILITY OVERRIDE"
+            not in with_think.system_prompt
+        )
+
+    def test_default_thinking_tokens_no_longer_decides(self):
+        """
+        Regression guard. The old filter tested `thinking_tokens is not None`,
+        but `thinking_tokens` defaults to 1024, so that was always true and
+        stripped `think` for every agent regardless of intent. The explicit
+        parameter now decides.
+        """
+        agent = build_agent(think_tool=True)
+        assert (
+            agent.thinking_tokens is not None
+        ), "precondition: thinking_tokens has a non-None default"
+        # think_tool wins over the non-None default.
+        assert agent.think_tool is True
+
+
+# --------------------------------------------------------------------------
+# #1965 - the consecutive-think guard, and containment of a stuck subtask
+# --------------------------------------------------------------------------
+
+
+class TestThinkLoopContainment:
+    """A model stuck analysing must be interrupted, then contained."""
+
+    def _thrashing_agent(self, monkeypatch):
+        """An agent whose model only ever calls `think`, never acting."""
+        agent = build_agent(think_tool=True)
+        turn = {"n": 0}
+
+        def scripted(task=None, *args, **kwargs):
+            turn["n"] += 1
+            if turn["n"] == 1:
+                return plan(("s1", []))
+            return [
+                tool_call(
+                    "think",
+                    current_state=f"state {turn['n']}",
+                    analysis="pondering",
+                    next_actions=["keep thinking"],
+                    confidence=0.5,
+                )
+            ]
+
+        monkeypatch.setattr(agent, "call_llm", scripted)
+        return agent, turn
+
+    def test_the_guard_actually_fires(self, monkeypatch):
+        """
+        Regression for #1965. think_call_count used to reset at the top of
+        every iteration, so one think per turn never reached the limit and the
+        guard was dead code.
+        """
+        agent, _ = self._thrashing_agent(monkeypatch)
+        agent.run("demo")
+
+        nudges = [
+            m
+            for m in agent.autonomous_loop._transcript.messages
+            if "times in a row" in str(m.get("content"))
+        ]
+        assert (
+            nudges
+        ), "the guard never fired despite endless think calls"
+
+    def test_the_nudge_reaches_the_model(self, monkeypatch):
+        """A nudge only in short_memory is invisible on the next request."""
+        agent, _ = self._thrashing_agent(monkeypatch)
+        agent.run("demo")
+
+        transcript = agent.autonomous_loop._transcript.messages
+        assert any(
+            "Take concrete action now" in str(m.get("content"))
+            for m in transcript
+        ), "the intervention never entered the transcript sent to the model"
+
+    def test_a_stuck_subtask_is_contained(self, monkeypatch):
+        """
+        A subtask that exhausts its budget must not stay `pending`: pending
+        keeps it eligible, so the outer loop re-selects it and re-runs the same
+        doomed budget up to MAX_SUBTASK_ITERATIONS times (100 x 20 = 2000
+        LLM calls for one stuck subtask).
+        """
+        agent, turn = self._thrashing_agent(monkeypatch)
+        agent.run("demo")
+
+        assert status_of(agent, "s1") == "failed"
+        assert turn["n"] < MAX_SUBTASK_LOOPS + 5, (
+            f"a stuck subtask consumed {turn['n']} LLM turns; it should be "
+            f"bounded by one budget of {MAX_SUBTASK_LOOPS}"
+        )
+
+    def test_a_real_action_resets_the_streak(self):
+        """`consecutive` must mean consecutive."""
+        agent = build_agent(think_tool=True)
+        agent.think_call_count = 1
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool("t", [{"step_id": "a"}])
+        # _subtask_done_tool is one of the non-think handlers that clears it.
+        loop._subtask_done_tool("a", "done", True)
+        assert agent.think_call_count == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q", "-p", "no:randomly"])

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -22,7 +22,10 @@ from swarms import (
     create_agents_from_yaml,
 )
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
-from swarms.schemas.agent_errors import AgentToolExecutionError
+from swarms.schemas.agent_errors import (
+    AgentInitializationError,
+    AgentToolExecutionError,
+)
 
 # Load environment variables
 load_dotenv()
@@ -2543,7 +2546,9 @@ class TestMaxTokens:
 
     def test_non_positive_falls_back_to_the_model(self):
         for bad in (0, -1, None):
-            agent = self._agent(model_name="gpt-4o-mini", max_tokens=bad)
+            agent = self._agent(
+                model_name="gpt-4o-mini", max_tokens=bad
+            )
             assert agent.max_tokens > 0
 
     def test_unknown_model_falls_back(self):

--- a/tests/structs/test_transcript.py
+++ b/tests/structs/test_transcript.py
@@ -1,0 +1,272 @@
+"""
+Tests for :class:`swarms.structs.transcript.Transcript` and its use on the
+integer ``max_loops`` path.
+
+Approach
+--------
+Fully offline. The ``Transcript`` tests are pure unit tests. The agent tests
+build a real ``Agent`` (construction performs no network I/O) and monkeypatch
+the single seam that would reach a provider, ``Agent.call_llm``, so the real
+``_run`` control flow is exercised end to end.
+
+The invariant under test throughout: an assistant message carrying
+``tool_calls`` must be followed by one ``{"role": "tool", "tool_call_id": ...}``
+message per call. A gap there makes the *next* request invalid, so it is the
+property that matters most.
+
+Run:
+    cd /Users/swarms_wd/Desktop/research/swarms
+    PYTHONPATH=. python3 -m pytest tests/structs/test_transcript.py -q -p no:randomly
+"""
+
+import json
+
+import pytest
+
+from swarms import Agent
+from swarms.structs.transcript import Transcript
+
+
+def tool_call(name, call_id="call_1", **arguments):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(arguments),
+        },
+    }
+
+
+def assert_calls_answered(messages):
+    """Every assistant tool_calls turn is followed by its tool results."""
+    for index, message in enumerate(messages):
+        if message["role"] != "assistant" or not message.get(
+            "tool_calls"
+        ):
+            continue
+        expected = [c["id"] for c in message["tool_calls"]]
+        following = [
+            messages[j]["tool_call_id"]
+            for j in range(
+                index + 1,
+                min(index + 1 + len(expected), len(messages)),
+            )
+            if messages[j]["role"] == "tool"
+        ]
+        assert following == expected, (
+            f"assistant turn {index} left tool calls unanswered: "
+            f"expected {expected}, got {following}"
+        )
+
+
+class TestTranscript:
+    def test_records_a_tool_call_and_its_result(self):
+        t = Transcript()
+        t.append_user("read it")
+        calls = t.record_assistant(
+            [tool_call("read_file", file_path="a")]
+        )
+
+        assert len(calls) == 1 and calls[0]["name"] == "read_file"
+        t.flush_tool_results(calls, {calls[0]["id"]: "contents"})
+
+        assert [m["role"] for m in t.messages] == [
+            "user",
+            "assistant",
+            "tool",
+        ]
+        assert t.messages[-1]["content"] == "contents"
+        assert_calls_answered(t.messages)
+
+    def test_text_only_response_is_an_assistant_turn(self):
+        t = Transcript()
+        calls = t.record_assistant("just talking")
+
+        assert calls == []
+        assert t.messages == [
+            {"role": "assistant", "content": "just talking"}
+        ]
+
+    def test_missing_result_is_filled_not_skipped(self):
+        """A gap would make the next request invalid, so it must be filled."""
+        t = Transcript()
+        calls = t.record_assistant([tool_call("grep", call_id="c9")])
+        t.flush_tool_results(calls, {})
+
+        assert t.messages[-1]["role"] == "tool"
+        assert t.messages[-1]["tool_call_id"] == "c9"
+        assert "no result recorded" in t.messages[-1]["content"]
+        assert_calls_answered(t.messages)
+
+    def test_multiple_calls_each_get_a_result(self):
+        t = Transcript()
+        calls = t.record_assistant(
+            [
+                tool_call("read_file", call_id="a"),
+                tool_call("grep", call_id="b"),
+            ]
+        )
+        t.flush_tool_results(calls, {"a": "one", "b": "two"})
+
+        assert [m["role"] for m in t.messages] == [
+            "assistant",
+            "tool",
+            "tool",
+        ]
+        assert_calls_answered(t.messages)
+
+    def test_call_without_an_id_gets_a_synthesised_one(self):
+        t = Transcript()
+        calls = t.record_assistant(
+            [{"function": {"name": "f", "arguments": "{}"}}]
+        )
+        assert calls and calls[0]["id"]
+        t.flush_tool_results(calls, {})
+        assert_calls_answered(t.messages)
+
+    def test_batch_output_maps_one_value_per_call(self):
+        t = Transcript()
+        calls = [{"id": "a"}, {"id": "b"}]
+        results = {}
+        t.map_batch_results(calls, ["one", "two"], results)
+        assert results == {"a": "one", "b": "two"}
+
+    def test_combined_batch_output_is_recorded_against_every_call(
+        self,
+    ):
+        t = Transcript()
+        calls = [{"id": "a"}, {"id": "b"}]
+        results = {}
+        t.map_batch_results(calls, "combined", results)
+        assert results == {"a": "combined", "b": "combined"}
+
+    def test_messages_property_is_a_copy(self):
+        t = Transcript()
+        t.append_user("x")
+        t.messages.append({"role": "user", "content": "mutated"})
+        assert len(t) == 1
+
+
+class TestIntegerMaxLoopsUsesMessages:
+    """The fixed-loop path sends a real conversation, not a flattened string."""
+
+    def _agent(self, **kwargs):
+        return Agent(
+            agent_name="IntPathTest",
+            model_name="gpt-4o-mini",
+            persistent_memory=False,
+            print_on=False,
+            verbose=False,
+            autosave=False,
+            # Keeps the suite offline: the summariser would otherwise make a
+            # real provider call after each tool execution.
+            tool_call_summary=False,
+            **kwargs,
+        )
+
+    def test_call_llm_receives_messages_not_a_task_string(
+        self, monkeypatch
+    ):
+        agent = self._agent(max_loops=1)
+        seen = {}
+
+        def capture(task=None, *args, **kwargs):
+            seen["task"] = task
+            seen["messages"] = kwargs.get("messages")
+            return "done"
+
+        monkeypatch.setattr(agent, "call_llm", capture)
+        agent.run("hello")
+
+        assert (
+            seen["task"] is None
+        ), "still sending a flattened task string"
+        assert isinstance(seen["messages"], list)
+        assert seen["messages"], "an empty conversation was sent"
+
+    def test_the_task_appears_as_a_user_turn(self, monkeypatch):
+        agent = self._agent(max_loops=1)
+        seen = {}
+
+        monkeypatch.setattr(
+            agent,
+            "call_llm",
+            lambda task=None, *a, **k: (
+                seen.setdefault("messages", k.get("messages")),
+                "done",
+            )[1],
+        )
+        agent.run("find the bug")
+
+        users = [
+            m["content"]
+            for m in seen["messages"]
+            if m["role"] == "user"
+        ]
+        assert any("find the bug" in u for u in users)
+
+    def test_tool_results_are_paired_across_loops(self, monkeypatch):
+        """The second loop must see the first loop's tool call answered."""
+
+        def get_weather(city: str) -> str:
+            """Return the weather for a city.
+
+            Args:
+                city: The city name.
+            """
+            return f"{city}: sunny"
+
+        agent = self._agent(max_loops=2, tools=[get_weather])
+        captured = []
+        turn = {"n": 0}
+
+        def scripted(task=None, *args, **kwargs):
+            captured.append(kwargs.get("messages"))
+            turn["n"] += 1
+            if turn["n"] == 1:
+                return [
+                    tool_call(
+                        "get_weather", call_id="w1", city="Paris"
+                    )
+                ]
+            return "It is sunny in Paris."
+
+        monkeypatch.setattr(agent, "call_llm", scripted)
+        agent.run("weather in Paris?")
+
+        assert len(captured) == 2, "the second loop did not run"
+        second = captured[1]
+        assert any(
+            m["role"] == "tool" for m in second
+        ), "the tool result was not sent as a tool message"
+        assert_calls_answered(second)
+
+    def test_transforms_keep_the_legacy_flattened_prompt(
+        self, monkeypatch
+    ):
+        """`transforms` rewrites history into a string by design."""
+        agent = self._agent(max_loops=1)
+        agent.transforms = (
+            object()
+        )  # any non-None value selects that path
+        seen = {}
+
+        def capture(task=None, *args, **kwargs):
+            seen["task"] = task
+            seen["messages"] = kwargs.get("messages")
+            return "done"
+
+        monkeypatch.setattr(agent, "call_llm", capture)
+        monkeypatch.setattr(
+            "swarms.structs.agent.handle_transforms",
+            lambda **kw: "FLATTENED",
+        )
+        agent.run("hello")
+
+        assert seen["task"] == "FLATTENED"
+        assert seen["messages"] is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q", "-p", "no:randomly"])


### PR DESCRIPTION
## Summary

The `max_loops="auto"` loop kept its own view of the task — the plan, the schedule, which subtask was finished — while sending the model a **flattened string** that hid what had actually happened. When those two views disagreed, the run failed silently and reported success.

This PR makes the loop's state honest, then makes it smaller by giving the model a faithful transcript.

Closes seven issues; adds 43 offline tests.

---

## Correctness fixes

Fixes #1964 — **batched tool calls were silently dropped.** `subtask_done` hit a `break` that abandoned the rest of the response, discarding every call the model batched after it while still marking the subtask complete. The execution prompt explicitly asks the model to batch its calls, and tool ordering within a response is not guaranteed, so this dropped real work at random. `complete_task` now defers its return until the whole response has executed.

Fixes #1963 — **tool failures never reached the model.** An exception was logged and thrown away, so the next iteration rebuilt an identical prompt and the model re-emitted the identical failing call until its budget ran out. Handler exceptions and malformed tool arguments now come back as the tool's result. A handler that raised no longer counts as having completed a subtask or finished the task.

Fixes #1966 — **failed dependencies unblocked their dependents.** `subtask_status.get(dep, "completed") in ["completed", "failed"]` let a *failed* dependency satisfy its dependents, and defaulted an *unknown* `step_id` to satisfied. One early failure cascaded into downstream subtasks "succeeding" against output that was never produced. Only a completed dependency now satisfies; dependents of a failed step are marked `skipped`. Dangling and self-referential ids are dropped at plan time with a warning.

Fixes #1965 — **the consecutive-think guard was dead code.** The counter reset at the top of every iteration and was checked at the bottom of the same one, so one `think` per turn never reached the limit. It now counts across a subtask, any non-`think` call breaks the streak, and the nudge is written to the transcript the model actually reads.

While testing that, the probe exposed the real containment bug: a subtask that exhausted its 20-iteration budget stayed `pending`, which kept it **eligible**, so the outer loop re-selected it and re-ran the same doomed budget up to 100 times.

```
stuck subtask, before:  2002 LLM turns, status pending
stuck subtask, after:     22 LLM turns, status failed
```

Exhausted subtasks are now marked `failed`, which terminates the run and cascades `skipped` to dependents. This also partially addresses #1974 — that issue stays open for the summary panel, which still announces "All subtasks completed" unconditionally.

## Transcript and plan

Fixes #1977 — **structured `messages[]` instead of a flattened string.** Every call did:

```python
messages.append({"role": "user", "content": task})  # task = the ENTIRE history, as text
```

so the model never saw `assistant` turns carrying `tool_calls`, nor `{"role": "tool", "tool_call_id": ...}` results — its own prior actions came back as prose in a *user* turn. Prompt caching was defeated, since the prefix was rebuilt every turn.

This is the root cause behind the bugs above: because the model could not see a faithful record of what it had done, the harness had to remember for it — and harness state can drift from the model's.

The same fix is applied to **the integer `max_loops` path** in `Agent._run`, which had the identical problem and affects every agent, workflow and swarm structure. `transforms` keeps the legacy flattened prompt by design.

New `swarms/structs/transcript.py` owns the invariant that matters: every recorded tool call receives a matching tool result before the next request — including on the retry/failure path, where a gap would make the retried request invalid.

Fixes #1978 — **the plan is mutable.** It was frozen after the planning phase, so work discovered mid-run had to be forced into an unrelated subtask. `create_plan` is now idempotent: steps merge by `step_id`, finished work keeps its status and summary, unmentioned finished steps are retained as history, still-pending steps left out are dropped, and a revision reports a diff rather than the whole plan.

Verified live — the model read a manifest it could not have known the contents of, then revised:

```
call 0: 3 steps ['read_manifest', 'revise_plan', 'create_item_files']
call 1: 7 steps [...same 3 (preserved)..., 'create_alpha_file', ... 'create_delta_file']
        -> Plan updated (added ['create_alpha_file', ...])
```

## New: `Agent(think_tool=...)`

The `think` tool was **unreachable**. The filter tested `thinking_tokens is not None`, but `thinking_tokens` defaults to `1024`, so the condition was always true and `think` was stripped for every agent — while the system prompt still instructed the model to call it, including *"**WARNING**: If you call `think` 2+ times consecutively, it will be BLOCKED."*

`think_tool` defaults to `False`, preserving the behaviour everyone has actually been getting, and the prompt now follows the flag so the model is never told to call a tool it lacks.

## Testing

- **43 new tests, fully offline** — verified passing with `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` blanked
- **17 of them fail against the unpatched loop** (checked in a throwaway `git worktree` at HEAD)
- **Regression suite unchanged**: `tests/agents/` + `tests/structs/test_agent.py` → 25 failed / 338 passed / 8 errors, byte-identical before and after. Those failures are pre-existing.
- Live end-to-end runs against `gpt-4o-mini` and `claude-sonnet-4-5` for the transcript, the dependency cascade, error recovery, and replanning

## Notes for review

- `CONTRIBUTING.md`, `SKILL.md`, `max_loops_agent.py` and the formatting change in `tests/structs/test_agent.py` were already in the working tree and are **not** part of the autonomous-loop work — included here because this is intended as a single PR. Drop them if that was not the intent.
- Follow-up, not addressed here: #1988 (`Conversation` cannot represent tool calls, so the loops keep a *parallel* transcript alongside `short_memory` — the proper fix), #1989, #1962, #1974, #1976.