### PR TITLE
[Tests] Revive the eight test_agent.py tests that have errored since 2025-10-21

### DIFF
--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -40,20 +40,58 @@ openai_api_key = os.getenv("OPENAI_API_KEY")
 
 
 @pytest.fixture
-def basic_flow(mocked_llm):
-    """Basic agent flow for testing"""
-    return Agent(llm=mocked_llm, max_loops=1)
+def mocked_llm():
+    """Stand-in for the LLM, so these tests need no provider.
+
+    Restored: `6f4803ef` (2025-10-21) deleted this fixture but left the two
+    fixtures that request it, so the eight tests below errored at setup with
+    "fixture 'mocked_llm' not found" and have not executed since.
+
+    Echoes the task back. `Agent.__call__` returning its input is what
+    test_flow_call asserts, and an echo keeps every other assertion about
+    plumbing rather than about model output.
+    """
+
+    class MockedLLM:
+        def run(self, task=None, *args, **kwargs):
+            return task
+
+        async def arun(self, task=None, *args, **kwargs):
+            return task
+
+    return MockedLLM()
 
 
 @pytest.fixture
-def flow_with_condition(mocked_llm):
+def basic_flow(mocked_llm, tmp_path):
+    """Basic agent flow for testing"""
+    return Agent(
+        agent_name="basic-flow",
+        llm=mocked_llm,
+        max_loops=1,
+        print_on=False,
+        verbose=False,
+        persistent_memory=False,
+        autosave=False,
+        workspace_dir=str(tmp_path),
+    )
+
+
+@pytest.fixture
+def flow_with_condition(mocked_llm, tmp_path):
     """Agent flow with stopping condition"""
     from swarms.structs.agent import stop_when_repeats
 
     return Agent(
+        agent_name="flow-with-condition",
         llm=mocked_llm,
         max_loops=1,
         stopping_condition=stop_when_repeats,
+        print_on=False,
+        verbose=False,
+        persistent_memory=False,
+        autosave=False,
+        workspace_dir=str(tmp_path),
     )
 
 
@@ -108,22 +146,19 @@ class TestBasicAgent:
         assert not stop_when_repeats("Continue the process")
 
     def test_flow_initialization(self, basic_flow):
-        """Test agent initialization"""
-        assert basic_flow.max_loops == 5
+        """The constructor arguments survive __init__.
+
+        Rewritten: this asserted `max_loops == 5` against a fixture that
+        passes 1, plus `.feedback` and `.memory`, which the Agent has not
+        had for a long time — it errored before ever running, so nothing
+        caught the drift.
+        """
+        assert basic_flow.max_loops == 1
         assert basic_flow.stopping_condition is None
-        assert basic_flow.loop_interval == 1
         assert basic_flow.retry_attempts == 3
-        assert basic_flow.feedback == []
-        assert basic_flow.memory == []
         assert basic_flow.task is None
         assert basic_flow.stopping_token == "<DONE>"
         assert not basic_flow.interactive
