### PR TITLE
[Fix] Agent.save() and Agent.load() resolve different state-file paths, so a saved agent never loads (#1994)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2575,7 +2575,7 @@ Subtask Breakdown:
             self._get_agent_workspace_dir(), candidate
         )
 
-    def save(self, file_path: str = None) -> None:
+    def save(self, file_path: Optional[str] = None) -> None:
         try:
             full_path = self._resolve_state_file(
                 file_path
@@ -2666,7 +2666,7 @@ Subtask Breakdown:
         except Exception as e:
             logger.warning(f"Error saving additional components: {e}")
 
-    def load(self, file_path: str = None) -> None:
+    def load(self, file_path: Optional[str] = None) -> None:
         try:
             resolved_path = self._resolve_state_file(
                 file_path

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2559,64 +2559,45 @@ Subtask Breakdown:
                 f"The model '{self.model_name}' may not be supported. Please use a supported model, or override the model name with the 'llm' parameter, which should be a class with a 'run(task: str)' method or a '__call__' method."
             )
 
+    def _resolve_state_file(
+        self, candidate: Optional[str]
+    ) -> Optional[str]:
+        if not candidate:
+            return None
+
+        if not candidate.endswith(".json"):
+            candidate = f"{candidate}.json"
+
+        if os.path.isabs(candidate):
+            return candidate
+
+        return os.path.join(
+            self._get_agent_workspace_dir(), candidate
+        )
+
     def save(self, file_path: str = None) -> None:
-        """
-        Save the agent state to a file using SafeStateManager with atomic writing
-        and backup functionality. Automatically handles complex objects and class instances.
-        Files are saved in the agent-specific workspace directory: workspace_dir/agent-{agent_name}-{uuid}/
-
-        Args:
-            file_path (str, optional): Custom path to save the state. If relative, will be saved in
-                                    the agent-specific workspace directory. If None, uses configured paths.
-
-        Raises:
-            OSError: If there are filesystem-related errors
-            Exception: For other unexpected errors
-        """
         try:
-            # Get agent-specific workspace directory
-            agent_workspace = self._get_agent_workspace_dir()
-
-            # Determine the save path
-            resolved_path = (
+            full_path = self._resolve_state_file(
                 file_path
                 or self.saved_state_path
                 or f"{self.agent_name}_state.json"
             )
 
-            # Ensure path has .json extension
-            if not resolved_path.endswith(".json"):
-                resolved_path += ".json"
-
-            # If file_path is absolute, use it as-is; otherwise, use agent workspace
-            if file_path and os.path.isabs(file_path):
-                full_path = file_path
-            else:
-                # Create full path in agent-specific workspace directory
-                full_path = os.path.join(
-                    agent_workspace, resolved_path
-                )
-
             backup_path = full_path + ".backup"
             temp_path = full_path + ".temp"
 
-            # Ensure directory exists
             os.makedirs(os.path.dirname(full_path), exist_ok=True)
 
-            # First save to temporary file using SafeStateManager
             SafeStateManager.save_state(self, temp_path)
 
-            # If current file exists, create backup
             if os.path.exists(full_path):
                 try:
                     os.replace(full_path, backup_path)
                 except Exception as e:
                     logger.warning(f"Could not create backup: {e}")
 
-            # Move temporary file to final location
             os.replace(temp_path, full_path)
 
-            # Clean up old backup if everything succeeded
             if os.path.exists(backup_path):
                 try:
                     os.remove(backup_path)
@@ -2625,7 +2606,6 @@ Subtask Breakdown:
                         f"Could not remove backup file: {e}"
                     )
 
-            # Log saved state information if verbose
             if self.verbose:
                 self._log_state_info(full_path, saved=True)
 
@@ -2633,7 +2613,6 @@ Subtask Breakdown:
                 f"Successfully saved agent state to: {full_path}"
             )
 
-            # Handle additional component saves
             self._save_additional_components(full_path)
 
         except OSError as e:
@@ -2688,42 +2667,16 @@ Subtask Breakdown:
             logger.warning(f"Error saving additional components: {e}")
 
     def load(self, file_path: str = None) -> None:
