### PR TITLE
[Refactor] Unify swarm and agent autosave behind a single WorkspaceManager

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -115,6 +115,7 @@ from swarms.utils.index import (
 from swarms.utils.litellm_tokenizer import count_tokens
 from swarms.utils.litellm_wrapper import LiteLLM
 from swarms.utils.output_types import OutputType
+from swarms.utils.workspace_manager import WorkspaceManager
 from swarms.utils.workspace_utils import get_workspace_dir
 
 
@@ -466,6 +467,9 @@ class Agent:
         # Always use environment variable for workspace_dir, ignore user input
         # Fallback to default if environment variable is not set
         self.workspace_dir = get_workspace_dir()
+        # Built on first use: file tools need the dir even without
+        # autosave, but constructing every agent must not create one.
+        self._workspace = None
         self.tags = tags
         self.use_cases = use_cases
         self.name = agent_name
@@ -680,25 +684,16 @@ class Agent:
                 )
                 self.system_prompt += "\n\n" + handoff_prompt
 
-        # Appended once here, not per run: the prompt must say that most tools
-        # need loading, or the model assumes the tool list it can see is
-        # everything and gives up instead of searching. Skipped when there is
-        # nothing to defer - an agent with no tools and a fixed loop would
-        # otherwise be told to use a `tool_search` it has not been given.
-        if self.dynamic_tools and (
-            exists(self.tools) or self.max_loops == "auto"
-        ):
-            self.system_prompt += DYNAMIC_TOOLS_NOTICE
-
-        # A loader is needed whenever there is anything to defer - local tools,
-        # MCP tools, or the autonomous loop's own set. Gating it on local tools
-        # alone missed the MCP-only case, which is the main reason to defer at
-        # all, and left MCP failures propagating raw out of llm_handling().
-        if self.dynamic_tools and (
+        # One condition so the notice cannot diverge from the loader.
+        defers_tools = self.dynamic_tools and (
             exists(self.tools)
             or self.mcp_enabled
             or self.max_loops == "auto"
-        ):
+        )
+
+        # Appended once here, not per run.
+        if defers_tools:
+            self.system_prompt += DYNAMIC_TOOLS_NOTICE
             self.setup_dynamic_tools()
         elif exists(self.tools):
             self.tool_handling()
@@ -760,6 +755,20 @@ class Agent:
         """
         self.system_prompt += self.skills.prompt_for_task(task)
 
+    @property
+    def workspace(self) -> "WorkspaceManager":
+        """
+        This agent's workspace manager, created on first access.
+
+        Returns:
+            WorkspaceManager: Rooted at ``{workspace}/agents/{name}-{uuid}``.
+        """
+        if self._workspace is None:
+            self._workspace = WorkspaceManager.for_agent(
+                self, verbose=self.verbose
+            )
+        return self._workspace
+
     def _get_agent_workspace_dir(self) -> str:
         """
         Get the agent-specific workspace directory path.
@@ -770,52 +779,7 @@ class Agent:
         Returns:
             str: The full path to the agent-specific workspace directory.
         """
-        # Generate a sanitized agent name in "name-of-agent" format (lowercase with hyphens)
-        if self.agent_name:
-            # Convert to lowercase and replace spaces/special chars with hyphens
-            safe_agent_name = (
-                self.agent_name.lower()
-                .replace(" ", "-")
-                .replace("_", "-")
-                .replace("/", "-")
-                .replace("\\", "-")
-                .replace(":", "-")
-                .replace("*", "-")
-                .replace("?", "-")
-                .replace('"', "-")
-                .replace("<", "-")
-                .replace(">", "-")
-                .replace("|", "-")
-                # Remove multiple consecutive hyphens
-                .replace("--", "-")
-                .replace("--", "-")
-                .strip("-")
-            )
-        else:
-            safe_agent_name = "agent"
-
-        # Extract UUID from agent ID
-        if self.id.startswith("agent-"):
-            agent_uuid = self.id.replace("agent-", "")
-        else:
-            agent_uuid = self.id
-
-        # Limit UUID length for directory name (use last 12 chars for brevity)
-        agent_uuid_short = (
-            agent_uuid[-12:] if len(agent_uuid) > 12 else agent_uuid
-        )
-
-        # Create directory name: {name-of-agent}-{uuid} (no "agent-" prefix)
-        dir_name = f"{safe_agent_name}-{agent_uuid_short}"
-
-        # Create full path: workspace_dir/agents/{name-of-agent}-{uuid}/
-        agents_dir = os.path.join(self.workspace_dir, "agents")
-        agent_workspace = os.path.join(agents_dir, dir_name)
-
-        # Ensure directory exists
-        os.makedirs(agent_workspace, exist_ok=True)
-
-        return agent_workspace
+        return self.workspace.dir
 
     def _get_agent_registry(self) -> Dict[str, Any]:
         """
@@ -1500,10 +1464,7 @@ class Agent:
                 attempt = 0
                 success = False
                 while attempt < self.retry_attempts and not success:
-                    # Hoisted out of the try: if an attempt fails after the
-                    # assistant turn is recorded, the except below still has to
-                    # answer its tool calls, or the retry would send a dangling
-                    # `tool_calls` turn and be rejected.
+                    # Outside the try: except must answer tool calls.
                     turn_calls = []
                     turn_results = {}
                     try:
@@ -1866,60 +1827,27 @@ class Agent:
         self, loop_count: Optional[int] = None
     ) -> None:
         """
-        Save the agent's configuration dictionary to a JSON file in the agent-specific workspace directory.
-        This method is called at each step of the agent's run to maintain an up-to-date
-        configuration snapshot. It only runs when autosave is enabled.
+        Write a config snapshot to the agent workspace, once per step.
 
         Args:
-            loop_count (Optional[int]): The current loop count for logging purposes. Defaults to None.
+            loop_count (Optional[int]): Current loop, recorded in the
+                saved metadata and used only for logging. Defaults to None.
 
         Note:
-            This method handles errors gracefully to ensure it doesn't interrupt the main execution.
-            The saved file will be named `config.json` in the agent-specific workspace directory:
-            workspace_dir/agents/{name-of-agent}-{uuid}/config.json
+            Writes ``config.json`` under
+            workspace_dir/agents/{name-of-agent}-{uuid}/. Never raises -
+            autosave must not interrupt a run.
         """
         if not self.autosave:
             return
 
-        try:
-            # Get agent-specific workspace directory
-            agent_workspace = self._get_agent_workspace_dir()
+        path = self.workspace.save_config(
+            additional_metadata={"loop_count": loop_count}
+        )
 
-            # Save as config.json in the agent-specific directory
-            file_path = os.path.join(agent_workspace, "config.json")
-
-            # Get the current configuration dictionary
-            config_dict = self.to_dict()
-
-            # Add metadata about when this was saved
-            config_dict["_autosave_metadata"] = {
-                "timestamp": time.strftime(
-                    "%Y-%m-%d %H:%M:%S", time.localtime()
-                ),
-                "loop_count": loop_count,
-                "agent_id": self.id,
-                "agent_name": self.agent_name,
-            }
-
-            # Write to JSON file atomically (write to temp file first, then rename)
-            temp_path = file_path + ".tmp"
-            with open(temp_path, "w", encoding="utf-8") as f:
-                json.dump(
-                    config_dict, f, indent=2, ensure_ascii=False
-                )
-
-            # Atomic rename
-            os.replace(temp_path, file_path)
-
-            if self.verbose and loop_count is not None:
-                logger.debug(
-                    f"Autosaved config at loop {loop_count} to {file_path}"
-                )
-
-        except Exception as e:
-            # Log error but don't raise - we don't want autosave to break execution
-            logger.warning(
-                f"Failed to autosave config step for agent '{self.agent_name}': {e}"
+        if path and self.verbose and loop_count is not None:
+            logger.debug(
+                f"Autosaved config at loop {loop_count} to {path}"
             )
 
     def _handle_run_error(self, error: any):
@@ -2121,10 +2049,7 @@ class Agent:
             always_loaded=keep,
         )
 
-        # A rebuilt loader starts empty, so anything fetched earlier has to go
-        # back in. Without this the autonomous loop's own setup silently drops
-        # every MCP tool, and the once-per-agent fetch guard stops them coming
-        # back.
+        # A rebuilt loader is empty; the fetch guard will not refetch.
         for schema in self._mcp_schemas_cache or []:
             self.tool_loader.register_schema(schema)
 
@@ -3865,7 +3790,7 @@ Subtask Breakdown:
         if self.print_on:
             formatter.print_panel(
                 response,
-                f"Agent Name {self.agent_name} [Max Loops: {loop_count} ]",
+                f"Agent Name {self.agent_name} [Loop: {loop_count}/{self.max_loops}]",
             )
 
     def parse_llm_output(self, response: Any):
