### PR TITLE
[Bug] AgentRearrange.remove_agent indexes a list by name, so every call raises TypeError

### DIFF
--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -70,7 +70,7 @@ class AgentRearrange(SerializableMixin):
         id (str): Unique identifier for the agent rearrange system
         name (str): Human-readable name for the system
         description (str): Description of the system's purpose
-        agents (Dict[str, Agent]): Dictionary mapping agent names to Agent objects
+        agents (List[Agent]): The agents in the swarm, in flow order
         flow (str): Flow pattern defining agent execution order
         max_loops (int): Maximum number of execution loops
         verbose (bool): Whether to enable verbose logging
@@ -346,8 +346,20 @@ class AgentRearrange(SerializableMixin):
 
         Args:
             agent_name (str): The name of the agent to be removed.
+
+        Raises:
+            ValueError: If no agent in the swarm has that name.
         """
-        del self.agents[agent_name]
+        for index, agent in enumerate(self.agents):
+            if agent.agent_name == agent_name:
+                logger.info(
+                    f"Removing agent {agent_name} from the swarm."
+                )
+                del self.agents[index]
+                return
+        raise ValueError(
+            f"No agent named {agent_name!r} in the swarm."
+        )
 
     def add_agents(self, agents: List[Agent]):
         """

--- a/tests/structs/test_agent_rearrange.py
+++ b/tests/structs/test_agent_rearrange.py
@@ -156,7 +156,9 @@ def test_add_agent():
     )
 
     agent_rearrange.add_agent(new_agent)
-    assert "EditorAgent" in agent_rearrange.agents
+    assert "EditorAgent" in [
+        a.agent_name for a in agent_rearrange.agents
+    ]
     assert len(agent_rearrange.agents) == 3
 
 
@@ -171,8 +173,13 @@ def test_remove_agent():
     )
 
     agent_rearrange.remove_agent("ReviewerAgent")
-    assert "ReviewerAgent" not in agent_rearrange.agents
+    assert "ReviewerAgent" not in [
+        a.agent_name for a in agent_rearrange.agents
+    ]
     assert len(agent_rearrange.agents) == 2
+
+    with pytest.raises(ValueError):
+        agent_rearrange.remove_agent("ReviewerAgent")
 
 
 def test_add_agents():


### PR DESCRIPTION
Fixes #2056

## The failure

`self.agents` is a list, but `remove_agent` indexed it by name:

```python
del self.agents[agent_name]
```

```
TypeError: list indices must be integers or slices, not str
```

Every call raised. `add_agent` already used list semantics, so the two methods disagreed about the container type.

## The change

Search by `agent_name`, delete by index, and raise `ValueError` when nothing matches — a missing agent is a caller error, not a container-type error.

The class docstring still described the pre-list type (`agents (Dict[str, Agent])`); corrected to `List[Agent]`.

## The tests were already there, and already failing

`tests/structs/test_agent_rearrange.py` covers both methods, and both fail on master:

```
FAILED test_add_agent      - AssertionError
FAILED test_remove_agent   - TypeError
```

`test_remove_agent` failed on the bug itself. `test_add_agent` failed for a related reason worth naming: it asserted

```python
assert "EditorAgent" in agent_rearrange.agents
```

which is a membership test for the string against a list of `Agent` objects — never true, whatever the code does. Both now compare `agent_name`, and `test_remove_agent` also pins the `ValueError` for an unknown name.

```
  master:    11 failed, 59 passed
  this PR:    9 failed, 61 passed

  fixed:  test_add_agent, test_remove_agent
  new:    none
```

The remaining 9 are identical on both sides and unrelated. `black 24.2.0` and `ruff 0.2.1` clean.
