### PR TITLE
[Bug] SwarmRouter accepts swarm_type="auto" then fails at first run()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,7 +510,6 @@ result = router.run("Write a blog post about transformer architectures.")
 | `"BatchedGridWorkflow"` | Grid-based batch execution |
 | `"LLMCouncil"` | LLM-based council decisions |
 | `"AutoSwarmBuilder"` | Auto-configures everything |
-| `"auto"` | Router selects swarm_type automatically |
 
 ---
 
@@ -938,7 +937,7 @@ agent = Agent(
 | High-stakes ruling with deliberation | `CouncilAsAJudge` |
 | Structured adversarial debate | `DebateWithJudge` |
 | Deep research, many loops | `HeavySwarm` |
-| Don't know yet / rapid prototyping | `AutoSwarmBuilder` or `SwarmRouter(swarm_type="auto")` |
+| Don't know yet / rapid prototyping | `AutoSwarmBuilder` |
 | Need to switch architectures easily | `SwarmRouter` |
 
 ---

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -137,7 +137,6 @@ SwarmType = Literal[
     "GroupChat",
     "MultiAgentRouter",
     "HierarchicalSwarm",
-    "auto",
     "MajorityVoting",
     "CouncilAsAJudge",
     "HeavySwarm",
@@ -303,7 +302,7 @@ class SwarmRouter(SerializableMixin):
         description: str = "Routes your task to the desired swarm",
         max_loops: int = 1,
         agents: List[Union[Agent, Callable]] = [],
-        swarm_type: SwarmType = "SequentialWorkflow",  # "ConcurrentWorkflow" # "auto"
+        swarm_type: SwarmType = "SequentialWorkflow",
         autosave: bool = False,
         rearrange_flow: str = None,
         output_type: OutputType = "dict",

--- a/tests/structs/test_swarm_router.py
+++ b/tests/structs/test_swarm_router.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import get_args
 
 from swarms.structs.swarm_router import (
     SwarmRouter,
@@ -473,19 +474,21 @@ def test_run_with_hierarchical_swarm():
     assert result is not None
 
 
-def test_run_with_auto():
-    """SwarmRouter dispatches to 'auto' (embedding-based selection)."""
-    sample_agents = create_sample_agents()
-
-    router = SwarmRouter(
-        agents=sample_agents,
-        swarm_type="auto",
-        max_loops=1,
-        verbose=False,
+def test_auto_is_rejected_at_construction():
+    from swarms.structs.swarm_router import (
+        SwarmRouterConfigError,
+        SwarmType,
     )
 
-    result = router.run("What is 1+1?")
-    assert result is not None
+    assert "auto" not in get_args(SwarmType)
+
+    with pytest.raises(SwarmRouterConfigError):
+        SwarmRouter(
+            agents=create_sample_agents(),
+            swarm_type="auto",
+            max_loops=1,
+            verbose=False,
+        )
 
 
 def test_run_with_majority_voting():


### PR DESCRIPTION
Fixes #2057

## The failure

`swarm_type="auto"` is in the `SwarmType` Literal, so `reliability_check` accepts it. It has no entry in `_initialize_swarm_factory`, so the first `run()` raises:

```
ValueError: Invalid swarm type: auto. Valid types are: HeavySwarm, AgentRearrange, ...
```

The caller has already built the router by then. A type hint that accepts a value which always fails at run time is worse than either accepting or rejecting it outright.

## Removed rather than implemented

The issue offers both options; this takes the first, for reasons already in the file:

- the class docstring's supported list and its "Factory-backed swarm types" list **both already exclude** `"auto"` — the Literal is the stale part, not the docs
- there is no auto-selection logic anywhere in `swarm_router.py`
- `"AutoSwarmBuilder"` is not in the Literal at all and already fails at construction, so the two auto-ish paths behaved inconsistently

Implementing it would be a feature and a routing decision; this is the honest minimum.

## After

```
SwarmRouterConfigError: SwarmRouter: Invalid swarm_type 'auto'. Valid types are:
AgentRearrange, MixtureOfAgents, SequentialWorkflow, ConcurrentWorkflow, GroupChat,
MultiAgentRouter, HierarchicalSwarm, MajorityVoting, CouncilAsAJudge, HeavySwarm,
BatchedGridWorkflow, LLMCouncil, DebateWithJudge, RoundRobin, PlannerWorkerSwarm.
```

At construction, with the valid set listed.

## Also updated

`CLAUDE.md` advertised it twice — the `swarm_type` table and the choosing-a-structure table. Both now point at `AutoSwarmBuilder`, which is what a caller reaching for `"auto"` actually wants.

## Tests

`test_run_with_auto` asserted the old behaviour and fails on master. Rewritten as `test_auto_is_rejected_at_construction`, pinning both halves — the value is absent from the Literal, and construction raises.

```
  master:    3 failed, 36 passed
  this PR:   2 failed, 37 passed

  fixed:  test_run_with_auto
  new:    none
```

The remaining 2 are identical on both sides — `test_run_with_batched_grid_workflow` is #2058, which this does not touch. `black 24.2.0` and `ruff 0.2.1` clean.