@@ -4351,9 +4276,7 @@ Summary: {summary}
             content=format_data_structure(output),
         )
 
-        # Returned so a caller building a structured transcript can attribute
-        # this back to the individual tool_call ids. Callers that do not need
-        # it simply ignore the value.
+        # Stored so a transcript builder can map it to tool_call ids.
         self._last_tool_output = output
 
         if self.print_on is True:

--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -1,6 +1,4 @@
 import concurrent.futures
-import json
-import os
 import time
 from typing import Callable, List, Optional, Union
 
@@ -18,8 +16,7 @@ from swarms.utils.history_output_formatter import (
     history_output_formatter,
 )
 from swarms.utils.loguru_logger import initialize_logger
-from swarms.utils.swarm_autosave import get_swarm_workspace_dir
-from swarms.utils.workspace_utils import get_workspace_dir
+from swarms.utils.workspace_manager import WorkspaceManager
 
 logger = initialize_logger(log_folder="concurrent_workflow")
 
@@ -154,7 +151,6 @@ class ConcurrentWorkflow:
         self.autosave = autosave
         self.verbose = verbose
         self.on_error = on_error
-        self.swarm_workspace_dir = None
         self.metadata_output_path = (
             f"concurrent_workflow_name_{name}_id_{self.id}.json"
         )
@@ -177,9 +173,13 @@ class ConcurrentWorkflow:
         if self.show_dashboard is True:
             self.agents = self.fix_agents()
 
-        # Setup autosave workspace if enabled
-        if self.autosave:
-            self._setup_autosave()
+        self.workspace = WorkspaceManager(
+            self,
+            name=self.name or "concurrent-workflow",
+            verbose=self.verbose,
+            enabled=self.autosave,
+        )
+        self.swarm_workspace_dir = self.workspace.dir
 
         # Capture the full __init__ configuration if telemetry is enabled.
         capture_init(self)
@@ -629,25 +629,11 @@ class ConcurrentWorkflow:
                     task, img, imgs, streaming_callback
                 )
 
-            # Save conversation history after successful execution
-            if self.autosave and self.swarm_workspace_dir:
-                try:
-                    self._save_conversation_history()
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to save conversation history: {e}"
-                    )
+            self.workspace.save_conversation()
 
             return result
         except Exception:
-            # Save conversation history on error
-            if self.autosave and self.swarm_workspace_dir:
-                try:
-                    self._save_conversation_history()
-                except Exception as save_error:
-                    logger.warning(
-                        f"Failed to save conversation history on error: {save_error}"
-                    )
+            self.workspace.save_conversation()
             raise
 
     def batch_run(
@@ -690,91 +676,3 @@ class ConcurrentWorkflow:
                 )
             )
         return results
-
-    def _setup_autosave(self):
-        """
-        Setup workspace directory for saving conversation history.
-
-        Creates the workspace directory structure if autosave is enabled.
-        Only conversation history will be saved to this directory.
-        """
-        try:
-            # Set default workspace directory if not set
-            if not os.getenv("WORKSPACE_DIR"):
-                default_workspace = os.path.join(
-                    os.getcwd(), "agent_workspace"
-                )
-                os.environ["WORKSPACE_DIR"] = default_workspace
-                # Clear the cache so get_workspace_dir() picks up the new value
-                get_workspace_dir.cache_clear()
-                if self.verbose:
-                    logger.info(
-                        f"WORKSPACE_DIR not set, using default: {default_workspace}"
-                    )
-
-            class_name = self.__class__.__name__
-            swarm_name = self.name or "concurrent-workflow"
-            self.swarm_workspace_dir = get_swarm_workspace_dir(
-                class_name, swarm_name, use_timestamp=True
-            )
-
-            if self.swarm_workspace_dir:
-                if self.verbose:
-                    logger.info(
-                        f"Autosave enabled. Conversation history will be saved to: {self.swarm_workspace_dir}"
-                    )
-        except Exception as e:
-            logger.warning(
-                f"Failed to setup autosave for ConcurrentWorkflow: {e}"
-            )
-            # Don't raise - autosave failures shouldn't break initialization
-            self.swarm_workspace_dir = None
-
-    def _save_conversation_history(self):
-        """
-        Save conversation history as a separate JSON file to the workspace directory.
-
-        Saves the conversation history to:
-        workspace_dir/swarms/ConcurrentWorkflow/{workflow-name}-{id}/conversation_history.json
-        """
-        if not self.swarm_workspace_dir:
-            return
-
-        try:
-            # Get conversation history
-            conversation_data = []
-            if hasattr(self, "conversation") and self.conversation:
-                if hasattr(self.conversation, "conversation_history"):
-                    conversation_data = (
-                        self.conversation.conversation_history
-                    )
-                elif hasattr(self.conversation, "to_dict"):
-                    conversation_data = self.conversation.to_dict()
-                else:
-                    conversation_data = []
-
-                # Create conversation history file path
-                conversation_path = os.path.join(
-                    self.swarm_workspace_dir,
-                    "conversation_history.json",
-                )
-
-                # Save conversation history as JSON
-                with open(
-                    conversation_path, "w", encoding="utf-8"
-                ) as f:
-                    json.dump(
-                        conversation_data,
-                        f,
-                        indent=2,
-                        default=str,
-                    )
-
-                if self.verbose:
-                    logger.debug(
-                        f"Saved conversation history to {conversation_path}"
-                    )
-        except Exception as e:
-            logger.warning(
-                f"Failed to save conversation history: {e}"
-            )

--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import json
-import os
 import queue as _queue
 import threading
 import traceback
@@ -43,8 +42,7 @@ from swarms.utils.history_output_formatter import (
     history_output_formatter,
 )
 from swarms.utils.output_types import OutputType
-from swarms.utils.swarm_autosave import get_swarm_workspace_dir
-from swarms.utils.workspace_utils import get_workspace_dir
+from swarms.utils.workspace_manager import WorkspaceManager
 
 
 class HierarchicalOrder(BaseModel):
@@ -380,11 +378,13 @@ class HierarchicalSwarm:
         )
         self.agent_as_judge = agent_as_judge
         self.judge_agent_model_name = judge_agent_model_name
-        self.swarm_workspace_dir = None
-
-        # Setup autosave workspace if enabled
-        if self.autosave:
-            self._setup_autosave()
+        self.workspace = WorkspaceManager(
+            self,
+            name=self.name or "hierarchical-swarm",
+            verbose=self.verbose,
+            enabled=self.autosave,
+        )
+        self.swarm_workspace_dir = self.workspace.dir
 
         self.initialize_swarm()
 
@@ -496,98 +496,6 @@ class HierarchicalSwarm:
         for agent in agents:
             if hasattr(agent, "output_type"):
                 agent.output_type = "final"
