### PR TITLE
[Bug] Agent(tools=[]) advertises a tool_search it has nothing to search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1086,8 +1086,6 @@ from swarms import Agent
 
 **Don't instantiate heavyweight structures inside tight loops** — create agents and workflows once, reuse them across calls.
 
-**Don't pass `tools=[]` (empty list)** — pass `tools=None` instead. An empty list can confuse schema generation.
-
 **Don't use `streaming_on=True` and `streaming_callback` together on the same agent** — `streaming_on` streams to stdout; `streaming_callback` streams to your function. Pick one.
 
 **Don't set `context_compression=False` on very long autonomous sessions** — without compression the agent will eventually hit the context limit and raise an error.

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -676,8 +676,11 @@ class Agent:
                 self.system_prompt += "\n\n" + handoff_prompt
 
         # One condition so the notice cannot diverge from the loader.
+        # Truthiness, not exists(): exists() is `is not None`, so tools=[]
+        # counted as having tools and bought an empty agent the tool_search
+        # schema plus the notice in every prompt.
         defers_tools = self.dynamic_tools and (
-            exists(self.tools)
+            bool(self.tools)
             or self.mcp_enabled
             or self.max_loops == "auto"
         )
@@ -686,7 +689,7 @@ class Agent:
         if defers_tools:
             self.system_prompt += DYNAMIC_TOOLS_NOTICE
             self.setup_dynamic_tools()
-        elif exists(self.tools):
+        elif self.tools:
             self.tool_handling()
 
         if self.llm is None:

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -3311,6 +3311,50 @@ class TestRunBatchedImagePairing:
                 )
 
 
+class TestEmptyToolsList:
+    """`tools=[]` must mean the same as `tools=None`.
+
+    `exists()` is `is not None`, so an empty list counted as having tools:
+    the agent was given the `tool_search` schema it had nothing to search and
+    DYNAMIC_TOOLS_NOTICE in every prompt.
+    """
+
+    @staticmethod
+    def _agent(**kwargs):
+        return Agent(
+            agent_name="empty_tools_agent",
+            model_name="gpt-4o-mini",
+            max_loops=1,
+            **kwargs,
+        )
+
+    def test_empty_list_advertises_no_tools(self):
+        assert self._agent(tools=[]).tools_list_dictionary == []
+
+    def test_empty_list_matches_none(self):
+        empty = self._agent(tools=[])
+        none = self._agent(tools=None)
+        assert (
+            empty.tools_list_dictionary == none.tools_list_dictionary
+        )
+        assert ("tool_search" in empty.system_prompt) == (
+            "tool_search" in none.system_prompt
+        )
+
+    def test_a_real_tool_still_defers(self):
+        def sample(x: str) -> str:
+            """Return x.
+
+            Args:
+                x: anything
+            """
+            return x
+
+        agent = self._agent(tools=[sample])
+        assert agent.tools_list_dictionary
+        assert "tool_search" in agent.system_prompt
+
+
 if __name__ == "__main__":
     # Run all tests
     results = run_all_tests()


### PR DESCRIPTION
## The failure

`Agent(tools=[])` is not the same as `Agent(tools=None)`:

```python
Agent(agent_name="T", model_name="gpt-4o-mini", max_loops=1, tools=[])
  tools_list_dictionary -> [ tool_search schema ]
  system_prompt         -> + DYNAMIC_TOOLS_NOTICE

Agent(agent_name="T", model_name="gpt-4o-mini", max_loops=1, tools=None)
  tools_list_dictionary -> []
  system_prompt         -> unchanged
```

An agent with no tools advertises a `tool_search` tool whose catalog is empty, and carries the notice telling the model to search it, on every request. The model can call it; it will find nothing.

## Cause

```python
defers_tools = self.dynamic_tools and (
    exists(self.tools) or self.mcp_enabled or self.max_loops == "auto"
)
```

`exists()` is `val is not None` (`swarms/utils/index.py`), so `exists([])` is `True`. An empty list counts as having tools. The `elif exists(self.tools): self.tool_handling()` branch below has the same problem.

## The change

Truthiness at those two call sites. `exists()` itself is used widely and is not touched.

`mcp_enabled` and `max_loops == "auto"` still enable deferral independently, so an autonomous agent with no explicit tools keeps the loader it needs:

```
tools=[f]                    schemas=1  notice=True     (unchanged)
max_loops="auto", no tools   schemas=1  notice=True     (unchanged)
tools=[]                     schemas=0  notice=False    (was 1 / True)
tools=None                   schemas=0  notice=False    (unchanged)
```

## CLAUDE.md

Removed:

> **Don't pass `tools=[]` (empty list)** — pass `tools=None` instead. An empty list can confuse schema generation.

That is this bug, written down as advice. It is no longer true, and leaving it would tell people to route around something that works.

## Tests

`TestEmptyToolsList` in `tests/structs/test_agent.py`, the file that owns this module. Three cases: empty list advertises nothing, empty list matches `None`, a real tool still defers. Reverting `agent.py` alone:

```
FAILED TestEmptyToolsList::test_empty_list_advertises_no_tools
FAILED TestEmptyToolsList::test_empty_list_matches_none
2 failed, 1 passed
```

The third stays green, which is the point — it pins the behaviour this must not change.

Full suite, merged into master, failure sets diffed by name:

```
  master    196 failed, 1702 passed, 12 errors
  this PR   196 failed, 1705 passed, 12 errors
  new failures: none
```

The +3 are the tests above. One run also showed `TestAgentToolUsage::test_tool_parallel_execution` failing; it passes alone, passes at file level on both sides, and did not recur on a second full run — cross-file order flake, not this change.

`black 24.2.0` and `ruff 0.2.1` clean.
