### PR TITLE
fix(aop): give every MCP request its own agent memory (#2047)

### DIFF
--- a/swarms/structs/aop.py
+++ b/swarms/structs/aop.py
@@ -23,6 +23,25 @@ from swarms.structs.omni_agent_types import AgentType
 from swarms.tools.mcp_manager import MCPManager
 from swarms.structs.ma_blocks import find_agent_by_name
 
+_ISOLATION_LOCKS_GUARD = threading.Lock()
+
+
+def _agent_execution_lock(agent: AgentType) -> threading.Lock:
+    lock = getattr(agent, "_aop_execution_lock", None)
+    if lock is None:
+        with _ISOLATION_LOCKS_GUARD:
+            lock = getattr(agent, "_aop_execution_lock", None)
+            if lock is None:
+                lock = threading.Lock()
+                agent._aop_execution_lock = lock
+    return lock
+
+
+def run_agent_isolated(agent: AgentType, **run_kwargs: Any) -> Any:
+    with _agent_execution_lock(agent):
+        agent.short_memory = agent.short_memory_init()
+        return agent.run(**run_kwargs)
+
 
 class TaskStatus(Enum):
     """Status of a task in the queue."""
@@ -459,8 +478,8 @@ class TaskQueue:
                     f"Processing task '{task.task_id}' for agent '{self.agent_name}'"
                 )
 