-
-    def _setup_autosave(self):
-        """
-        Setup workspace directory for saving conversation history.
-
-        Creates the workspace directory structure if autosave is enabled.
-        Only conversation history will be saved to this directory.
-        """
-        try:
-            # Set default workspace directory if not set
-            if not os.getenv("WORKSPACE_DIR"):
-                default_workspace = os.path.join(
-                    os.getcwd(), "agent_workspace"
-                )
-                os.environ["WORKSPACE_DIR"] = default_workspace
-                # Clear the cache so get_workspace_dir() picks up the new value
-                get_workspace_dir.cache_clear()
-                if self.verbose:
-                    logger.info(
-                        f"WORKSPACE_DIR not set, using default: {default_workspace}"
-                    )
-
-            class_name = self.__class__.__name__
-            swarm_name = self.name or "hierarchical-swarm"
-            self.swarm_workspace_dir = get_swarm_workspace_dir(
-                class_name, swarm_name, use_timestamp=True
-            )
-
-            if self.swarm_workspace_dir:
-                if self.verbose:
-                    logger.info(
-                        f"Autosave enabled. Conversation history will be saved to: {self.swarm_workspace_dir}"
-                    )
-        except Exception as e:
-            logger.warning(
-                f"Failed to setup autosave for HierarchicalSwarm: {e}"
-            )
-            # Don't raise - autosave failures shouldn't break initialization
-            self.swarm_workspace_dir = None
-
-    def _save_conversation_history(self):
-        """
-        Save conversation history as a separate JSON file to the workspace directory.
-
-        Saves the conversation history to:
-        workspace_dir/swarms/HierarchicalSwarm/{swarm-name}-{id}/conversation_history.json
-        """
-        if not self.swarm_workspace_dir:
-            return
-
-        try:
-            # Get conversation history
-            if hasattr(self, "conversation") and self.conversation:
-                if hasattr(self.conversation, "conversation_history"):
-                    conversation_data = (
-                        self.conversation.conversation_history
-                    )
-                elif hasattr(self.conversation, "to_dict"):
-                    conversation_data = self.conversation.to_dict()
-                else:
-                    conversation_data = []
-
-                # Create conversation history file path
-                conversation_path = os.path.join(
-                    self.swarm_workspace_dir,
-                    "conversation_history.json",
-                )
-
-                # Save conversation history as JSON
-                with open(
-                    conversation_path, "w", encoding="utf-8"
-                ) as f:
-                    json.dump(
-                        conversation_data,
-                        f,
-                        indent=2,
-                        default=str,
-                    )
-
-                if self.verbose:
-                    logger.debug(
-                        f"Saved conversation history to {conversation_path}"
-                    )
-            else:
-                if self.verbose:
-                    logger.debug(
-                        "No conversation object found, skipping conversation history save"
-                    )
-        except Exception as e:
-            logger.warning(
-                f"Failed to save conversation history: {e}"
-            )
 
     def add_context_to_director(self):
         """
@@ -1003,14 +911,7 @@ class HierarchicalSwarm:
                 conversation=self.conversation, type=self.output_type
             )
 
-            # Save conversation history after successful execution
-            if self.autosave and self.swarm_workspace_dir:
-                try:
-                    self._save_conversation_history()
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to save conversation history: {e}"
-                    )
+            self.workspace.save_conversation()
 
             return result
 
@@ -1020,14 +921,7 @@ class HierarchicalSwarm:
                 self.dashboard.update_director_status("ERROR")
                 self.dashboard.stop()
 
-            # Save conversation history on error
-            if self.autosave and self.swarm_workspace_dir:
-                try:
-                    self._save_conversation_history()
-                except Exception as save_error:
-                    logger.warning(
-                        f"Failed to save conversation history on error: {save_error}"
-                    )
+            self.workspace.save_conversation()
 
             error_msg = f"[ERROR] Swarm run failed: {str(e)}"
             logger.error(

--- a/swarms/structs/majority_voting.py
+++ b/swarms/structs/majority_voting.py
@@ -9,6 +9,7 @@ from swarms.utils.history_output_formatter import (
     history_output_formatter,
 )
 from swarms.utils.output_types import OutputType
+from swarms.utils.workspace_manager import WorkspaceManager
 from swarms.telemetry.otel import (
     ContextThreadPoolExecutor,
     capture_init,
@@ -128,6 +129,13 @@ class MajorityVoting:
         self.description = description
         self.agents = agents
         self.autosave = autosave
+        self.workspace = WorkspaceManager(
+            self,
+            name=self.name or "majority-voting",
+            verbose=verbose,
+            enabled=autosave,
+        )
+        self.swarm_workspace_dir = self.workspace.dir
         self.verbose = verbose
         self.max_loops = max_loops
         self.output_type = output_type
@@ -247,6 +255,8 @@ class MajorityVoting:
                 role=self.consensus_agent.agent_name,
                 content=consensus_output,
             )
+
+        self.workspace.save_conversation()
 
         return history_output_formatter(
             conversation=self.conversation,

--- a/swarms/structs/planner_worker_swarm.py
+++ b/swarms/structs/planner_worker_swarm.py
@@ -23,6 +23,7 @@ from swarms.schemas.planner_worker_schemas import (
 from swarms.structs.agent import Agent
 from swarms.structs.conversation import Conversation
 from swarms.tools.base_tool import BaseTool
+from swarms.utils.workspace_manager import WorkspaceManager
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
 )
@@ -571,6 +572,13 @@ class PlannerWorkerSwarm:
         self.max_workers = max_workers
         self.output_type = output_type
         self.autosave = autosave
+        self.workspace = WorkspaceManager(
+            self,
+            name=self.name or "planner-worker-swarm",
+            verbose=verbose,
+            enabled=autosave,
+        )
+        self.swarm_workspace_dir = self.workspace.dir
         self.verbose = verbose
 
         # Internal state
@@ -927,6 +935,8 @@ class PlannerWorkerSwarm:
                     f"[PlannerWorkerSwarm] Goal achieved in cycle {cycle + 1}"
                 )
                 break
+
+        self.workspace.save_conversation()
 
         return history_output_formatter(
             conversation=self.conversation,

--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -4,7 +4,6 @@ import os
 from concurrent.futures import as_completed
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from loguru import logger as loguru_logger
 from swarms.prompts.agent_acknowledgement_prompt import (
     AGENT_COLLAB_PROMPT,
 )
@@ -17,8 +16,7 @@ from swarms.telemetry.otel import (
 )
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.output_types import OutputType
-from swarms.utils.swarm_autosave import get_swarm_workspace_dir
-from swarms.utils.workspace_utils import get_workspace_dir
+from swarms.utils.workspace_manager import WorkspaceManager
 
 logger = initialize_logger(log_folder="sequential_workflow")
 
@@ -155,7 +153,13 @@ class SequentialWorkflow:
             if drift_detection
             else None
         )
-        self.swarm_workspace_dir = None
+        self.workspace = WorkspaceManager(
+            self,
+            name=self.name or "sequential-workflow",
+            verbose=self.verbose,
+            enabled=self.autosave,
+        )
+        self.swarm_workspace_dir = self.workspace.dir
 
         self.reliability_check()
         self.flow = self.sequential_flow()
@@ -169,10 +173,6 @@ class SequentialWorkflow:
             output_type=self.output_type,
             team_awareness=self.team_awareness,
         )
-
-        # Setup autosave workspace if enabled
-        if self.autosave:
-            self._setup_autosave()
 
         # Capture the full __init__ configuration if telemetry is enabled.
         capture_init(self)
@@ -294,6 +294,12 @@ class SequentialWorkflow:
     @trace_run(
         "SequentialWorkflow.run", input_params=("task", "img", "imgs")
     )
+    def _autosave_conversation(self) -> None:
+        """Persist history; SequentialWorkflow keeps it on AgentRearrange."""
+        self.workspace.save_conversation(
+            getattr(self.agent_rearrange, "conversation", None)
+        )
+
     def run(
         self,
         task: str,
@@ -342,26 +348,12 @@ class SequentialWorkflow:
                     task, result, run_kwargs
                 )
 
-            # Save conversation history after successful execution
-            if self.autosave and self.swarm_workspace_dir:
-                try:
-                    self._save_conversation_history()
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to save conversation history: {e}"
-                    )
+            self._autosave_conversation()
 
             return result
 
         except Exception as e:
-            # Save conversation history on error
-            if self.autosave and self.swarm_workspace_dir:
-                try:
-                    self._save_conversation_history()
-                except Exception as save_error:
-                    logger.warning(
-                        f"Failed to save conversation history on error: {save_error}"
-                    )
+            self._autosave_conversation()
 
             logger.error(
                 f"An error occurred while executing the task: {e}"
@@ -550,102 +542,3 @@ class SequentialWorkflow:
                 f"An error occurred while executing the batch of tasks concurrently: {e}"
             )
             raise
-
-    def _setup_autosave(self):
-        """
-        Setup workspace directory for saving conversation history.
-
-        Creates the workspace directory structure if autosave is enabled.
-        Only conversation history will be saved to this directory.
-        """
-        try:
-            # Set default workspace directory if not set
-            if not os.getenv("WORKSPACE_DIR"):
-                default_workspace = os.path.join(
-                    os.getcwd(), "agent_workspace"
-                )
-                os.environ["WORKSPACE_DIR"] = default_workspace
-                # Clear the cache so get_workspace_dir() picks up the new value
-                get_workspace_dir.cache_clear()
-                if self.verbose:
-                    loguru_logger.info(
-                        f"WORKSPACE_DIR not set, using default: {default_workspace}"
-                    )
-
-            class_name = self.__class__.__name__
-            swarm_name = self.name or "sequential-workflow"
-            self.swarm_workspace_dir = get_swarm_workspace_dir(
-                class_name, swarm_name, use_timestamp=True
-            )
-
-            if self.swarm_workspace_dir:
-                if self.verbose:
-                    loguru_logger.info(
-                        f"Autosave enabled. Conversation history will be saved to: {self.swarm_workspace_dir}"
-                    )
-        except Exception as e:
-            loguru_logger.warning(
-                f"Failed to setup autosave for SequentialWorkflow: {e}"
-            )
-            # Don't raise - autosave failures shouldn't break initialization
-            self.swarm_workspace_dir = None
-
-    def _save_conversation_history(self):
-        """
-        Save conversation history as a separate JSON file to the workspace directory.
-
-        Saves the conversation history to:
-        workspace_dir/swarms/SequentialWorkflow/{workflow-name}-{id}/conversation_history.json
-        """
-        if not self.swarm_workspace_dir:
-            return
-
-        try:
-            # Get conversation history from agent_rearrange
-            conversation_data = []
-            if (
-                hasattr(self, "agent_rearrange")
-                and self.agent_rearrange
-            ):
-                if (
-                    hasattr(self.agent_rearrange, "conversation")
-                    and self.agent_rearrange.conversation
-                ):
-                    if hasattr(
-                        self.agent_rearrange.conversation,
-                        "conversation_history",
-                    ):
-                        conversation_data = (
-                            self.agent_rearrange.conversation.conversation_history
-                        )
-                    elif hasattr(
-                        self.agent_rearrange.conversation, "to_dict"
-                    ):
-                        conversation_data = (
-                            self.agent_rearrange.conversation.to_dict()
-                        )
-                    else:
-                        conversation_data = []
-
-            # Create conversation history file path
-            conversation_path = os.path.join(
-                self.swarm_workspace_dir, "conversation_history.json"
-            )
-
-            # Save conversation history as JSON
-            with open(conversation_path, "w", encoding="utf-8") as f:
-                json.dump(
-                    conversation_data,
-                    f,
-                    indent=2,
-                    default=str,
-                )
-
-            if self.verbose:
-                loguru_logger.debug(
-                    f"Saved conversation history to {conversation_path}"
-                )
-        except Exception as e:
-            loguru_logger.warning(
-                f"Failed to save conversation history: {e}"
-            )

--- a/swarms/structs/spreadsheet_swarm.py
+++ b/swarms/structs/spreadsheet_swarm.py
@@ -9,7 +9,7 @@ from swarms.structs.multi_agent_exec import (
     run_agents_with_different_tasks,
 )
 from swarms.structs.omni_agent_types import AgentType
-from swarms.utils.file_processing import create_file_in_folder
+from swarms.utils.workspace_manager import WorkspaceManager
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.workspace_utils import get_workspace_dir
 
@@ -69,20 +69,25 @@ class SpreadSheetSwarm:
         self.load_path = load_path
         self.verbose = verbose
 
-        # --------------- NEW CHANGE START ---------------
-        # The save_file_path now uses the formatted_time and uuid_hex
-        # Save CSV files in the workspace_dir instead of root directory
-        if self.workspace_dir:
-            os.makedirs(self.workspace_dir, exist_ok=True)
+        self.workspace = WorkspaceManager(
+            self,
+            name=self.name or "spreadsheet-swarm",
+            verbose=verbose,
+            enabled=autosave,
+        )
+        self.swarm_workspace_dir = self.workspace.dir
+
+        # An explicitly passed save_file_path used to be overwritten here.
+        if not self.save_file_path:
+            base = (
+                self.workspace.dir
+                or self.workspace_dir
+                or os.getcwd()
+            )
+            os.makedirs(base, exist_ok=True)
             self.save_file_path = os.path.join(
-                self.workspace_dir,
-                f"spreadsheet_swarm_run_id_{uuid_hex}.csv",
+                base, f"spreadsheet_swarm_run_id_{uuid_hex}.csv"
             )
-        else:
-            self.save_file_path = (
-                f"spreadsheet_swarm_run_id_{uuid_hex}.csv"
-            )
-        # --------------- NEW CHANGE END ---------------
 
         self.outputs = []
         self.tasks_completed = 0
@@ -367,12 +372,9 @@ class SpreadSheetSwarm:
         """
         Save the swarm metadata to a JSON file.
         """
-        out = self.export_to_json()
-
-        create_file_in_folder(
-            folder_path=f"{self.workspace_dir}/Spreedsheet-Swarm-{self.name}/{self.name}",
-            file_name=f"spreedsheet-swarm-{uuid_hex}-metadata.json",
-            content=out,
+        self.workspace.save_text(
+            f"spreadsheet-swarm-{uuid_hex}-metadata.json",
+            self.export_to_json(),
         )
 
     def _save_metadata(self):

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -41,10 +41,7 @@ from swarms.telemetry.otel import (
     trace_run,
 )
 from swarms.utils.output_types import OutputType
-from swarms.utils.swarm_autosave import (
-    autosave_swarm,
-    get_swarm_workspace_dir,
-)
+from swarms.utils.workspace_manager import WorkspaceManager
 from swarms.utils.generate_id import generate_id
 
 _DOCS_URL = "https://docs.swarms.world/api/swarm-router"
@@ -127,14 +124,6 @@ def _msg_swarm_cached(swarm_type: str) -> str:
 
 def _msg_autosave_enabled(workspace_dir: str) -> str:
     return f"Autosave enabled. Swarm workspace: {workspace_dir}"
-
-
-def _msg_autosave_setup_failed(err: Exception) -> str:
-    return f"Failed to setup autosave for SwarmRouter: {err}"
-
-
-def _msg_autosave_after_exec_failed(err: Exception) -> str:
-    return f"Failed to autosave after execution: {err}"
 
 
 def _msg_batch_run_error(err: Exception, tb: str) -> str:
@@ -394,9 +383,8 @@ class SwarmRouter(SerializableMixin):
         self._swarm_factory = self._initialize_swarm_factory()
         self._swarm_cache = {}  # Cache for created swarms
 
-        # Setup autosave workspace if enabled
-        if self.autosave:
-            self._setup_autosave()
+        # Always built: a disabled manager no-ops, an absent one raises.
+        self._setup_autosave()
 
         # Reliability check
         self.reliability_check()
@@ -405,35 +393,21 @@ class SwarmRouter(SerializableMixin):
         capture_init(self)
 
     def _setup_autosave(self):
-        """Set up autosave storage and persist the initial router config.
+        """Create the autosave workspace and write the initial config."""
+        self.workspace = WorkspaceManager(
+            self,
+            name=self.name or "swarm-router",
+            use_timestamp=self.autosave_use_timestamp,
+            enabled=self.autosave,
+        )
+        self.swarm_workspace_dir = self.workspace.dir
 