-        """
-        Load agent state from a file using SafeStateManager.
-        Automatically preserves class instances and complex objects.
-
-        Args:
-            file_path (str, optional): Path to load state from.
-                                    If None, uses default path from agent config.
-
-        Raises:
-            FileNotFoundError: If state file doesn't exist
-            Exception: If there's an error during loading
-        """
         try:
-            # Resolve load path conditionally with a check for self.load_state_path
-            resolved_path = (
+            resolved_path = self._resolve_state_file(
                 file_path
                 or self.load_state_path
-                or (
-                    f"{self.saved_state_path}.json"
-                    if self.saved_state_path
-                    else (
-                        f"{self.agent_name}.json"
-                        if self.agent_name
-                        else (
-                            f"{self.workspace_dir}/{self.agent_name}_state.json"
-                            if self.workspace_dir and self.agent_name
-                            else None
-                        )
-                    )
-                )
+                or self.saved_state_path
+                or f"{self.agent_name}_state.json"
             )
 
-            # Load state using SafeStateManager
             SafeStateManager.load_state(self, resolved_path)
 
-            # Reinitialize any necessary runtime components
             self._reinitialize_after_load()
 
             if self.verbose:

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -11,10 +11,12 @@ import pytest
 import yaml
 from dotenv import load_dotenv
 
+import swarms.structs.agent as agent_module
 import swarms.utils.litellm_wrapper as litellm_wrapper
 from swarms import Agent
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
 from swarms.schemas.agent_errors import AgentToolExecutionError
+from swarms.utils.workspace_utils import get_workspace_dir
 
 load_dotenv()
 
@@ -1519,3 +1521,134 @@ class TestAgentUsage:
             "cached_tokens": 0,
             "total_tokens": sum(100 * i + i for i in range(1, 7)),
         }