-            # Execute the agent
-            result = self.agent.run(
+            result = run_agent_isolated(
+                self.agent,
                 task=task.task,
                 img=task.img,
                 imgs=task.imgs,
@@ -1322,7 +1341,8 @@ class AOP:
                 f"Executing agent '{agent.agent_name}' with timeout {timeout}s"
             )
 
-            out = agent.run(
+            out = run_agent_isolated(
+                agent,
                 task=task,
                 img=img,
                 imgs=imgs,

--- a/tests/structs/test_aop.py
+++ b/tests/structs/test_aop.py
@@ -1,0 +1,144 @@
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("mcp.server.fastmcp")
+
+from swarms.structs.aop import (  # noqa: E402
+    _agent_execution_lock,
+    run_agent_isolated,
+)
+
+
+class FakeConversation:
+    def __init__(self):
+        self.messages = []
+
+
+class FakeAgent:
+    def __init__(self, name="worker", delay=0.0):
+        self.agent_name = name
+        self.short_memory = FakeConversation()
+        self.delay = delay
+        self.inits = 0
+        self.seen = []
+
+    def short_memory_init(self):
+        self.inits += 1
+        return FakeConversation()
+
+    def run(self, task=None, **kwargs):
+        self.short_memory.messages.append(task)
+        if self.delay:
+            time.sleep(self.delay)
+        self.seen.append(list(self.short_memory.messages))
+        self.last_kwargs = kwargs
+        return f"answer:{task}"
+
+
+class TestAgentMemoryIsolation:
+    def test_the_unreset_agent_accumulates_across_calls(self):
+        agent = FakeAgent()
+
+        agent.run(task="first")
+        agent.run(task="second")
+
+        assert agent.seen[1] == ["first", "second"]
+
+    def test_each_task_starts_from_a_fresh_conversation(self):
+        agent = FakeAgent()
+
+        run_agent_isolated(agent, task="first")
+        run_agent_isolated(agent, task="second")
+
+        assert agent.seen[0] == ["first"]
+        assert agent.seen[1] == ["second"]
+        assert agent.inits == 2
+
+    def test_a_later_caller_never_sees_an_earlier_task(self):
+        agent = FakeAgent()
+
+        run_agent_isolated(agent, task="my salary is 12345")
+        run_agent_isolated(agent, task="unrelated question")
+
+        assert agent.seen[1] == ["unrelated question"]
+        assert "my salary is 12345" not in agent.seen[1]
+
+    def test_run_kwargs_are_forwarded_unchanged(self):
+        agent = FakeAgent()
+
+        run_agent_isolated(
+            agent,
+            task="t",
+            img="a.png",
+            imgs=["b.png"],
+            correct_answer="42",
+        )
+
+        assert agent.last_kwargs == {
+            "img": "a.png",
+            "imgs": ["b.png"],
+            "correct_answer": "42",
+        }
+
+    def test_the_agents_return_value_is_passed_through(self):
+        agent = FakeAgent()
+
+        assert run_agent_isolated(agent, task="t") == "answer:t"
+
+    def test_concurrent_callers_each_see_only_their_own_task(self):
+        agent = FakeAgent(delay=0.01)
+        tasks = [f"task-{i}" for i in range(8)]
+
+        threads = [
+            threading.Thread(
+                target=run_agent_isolated,
+                args=(agent,),
+                kwargs={"task": t},
+            )
+            for t in tasks
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(agent.seen) == len(tasks)
+        assert all(len(history) == 1 for history in agent.seen)
+        assert sorted(h[0] for h in agent.seen) == sorted(tasks)
+
+
+class TestExecutionLock:
+    def test_the_same_agent_always_gets_the_same_lock(self):
+        agent = FakeAgent()
+
+        assert _agent_execution_lock(agent) is _agent_execution_lock(
+            agent
+        )
+
+    def test_separate_agents_do_not_share_a_lock(self):
+        assert _agent_execution_lock(FakeAgent("a")) is not (
+            _agent_execution_lock(FakeAgent("b"))
+        )
+
+    def test_two_agents_run_without_blocking_each_other(self):
+        first, second = FakeAgent("a", delay=0.05), FakeAgent(
+            "b", delay=0.05
+        )
+
+        started = time.time()
+        threads = [
+            threading.Thread(
+                target=run_agent_isolated,
+                args=(a,),
+                kwargs={"task": "t"},
+            )
+            for a in (first, second)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert time.time() - started < 0.09


### PR DESCRIPTION
Closes #2047.

`AOP` exposes each registered agent as an MCP tool and reuses one long-lived `Agent` for every call, with no reset of `short_memory` anywhere in the module. Because AOP is a **server**, the sharing is between unrelated callers rather than between steps of one workflow: **client A's task and answer stayed in context for client B's later call to the same tool.**

## Problem

`grep -c "short_memory" swarms/structs/aop.py` returned `0`. Both execution paths went straight to `agent.run`:

| Path | Site | Reached when |
|---|---|---|
| Queue | `TaskQueue._process_task` (`aop.py:463`) | `queue_enabled=True`, the default |
| Direct | `AOP._execute_agent_with_timeout` (`aop.py:1325`) | `queue_enabled=False` |

Three consequences, in descending severity: cross-request leakage between unrelated clients; unbounded growth, so a long-running server's requests get steadily more expensive until they hit the context limit; and nondeterminism, since the same request answers differently depending on what ran before it.

## Fix

Both sites now call one `run_agent_isolated`, which reinitialises `short_memory` from `short_memory_init()` before the run. That is the reset `planner_worker_swarm.py:445` and `auction_swarm.py:402` already use.

## Design decisions

- **A reset on its own is not sufficient, so the reset and the run are held under one per-agent lock.** Two callers can be inside `run()` simultaneously by two separate routes: `max_workers_per_agent` spawns that many worker threads against a single shared `Agent` (`TaskQueue.start_workers`, `aop.py:301`), and the MCP tool handler `agent_tool` is a **sync** function, so FastMCP dispatches concurrent requests onto its thread pool. An unguarded reset would clear one caller's history while another was still using it — turning a leak into a truncation. `test_concurrent_callers_each_see_only_their_own_task` is the pin for this.
- **The lock lives on the agent, not on `AOP`.** The queue path holds `self.agent` inside `TaskQueue` and the direct path receives `agent` as a parameter; keying off the agent is what lets both routes reach the same lock without threading a registry through `TaskQueue`.
- **`short_memory_init()` rather than clearing the existing conversation** — it is the constructor `Agent.__init__` itself uses (`agent.py:634`), so the system prompt, rules, user, and `memory_md_path` are rebuilt exactly as a fresh agent would have them.
- **Per-tool opt-in conversational memory is deliberately not here.** The issue raises it as the right shape for deployments that genuinely want carry-over; it needs per-client session scoping, which is a design decision rather than a bug fix.

## Behavior-change note

With `max_workers_per_agent > 1`, per-agent execution is now serialised. That setting never gave safe parallelism — the workers shared one `Agent` and one conversation — so what changes is throughput on a configuration that was previously returning corrupted context. **Separate agents still run concurrently**, which `test_two_agents_run_without_blocking_each_other` pins. The default is `max_workers_per_agent=1`, so most deployments see no scheduling change at all.

## Verification

- **Unit**: 9 new tests in `tests/structs/test_aop.py`.

  ```
  $ pytest tests/structs/test_aop.py -q
    9 passed
  ```
- **Suite**, `tests/structs/`, against clean `master` @ `a193a8e0`:

  ```
  master     : 113 failed, 817 passed, 23 skipped, 5 errors
  this branch: 113 failed, 826 passed, 23 skipped, 5 errors
  ```

  +9, and the failure and error counts are **identical** — all pre-existing. The 5 errors are `test_groupchat.py`, which is #2059.
- **Lint**, at the versions `lint.yml` pins (`black==24.2.0`, `ruff==0.2.1`): `967 files would be left unchanged`, ruff clean.

### The new test file does not repeat what #2016 removed

#2016 deleted `tests/structs/test_aop.py` because it imported `swarms.structs.aop` at module level, `mcp.server.fastmcp` is absent from the pinned `mcp` release, and the resulting collection error aborted the entire `test` job before anything ran. This file guards the import with `pytest.importorskip("mcp.server.fastmcp")`.

Verified rather than assumed, by blocking **only** that submodule and re-running collection:

```
$ pytest tests/structs/test_aop.py -q          # mcp.server.fastmcp missing
  1 skipped

$ pytest tests/structs/ --collect-only         # without this file
  43 tests collected, 33 errors
$ pytest tests/structs/ --collect-only         # with this file
  43 tests collected, 33 errors
```

Same error count either way: the file skips rather than adding one. (Those 33 are an artifact of the local block being broader than CI's real condition — the point is the delta, which is zero.)

- **Not verified here**: no MCP server is stood up and no provider is called. The tests drive `run_agent_isolated` against a fake agent recording the conversation it saw per call, so what they pin is the isolation contract — reset, forwarding, return value, and the concurrency guarantee — not FastMCP's transport. `test_the_unreset_agent_accumulates_across_calls` asserts the fake reproduces the original leak, so the other assertions are meaningful rather than vacuous.