-        Autosave failures are logged as warnings and do not prevent the router
-        from initializing.
-        """
-        try:
-            class_name = self.__class__.__name__
-            swarm_name = self.name or "swarm-router"
-            self.swarm_workspace_dir = get_swarm_workspace_dir(
-                class_name, swarm_name, self.autosave_use_timestamp
+        if self.swarm_workspace_dir:
+            self.workspace.save_config()
+            self._log(
+                "info",
+                _msg_autosave_enabled(self.swarm_workspace_dir),
             )
-
-            if self.swarm_workspace_dir:
-                # Save initial configuration
-                autosave_swarm(
-                    self,
-                    self.swarm_workspace_dir,
-                    save_config=True,
-                    save_state=False,
-                    save_metadata=False,
-                )
-                self._log(
-                    "info",
-                    _msg_autosave_enabled(self.swarm_workspace_dir),
-                )
-        except Exception as e:
-            self._log("warning", _msg_autosave_setup_failed(e))
-            # Don't raise - autosave failures shouldn't break initialization
-            self.swarm_workspace_dir = None
 
     def reliability_check(self):
         """Validate the router configuration and finish setup.
@@ -867,29 +841,16 @@ class SwarmRouter(SerializableMixin):
 
         result = self.swarm.run(**args, **kwargs)
 
-        # Autosave after successful execution
-        if self.autosave and self.swarm_workspace_dir:
-            try:
-                autosave_swarm(
-                    self,
-                    self.swarm_workspace_dir,
-                    save_config=False,  # Don't overwrite initial config
-                    save_state=True,
-                    save_metadata=True,
-                    execution_result=result,
-                    additional_data={
-                        "execution_metadata": {
-                            "task": task if task else None,
-                            "tasks": tasks if tasks else None,
-                            "status": "completed",
-                        }
-                    },
-                )
-            except Exception as e:
-                self._log(
-                    "warning",
-                    _msg_autosave_after_exec_failed(e),
-                )
+        # Config is written at init; overwriting it here would lose it.
+        self.workspace.save_state()
+        self.workspace.save_metadata(
+            execution_result=result,
+            execution_metadata={
+                "task": task if task else None,
+                "tasks": tasks if tasks else None,
+                "status": "completed",
+            },
+        )
 
         return result
 

--- a/swarms/tools/dynamic_tool_loader.py
+++ b/swarms/tools/dynamic_tool_loader.py
@@ -271,9 +271,13 @@ class DynamicToolLoader:
             wanted = [
                 n.strip() for n in query[len("select:") :].split(",")
             ]