+class TestStateFilePathAgreement:
+
+    @pytest.fixture(autouse=True)
+    def workspace(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("WORKSPACE_DIR", str(tmp_path))
+        get_workspace_dir.cache_clear()
+        yield tmp_path
+        get_workspace_dir.cache_clear()
+
+    @staticmethod
+    def _agent(tmp_path, name="Boss", saved_state_path=None):
+        agent = Agent.__new__(Agent)
+        agent.agent_name = name
+        agent.id = "agent-6fd6a53ba3f2"
+        agent.workspace_dir = str(tmp_path)
+        agent._workspace = None
+        agent.saved_state_path = saved_state_path
+        agent.load_state_path = None
+        agent.verbose = False
+        return agent
+
+    @staticmethod
+    def _paths_used(agent, saved_state_path):
+        agent.saved_state_path = saved_state_path
+
+        saved = {}
+
+        def fake_save_state(_self, path):
+            saved.setdefault("temp", path)
+            with open(path, "w") as handle:
+                handle.write("{}")
+
+        with patch.object(
+            agent_module.SafeStateManager,
+            "save_state",
+            side_effect=fake_save_state,
+        ):
+            Agent.save(agent)
+
+        loaded = {}
+        with patch.object(
+            agent_module.SafeStateManager,
+            "load_state",
+            side_effect=lambda _self, path: loaded.setdefault(
+                "path", path
+            ),
+        ), patch.object(Agent, "_reinitialize_after_load"):
+            Agent.load(agent)
+
+        return saved["temp"][: -len(".temp")], loaded["path"]
+
+    def test_save_and_load_pick_the_same_file(self, tmp_path):
+        agent = self._agent(tmp_path)
+        save_path, load_path = self._paths_used(
+            agent, "my_agent_state.json"
+        )
+
+        assert save_path == load_path
+
+    def test_load_no_longer_doubles_the_extension(self, tmp_path):
+        agent = self._agent(tmp_path)
+        _, load_path = self._paths_used(agent, "my_agent_state.json")
+
+        assert not load_path.endswith(".json.json")
+        assert os.path.basename(load_path) == "my_agent_state.json"
+
+    def test_load_looks_in_the_workspace_not_the_cwd(self, tmp_path):
+        agent = self._agent(tmp_path)
+        _, load_path = self._paths_used(agent, "my_agent_state.json")
+
+        assert os.path.isabs(load_path)
+        assert load_path.startswith(str(tmp_path))
+
+    def test_a_missing_extension_is_added_once_on_both_sides(
+        self, tmp_path
+    ):
+        agent = self._agent(tmp_path)
+        save_path, load_path = self._paths_used(agent, "no_extension")
+
+        assert os.path.basename(save_path) == "no_extension.json"
+        assert save_path == load_path
+
+    def test_the_default_filename_matches_when_nothing_is_configured(
+        self, tmp_path
+    ):
+        agent = self._agent(tmp_path, name="Boss")
+        save_path, load_path = self._paths_used(agent, None)
+
+        assert os.path.basename(save_path) == "Boss_state.json"
+        assert save_path == load_path
+
+    def test_an_absolute_path_is_used_as_given(self, tmp_path):
+        target = str(tmp_path / "elsewhere" / "state.json")
+        agent = self._agent(tmp_path)
+
+        assert Agent._resolve_state_file(agent, target) == target
+
+    def test_an_extensionless_absolute_path_gains_the_extension(
+        self, tmp_path
+    ):
+        agent = self._agent(tmp_path)
+        target = str(tmp_path / "backups" / "state")
+
+        assert (
+            Agent._resolve_state_file(agent, target)
+            == f"{target}.json"
+        )
+
+    def test_no_candidate_resolves_to_none(self, tmp_path):
+        agent = self._agent(tmp_path)
+
+        assert Agent._resolve_state_file(agent, None) is None
+        assert Agent._resolve_state_file(agent, "") is None
+
+    def test_load_state_path_still_wins_over_saved_state_path(
+        self, tmp_path
+    ):
+        agent = self._agent(tmp_path, saved_state_path="ignored.json")
+        agent.load_state_path = "explicit.json"
+
+        loaded = {}
+        with patch.object(
+            agent_module.SafeStateManager,
+            "load_state",
+            side_effect=lambda _self, path: loaded.setdefault(
+                "path", path
+            ),
+        ), patch.object(Agent, "_reinitialize_after_load"):
+            Agent.load(agent)
+
+        assert os.path.basename(loaded["path"]) == "explicit.json"

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1521,6 +1521,8 @@ class TestAgentUsage:
             "cached_tokens": 0,
             "total_tokens": sum(100 * i + i for i in range(1, 7)),
         }
+
+
 class TestStateFilePathAgreement:
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Fault 1 of #1994 — deliberately **not** `Closes`, per @kyegomez's review: fault 2 is still open and the issue should not auto-close on this.

`Agent.load()` built the state-file path differently from `Agent.save()`, so **a file `save()` had written seconds earlier was unreadable** — `load()` raised `FileNotFoundError` for the agent's own state. This is fault 1 of #1994; fault 2 is deliberately not here, for a reason given at the bottom.

## Problem

`save()` (`agent.py:2627`) added the extension only when missing and joined the agent workspace. `load()` (`agent.py:2751`) did neither:

```python
                    f"{self.saved_state_path}.json"
                    if self.saved_state_path
```

Two faults in that one expression: `.json` appended to a name that already ends in `.json`, and no workspace join, so the relative name resolved against the process cwd.

Reproducer — a bare `Agent` carrying only the attributes the path code reads, so it runs offline:

```
$ python repro_1994.py            # master @ 7243327f
saved_state_path : my_agent_state.json
save() wrote to  : <workspace>/agents/boss-6fd6a53ba3f2/my_agent_state.json
load() reads from: my_agent_state.json.json
same file?       : False
load path exists?: False
```

**`autosave=True` is the pattern this breaks.** `CLAUDE.md` recommends it for long-running agents, and there are five internal `self.save()` call sites in the run loop — so state was being written on schedule and was never readable back through the documented API.

## Fix

Both sides go through one resolver, so they cannot drift again:

```python
def _resolve_state_file(self, candidate: Optional[str]) -> Optional[str]:
    if not candidate:
        return None
    if not candidate.endswith(".json"):
        candidate = f"{candidate}.json"
    if os.path.isabs(candidate):
        return candidate
    return os.path.join(self._get_agent_workspace_dir(), candidate)
```

