### PR TITLE
[Bug] Agent.load() raises AttributeError for every agent — 'property workspace has no setter'

### DIFF
--- a/swarms/structs/safe_loading.py
+++ b/swarms/structs/safe_loading.py
@@ -40,6 +40,31 @@ class SafeLoaderUtils:
         )
 
     @staticmethod
+    def is_settable(obj: Any, key: str) -> bool:
+        """Can ``key`` actually be assigned on ``obj``?
+
+        A read-only ``property`` on the class raises AttributeError on
+        assignment. ``create_state_dict`` reads instance state and happily
+        serialises such values, so a state file can carry a key that cannot
+        be written back — Agent has two, ``workspace`` and ``mcp_enabled``,
+        which made ``Agent.load()`` raise for every agent.
+
+        These are derived values in any case: whatever they should be is
+        recomputed from the state that *is* restorable, so skipping them
+        loses nothing.
+
+        Args:
+            obj: Object the state is being loaded into, or its class
+            key: Attribute name from the state file
+
+        Returns:
+            bool: False only for a class-level property with no setter
+        """
+        owner = obj if isinstance(obj, type) else type(obj)
+        attr = getattr(owner, key, None)
+        return not (isinstance(attr, property) and attr.fset is None)
+
+    @staticmethod
     def is_safe_type(value: Any) -> bool:
         """
         Check if a value is of a safe, serializable type.
@@ -220,12 +245,14 @@ class SafeStateManager:
                     not key.startswith("_")
                     and key not in preserved
                     and SafeLoaderUtils.is_safe_type(value)
+                    and SafeLoaderUtils.is_settable(obj, key)
                 ):
                     setattr(obj, key, value)
 
             # Restore preserved instances
             for key, value in preserved.items():
-                setattr(obj, key, value)
+                if SafeLoaderUtils.is_settable(obj, key):
+                    setattr(obj, key, value)
 
             logger.info(
                 f"Successfully loaded state from: {file_path}"

--- a/tests/structs/test_safe_loading.py
+++ b/tests/structs/test_safe_loading.py
@@ -1,0 +1,99 @@
+"""SafeStateManager must be able to load back what it saved.
+
+Agent.load() raised AttributeError for *every* agent: create_state_dict
+serialises instance state including class-level read-only properties, and
+load_state then tried to setattr them back. Agent has two — `workspace` and
+`mcp_enabled` — so the very first one hit ended the load.
+
+Nothing caught it because the only save/load round-trip test in the repo,
+TestBasicAgent::test_save_and_load, has errored at setup since 2025-10-21
+on a fixture that was deleted out from under it (#2010).
+
+Offline: the LLM is a stub, and the workspace is a tmp_path.
+"""
+
+import os
+
+import pytest
+
+from swarms import Agent
+from swarms.structs.safe_loading import SafeLoaderUtils
+
+
+class _StubLLM:
+    def run(self, task=None, *args, **kwargs):
+        return task
+
+
+def _agent(tmp_path, name, **overrides):
+    kwargs = dict(
+        agent_name=name,
+        llm=_StubLLM(),
+        max_loops=1,
+        print_on=False,
+        verbose=False,
+        persistent_memory=False,
+        autosave=False,
+        workspace_dir=str(tmp_path),
+    )
+    kwargs.update(overrides)
+    return Agent(**kwargs)
+
+
+def test_agent_has_read_only_properties_in_its_state():
+    """The premise: if this ever stops holding, the guard is unneeded."""
+    read_only = [
+        name
+        for name, value in vars(Agent).items()
+        if isinstance(value, property) and value.fset is None
+    ]
+
+    assert read_only, "Agent no longer has read-only properties"
+    for name in read_only:
+        assert not SafeLoaderUtils.is_settable(Agent, name)
+
+
+def test_is_settable_allows_ordinary_attributes():
+    assert SafeLoaderUtils.is_settable(Agent, "max_loops")
+    assert SafeLoaderUtils.is_settable(Agent, "agent_name")
+
+
+def test_save_then_load_does_not_raise(tmp_path):
+    """The reported crash: load() blew up on the first read-only property."""
+    path = str(tmp_path / "state.json")
+    _agent(tmp_path, "saver").save(path)
+
+    assert os.path.exists(path)
+
+    # Fails on unfixed code with:
+    #   AttributeError: property 'workspace' of 'Agent' object has no setter
+    _agent(tmp_path, "loader").load(path)
+
+
+def test_scalar_state_actually_round_trips(tmp_path):
+    """Not just "does not raise" — the saved values come back."""
+    path = str(tmp_path / "state.json")
+    _agent(tmp_path, "saver", max_loops=3).save(path)
+
+    restored = _agent(tmp_path, "loader", max_loops=9)
+    restored.load(path)
+
+    assert restored.max_loops == 3
+    assert restored.agent_name == "saver"
+
+
+def test_read_only_properties_survive_the_load(tmp_path):
+    """Skipping them must not blank them out."""
+    path = str(tmp_path / "state.json")
+    _agent(tmp_path, "saver").save(path)
+
+    restored = _agent(tmp_path, "loader")
+    before = restored.workspace
+    restored.load(path)
+
+    assert restored.workspace == before
+
+
+def test_missing_file_still_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        _agent(tmp_path, "loader").load(str(tmp_path / "nope.json"))


### PR DESCRIPTION
## What is wrong

`Agent.load()` cannot complete for any agent:

```
AttributeError: property 'workspace' of 'Agent' object has no setter
```

Not a corner case — every `Agent` has the property, so every `load()` hits it.

## Why

`SafeStateManager.load_state` assigns every safe-typed key from the file straight back onto the object, in two loops:

```python
            for key, value in state_dict.items():
                if (not key.startswith("_") and key not in preserved
                        and SafeLoaderUtils.is_safe_type(value)):
                    setattr(obj, key, value)

            for key, value in preserved.items():
                setattr(obj, key, value)
```

`create_state_dict` reads instance state, and that includes class-level **read-only properties**. `Agent` has two:

```
>>> [n for n, v in vars(Agent).items() if isinstance(v, property) and v.fset is None]
['workspace', 'mcp_enabled']
```

So `save()` writes keys that `load()` then cannot write back. Whichever is reached first ends the load. Both loops were affected — fixing only the first still failed on `workspace`, which arrives via `preserved`.

## The fix

`SafeLoaderUtils.is_settable(obj, key)` returns False for a class attribute that is a `property` with no setter, and both loops consult it.

Skipping them is correct rather than merely convenient: `workspace` and `mcp_enabled` are **derived**. They are computed from state that *is* restorable, so there is nothing to restore. `test_read_only_properties_survive_the_load` pins that they still hold their computed value afterwards rather than being blanked.

It accepts a class or an instance, so it is usable for the assertion in the test as well as from `load_state`.

## Why nobody noticed

The repo's only save/load round-trip test — `TestBasicAgent::test_save_and_load` — has errored at *setup* since 2025-10-21, on a fixture deleted out from under it. That is #2010, filed by @Steve-Dusty, and this is exactly the cost it describes:

> One of the eight is `TestBasicAgent::test_save_and_load` — the only round-trip test `Agent.save()`/`Agent.load()` had … That is the cost of leaving these erroring: they look like coverage and are not.

I found this by reviving that fixture (a separate PR, stacked on this one). The first thing the revived test did was reproduce this.

## Tests

`tests/structs/test_safe_loading.py` is a new file — nothing under `tests/` owned `safe_loading.py`. Offline: stub LLM, `tmp_path` workspace.

- the crash itself (`save()` then `load()` must not raise)
- a real scalar round trip — `max_loops` 9 → 3, `agent_name` restored — so this is not just "does not throw"
- read-only properties still correct after a load
- the premise: `Agent` still *has* read-only properties, so the guard is not dead code
- `FileNotFoundError` still propagates

```
against unfixed safe_loading.py   5 failed, 1 passed
against this branch               6 passed
```

`tests/structs/test_agent.py` failure set is byte-identical to master (27 = 27) — diffed against a clean worktree, not eyeballed. `black==24.2.0 --check` and `ruff==0.2.1 check` clean.

## Scope note

This does not make `load()` restore the conversation. `preserve_instances` deliberately keeps live objects (the LLM, `short_memory`) rather than rehydrating them, so `load()` restores scalar configuration only. That is existing behaviour and I have left it alone; the tests assert what it actually does.