-
-    def test_provide_feedback(self, basic_flow):
-        """Test feedback functionality"""
-        feedback = "Test feedback"
-        basic_flow.provide_feedback(feedback)
-        assert feedback in basic_flow.feedback
 
     @patch("time.sleep", return_value=None)
     def test_run_without_stopping_condition(
@@ -147,27 +182,57 @@ class TestBasicAgent:
         responses = basic_flow.bulk_run(inputs)
         assert responses is not None
 
-    def test_save_and_load(self, basic_flow, tmp_path):
-        """Test save and load functionality"""
-        file_path = tmp_path / "memory.json"
-        basic_flow.memory.append(["Test1", "Test2"])
+    def test_save_and_load(self, basic_flow, mocked_llm, tmp_path):
+        """State written by save() comes back through load().
+
+        Rewritten against the current API: the original appended to a
+        `.memory` list the Agent no longer has. This is the only round-trip
+        test save()/load() has at the Agent level, and it has not executed
+        since 2025-10-21 — which is how the load() crash fixed in the parent
+        commit shipped unnoticed.
+
+        load() restores scalar configuration; it deliberately preserves live
+        instances (the LLM, short_memory) rather than rehydrating them, so
+        the conversation is not part of the round trip.
+        """
+        file_path = str(tmp_path / "agent_state.json")
+        basic_flow.max_loops = 3
         basic_flow.save(file_path)
 
-        new_flow = Agent(llm=basic_flow.llm, max_loops=5)
-        new_flow.load(file_path)
-        assert new_flow.memory == [["Test1", "Test2"]]
+        assert os.path.exists(file_path)
+
+        restored = Agent(
+            agent_name="basic-flow-restored",
+            llm=mocked_llm,
+            max_loops=9,
+            print_on=False,
+            verbose=False,
+            persistent_memory=False,
+            autosave=False,
+            workspace_dir=str(tmp_path),
+        )
+        restored.load(file_path)
+
+        assert restored.max_loops == 3
+        assert restored.agent_name == "basic-flow"
 
     def test_flow_call(self, basic_flow):
-        """Test calling agent directly"""
-        response = basic_flow("Test call")
-        assert response == "Test call"
+        """__call__ forwards to run() rather than doing its own thing.
 
-    def test_format_prompt(self, basic_flow):
-        """Test prompt formatting"""
-        formatted_prompt = basic_flow.format_prompt(
-            "Hello {name}", name="John"
+        Rewritten: this asserted the call returned its own input, which was
+        only ever true of the deleted mock. Comparing two live calls does not
+        work either — the conversation grows between them, so the second
+        returns something different. What is worth pinning is the delegation.
+        """
+        with patch.object(
+            basic_flow, "run", return_value="routed"
+        ) as run:
+            assert basic_flow("Test call") == "routed"
+
+        run.assert_called_once()
+        assert "Test call" in run.call_args.args or (
+            run.call_args.kwargs.get("task") == "Test call"
         )
-        assert formatted_prompt == "Hello John"
 
 
 # ============================================================================


### PR DESCRIPTION
Closes #2010

> **Stacked on #2014.** That PR's commit is the parent here — review/merge it first. It fixes the `Agent.load()` crash that the revived save/load test reproduces on its very first run, so this branch cannot go green without it. The diff above the parent is one file.

## The result

```
master   19 failed, 78 passed, 8 errors
here     19 failed, 84 passed, 0 errors
```

The 19 failures are pre-existing and the set is byte-identical — diffed against a clean master worktree, not eyeballed.

## What was wrong

`6f4803ef` (2025-10-21) deleted `mocked_llm` but left behind the two fixtures that request it, and the eight tests that request those:

```
fixture 'mocked_llm' not found
```

Because they *error* rather than fail, they read as infrastructure noise. They have looked like coverage for ten months.

## Restoring the fixture is not the whole job

With `mocked_llm` back, three of the eight still fail — they assert an `Agent` API that has not existed for years. That is worth seeing, because it is the drift the erroring hid:

| test | assumed | reality |
|---|---|---|
| `test_flow_initialization` | `.feedback`, `.memory`, `max_loops == 5` | neither attribute exists; the fixture passes `max_loops=1` |
| `test_provide_feedback` | `.provide_feedback()` | method gone |
| `test_format_prompt` | `.format_prompt()` | method gone |
| `test_save_and_load` | `.memory` list | it is `short_memory`, a `Conversation` |
| `test_flow_call` | `agent("x") == "x"` | only ever true of the deleted mock |

So:

- **Deleted** `test_provide_feedback` and `test_format_prompt`. Their subject does not exist; there is nothing to assert.
- **Rewrote** `test_flow_initialization` against the attributes that do exist, with the `max_loops` assertion matching the fixture rather than contradicting it.
- **Rewrote** `test_save_and_load` as a real scalar round trip through the Agent API — `max_loops` 9 → 3, `agent_name` restored. `load()` deliberately preserves live instances rather than rehydrating them, so the conversation is not part of the round trip and the test no longer pretends otherwise.
- **Rewrote** `test_flow_call` to pin the delegation (`__call__` forwards to `run()`). Comparing two live calls does not work — the conversation grows between them, so the second returns something different.

The other three (`test_bulk_run`, both `test_run_*`) needed nothing but the fixture back.

## The fixture

`mocked_llm` is a stub with `run`/`arun` that echoes the task, so these need no provider. The two agent fixtures now also pin a `tmp_path` workspace and disable `autosave` and `persistent_memory`, so the revived tests write nothing to the repo — worth doing given they had not run in ten months and nobody knew what they touched.

## Why the stack matters

The first thing the revived `test_save_and_load` did was reproduce a live bug:

```
AttributeError: property 'workspace' of 'Agent' object has no setter
```

`Agent.load()` was raising for *every* agent. That is #2014, and it is exactly the cost @Steve-Dusty describes in #2010 — the test was there the whole time, and it was not running.

`black==24.2.0 --check .` and `ruff==0.2.1 check .` clean across the tree.