`load_state_path` keeps its precedence over `saved_state_path`; only the final path construction is shared. After:

```
save() wrote to  : <workspace>/agents/boss-6fd6a53ba3f2/my_agent_state.json
load() reads from: <workspace>/agents/boss-6fd6a53ba3f2/my_agent_state.json
same file?       : True
load path exists?: True
```

## Two smaller mismatches in the same expression

- **The last-resort filename disagreed too.** `load()` fell back to `f"{agent_name}.json"`, `save()` to `f"{agent_name}_state.json"` — the same class of bug one level down, reached whenever `saved_state_path` is unset. `load()` now uses `save()`'s name.
- **The final fallback was unreachable.** `f"{workspace_dir}/{agent_name}_state.json"` sat in the `else` branch of `if self.agent_name`, behind a `workspace_dir and self.agent_name` guard — so it could only be *evaluated* when `agent_name` was falsy and could only *fire* when it was truthy. It has never produced a path. Removed rather than carried into the new expression.

## Behavior-change note

Two changes, both of them the fix rather than a side effect of it.

**A relative `file_path` passed to `load()`** now resolves against the agent workspace instead of the cwd. Anyone relying on cwd resolution will need an absolute path, which `_resolve_state_file` passes through untouched. cwd resolution is precisely why `load()` could not find `save()`'s output.

**An extensionless absolute path passed to `save()`** now gains `.json`. An earlier revision of this description claimed `save()`'s absolute behaviour was unchanged, on the reasoning that the old `isabs` branch was equivalent to the `os.path.join` it fell through to. That was wrong, and @kyegomez caught it: the old branch assigned `full_path = file_path` — the **raw argument** — so it skipped the extension append two lines above. Traced side by side:

| `save(file_path=…)` | master @ `7243327f` | this PR |
|---|---|---|
| `/backups/state` | `/backups/state` | `/backups/state.json` ← **changed** |
| `/backups/state.json` | `/backups/state.json` | same |
| `rel` | `<workspace>/rel.json` | same |
| `rel.json` | `<workspace>/rel.json` | same |
| `None` | `<workspace>/<configured>.json` | same |

Verified by running both, not by reading:

```
$ python abs_check.py             # master @ 7243327f
save('/backups/state')      -> /backups/state
$ python abs_check.py             # this branch
save('/backups/state')      -> /backups/state.json
```

This is an argument for the PR, not against it. On `master`, `save("/backups/state")` wrote `/backups/state` while `load("/backups/state")` looked for `/backups/state.json` — the same round-trip failure as the relative case, on the other branch. The resolver fixes both. A caller passing an extensionless absolute path will find their file somewhere new, which is why it is called out here; `test_an_extensionless_absolute_path_gains_the_extension` pins it.

## Verification

**The tests fail on unfixed `master`.** Five of the nine, for the right reason — the real `save()` and `load()` disagreeing about a real path:

```
E  AssertionError: assert '/private/var/.../agents/boss-6fd6a53ba3f2/my_agent_state.json'
                       == 'my_agent_state.json.json'
E  AssertionError: assert not 'my_agent_state.json.json'.endswith('.json.json')
E  AssertionError: assert False = os.path.isabs('my_agent_state.json.json')
E  AssertionError: assert '/private/var/.../no_extension.json' == 'no_extension.json'
E  AssertionError: assert '/private/var/.../Boss_state.json'   == 'Boss.json'
```

Being precise about the other three, since "9 of 9 fail" would overstate it: three of them (`test_an_absolute_path_is_used_as_given`, `test_an_extensionless_absolute_path_gains_the_extension`, `test_no_candidate_resolves_to_none`) fail on `master` only with `AttributeError: no attribute '_resolve_state_file'` — they pin the resolver's contract, they are not regression tests. The ninth, `test_load_state_path_still_wins_over_saved_state_path`, **passes on `master`** by design: it guards precedence that this PR must not change.