-            return [
+            exact = [
                 self._catalog[n] for n in wanted if n in self._catalog
             ]
+            if exact:
+                return exact
+            # A miss usually means a guessed name, not a missing tool.
+            query = " ".join(wanted)
 
         terms = _tokenize(query)
         if not terms:

--- a/swarms/utils/__init__.py
+++ b/swarms/utils/__init__.py
@@ -30,6 +30,7 @@ from swarms.utils.litellm_wrapper import (
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.output_types import HistoryOutputType
 from swarms.utils.parse_code import extract_code_from_markdown
+from swarms.utils.workspace_manager import WorkspaceManager
 
 __all__ = [
     "load_json",
@@ -52,4 +53,5 @@ __all__ = [
     "format_data_structure",
     "format_dict_to_string",
     "initialize_logger",
+    "WorkspaceManager",
 ]

--- a/swarms/utils/workspace_manager.py
+++ b/swarms/utils/workspace_manager.py
@@ -1,0 +1,502 @@
+"""
+One owner for a swarm's autosave directory and every write into it.
+
+Each swarm used to carry its own ``_setup_autosave`` and
+``_save_conversation_history`` pair. They were copies of each other, so a fix
+to one silently left the others wrong. :class:`WorkspaceManager` holds that
+logic once; a swarm builds one in ``__init__`` and calls it from ``run``.
+
+Example:
+    >>> self.workspace = WorkspaceManager(self, verbose=self.verbose)
+    >>> self.swarm_workspace_dir = self.workspace.dir
+    >>> self.workspace.save_conversation(self.conversation)
+
+Nothing here raises. Autosave is a side effect of a run, never a reason for
+one to fail, so every method logs and returns ``None`` on error.
+"""
+
+import json
+import os
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional, Sequence
+
+from loguru import logger
+
+from swarms.utils.workspace_utils import get_workspace_dir
+
+DEFAULT_WORKSPACE_DIRNAME = "agent_workspace"
+CONVERSATION_FILENAME = "conversation_history.json"
+
+_INVALID_PATH_CHARS = '<>:"/\\|?*'
+_MAX_NAME_LEN = 100
+
+
+def sanitize_name(name: str) -> str:
+    """
+    Make a name safe to use as a single path segment.
+
+    Args:
+        name (str): The raw swarm or class name.
+
+    Returns:
+        str: A filesystem-safe name, or ``"unnamed"`` when empty.
+    """
+    if not name:
+        return "unnamed"
+
+    sanitized = str(name)
+    for char in _INVALID_PATH_CHARS:
+        sanitized = sanitized.replace(char, "_")
+
+    sanitized = sanitized.strip(". ").replace(" ", "-")
+    return sanitized[:_MAX_NAME_LEN] or "unnamed"
+
+
+def agent_dir_name(agent_name: str, agent_id: str) -> str:
+    """
+    Build an agent's directory name as ``{name-of-agent}-{uuid12}``.
+
+    Args:
+        agent_name (str): The agent's name; lowercased and hyphenated.
+        agent_id (str): The agent id, with any ``agent-`` prefix dropped.
+
+    Returns:
+        str: The directory name, e.g. ``"my-agent-a1b2c3d4e5f6"``.
+    """
+    safe = (agent_name or "agent").lower()
+    for char in _INVALID_PATH_CHARS + " _":
+        safe = safe.replace(char, "-")
+    while "--" in safe:
+        safe = safe.replace("--", "-")
+    safe = safe.strip("-")[:_MAX_NAME_LEN] or "agent"
+
+    uuid_part = str(agent_id or "")
+    if uuid_part.startswith("agent-"):
+        uuid_part = uuid_part[len("agent-") :]
+    return f"{safe}-{uuid_part[-12:]}"
+
+
+def ensure_workspace_env(verbose: bool = False) -> Optional[str]:
+    """
+    Resolve ``WORKSPACE_DIR``, defaulting it under the current directory.
+
+    Args:
+        verbose (bool): Log the default when one has to be invented.
+
+    Returns:
+        Optional[str]: The workspace path, or ``None`` if unresolvable.
+    """
+    if not os.getenv("WORKSPACE_DIR"):
+        default = os.path.join(os.getcwd(), DEFAULT_WORKSPACE_DIRNAME)
+        os.environ["WORKSPACE_DIR"] = default
+        # get_workspace_dir is lru_cached, so a stale miss would stick.
+        get_workspace_dir.cache_clear()
+        if verbose:
+            logger.info(
+                f"WORKSPACE_DIR not set, using default: {default}"
+            )
+
+    return get_workspace_dir()
+
+
+def conversation_to_data(conversation: Any) -> Any:
+    """
+    Pull serialisable history out of a Conversation-like object.
+
+    Args:
+        conversation (Any): A ``Conversation``, or anything exposing
+            ``conversation_history`` or ``to_dict``.
+
+    Returns:
+        Any: The history, or ``[]`` when nothing can be read.
+    """
+    if conversation is None:
+        return []
+
+    history = getattr(conversation, "conversation_history", None)
+    if history is not None:
+        return history
+
+    to_dict = getattr(conversation, "to_dict", None)
+    if callable(to_dict):
+        return to_dict()
+
+    return []
+
+
+class WorkspaceManager:
+    """
+    A swarm's autosave directory, created once and written to on demand.
+
+    The directory is ``{WORKSPACE_DIR}/swarms/{ClassName}/{name}-{stamp}``,
+    created eagerly so ``dir`` is usable straight after construction.
+
+    Args:
+        owner (Any): The swarm instance. Its class name and ``name``
+            attribute pick the directory, and it is the default source
+            for conversation and config data.
+        name (Optional[str]): Overrides ``owner.name`` in the path.
+        use_timestamp (bool): Timestamp in the directory name when
+            ``True``, otherwise a short UUID.
+        verbose (bool): Log the directory and each successful write.
+        enabled (bool): When ``False`` nothing is created or written and
+            ``dir`` stays ``None``.
+
+    Attributes:
+        dir (Optional[str]): The directory, or ``None`` when disabled or
+            setup failed.
+    """
+
+    def __init__(
+        self,
+        owner: Any,
+        name: Optional[str] = None,
+        use_timestamp: bool = True,
+        verbose: bool = False,
+        enabled: bool = True,
+        subpath: Optional[Sequence[str]] = None,
+        metadata_base: Optional[Dict[str, Any]] = None,
+    ):
+        self.owner = owner
+        self.class_name = owner.__class__.__name__
+        self.name = name or getattr(owner, "name", None) or "unnamed"
+        self.use_timestamp = use_timestamp
+        self.verbose = verbose
+        self.enabled = enabled
+        self.subpath = subpath
+        self.metadata_base = metadata_base
+        self.dir: Optional[str] = self._setup() if enabled else None
+
+    @classmethod
+    def for_agent(
+        cls,
+        agent: Any,
+        verbose: bool = False,
+        enabled: bool = True,
+    ) -> "WorkspaceManager":
+        """
+        Build a manager over an Agent's own ``agents/{name}-{uuid}`` dir.
+
+        Agents predate the ``swarms/`` layout and their path is load-bearing:
+        the autonomous loop's file tools resolve against it.
+
+        Args:
+            agent (Any): The agent, read for ``agent_name`` and ``id``.
+            verbose (bool): Log the directory and each successful write.
+            enabled (bool): When ``False`` nothing is created or written.
+
+        Returns:
+            WorkspaceManager: Rooted at the agent's workspace directory.
+        """
+        name = getattr(agent, "agent_name", None)
+        return cls(
+            agent,
+            name=name,
+            verbose=verbose,
+            enabled=enabled,
+            subpath=(
+                "agents",
+                agent_dir_name(name, getattr(agent, "id", "")),
+            ),
+            metadata_base={
+                "agent_id": getattr(agent, "id", None),
+                "agent_name": name,
+            },
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"WorkspaceManager({self.class_name}, dir={self.dir!r})"
+        )
+
+    def __bool__(self) -> bool:
+        """True when writes will actually land somewhere."""
+        return bool(self.dir)
+
+    def _setup(self) -> Optional[str]:
+        """
+        Create the directory for this swarm.
+
+        Returns:
+            Optional[str]: The created path, or ``None`` on failure.
+        """
+        try:
+            workspace_dir = ensure_workspace_env(self.verbose)
+            if not workspace_dir:
+                logger.warning(
+                    "WORKSPACE_DIR unresolved; autosave disabled for "
+                    f"{self.class_name}"
+                )
+                return None
+
+            stamp = (
+                datetime.now().strftime("%Y%m%d_%H%M%S")
+                if self.use_timestamp
+                else uuid.uuid4().hex[:12]
+            )
+            if self.subpath:
+                path = os.path.join(workspace_dir, *self.subpath)
+            else:
+                path = os.path.join(
+                    workspace_dir,
+                    "swarms",
+                    sanitize_name(self.class_name),
+                    f"{sanitize_name(self.name)}-{stamp}",
+                )
+            os.makedirs(path, exist_ok=True)
+
+            if self.verbose:
+                logger.info(f"Autosave enabled, writing to: {path}")
+            return path
+        except Exception as e:
+            logger.warning(
+                f"Failed to setup autosave for {self.class_name}: {e}"
+            )
+            return None
+
+    def save_json(self, filename: str, data: Any) -> Optional[str]:
+        """
+        Write ``data`` as JSON into the workspace directory.
+
+        Args:
+            filename (str): File name to write inside the directory.
+            data (Any): Anything ``json.dumps`` can take with
+                ``default=str``.
+
+        Returns:
+            Optional[str]: The written path, or ``None`` if skipped.
+        """
+        if not self.dir:
+            return None
+
+        try:
+            path = os.path.join(self.dir, filename)
+            # Written via temp+replace: config.json is rewritten every loop,
+            # so a crash mid-write would otherwise truncate it.
+            temp_path = f"{path}.tmp"
+            with open(temp_path, "w", encoding="utf-8") as f:
+                json.dump(
+                    data,
+                    f,
+                    indent=2,
+                    default=str,
+                    ensure_ascii=False,
+                )
+            os.replace(temp_path, path)
+
+            if self.verbose:
+                logger.debug(f"Saved {filename} to {path}")
+            return path
+        except Exception as e:
+            logger.warning(f"Failed to save {filename}: {e}")
+            return None
+
+    def save_text(self, filename: str, content: str) -> Optional[str]:
+        """
+        Write text into the workspace directory, atomically.
+
+        Args:
+            filename (str): File name to write inside the directory.
+            content (str): The text to write.
+
+        Returns:
+            Optional[str]: The written path, or ``None`` if skipped.
+        """
+        if not self.dir:
+            return None
+
+        try:
+            path = os.path.join(self.dir, filename)
+            temp_path = f"{path}.tmp"
+            with open(temp_path, "w", encoding="utf-8") as f:
+                f.write(content)
+            os.replace(temp_path, path)
+
+            if self.verbose:
+                logger.debug(f"Saved {filename} to {path}")
+            return path
+        except Exception as e:
+            logger.warning(f"Failed to save {filename}: {e}")
+            return None
+
+    def save_conversation(
+        self,
+        conversation: Any = None,
+        filename: str = CONVERSATION_FILENAME,
+    ) -> Optional[str]:
+        """
+        Write conversation history to ``conversation_history.json``.
+
+        Args:
+            conversation (Any): The conversation to save. Defaults to
+                ``owner.conversation`` when omitted, which is wrong for
+                swarms that keep it elsewhere - pass it explicitly there.
+            filename (str): Overrides the output file name.
+
+        Returns:
+            Optional[str]: The written path, or ``None`` if skipped.
+        """
+        if conversation is None:
+            conversation = getattr(self.owner, "conversation", None)
+
+        return self.save_json(
+            filename, conversation_to_data(conversation)
+        )
+
+    def save_config(
+        self, additional_metadata: Optional[Dict[str, Any]] = None
+    ) -> Optional[str]:
+        """
+        Write the owner's configuration to ``config.json``.
+
+        Args:
+            additional_metadata (Optional[Dict[str, Any]]): Merged into
+                the ``_autosave_metadata`` block.
+
+        Returns:
+            Optional[str]: The written path, or ``None`` if skipped.
+        """
+        if not self.dir:
+            return None
+
+        try:
+            to_dict = getattr(self.owner, "to_dict", None)
+            if callable(to_dict):
+                config = to_dict()
+            else:
+                config = {
+                    k: v
+                    for k, v in vars(self.owner).items()
+                    if not k.startswith("_") and not callable(v)
+                }
+
+            base = self.metadata_base
+            if base is None:
+                base = {
+                    "class_name": self.class_name,
+                    "swarm_name": self.name,
+                    "swarm_id": getattr(self.owner, "id", None),
+                }
+            config["_autosave_metadata"] = {
+                "timestamp": datetime.now().isoformat(),
+                **base,
+                **(additional_metadata or {}),
+            }
+            return self.save_json("config.json", config)
+        except Exception as e:
+            logger.warning(f"Failed to save swarm config: {e}")
+            return None
+
+    def save_state(
+        self, state_data: Optional[Dict[str, Any]] = None
+    ) -> Optional[str]:
+        """
+        Write a state snapshot to ``state.json``.
+
+        Args:
+            state_data (Optional[Dict[str, Any]]): Extra keys merged over
+                the defaults.
+
+        Returns:
+            Optional[str]: The written path, or ``None`` if skipped.
+        """
+        if not self.dir:
+            return None
+
+        state = {
+            "timestamp": datetime.now().isoformat(),
+            "swarm_name": self.name,
+            "swarm_id": getattr(self.owner, "id", None),
+            "swarm_type": getattr(self.owner, "swarm_type", None),
+            "conversation": conversation_to_data(
+                getattr(self.owner, "conversation", None)
+            ),
+        }
+
+        logs = getattr(self.owner, "logs", None)
+        if logs is not None:
+            state["logs"] = [str(log) for log in logs]
+
+        state.update(state_data or {})
+        return self.save_json("state.json", state)
+
+    def save_metadata(
+        self,
+        execution_result: Any = None,
+        execution_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """
+        Write run metadata to ``metadata.json``.
+
+        Args:
+            execution_result (Any): Summarised, not stored whole.
+            execution_metadata (Optional[Dict[str, Any]]): Extra keys
+                merged over the defaults.
+
+        Returns:
+            Optional[str]: The written path, or ``None`` if skipped.
+        """
+        if not self.dir:
+            return None
+
+        agents = getattr(self.owner, "agents", None)
+        metadata = {
+            "execution_timestamp": datetime.now().isoformat(),
+            "swarm_name": self.name,
+            "swarm_id": getattr(self.owner, "id", None),
+            "swarm_type": getattr(self.owner, "swarm_type", None),
+            "max_loops": getattr(self.owner, "max_loops", None),
+            "agents_count": len(agents) if agents else 0,
+        }
+
+        if execution_result is not None:
+            metadata["execution_result_summary"] = _summarize(
+                execution_result
+            )
+
+        metadata.update(execution_metadata or {})
+        return self.save_json("metadata.json", metadata)
+
+    def save_all(
+        self,
+        conversation: Any = None,
+        execution_result: Any = None,
+    ) -> Dict[str, Optional[str]]:
+        """
+        Write config, state, metadata and conversation in one call.
+
+        Args:
+            conversation (Any): Passed through to ``save_conversation``.
+            execution_result (Any): Passed through to ``save_metadata``.
+
+        Returns:
+            Dict[str, Optional[str]]: Written path per file, ``None`` for
+            any that was skipped.
+        """
+        return {
+            "config": self.save_config(),
+            "state": self.save_state(),
+            "metadata": self.save_metadata(execution_result),
+            "conversation": self.save_conversation(conversation),
+        }
+
+
+def _summarize(result: Any) -> Any:
+    """
+    Describe a run result without embedding the whole thing.
+
+    Args:
+        result (Any): The value returned by a swarm run.
+
+    Returns:
+        Any: A short scalar or a type/length pair.
+    """
+    if isinstance(result, (str, int, float, bool)):
+        return str(result)
+    if isinstance(result, (list, dict)):
+        return {
+            "type": type(result).__name__,
+            "length": len(result),
+        }
+    return type(result).__name__

--- a/tests/utils/test_workspace_manager.py
+++ b/tests/utils/test_workspace_manager.py
@@ -1,0 +1,338 @@
+"""
+Tests for ``swarms.utils.workspace_manager.WorkspaceManager``.
+
+Every test points WORKSPACE_DIR at a tmp_path, so nothing touches the real
+workspace. No network and no LLM: the manager only ever touches the disk.
+"""
+
+import json
+import os
+
+import pytest
+
+from swarms.utils.workspace_manager import (
+    CONVERSATION_FILENAME,
+    agent_dir_name,
+    WorkspaceManager,
+    conversation_to_data,
+    ensure_workspace_env,
+    sanitize_name,
+)
+from swarms.utils.workspace_utils import get_workspace_dir
+
+
+@pytest.fixture(autouse=True)
+def workspace(tmp_path, monkeypatch):
+    """Point WORKSPACE_DIR at a tmp dir and clear the lru_cache."""
+    monkeypatch.setenv("WORKSPACE_DIR", str(tmp_path))
+    get_workspace_dir.cache_clear()
+    yield tmp_path
+    get_workspace_dir.cache_clear()
+
+
+class FakeConversation:
+    def __init__(self, history=None):
+        self.conversation_history = (
+            history
+            if history is not None
+            else [{"role": "user", "content": "hi"}]
+        )
+
+
+class DictOnlyConversation:
+    def to_dict(self):
+        return [{"role": "assistant", "content": "from to_dict"}]
+
+
+class FakeSwarm:
+    def __init__(self, name="test-swarm", conversation=None):
+        self.name = name
+        self.id = "swarm-id-1"
+        self.max_loops = 2
+        self.agents = [object(), object()]
+        self.conversation = conversation or FakeConversation()
+
+
+class TestSanitizeName:
+    def test_empty_becomes_unnamed(self):
+        assert sanitize_name("") == "unnamed"
+        assert sanitize_name(None) == "unnamed"
+
+    def test_path_separators_cannot_escape_the_directory(self):
+        """A name with a slash must not create a nested path."""
+        assert "/" not in sanitize_name("evil/../../etc")
+        assert "\\" not in sanitize_name("evil\\win")
+
+    def test_spaces_become_hyphens(self):
+        assert sanitize_name("my swarm") == "my-swarm"
+
+    def test_long_names_are_truncated(self):
+        assert len(sanitize_name("x" * 500)) == 100
+
+    def test_name_of_only_dots_does_not_become_empty(self):
+        """'..' would otherwise strip to '' and yield a bare path."""
+        assert sanitize_name("..") == "unnamed"
+
+
+class TestEnsureWorkspaceEnv:
+    def test_returns_the_configured_dir(self, workspace):
+        assert ensure_workspace_env() == str(workspace)
+
+    def test_defaults_when_unset(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("WORKSPACE_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+        get_workspace_dir.cache_clear()
+        resolved = ensure_workspace_env()
+        assert resolved.endswith("agent_workspace")
+        assert os.environ["WORKSPACE_DIR"] == resolved
+
+
+class TestConversationToData:
+    def test_none_is_empty(self):
+        assert conversation_to_data(None) == []
+
+    def test_reads_conversation_history(self):
+        conv = FakeConversation([{"role": "user", "content": "a"}])
+        assert conversation_to_data(conv) == [
+            {"role": "user", "content": "a"}
+        ]
+
+    def test_falls_back_to_to_dict(self):
+        data = conversation_to_data(DictOnlyConversation())
+        assert data[0]["content"] == "from to_dict"
+
+    def test_object_with_neither_is_empty(self):
+        assert conversation_to_data(object()) == []
+
+
+class TestSetup:
+    def test_directory_layout(self, workspace):
+        wm = WorkspaceManager(FakeSwarm(name="my-swarm"))
+        rel = os.path.relpath(wm.dir, workspace)
+        parts = rel.split(os.sep)
+        assert parts[0] == "swarms"
+        assert parts[1] == "FakeSwarm"
+        assert parts[2].startswith("my-swarm-")
+        assert os.path.isdir(wm.dir)
+
+    def test_disabled_creates_nothing(self, workspace):
+        wm = WorkspaceManager(FakeSwarm(), enabled=False)
+        assert wm.dir is None
+        assert not bool(wm)
+        assert not (workspace / "swarms").exists()
+
+    def test_name_argument_overrides_owner_name(self):
+        wm = WorkspaceManager(
+            FakeSwarm(name="owner"), name="override"
+        )
+        assert os.path.basename(wm.dir).startswith("override-")
+
+    def test_uuid_mode(self):
+        wm = WorkspaceManager(FakeSwarm(), use_timestamp=False)
+        stamp = os.path.basename(wm.dir).rsplit("-", 1)[1]
+        assert len(stamp) == 12
+
+    def test_two_managers_do_not_collide(self):
+        a = WorkspaceManager(FakeSwarm(), use_timestamp=False)
+        b = WorkspaceManager(FakeSwarm(), use_timestamp=False)
+        assert a.dir != b.dir
+
+
+class TestSaves:
+    def test_save_conversation_writes_history(self):
+        swarm = FakeSwarm()
+        wm = WorkspaceManager(swarm)
+        path = wm.save_conversation()
+
+        assert os.path.basename(path) == CONVERSATION_FILENAME
+        with open(path) as f:
+            assert json.load(f) == [{"role": "user", "content": "hi"}]
+
+    def test_explicit_conversation_beats_the_owner(self):
+        wm = WorkspaceManager(FakeSwarm())
+        path = wm.save_conversation(
+            FakeConversation([{"role": "x", "content": "explicit"}])
+        )
+        with open(path) as f:
+            assert json.load(f)[0]["content"] == "explicit"
+
+    def test_save_all_writes_four_files(self):
+        wm = WorkspaceManager(FakeSwarm())
+        paths = wm.save_all(execution_result=["a", "b"])
+
+        assert set(paths) == {
+            "config",
+            "state",
+            "metadata",
+            "conversation",
+        }
+        assert all(paths.values())
+        assert sorted(os.listdir(wm.dir)) == [
+            "config.json",
+            CONVERSATION_FILENAME,
+            "metadata.json",
+            "state.json",
+        ]
+
+    def test_metadata_summarizes_rather_than_embeds(self):
+        wm = WorkspaceManager(FakeSwarm())
+        with open(wm.save_metadata(execution_result=["a", "b"])) as f:
+            meta = json.load(f)
+        assert meta["execution_result_summary"] == {
+            "type": "list",
+            "length": 2,
+        }
+        assert meta["agents_count"] == 2
+
+    def test_unserializable_values_do_not_raise(self):
+        """default=str must absorb objects json cannot encode."""
+        swarm = FakeSwarm()
+        swarm.conversation = FakeConversation([{"obj": object()}])
+        wm = WorkspaceManager(swarm)
+        assert wm.save_conversation() is not None
+
+    def test_disabled_manager_writes_nothing(self):
+        wm = WorkspaceManager(FakeSwarm(), enabled=False)
+        assert wm.save_conversation() is None
+        assert wm.save_config() is None
+        assert wm.save_state() is None
+        assert wm.save_metadata() is None
+
+
+class TestNeverRaises:
+    def test_setup_failure_disables_rather_than_raises(
+        self, monkeypatch
+    ):
+        def boom(*a, **kw):
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(os, "makedirs", boom)
+        wm = WorkspaceManager(FakeSwarm())
+        assert wm.dir is None
+        assert wm.save_conversation() is None
+
+    def test_write_failure_returns_none(self, monkeypatch):
+        wm = WorkspaceManager(FakeSwarm())
+
+        def boom(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("builtins.open", boom)
+        assert wm.save_conversation() is None
+
+    def test_owner_without_optional_attributes(self):
+        """A bare owner must still produce config/state/metadata."""
+
+        class Bare:
+            pass
+
+        wm = WorkspaceManager(Bare(), name="bare")
+        assert wm.save_config() is not None
+        assert wm.save_state() is not None
+        assert wm.save_metadata() is not None
+
+
+class TestAgentLayout:
+    """Agents keep the older ``agents/{name}-{uuid}`` path, not ``swarms/``."""
+
+    @staticmethod
+    def _legacy_dir_name(agent_name, agent_id):
+        """The exact algorithm agent.py used before the migration."""
+        if agent_name:
+            s = (
+                agent_name.lower()
+                .replace(" ", "-")
+                .replace("_", "-")
+                .replace("/", "-")
+                .replace("\\", "-")
+                .replace(":", "-")
+                .replace("*", "-")
+                .replace("?", "-")
+                .replace('"', "-")
+                .replace("<", "-")
+                .replace(">", "-")
+                .replace("|", "-")
+                .replace("--", "-")
+                .replace("--", "-")
+                .strip("-")
+            )
+        else:
+            s = "agent"
+        u = (
+            agent_id.replace("agent-", "")
+            if agent_id.startswith("agent-")
+            else agent_id
+        )
+        return f"{s}-{u[-12:] if len(u) > 12 else u}"
+
+    @pytest.mark.parametrize(
+        "name,agent_id",
+        [
+            ("My Agent", "agent-abcdef123456789"),
+            ("weird/name:with*chars", "agent-0011223344556677"),
+            ("Multi__Under___scores", "xyz"),
+            ("", "agent-deadbeefcafe"),
+            ("Trailing---", "agent-1234"),
+            ("a", "short"),
+        ],
+    )
+    def test_matches_the_pre_migration_naming(self, name, agent_id):
+        """The path is load-bearing: file tools resolve against it."""
+        assert agent_dir_name(
+            name, agent_id
+        ) == self._legacy_dir_name(name, agent_id)
+
+    def test_for_agent_uses_the_agents_directory(self, workspace):
+        class FakeAgent:
+            agent_name = "My Agent"
+            id = "agent-abcdef123456789"
+
+        wm = WorkspaceManager.for_agent(FakeAgent())
+        rel = os.path.relpath(wm.dir, workspace).split(os.sep)
+        assert rel[0] == "agents"
+        assert rel[1] == "my-agent-def123456789"
+        assert "swarms" not in rel
+
+    def test_agent_metadata_keys(self):
+        class FakeAgent:
+            agent_name = "Saver"
+            id = "agent-1234567890abcdef"
+
+        wm = WorkspaceManager.for_agent(FakeAgent())
+        with open(
+            wm.save_config(additional_metadata={"loop_count": 3})
+        ) as f:
+            meta = json.load(f)["_autosave_metadata"]
+
+        assert meta["agent_name"] == "Saver"
+        assert meta["agent_id"] == "agent-1234567890abcdef"
+        assert meta["loop_count"] == 3
+        assert "swarm_name" not in meta
+
+
+class TestAtomicWrite:
+    def test_no_temp_file_is_left_behind(self):
+        wm = WorkspaceManager(FakeSwarm())
+        wm.save_conversation()
+        assert not [
+            f for f in os.listdir(wm.dir) if f.endswith(".tmp")
+        ]
+
+    def test_a_failed_write_leaves_the_previous_file_intact(
+        self, monkeypatch
+    ):
+        """The point of temp+replace: config.json is rewritten each loop."""
+        wm = WorkspaceManager(FakeSwarm())
+        path = wm.save_conversation()
+        original = open(path).read()
+
+        real_replace = os.replace
+
+        def boom(*a, **kw):
+            raise OSError("interrupted")
+
+        monkeypatch.setattr(os, "replace", boom)
+        assert wm.save_conversation() is None
+        monkeypatch.setattr(os, "replace", real_replace)
+
+        assert open(path).read() == original


### PR DESCRIPTION
## What this does

Every structure that autosaves had grown its own copy of the same logic.
`SequentialWorkflow`, `ConcurrentWorkflow` and `HierarchicalSwarm` each carried a
**byte-identical** `_setup_autosave` and a near-identical `_save_conversation_history`,
differing only in a logger name and a default string — so a fix to one silently left
the others wrong. `Agent` had a third variant, `SwarmRouter` a fourth via
`swarm_autosave`, and three more classes advertised an `autosave` flag that did
nothing at all.

`WorkspaceManager` (`swarms/utils/workspace_manager.py`) owns that logic once:

```python
self.workspace = WorkspaceManager(self, name=..., verbose=..., enabled=self.autosave)
self.swarm_workspace_dir = self.workspace.dir

self.workspace.save_conversation()   # conversation_history.json
self.workspace.save_config()         # config.json
self.workspace.save_state()          # state.json
self.workspace.save_metadata(result) # metadata.json
self.workspace.save_all()            # all four
```

Two design choices do most of the work:

- **A disabled manager is a live no-op object, not `None`.** Every
  `if self.autosave and self.swarm_workspace_dir:` guard disappears from call sites.
- **Nothing raises.** Every surrounding `try/except` disappears too. Autosave is a
  side effect of a run, never a reason for one to fail.

Conversation is resolved lazily at save time, which is what lets one class serve
`HierarchicalSwarm` (conversation built later in `initialize_swarm()`) and
`SequentialWorkflow` (conversation lives on the inner `AgentRearrange`).

## Migrated

| Class | Change |
|---|---|
| `SequentialWorkflow` | −98 lines of duplicated autosave |
| `ConcurrentWorkflow` | −87 |
| `HierarchicalSwarm` | −92 |
| `SwarmRouter` | replaces `swarm_autosave`; 2 dead helpers removed |
| `Agent` | −119, keeping its own `agents/{name}-{uuid}` layout |
| `MajorityVoting` | dead flag → real autosave |
| `PlannerWorkerSwarm` | dead flag → real autosave |
| `SpreadSheetSwarm` | ad-hoc path → standard layout |

**992 insertions, 555 deletions** — and 502 of those insertions are the new module,
338 the new tests. The existing classes lose far more than they gain.

## Bugs fixed along the way

1. **`SwarmRouter` raised `AttributeError` whenever `autosave=False`.**
   `_setup_autosave()` was called only `if self.autosave`, so `self.workspace` never
   existed, but `run()` used it unconditionally. This took out 22 tests until fixed.
2. **`MajorityVoting.autosave` was assigned and never read.** The API advertised
   autosave and silently did nothing.
3. **`PlannerWorkerSwarm.autosave` was assigned and never read**, while its docstring
   promised *"Whether to save conversation history."*
4. **`SpreadSheetSwarm` ignored a caller-supplied `save_file_path`** — it was
   overwritten three lines after being assigned.

## Behaviour changes worth a second opinion

- **`config.json` is now written atomically for swarms too.** `Agent` already used
  temp + `os.replace`; the swarm classes wrote directly. Since `config.json` is
  rewritten on every loop, a crash mid-write truncated it. There is a test that a
  failed `os.replace` leaves the previous file intact.
- **Three classes now write files that previously wrote none** — `MajorityVoting`,
  `PlannerWorkerSwarm`, `SpreadSheetSwarm` metadata. This is the flag finally doing
  what it says, but it is new I/O; all three default to `autosave=False`.
- **The agent `_autosave_metadata.timestamp` format changed** from
  `"2026-08-23 17:23:30"` to ISO `"2026-08-23T17:23:30.919620"`. The two examples
  that read it only print it. Easy to revert if preferred.

## What deliberately did *not* move

- **`AgentRearrange`** — its `autosave` gates `log_agent_data()`, a telemetry upload,
  not a disk write. Wiring it would also hurt: it defaults `autosave=True` and
  `SequentialWorkflow` constructs it without passing the flag, so every sequential run
  would silently create a second workspace directory next to the one it already writes.
- **`GraphWorkflow`** — `checkpoint_dir` is per-node checkpointing with nested-workflow
  inheritance, a different mechanism.
- **`BaseSwarm`** — only the alt swarms inherit it, none of the main architectures.
- **`swarms/utils/swarm_autosave.py`** is now unused by the framework but is left in
  place: `examples/multi_agent/skill_orchestra_examples/skill_orchestra.py` still
  imports `get_swarm_workspace_dir` from it.

## Agent layout is preserved exactly

Agents keep `agents/{name-of-agent}-{uuid12}` rather than moving to the
`swarms/{Class}/{name}-{stamp}` layout, because the path is load-bearing: the
autonomous loop's file tools resolve against it in six places and four examples read
it. The replacement `agent_dir_name()` is verified against the previous algorithm on
adversarial inputs (`Multi__Under___scores`, `weird/name:with*chars`, empty name,
trailing hyphens) — 0 mismatches, frozen as a parametrised test.

The workspace is also still built on **first use, not at construction**, so creating an
`Agent` does not leave a directory behind.

## Unrelated fix included

`tool_search`'s `select:` was an exact-match lookup with no fallback. A model guessing
`exa_web_search` for the real `web_search_exa` got nothing back — and with
`max_loops=1` there was no turn left to retry, so the run produced no output at all.
A total miss now falls through to keyword search over the requested names; exact hits
still win, and a genuine miss still lists the catalog.

```
select:exa_web_search,exa_web_get_contents
  → before: No tools matched ...
  → after:  Loaded 2: web_search_exa, web_fetch_exa
```

## Testing

`tests/utils/test_workspace_manager.py` — **35 tests, fully offline**. Covers directory
layout, the disabled path, names that would otherwise escape the directory (`..`,
slashes), the agent-layout naming parity, atomic-write behaviour, and three
never-raises cases (unwritable FS, disk full, bare owner object).

Every suite was diffed against a clean-`master` worktree rather than trusting a raw
pass/fail count, since the suite has pre-existing failures:

| Suite | Baseline | This branch | Regressions |
|---|---|---|---|
| `test_agent.py` + `test_dynamic_tool_loader.py` | 28 failing | 28 failing | **0** |
| `test_sequential_workflow.py` | — | 27/27 pass | **0** |
| `test_concurrent_workflow.py` | — | 10/10 pass | **0** |
| `test_hierarchical_swarm.py` | identical set | identical set | **0** |
| `test_swarm_router.py` | 2 failed, 30 passed | 2 failed, 30 passed | **0** |
| `majority_voting` + `planner_worker` + `spreadsheet` | 5 failed, 77 passed | 5 failed, 112 passed | **0** |

Two `HierarchicalSwarm` context tests looked like regressions at first; they are not.
The baseline worktree had no `.env`, so its live feedback-director call failed and
stayed short. With `.env` present, clean `master` fails those same two tests — they
assert on live LLM response length (`second < first * 5`).

`black --line-length 70 swarms/ tests/` and `ruff check .` both clean.
