### PR TITLE
[Bug] MixtureOfAgents silently keeps one worker's answer when agents share a name

### DIFF
--- a/swarms/structs/context_utils.py
+++ b/swarms/structs/context_utils.py
@@ -131,11 +131,10 @@ def get_final_agent_answer(
     Returns:
         The same mapping with transcripts replaced by answers.
     """
+    # Paired by position, not by name: the mapping is built in agent order
+    # and duplicate names are suffixed to keep one entry per agent, so a
+    # name lookup would resolve every duplicate to the first agent's key.
     answers = dict(agent_outputs)
-    for agent in agents:
-        name = getattr(agent, "agent_name", None)
-        if name in answers:
-            answers[name] = agent_answer(
-                agent, fallback=answers[name]
-            )
+    for agent, key in zip(agents, answers):
+        answers[key] = agent_answer(agent, fallback=answers[key])
     return answers

--- a/swarms/structs/multi_agent_exec.py
+++ b/swarms/structs/multi_agent_exec.py
@@ -169,6 +169,16 @@ def run_agents_concurrently(
                         or getattr(agent, "name", None)
                         or str(agent)
                     )
+                    # agent_name defaults to the same string for every
+                    # Agent, so a swarm whose agents did not set one had
+                    # every result land on one key and only the last
+                    # survive. Suffix instead of overwrite: callers ask for
+                    # this dict to get one entry per agent.
+                    if name in output_dict:
+                        suffix = 2
+                        while f"{name} ({suffix})" in output_dict:
+                            suffix += 1
+                        name = f"{name} ({suffix})"
                     output_dict[name] = result
                 return output_dict
             else:

--- a/tests/structs/test_multi_agent_exec.py
+++ b/tests/structs/test_multi_agent_exec.py
@@ -1,0 +1,51 @@
+"""Tests for swarms.structs.multi_agent_exec."""
+
+from swarms.structs.multi_agent_exec import run_agents_concurrently
+
+
+class _Stub:
+    """Minimal stand-in for an Agent: a name and a fixed answer."""
+
+    def __init__(self, agent_name: str, answer: str):
+        self.agent_name = agent_name
+        self._answer = answer
+
+    def run(self, task=None, **kwargs):
+        return self._answer
+
+
+def test_output_dict_keeps_one_entry_per_agent_when_names_collide():
+    """Agent.agent_name defaults to the same string for every agent.
+
+    A swarm whose agents never set one used to collapse into a single dict
+    entry, so MixtureOfAgents recorded one worker per layer and aggregated a
+    single opinion instead of the mixture it was asked for.
+    """
+    agents = [
+        _Stub("swarm-worker-01", f"answer-{i}") for i in range(3)
+    ]
+
+    outputs = run_agents_concurrently(
+        agents=agents, task="t", return_agent_output_dict=True
+    )
+
+    assert len(outputs) == 3, outputs
+    assert sorted(outputs.values()) == [
+        "answer-0",
+        "answer-1",
+        "answer-2",
+    ]
+
+
+def test_output_dict_leaves_distinct_names_untouched():
+    agents = [_Stub(f"worker-{i}", f"answer-{i}") for i in range(3)]
+
+    outputs = run_agents_concurrently(
+        agents=agents, task="t", return_agent_output_dict=True
+    )
+
+    assert outputs == {
+        "worker-0": "answer-0",
+        "worker-1": "answer-1",
+        "worker-2": "answer-2",
+    }


### PR DESCRIPTION
## The failure

`Agent.agent_name` defaults to `"swarm-worker-01"`. Build a MixtureOfAgents out of agents that set `model_name` but not `agent_name` — a multi-model mixture is the obvious case — and every worker answers under the same key:

```python
agents = [Stub("swarm-worker-01", f"answer-{i}") for i in range(3)]
run_agents_concurrently(agents=agents, task="t", return_agent_output_dict=True)

{'swarm-worker-01': 'answer-2'}      # 3 agents in, 1 answer out
```

Two answers are gone. Nothing raises, nothing logs.

## Why it matters

`MixtureOfAgents.step()` returns that dict, and `_run` iterates it:

```python
for agent_name, agent_output in step_output.items():
    self.conversation.add(role=agent_name, content=agent_output)
```

So the conversation gets one worker message per layer instead of N, and the aggregator synthesises a single opinion. The mixture still runs every agent, pays for every agent, and then throws all but one away — which is the entire premise of the structure.

## The change

Suffix duplicate keys instead of overwriting, so the mapping holds one entry per agent as its docstring already promises ("a dict mapping agent names to outputs", "preserves agent input order").

`get_final_agent_answer` pairs by position rather than by name lookup. It receives the mapping in agent order, and a name lookup would resolve every duplicate back to the first agent's key — so leaving it alone would have replaced the fix with a subtler version of the same bug.

## After

```
{'swarm-worker-01': 'answer-0',
 'swarm-worker-01 (2)': 'answer-1',
 'swarm-worker-01 (3)': 'answer-2'}
```

Distinct names are untouched:

```
{'worker-0': 'answer-0', 'worker-1': 'answer-1', 'worker-2': 'answer-2'}
```

## Tests

`tests/structs/test_multi_agent_exec.py` — new, because nothing owned that module. Two cases: names collide, names distinct. Reverting `multi_agent_exec.py` alone fails the first and leaves the second green:

```
FAILED test_output_dict_keeps_one_entry_per_agent_when_names_collide
1 failed, 1 passed
```

They use a stub with a `run` method rather than a real `Agent`, so they need no API key and no network.

Full suite, this branch merged into master, failure sets diffed by name:

```
  master    196 failed, 1702 passed, 12 errors
  this PR   196 failed, 1704 passed, 12 errors
  new failures: none
```

The +2 are the tests above. `black 24.2.0` and `ruff 0.2.1` clean.
