### PR TITLE
[Bug] The handoff roster is re-appended to system_prompt on every run(), so a reused agent's prompt grows without bound

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -286,15 +286,19 @@ class AutonomousAgentLoop:
                         self.agent.tools_list_dictionary.append(tool)
                         existing_tool_names.add(tool_name)
 
-                # Add handoff prompt to system prompt
+                # Add handoff prompt to system prompt, once. Agent.__init__
+                # already appended it for handoffs given at construction, and
+                # this runs per run() -- so without the check a reused agent
+                # carries one more copy of the roster after every call.
                 agent_registry = self.agent._get_agent_registry()
                 if agent_registry:
                     handoff_prompt = get_handoffs_prompt(
                         list(agent_registry.values())
                     )
-                    self.agent.system_prompt += (
-                        "\n\n" + handoff_prompt
-                    )
+                    if handoff_prompt not in self.agent.system_prompt:
+                        self.agent.system_prompt += (
+                            "\n\n" + handoff_prompt
+                        )
 
             # Reinitialize LLM with planning tools (and handoff tool if configured)
             if self.agent.llm is not None:

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -855,5 +855,80 @@ class TestThinkLoopContainment:
         assert agent.think_call_count == 0
 
 
+# --------------------------------------------------------------------------
+# #1968 — the handoff prompt is appended per run()
+# --------------------------------------------------------------------------
+
+
+class TestHandoffPromptIsAppendedOnce:
+    """`Agent.system_prompt` is durable state; the loop runs per call."""
+
+    @staticmethod
+    def _agent_with_handoffs():
+        worker = Agent(
+            agent_name="Worker",
+            agent_description="does the work",
+            model_name="gpt-4o-mini",
+            max_loops=1,
+            persistent_memory=False,
+            print_on=False,
+            autosave=False,
+        )
+        return build_agent(handoffs=[worker])
+
+    def test_running_three_times_does_not_stack_three_rosters(
+        self, monkeypatch
+    ):
+        agent = self._agent_with_handoffs()
+        marker = "**Available Agents:**"
+        assert marker in agent.system_prompt, (
+            "Agent.__init__ is expected to append the roster; if this fails "
+            "the premise of the test has changed, not the fix"
+        )
+
+        for _ in range(3):
+            script_llm(
+                agent,
+                monkeypatch,
+                [
+                    plan(("a", [])),
+                    [
+                        tool_call(
+                            "subtask_done",
+                            step_id="a",
+                            summary="ok",
+                            success=True,
+                        )
+                    ],
+                    [tool_call("complete_task", summary="done")],
+                ],
+            )
+            agent.run("demo")
+
+        assert agent.system_prompt.count(marker) == 1, (
+            f"the handoff roster appears {agent.system_prompt.count(marker)} "
+            f"times after three runs; system_prompt grows without bound for "
+            f"any reused agent with handoffs"
+        )
+
+    def test_the_roster_is_still_there_for_the_model(
+        self, monkeypatch
+    ):
+        """Deduplicating must not remove it — the loop needs it present."""
+        agent = self._agent_with_handoffs()
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                plan(("a", [])),
+                [tool_call("complete_task", summary="done")],
+            ],
+        )
+        agent.run("demo")
+
+        assert "**Available Agents:**" in agent.system_prompt
+        assert "Worker" in agent.system_prompt
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-q", "-p", "no:randomly"])


### PR DESCRIPTION
## What is wrong

`AutonomousAgentLoop.run()` appends the handoff prompt straight onto durable agent state:

```python
                agent_registry = self.agent._get_agent_registry()
                if agent_registry:
                    handoff_prompt = get_handoffs_prompt(
                        list(agent_registry.values())
                    )
                    self.agent.system_prompt += "\n\n" + handoff_prompt
```

`system_prompt` outlives the call; `run()` does not. So every `run()` on an agent with handoffs leaves one more copy of the roster behind.

`Agent.__init__` already appends the same prompt for handoffs given at construction, so the count starts at 1 before the loop has run at all. Three runs of one agent:

```
agent.system_prompt.count("**Available Agents:**")  ->  4
```

That is the assertion failure the new test produces against unpatched `master`. The model then reads the same delegation instructions and the same agent list four times over, and the prompt keeps growing for the life of the object — which matters most for exactly the agents this affects: long-lived ones reused across tasks.

## The fix

The handoff **tool** block immediately above this already guards against the same thing — it builds `existing_tool_names` and skips any schema already registered. The prompt append was the one part of that block with no equivalent check. This adds it.

Deduplicating rather than deleting the append: `__init__` only sees handoffs passed to the constructor, so an agent whose `handoffs` are set afterwards still needs the loop to add the roster. The check keeps that working while making the second and later calls no-ops.

## Verification

```
PYTHONPATH=. pytest tests/agents/test_autonomous_loop.py -q -p no:randomly
33 passed
```

The two new tests live in the existing autonomous-loop suite, which is fully offline — `Agent.call_llm` is the only seam patched, so the real loop, real tool dispatch and real state transitions run. Confirmed the first one fails on unpatched source (stashing only `swarms/`):

```
FAILED TestHandoffPromptIsAppendedOnce::test_running_three_times_does_not_stack_three_rosters
  where 4 = ….count('**Available Agents:**')
1 failed, 1 passed
```

The second test asserts the roster is still present after a run, so a future "fix" that simply drops the append fails too.

`black==24.2.0 --check` and `ruff==0.2.1 check` both clean on the two touched files.

Closes #1968