### PR TITLE
[Bug] WORKSPACE_DIR is discarded at `import swarms`, so setting it never takes effect

### DIFF
--- a/swarms/telemetry/bootup.py
+++ b/swarms/telemetry/bootup.py
@@ -21,10 +21,13 @@ def bootup():
         # Silence wandb
         os.environ["WANDB_SILENT"] = "true"
 
-        # Setup workspace dir only if needed
-        if not workspace_path.exists():
-            workspace_path.mkdir(parents=True, exist_ok=True)
-        os.environ["WORKSPACE_DIR"] = str(workspace_path)
+        # Only default it. Assigning unconditionally discarded whatever the
+        # caller had exported, so WORKSPACE_DIR never survived `import swarms`.
+        if not os.getenv("WORKSPACE_DIR"):
+            os.environ["WORKSPACE_DIR"] = str(workspace_path)
+        Path(os.environ["WORKSPACE_DIR"]).mkdir(
+            parents=True, exist_ok=True
+        )
 
         # Suppress deprecation warnings
         warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/swarms/utils/disable_logging.py
+++ b/swarms/utils/disable_logging.py
@@ -9,8 +9,6 @@ def disable_logging():
     Disables logging for specific modules and sets up file and stream handlers.
     Runs in a separate thread to avoid blocking the main thread.
     """
-    os.environ["WORKSPACE_DIR"] = "agent_workspace"
-
     warnings.filterwarnings("ignore", category=UserWarning)
 
     # disable tensorflow warnings
@@ -46,7 +44,7 @@ def disable_logging():
     logging.getLogger().handlers = []
 
     # Get the workspace directory from the environment variables
-    workspace_dir = os.environ["WORKSPACE_DIR"]
+    workspace_dir = os.getenv("WORKSPACE_DIR") or "agent_workspace"
 
     # Check if the workspace directory exists, if not, create it
     if not os.path.exists(workspace_dir):


### PR DESCRIPTION
## The failure

`WORKSPACE_DIR` does not survive `import swarms`. Set it, import, and it is gone:

```
$ cd /tmp/run
$ WORKSPACE_DIR=/tmp/mydir python -c "
import os; before = os.environ['WORKSPACE_DIR']
import swarms
print(' before:', before)
print(' after :', os.environ['WORKSPACE_DIR'])"

 before: /tmp/mydir
 after : agent_workspace
```

Silently. Nothing warns, and the value is not just wrong but relative, so it now resolves against whatever the process's cwd happens to be.

Everything keyed on it follows: `Agent.workspace_dir` (`agent.py:460`), autosave, saved state, and — since #2022 — the log files. In the run above the logger reports `/tmp/run/agent_workspace/logs`, a directory that does not exist, while `/tmp/mydir/logs` was created and then abandoned. The per-module router swallows the resulting `OSError` by design, so those lines are simply lost.

## Cause

Two unconditional writes, both reached by `bootup()` on line 7 of `swarms/__init__.py`:

```
telemetry/bootup.py:27      os.environ["WORKSPACE_DIR"] = str(Path.cwd() / "agent_workspace")
utils/disable_logging.py:12 os.environ["WORKSPACE_DIR"] = "agent_workspace"
```

`bootup()` calls `disable_logging()` a few lines later, so the second overwrites the first, and the relative string is what a caller ends up with.

The comment above the first already describes the intended behaviour — "Setup workspace dir only if needed" — but the guard it sits on covers the `mkdir`, not the assignment.

## The change

Default it only when unset, and create whichever directory is in play. `disable_logging` only ever *reads* the value (line 49), so its assignment is deleted rather than guarded.

## After

```
 before: /tmp/mydir
 after : /tmp/mydir
 logdir: /tmp/mydir/logs   exists: True
```

Unset is unchanged — still `{cwd}/agent_workspace`, absolute:

```
$ cd /tmp/run && python -c "import swarms, os; print(os.environ['WORKSPACE_DIR'])"
/private/tmp/run/agent_workspace
```

## Tests

No new test. Both call sites are two-line environment defaults, not a unit under test, and reproducing this needs a subprocess with a controlled env and cwd — a test that would cost more to maintain than the four lines it guards. The before/after above is the check; happy to add one if you would rather have it pinned.

Full suite, this branch merged into master, failure sets diffed by name:

```
  master     196 failed, 1678 passed, 28 skipped, 20 errors
  this PR    196 failed, 1678 passed, 28 skipped, 20 errors
  new failures: none
```

`black 24.2.0` and `ruff 0.2.1` clean on both files.
