### PR TITLE
fix(social-algorithms): wrap the owned agents, not the Agent class (#2049)

### DIFF
--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -1,6 +1,6 @@
 import time
 import uuid
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Set
 from dataclasses import dataclass
 
 from swarms.structs.agent import Agent
@@ -533,6 +533,78 @@ class SocialAlgorithms:
 
         return algorithm_result
 
+    def _patch_agent_for_logging(
+        self, agent: AgentType
+    ) -> Callable[[], None]:
+        """
+        Route one agent's ``run`` and ``talk_to`` through communication logging.
+
+        Args:
+            agent (AgentType): The agent to wrap. Anything without a callable
+                ``run`` is skipped.
+
+        Returns:
+            Callable[[], None]: A no-argument callable that undoes the patch.
+
+        Notes:
+            The wrappers are installed as *instance* attributes. Assigning to
+            ``Agent.run`` instead would wrap every agent in the process for the
+            duration of the call, including agents owned by unrelated structures
+            on other threads, and two overlapping instances would capture each
+            other's wrappers as "the original" and leave the class permanently
+            patched once both had finished.
+
+            The wrappers take ``*args``/``**kwargs`` and forward them unchanged
+            rather than restating ``Agent.run``'s signature, so a parameter added
+            to ``Agent.run`` later keeps working here with no edit.
+        """
+        original_run = getattr(agent, "run", None)
+        if not callable(original_run):
+            return lambda: None
+
+        sender = getattr(agent, "agent_name", str(agent))
+
+        # An agent may already carry its own instance-level override; remember
+        # it so the restore puts that back rather than exposing the class method.
+        overridden: Dict[str, Any] = {
+            name: agent.__dict__[name]
+            for name in ("run", "talk_to")
+            if name in agent.__dict__
+        }
+
+        def logged_run(*args: Any, **kwargs: Any) -> Any:
+            task = args[0] if args else kwargs.get("task")
+            self._log_communication(sender, sender, task)
+            return original_run(*args, **kwargs)
+
+        agent.run = logged_run
+
+        original_talk_to = getattr(agent, "talk_to", None)
+        if callable(original_talk_to):
+
+            def logged_talk_to(*args: Any, **kwargs: Any) -> Any:
+                receiver = args[0] if args else kwargs.get("agent")
+                task = (
+                    args[1] if len(args) > 1 else kwargs.get("task")
+                )
+                self._log_communication(
+                    sender,
+                    getattr(receiver, "agent_name", str(receiver)),
+                    task,
+                )
+                return original_talk_to(*args, **kwargs)
+
+            agent.talk_to = logged_talk_to
+
+        def restore() -> None:
+            for name in ("run", "talk_to"):
+                if name in overridden:
+                    setattr(agent, name, overridden[name])
+                else:
+                    agent.__dict__.pop(name, None)
+
+        return restore
+
     def _wrap_algorithm_with_logging(self) -> Callable:
         """
         Wrap the social algorithm with communication logging.
@@ -541,47 +613,27 @@ class SocialAlgorithms:
             Callable: The wrapped algorithm with logging capabilities.
         """
 
-        def wrapped_algorithm(agents, task, **kwargs):
-            # Store original agent methods
-            original_talk_to = Agent.talk_to
-            original_run = Agent.run
+        def wrapped_algorithm(
+            agents: List[AgentType], task: str, **kwargs: Any
+        ) -> Any:
+            restores: List[Callable[[], None]] = []
+            patched: Set[int] = set()
 
-            def logged_talk_to(
-                agent_self, agent, task, img=None, *args, **kwargs
-            ):
-                # Log the communication
-                self._log_communication(
-                    agent_self.agent_name, agent.agent_name, task
-                )
-                # Call original method
-                return original_talk_to(
-                    agent_self, agent, task, img, *args, **kwargs
-                )
-
-            def logged_run(
-                agent_self, task, img=None, *args, **kwargs
-            ):
-                # Log the communication (self-communication)
-                self._log_communication(
-                    agent_self.agent_name, agent_self.agent_name, task
-                )
-                # Call original method
-                return original_run(
-                    agent_self, task, img, *args, **kwargs
-                )
-
-            # Temporarily replace methods
-            Agent.talk_to = logged_talk_to
-            Agent.run = logged_run
+            # The same agent can legitimately appear twice in one roster;
+            # patching it twice would nest the wrapper and log every call twice.
+            for agent in agents:
+                if id(agent) in patched:
+                    continue
+                patched.add(id(agent))
+                restores.append(self._patch_agent_for_logging(agent))
 
             try:
                 # Execute the algorithm
                 result = self.social_algorithm(agents, task, **kwargs)
                 return result
             finally:
-                # Restore original methods
-                Agent.talk_to = original_talk_to
-                Agent.run = original_run
+                for restore in reversed(restores):
+                    restore()
 
         return wrapped_algorithm
 

--- a/tests/structs/test_social_algorithms.py
+++ b/tests/structs/test_social_algorithms.py
@@ -1,0 +1,203 @@
+"""Tests for SocialAlgorithms communication logging (issue #2049).
+
+The logging wrapper used to replace ``Agent.run``/``Agent.talk_to`` on the
+class, so it caught every agent in the process and two overlapping instances
+left the class permanently wrapped. These tests pin the wrapping to the
+agents the structure was handed.
+"""
+
+import threading
+
+from swarms.structs.agent import Agent
+from swarms.structs.social_algorithms import SocialAlgorithms
+
+
+class FakeAgent(Agent):
+    """An Agent for isinstance checks that never touches an LLM."""
+
+    def __init__(self, name: str = "worker"):
+        self.agent_name = name
+        self.calls = []
+
+    def run(self, task=None, *args, **kwargs):
+        self.calls.append(task)
+        return f"answer:{task}"
+
+    def talk_to(self, agent, task, img=None, *args, **kwargs):
+        return agent.run(task=f"From {self.agent_name}: {task}")
+
+
+def build(agents, algorithm):
+    return SocialAlgorithms(
+        agents=agents,
+        social_algorithm=algorithm,
+        enable_communication_logging=True,
+    )
+
+
+class TestLoggingIsScopedToOwnedAgents:
+    def test_the_agent_class_is_never_patched(self):
+        agent = FakeAgent()
+        seen = {}
+
+        def algorithm(agents, task, **kwargs):
+            seen["run"] = Agent.run
+            seen["talk_to"] = Agent.talk_to
+            return agents[0].run(task)
+
+        original_run, original_talk_to = Agent.run, Agent.talk_to
+        build([agent], algorithm)._wrap_algorithm_with_logging()(
+            [agent], "task"
+        )
+
+        assert seen["run"] is original_run
+        assert seen["talk_to"] is original_talk_to
+        assert Agent.run is original_run
+        assert Agent.talk_to is original_talk_to
+
+    def test_an_unowned_agent_is_not_logged(self):
+        owned, bystander = FakeAgent("owned"), FakeAgent("bystander")
+        structure = build([owned], lambda agents, task, **kw: None)
+
+        wrapped = structure._wrap_algorithm_with_logging()
+
+        def algorithm(agents, task, **kwargs):
+            bystander.run("a secret from another swarm")
+            return agents[0].run(task)
+
+        structure.social_algorithm = algorithm
+        wrapped([owned], "owned task")
+
+        logged = [
+            step.message for step in structure.communication_history
+        ]
+        assert logged == ["owned task"]
+
+    def test_owned_agent_calls_are_logged(self):
+        agent = FakeAgent("worker")
+        structure = build(
+            [agent], lambda agents, task, **kw: agents[0].run(task)
+        )
+
+        structure._wrap_algorithm_with_logging()([agent], "task")
+
+        assert len(structure.communication_history) == 1
+        step = structure.communication_history[0]
+        assert step.sender_agent == "worker"
+        assert step.receiver_agent == "worker"
+        assert step.message == "task"
+
+
+class TestRestore:
+    def test_the_wrapper_is_removed_when_the_algorithm_returns(self):
+        agent = FakeAgent()
+        structure = build(
+            [agent], lambda agents, task, **kw: agents[0].run(task)
+        )
+
+        structure._wrap_algorithm_with_logging()([agent], "task")
+
+        assert "run" not in agent.__dict__
+        assert "talk_to" not in agent.__dict__
+
+    def test_the_wrapper_is_removed_when_the_algorithm_raises(self):
+        agent = FakeAgent()
+
+        def algorithm(agents, task, **kwargs):
+            raise RuntimeError("boom")
+
+        structure = build([agent], algorithm)
+
+        try:
+            structure._wrap_algorithm_with_logging()([agent], "task")
+        except RuntimeError:
+            pass
+
+        assert "run" not in agent.__dict__
+
+    def test_a_pre_existing_instance_override_survives(self):
+        agent = FakeAgent()
+
+        def override(task=None, **kwargs):
+            return "override"
+
+        agent.run = override
+
+        structure = build(
+            [agent], lambda agents, task, **kw: agents[0].run(task)
+        )
+        structure._wrap_algorithm_with_logging()([agent], "task")
+
+        assert agent.run is override
+
+    def test_a_repeated_agent_is_patched_once(self):
+        agent = FakeAgent()
+        structure = build(
+            [agent], lambda agents, task, **kw: agents[0].run(task)
+        )
+
+        structure._wrap_algorithm_with_logging()(
+            [agent, agent], "task"
+        )
+
+        assert len(structure.communication_history) == 1
+        assert "run" not in agent.__dict__
+
+
+class TestConcurrentInstances:
+    def test_two_overlapping_instances_stay_independent(self):
+        a, b = FakeAgent("a"), FakeAgent("b")
+        both_patched = threading.Barrier(2, timeout=5)
+
+        def algorithm(agents, task, **kwargs):
+            both_patched.wait()
+            return agents[0].run(task)
+
+        first = build([a], algorithm)
+        second = build([b], algorithm)
+
+        threads = [
+            threading.Thread(
+                target=lambda s=s, ag=ag: s._wrap_algorithm_with_logging()(
+                    [ag], f"{ag.agent_name} task"
+                ),
+                daemon=True,
+            )
+            for s, ag in ((first, a), (second, b))
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert [
+            step.message for step in first.communication_history
+        ] == ["a task"]
+        assert [
+            step.message for step in second.communication_history
+        ] == ["b task"]
+
+    def test_the_class_is_left_clean_after_overlapping_runs(self):
+        a, b = FakeAgent("a"), FakeAgent("b")
+        original_run = Agent.run
+        both_patched = threading.Barrier(2, timeout=5)
+
+        def algorithm(agents, task, **kwargs):
+            both_patched.wait()
+            return agents[0].run(task)
+
+        threads = [
+            threading.Thread(
+                target=lambda ag=ag: build(
+                    [ag], algorithm
+                )._wrap_algorithm_with_logging()([ag], "task"),
+                daemon=True,
+            )
+            for ag in (a, b)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert Agent.run is original_run


### PR DESCRIPTION
Closes #2049.

`SocialAlgorithms` logged agent communication by assigning `Agent.run` and `Agent.talk_to` **on the class**, so the wrapper caught every agent in the process for the duration of a call. This moves the wrapping onto the agent instances the structure was handed, so **an agent belonging to another swarm on another thread is no longer logged, wrapped, or left permanently patched.**

## Problem

`swarms/structs/social_algorithms.py:574-585` (before this change):

```python
            # Temporarily replace methods
            Agent.talk_to = logged_talk_to
            Agent.run = logged_run

            try:
                result = self.social_algorithm(agents, task, **kwargs)
                return result
            finally:
                # Restore original methods
                Agent.talk_to = original_talk_to
                Agent.run = original_run
```

Two distinct symptoms:

1. **Unowned agents are logged.** Any `Agent.run` call anywhere in the process during that window goes through this structure's `_log_communication`, so `communication_history` reports steps the structure never performed.
2. **Two instances corrupt the class permanently.** `original_run` is captured per call. A patches, B patches (capturing A's *wrapper* as its "original"), A restores, B restores — `Agent.run` is now A's wrapper forever, after A has finished. `run_async` (`:588`) and the `parallel_execution` / `max_workers` constructor options (`:116-129`) make that interleaving expected usage.

## Fix

New `_patch_agent_for_logging(agent) -> Callable[[], None]` installs the wrappers as **instance** attributes and returns its own undo callable. `_wrap_algorithm_with_logging` patches each agent in the roster and runs every undo in reverse order in `finally`.

| Concern | Handling |
|---|---|
| Scoping | Only agents in the roster passed to the algorithm are wrapped. The `Agent` class is never assigned to. |
| Restore | The helper records whether `run`/`talk_to` were *already* instance-level overrides, so the undo restores the caller's own override instead of uncovering the class method. |
| Raising path | Undo runs in `finally`, so an algorithm that throws still leaves the agents clean. |
| Duplicate agents | The same object may legitimately appear twice in one roster. `patched` keys on `id()`, so the wrapper is not nested and calls are not double-logged. |
| Signature drift | The wrappers now take `*args`/`**kwargs` and forward unchanged. The old `logged_run(agent_self, task, img=None, ...)` restated a signature that has since grown `imgs`, `correct_answer`, `streaming_callback` and `n` (`swarms/structs/agent.py:3274`). |

## Files

| File | Change |
|---|---|
| `swarms/structs/social_algorithms.py` | `_patch_agent_for_logging` added; `_wrap_algorithm_with_logging` rewritten to patch instances. `Set` added to the `typing` import. |
| `tests/structs/test_social_algorithms.py` | **new** — see the note on the new file below. |

## Design decisions

- **Instance attributes, not the class.** The alternative the issue floats — dropping the interception entirely and recording at the structure's own call sites — cannot work here: `social_algorithm` is a *user-supplied* callable that calls `agent.run(...)` itself, so the structure has no call site to instrument. Wrapping the roster is the narrowest interception that still sees those calls.
- **`*args`/`**kwargs` forwarding rather than a restated signature.** Keeps the wrapper correct the next time `Agent.run` gains a parameter; the previous wrapper had already fallen four parameters behind.
- **Restore by removing the instance attribute, not by re-assigning the class method.** `agent.__dict__.pop(name, None)` uncovers the real bound method, which is the only way to leave an agent byte-identical to how it arrived when it had no override of its own.

## Behavior-change note

An agent reached *through* a logged agent but not itself in the roster — the receiver inside `Agent.talk_to`, which calls `agent.run(...)` on the other party — no longer produces its own self-communication entry in `communication_history`. That entry only ever existed because the class was patched; logging agents the structure does not own is precisely the defect. Sender→receiver `talk_to` steps and the roster agents' own `run` steps are unchanged. If a caller wants the receiver logged, it belongs in the roster.

## Verification

- **New file**: `tests/structs/test_social_algorithms.py` — 9 tests, **9 passed**.

  ```
  $ .venv/bin/python -m pytest tests/structs/test_social_algorithms.py -q
  .........                                                          [100%]
  9 passed in 1.19s
  ```

- **The tests fail on the unfixed base.** Same tests against `upstream/master`'s `social_algorithms.py`:

  ```
  5 failed, 4 passed in 1.85s
  FAILED ...::test_the_agent_class_is_never_patched
  FAILED ...::test_an_unowned_agent_is_not_logged
  FAILED ...::test_owned_agent_calls_are_logged
  FAILED ...::test_a_repeated_agent_is_patched_once
  FAILED ...::test_two_overlapping_instances_stay_independent
  ```

  `test_two_overlapping_instances_stay_independent` fails with `assert [] == ['a task']` — on the old code the second instance's patch swallows the first's logging entirely.

- **Full `tests/structs` suite**, both runs on this machine, same interpreter:

  | | passed | failed | skipped | errors |
  |---|---|---|---|---|
  | clean `upstream/master` @ `c6134af1` (git worktree) | 818 | 112 | 23 | 5 |
  | this branch | **827** | 112 | 23 | 5 |

  Identical failure and error sets; the +9 is exactly this PR's new tests. The 112 pre-existing failures (`test_one_on_one_debate`, `test_reasoning_agent_router`, `test_self_moa_seq`, `test_spreadsheet`, the `test_groupchat` collection errors, …) reproduce unchanged on the clean base and are untouched by this PR.

- **Lint**: `black --check` clean on both files. `ruff check` with the CI rule set produces no findings on either file, and none that the clean base did not already produce.

- **Not verified here**: no live-LLM path was exercised. `FakeAgent` subclasses `Agent` (so the constructor's `isinstance(agent, Agent)` check at `:193` passes) and overrides `run`/`talk_to` without calling `super().__init__`, so no model is ever contacted. The instance-attribute mechanism under test — assignment shadowing the class method, `__dict__.pop` uncovering it — is plain Python attribute lookup and is identical for a real `Agent`, which declares no `__slots__` and no `__setattr__`.

## Note on the new test file

`tests/structs/` had no `SocialAlgorithms` test file and no existing module these fit into — the closest neighbours (`test_swarm_architectures.py`, `test_multi_agent_debate.py`) cover unrelated structures. Adding to one of those would misfile them, so this is a new module rather than a preference for new files.

## Follow-ups deliberately left out of this PR

Untouched here, each its own concern: the `Agent.talk_to` double-logging shape (sender→receiver, then the receiver's own `run`) predates this change and is unchanged; `_log_communication` still truncates at 100 chars only in the verbose log line.
