### PR TITLE
fix(autonomous-loop): stop re-appending the handoff prompt every run (#1968)

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -94,6 +94,10 @@ class AutonomousAgentLoop:
         # `short_memory` is kept in sync alongside it because persistence,
         # output formatting and the final summary all read from there.
         self._transcript = Transcript()
+        # The handoff block this loop last appended to the agent's
+        # system_prompt. Held so a later run can remove it before appending the
+        # current one, instead of stacking a fresh copy every run.
+        self._applied_handoff_block: Optional[str] = None
 
     def _say_user(self, content: str, mirror: bool = True) -> None:
         """Add a user turn to the transcript (and to short_memory)."""
@@ -286,15 +290,39 @@ class AutonomousAgentLoop:
                         self.agent.tools_list_dictionary.append(tool)
                         existing_tool_names.add(tool_name)
 
-                # Add handoff prompt to system prompt
+                # Add handoff prompt to system prompt.
+                #
+                # This runs on every run(), so a bare append accumulated a
+                # fresh copy each time and grew the prompt without bound on a
+                # reused agent. The block this loop last applied is remembered
+                # and removed before the current one goes on, which keeps the
+                # prompt the same size across runs while still refreshing it
+                # when the registry changes — a plain "already present" guard
+                # would pin the first registry's text forever.
                 agent_registry = self.agent._get_agent_registry()
                 if agent_registry:
                     handoff_prompt = get_handoffs_prompt(
                         list(agent_registry.values())
                     )
-                    self.agent.system_prompt += (
-                        "\n\n" + handoff_prompt
-                    )
+                    handoff_block = "\n\n" + handoff_prompt
+
+                    previous_block = self._applied_handoff_block
+                    if (
+                        previous_block
+                        and previous_block in self.agent.system_prompt
+                    ):
+                        self.agent.system_prompt = (
+                            self.agent.system_prompt.replace(
+                                previous_block, "", 1
+                            )
+                        )
+
+                    # Only append when it is not already there, so a prompt
+                    # that carries the text for another reason is left alone.
+                    if handoff_block not in self.agent.system_prompt:
+                        self.agent.system_prompt += handoff_block
+
+                    self._applied_handoff_block = handoff_block
 
             # Reinitialize LLM with planning tools (and handoff tool if configured)
             if self.agent.llm is not None:

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -855,5 +855,100 @@ class TestThinkLoopContainment:
         assert agent.think_call_count == 0
 
 
+class TestHandoffPromptIsNotReappended:
+    """#1968 — the handoff prompt was appended to ``system_prompt`` inside the
+    per-run setup, so every ``run()`` stacked another copy and a long-lived
+    agent's prompt grew without bound. Measured before the fix: +1,988
+    characters per run, linearly.
+
+    The loop is driven directly rather than through ``run()``: the append
+    happens during setup, before the model is contacted, so stopping at the
+    first provider call exercises the real code path offline.
+    """
+
+    class _Stop(Exception):
+        """Halts the loop immediately after setup."""
+
+    def _run_setup_only(self, agent, monkeypatch):
+        """Run the loop far enough to apply the handoff prompt, then stop."""
+
+        def boom(*args, **kwargs):
+            raise TestHandoffPromptIsNotReappended._Stop()
+
+        monkeypatch.setattr(type(agent), "llm_handling", boom)
+        try:
+            agent._run_autonomous_loop(task="anything")
+        except Exception:
+            pass
+
+    def test_prompt_does_not_grow_across_runs(self, monkeypatch):
+        worker = build_agent(agent_name="Worker", max_loops=1)
+        agent = build_agent(agent_name="Boss", handoffs=[worker])
+
+        lengths = []
+        for _ in range(3):
+            self._run_setup_only(agent, monkeypatch)
+            lengths.append(len(agent.system_prompt))
+
+        # The regression: these were 17347, 19335, 21323.
+        assert lengths[0] == lengths[1] == lengths[2]
+
+    def test_the_handoff_prompt_is_still_present(self, monkeypatch):
+        """Not growing must not mean never applied — the delegation
+        instructions have to survive, or handoffs stop working entirely.
+        """
+        worker = build_agent(agent_name="Worker", max_loops=1)
+        agent = build_agent(agent_name="Boss", handoffs=[worker])
+
+        self._run_setup_only(agent, monkeypatch)
+
+        assert "Worker" in agent.system_prompt
+
+    def test_a_changed_registry_refreshes_the_prompt(
+        self, monkeypatch
+    ):
+        """A plain "already present" guard would pin the first registry's text
+        forever, so a handoff target added later would never be described.
+        """
+        alpha = build_agent(agent_name="Alpha", max_loops=1)
+        beta = build_agent(agent_name="Beta", max_loops=1)
+        agent = build_agent(agent_name="Boss", handoffs=[alpha])
+
+        self._run_setup_only(agent, monkeypatch)
+        assert "Alpha" in agent.system_prompt
+        assert "Beta" not in agent.system_prompt
+
+        agent.handoffs = [alpha, beta]
+        self._run_setup_only(agent, monkeypatch)
+        assert "Alpha" in agent.system_prompt
+        assert "Beta" in agent.system_prompt
+
+    def test_the_refreshed_prompt_is_still_stable(self, monkeypatch):
+        """After the registry changes, further runs must not resume growing."""
+        alpha = build_agent(agent_name="Alpha", max_loops=1)
+        beta = build_agent(agent_name="Beta", max_loops=1)
+        agent = build_agent(agent_name="Boss", handoffs=[alpha])
+
+        self._run_setup_only(agent, monkeypatch)
+        agent.handoffs = [alpha, beta]
+        self._run_setup_only(agent, monkeypatch)
+        after_change = len(agent.system_prompt)
+
+        self._run_setup_only(agent, monkeypatch)
+        self._run_setup_only(agent, monkeypatch)
+
+        assert len(agent.system_prompt) == after_change
+
+    def test_an_agent_without_handoffs_is_untouched(
+        self, monkeypatch
+    ):
+        agent = build_agent(agent_name="Solo")
+        before = agent.system_prompt
+
+        self._run_setup_only(agent, monkeypatch)
+
+        assert agent.system_prompt == before
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-q", "-p", "no:randomly"])


### PR DESCRIPTION
Closes #1968.

## The problem

`AutonomousAgentLoop._run_autonomous_loop` appended the handoff prompt to `self.agent.system_prompt` inside per-run setup, so a reused agent accumulated a fresh copy on every `run()`.

Measured on `master` @ `07f3bd39`:

```
base system_prompt length : 15359
after run 1/2/3           : [17347, 19335, 21323]
grew every run            : True
```

**+1,988 characters per run, linearly, with no ceiling.** On a long-lived agent that is context the model pays for on every call, filled with duplicated instructions.

Worth noting: the tool append immediately above it *does* guard against duplicates by name (`if tool_name not in existing_tool_names`), so idempotency was considered for the tools and missed for the prompt.

## The fix, and why not the shorter one

The loop remembers the block it applied and removes it before applying the current one.

A plain "already present" check would have been two lines shorter and wrong: it would pin the **first** registry's text forever, so a handoff target added between runs would never be described to the model. Remove-then-reapply keeps the prompt one copy long *and* lets it change when the registry does.

## Something reviewers should know

`Agent.__init__` already applies the handoff prompt once. So on an unchanged registry the correct result is that `run()` leaves `system_prompt` **exactly as it found it** — not that it appends once. That surprised me mid-verification, and it is why the tests assert two things rather than one: the size is stable, *and* the delegation instructions are still present. A fix that stopped the growth by never applying the prompt would look identical on the first assertion and would silently break handoffs.

## Verification

**1. The reproducer stops reproducing.**

```
after run 1/2/3 : [15359, 15359, 15359]      # was [17347, 19335, 21323]
grew every run  : False
```

**2. Handoffs still work, and a changed registry still refreshes.** Driving the loop with `handoffs=[Alpha]`, then adding `Beta` between runs:

```
run1  len 15358   mentions Alpha: True   mentions Beta: False
run2  len 15453   mentions Alpha: True   mentions Beta: True   <- a stale guard would be False
run4  len 15453                                                <- stable again, no resumed growth
```

The prompt grew by the 95-character delta between the two registries, not by another full copy.

**3. The tests are real regression tests.** Against unfixed `master`, **2 of the 5 fail** — `test_prompt_does_not_grow_across_runs` and `test_the_refreshed_prompt_is_still_stable`, exactly the two asserting the growth invariant. The other three pass there, because `master` does apply the prompt; it just stacks copies. I would rather say that than claim five.

**Full file**: `tests/agents/test_autonomous_loop.py` goes **31 → 36 passed**, nothing else affected. Lint with the CI-pinned versions (`black==24.2.0`, `ruff==0.2.1`, line-length 70): `black --check` clean on both files, `ruff check .` clean repo-wide.

**Not verified here**: no provider call was made. The tests drive the loop to the first `llm_handling` call and stop there — the append happens during setup, before the model is contacted, so the real code path runs offline. What is not covered is the loop's behaviour *after* that point, which this change does not touch.
