### PR TITLE
[Bug] BatchedGridWorkflow is an advertised SwarmType the router can never dispatch (#2058)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,7 +507,6 @@ result = router.run("Write a blog post about transformer architectures.")
 | `"HeavySwarm"` | Intensive multi-loop deep analysis |
 | `"RoundRobin"` | Round-robin task distribution |
 | `"PlannerWorkerSwarm"` | Planner + worker delegation |
-| `"BatchedGridWorkflow"` | Grid-based batch execution |
 | `"LLMCouncil"` | LLM-based council decisions |
 | `"AutoSwarmBuilder"` | Auto-configures everything |
 

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -18,7 +18,6 @@ from swarms.prompts.multi_agent_collab_prompt import (
 )
 from swarms.structs.agent import Agent
 from swarms.structs.agent_rearrange import AgentRearrange
-from swarms.structs.batched_grid_workflow import BatchedGridWorkflow
 from swarms.structs.concurrent_workflow import ConcurrentWorkflow
 from swarms.structs.council_as_judge import CouncilAsAJudge
 from swarms.structs.debate_with_judge import DebateWithJudge
@@ -140,7 +139,6 @@ SwarmType = Literal[
     "MajorityVoting",
     "CouncilAsAJudge",
     "HeavySwarm",
-    "BatchedGridWorkflow",
     "LLMCouncil",
     "DebateWithJudge",
     "RoundRobin",
@@ -215,7 +213,7 @@ class SwarmRouter(SerializableMixin):
             ``SequentialWorkflow``, ``ConcurrentWorkflow``, ``AgentRearrange``,
             ``MixtureOfAgents``, ``HierarchicalSwarm``, ``GroupChat``,
             ``MultiAgentRouter``, ``MajorityVoting``, ``CouncilAsAJudge``,
-            ``HeavySwarm``, ``BatchedGridWorkflow``, ``LLMCouncil``,
+            ``HeavySwarm``, ``LLMCouncil``,
             ``DebateWithJudge``, ``RoundRobin``, and ``PlannerWorkerSwarm``.
         autosave (bool, optional): When ``True``, save ``config.json`` on init
             and ``state.json`` + ``metadata.json`` after each run to
@@ -279,7 +277,7 @@ class SwarmRouter(SerializableMixin):
         ``SequentialWorkflow``, ``ConcurrentWorkflow``, ``AgentRearrange``,
         ``MixtureOfAgents``, ``HierarchicalSwarm``, ``GroupChat``,
         ``MultiAgentRouter``, ``MajorityVoting``, ``CouncilAsAJudge``,
-        ``HeavySwarm``, ``BatchedGridWorkflow``, ``LLMCouncil``,
+        ``HeavySwarm``, ``LLMCouncil``,
         ``DebateWithJudge``, ``RoundRobin``, ``PlannerWorkerSwarm``.
 
     Example:
@@ -521,7 +519,6 @@ class SwarmRouter(SerializableMixin):
             "MultiAgentRouter": self._create_multi_agent_router,
             "SequentialWorkflow": self._create_sequential_workflow,
             "ConcurrentWorkflow": self._create_concurrent_workflow,
-            "BatchedGridWorkflow": self._create_batched_grid_workflow,
             "LLMCouncil": self._create_llm_council,
             "DebateWithJudge": self._create_debate_with_judge,
             "RoundRobin": self._create_round_robin_swarm,
@@ -589,15 +586,6 @@ class SwarmRouter(SerializableMixin):
             *args,
             **self._base_kwargs(flow=self.rearrange_flow),
             **kwargs,
-        )
-
-    def _create_batched_grid_workflow(self, *args, **kwargs):
-        """Create a ``BatchedGridWorkflow`` for grid-style batch execution."""
-        return BatchedGridWorkflow(
-            name=self.name,
-            description=self.description,
-            agents=self.agents,
-            max_loops=self.max_loops,
         )
 
     def _create_council_as_judge(self, *args, **kwargs):

--- a/tests/structs/test_swarm_router.py
+++ b/tests/structs/test_swarm_router.py
@@ -6,6 +6,7 @@ from swarms.structs.swarm_router import (
     SwarmRouterConfig,
     SwarmRouterRunError,
     SwarmRouterConfigError,
+    SwarmType,
 )
 from swarms.structs.agent import Agent
 
@@ -538,19 +539,17 @@ def test_run_with_heavy_swarm():
     assert result is not None
 
 
-def test_run_with_batched_grid_workflow():
-    """SwarmRouter dispatches to BatchedGridWorkflow."""
-    sample_agents = create_sample_agents()
+def test_batched_grid_workflow_is_rejected_at_construction():
+    """BatchedGridWorkflow is not routable and is not offered as a SwarmType."""
+    assert "BatchedGridWorkflow" not in get_args(SwarmType)
 
-    router = SwarmRouter(
-        agents=sample_agents,
-        swarm_type="BatchedGridWorkflow",
-        max_loops=1,
-        verbose=False,
-    )
-
-    result = router.run("What is 1+1?")
-    assert result is not None
+    with pytest.raises(SwarmRouterConfigError):
+        SwarmRouter(
+            agents=create_sample_agents(),
+            swarm_type="BatchedGridWorkflow",
+            max_loops=1,
+            verbose=False,
+        )
 
 
 def test_run_with_llm_council():


### PR DESCRIPTION
Closes #2058.

## What is wrong

`SwarmRouter` dispatches every swarm with `task=` (`swarm_router.py:872`), but `BatchedGridWorkflow.run` takes `tasks: List[str]` (`batched_grid_workflow.py:113`). Selecting it raises on the first `run()`:

```
TypeError: BatchedGridWorkflow.run() got an unexpected keyword argument 'task'
```

It was a member of the `SwarmType` Literal with a factory entry, so `reliability_check` accepted it at construction and the type hint, the class docstring and IDE completion all offered an option that could not work.

## Why removing rather than adapting

The mismatch is structural, not a wiring slip. `BatchedGridWorkflow` pairs agent *i* with task *i*, so it is many-tasks-to-many-agents; `SwarmRouter.run(task)` is one task for the whole swarm. No signature satisfies both without changing what the router means, and widening `run()` to accept a task list for exactly one swarm type would push that special case into every caller.

This follows #2063, which removed `"auto"` from the same Literal for the same reason.

## What this does

Drops the `SwarmType` entry, the `_initialize_swarm_factory` entry, `_create_batched_grid_workflow`, the now-unused import, and the two docstring lists that named it. `BatchedGridWorkflow` itself is untouched and still works constructed directly.

`test_run_with_batched_grid_workflow` asserted the dispatch that never worked, so it now asserts the rejection. Verified it fails on the unfixed source and passes with the change; the rest of the file is 38 passed, with one pre-existing failure that needs `OPENAI_API_KEY` for a live call.