```
$ pytest tests/structs/test_agent.py -k TestStateFilePathAgreement   # this file, on master
8 failed, 1 passed, 88 deselected
```

**Suite**, `tests/structs/test_agent.py`:

```
master @ 7243327f : 88 passed
this branch       : 97 passed
```

+9, no failures either side. The file is clean on this base — #2015 revived `TestBasicAgent`, so the eight setup errors that used to sit here (including `TestBasicAgent::test_save_and_load`, the only round-trip test this repo had for the very thing #1994 reports) now run.

**Lint**, with the versions `lint.yml` pins (`black==24.2.0`, `ruff==0.2.1`, line-length 70):

```
$ black . --check --diff    966 files would be left unchanged
$ ruff check .              (clean)
```

**CI status**, since the checkmarks should not decide the review: `lint` passes — the check that would actually catch a problem in the two files here, running the pinned `black==24.2.0` / `ruff==0.2.1` above. The rest (`build 3.10/3.11/3.12`, `pyre`, `test`, `test-main-features`) are red on untouched `master` too. The `test` job never reaches a single test on either branch: `pytest` treats a collection error as fatal and `tests/structs/test_aop.py` dies on `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`, which is why the numbers above are local. Running the one file sidesteps that collection error.

**Not verified here**: no provider call and no real agent construction. The tests build agents with `Agent.__new__` carrying only the attributes the path code reads, and stub `SafeStateManager` at both ends — the point is which path each function picks, not what gets serialised into it. Precedent for that shape is `TestToolExecutionRetry` in the same file. What is *not* covered is whether the state written round-trips semantically; that is `SafeStateManager`'s contract and this PR does not touch it.

## What I deliberately left out

**Fault 2 — the workspace directory is random per construction.** `_get_agent_workspace_dir` keys on `self.id`, regenerated on every `Agent(...)` unless the caller passes `id=`, so a restarted process still cannot find what the previous one saved. Fixing it means keying the directory on something durable and **moving where existing agents write**, which is a decision rather than a patch — @ayaangazali flagged the same thing when filing. So this PR makes the same-process round trip correct and leaves the cross-process one to whoever makes that call. The header of this description is the record of that, since the diff itself now carries no prose.

**Relationship to #1958**, now landed in `7243327f`. That change stopped `saved_state_path` being overwritten in `__init__`; these are separate, pre-existing defects in how the path is *built*, which is why the round trip still failed after it — the reproducer above runs on `master` **with** #1958 in place and still shows `same file? False`. The two touch different regions of `agent.py` (`__init__` there, `save`/`load` here) and this branch rebased onto it with no conflict in `agent.py`.

One thing that came out of the rebase and is worth flagging separately: #1958's fallback makes `saved_state_path` default to `f"{generate_api_key(prefix='agent-')}_state.json"` — a fresh random filename on every construction. So a real `Agent` now never reaches either side's `f"{agent_name}_state.json"` last resort, and the cross-process round trip has a *second* random component on top of fault 2's random directory. That is a decision about defaults rather than anything this PR should change, so I have left it alone here.

**Rebased**, as asked. This is now cut from `master` @ `7243327f`, ~14 merges ahead of the `d34de4e5` it was opened against. `agent.py` merged with no conflict; the only conflict was where the test class sits in the slimmed test file. **#2014 is an ancestor of this branch** (`27c47f1b`), so the two are now exercised together — that is what the 97-passed run above is against, and `Agent.load()` no longer raising on read-only properties is in it.

**Rebase note**: since the `WorkspaceManager` refactor (#2011), `_get_agent_workspace_dir` resolves through `self.workspace`, whose directory comes from `WORKSPACE_DIR` rather than from `agent.workspace_dir`. The test class therefore pins `WORKSPACE_DIR` at a `tmp_path` and clears the `get_workspace_dir` cache — the same autouse fixture `tests/utils/test_workspace_manager.py` uses.

**On `TestBasicAgent::test_save_and_load`** — agreed it is the most valuable finding, and it is already tracked: filed as #2010, and #2015 has since landed and revived all eight of those tests. That is why this branch reports 97 passed with no errors where the earlier revision reported 8 setup errors.

