### PR TITLE
[Bug] The SIGALRM timeout breaks run() off the main thread, and silently disables sub-second budgets

### DIFF
--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -1,3 +1,4 @@
+import threading
 import time
 import uuid
 from contextlib import contextmanager
@@ -321,24 +322,25 @@ class SocialAlgorithms:
         Raises:
             TimeoutError: If the function execution exceeds max_execution_time.
         """
-        import signal
+        outcome: Dict[str, Any] = {}
 
-        def timeout_handler(signum, frame):
+        def target() -> None:
+            try:
+                outcome["result"] = func(*args, **kwargs)
+            except BaseException as exc:
+                outcome["error"] = exc
+
+        worker = threading.Thread(target=target, daemon=True)
+        worker.start()
+        worker.join(self.max_execution_time)
+
+        if worker.is_alive():
             raise TimeoutError(
                 f"Algorithm execution exceeded {self.max_execution_time} seconds"
             )
-
-        # Set up timeout
-        old_handler = signal.signal(signal.SIGALRM, timeout_handler)
-        signal.alarm(int(self.max_execution_time))
-
-        try:
-            result = func(*args, **kwargs)
-            return result
-        finally:
-            # Restore original handler
-            signal.alarm(0)
-            signal.signal(signal.SIGALRM, old_handler)
+        if "error" in outcome:
+            raise outcome["error"]
+        return outcome.get("result")
 
     def _format_output(self, result: Any) -> Any:
         """

--- a/tests/structs/test_social_algorithms.py
+++ b/tests/structs/test_social_algorithms.py
@@ -459,7 +459,7 @@ class TestAlgorithmArgs:
 
 
 class TestTimeout:
-    """The timeout is SIGALRM-based, so it only works on the main thread."""
+    """The timeout is a joined worker thread, so it works from any thread."""
 
     def test_a_generous_timeout_does_not_interfere(self):
         swarm = _swarm(_pipeline, max_execution_time=30)
@@ -472,10 +472,6 @@ class TestTimeout:
 
         assert swarm.run("t").total_steps == 2
 
-    @pytest.mark.xfail(
-        reason="signal.alarm truncates to int, so alarm(0) cancels the timeout",
-        strict=False,
-    )
     def test_a_sub_second_budget_still_times_out(self):
         def slow(agents, task, **kwargs):
             time.sleep(2)
@@ -486,10 +482,6 @@ class TestTimeout:
         with pytest.raises(TimeoutError):
             swarm.run("t")
 
-    @pytest.mark.xfail(
-        reason="signal.signal cannot be called off the main thread",
-        strict=False,
-    )
     def test_run_works_on_a_worker_thread(self):
         swarm = _swarm(_pipeline)
         outcome = {}
@@ -505,13 +497,6 @@ class TestTimeout:
         thread.join()
 
         assert outcome.get("steps") == 2
-
-    @pytest.mark.xfail(
-        reason="run_async runs on a worker thread, where SIGALRM is unavailable",
-        strict=False,
-    )
-    def test_run_async_works_on_the_default_configuration(self):
-        assert _swarm(_pipeline).run_async("t").total_steps == 2
 
 
 class TestAlgorithmInfo:


### PR DESCRIPTION
Closes #2070. Rebased onto `master` after #2072, #2074 and #2075; **rescoped**, see below.

## Why

`_execute_with_timeout` implemented the budget with `signal.SIGALRM`. Three things follow from that:

1. **`signal.signal` only works on the main thread.** Calling `run()` from any worker thread raises `ValueError: signal only works in main thread of the main interpreter` — not a timeout, a crash.
2. **Sub-second budgets silently disabled the timeout.** `signal.alarm(int(self.max_execution_time))` truncates, and `alarm(0)` means *cancel any pending alarm*. `max_execution_time=0.2` therefore ran with no timeout at all — the opposite of what was asked for.
3. **Windows has no `SIGALRM`.** The default path raised `AttributeError` there.

## What

```python
worker = threading.Thread(target=target, daemon=True)
worker.start()
worker.join(self.max_execution_time)

if worker.is_alive():
    raise TimeoutError(...)
```

Works from any thread, takes the float budget as given, portable. Exceptions from the call are captured and re-raised on the caller's thread, so `run`'s existing `except TimeoutError` / `except Exception` handling is unchanged. `import signal` goes away; `threading` joins the module imports.

**The one behaviour change:** a timed-out worker is abandoned, not interrupted. `SIGALRM` raised inside the running frame and actually stopped the work; a joined thread cannot, and Python has no safe way to kill one. It is bounded — the thread is a daemon, so it cannot hold up interpreter exit, and the caller still gets `TimeoutError` on schedule.

## Rescoped after #2074 — and it found a dead test

The original issue leads with *"`run_async` always raises"*. **#2074 removed `run_async` entirely**, so that symptom is gone. Defects 1–3 above are all still live on `master` and are what this now fixes.

#2074 also landed tests for exactly these, marked `xfail`:

```python
@pytest.mark.xfail(reason="signal.alarm truncates to int, so alarm(0) cancels the timeout", strict=False)
@pytest.mark.xfail(reason="signal.signal cannot be called off the main thread", strict=False)
```

They pass now, so **the markers come off** rather than me adding duplicates — the coverage was already written, it was just pinned to the broken behaviour. **This PR adds no new tests.**

It also left a third one behind:

```python
@pytest.mark.xfail(reason="run_async runs on a worker thread, where SIGALRM is unavailable", strict=False)
def test_run_async_works_on_the_default_configuration(self):
    assert _swarm(_pipeline).run_async("t").total_steps == 2
```

`run_async` no longer exists, so that is `AttributeError`, not a timeout problem — and `strict=False` reported it as a clean xfail, so nothing complained. Deleted. Worth knowing generally: a non-strict xfail will hide a test that references a removed API indefinitely.

The class docstring said *"The timeout is SIGALRM-based, so it only works on the main thread"*, which is now false; corrected.

## Verified

By restoring `swarms/structs/social_algorithms.py` from `master` and keeping the test file:

```
master source:  2 failed, 46 passed
                  TestTimeout::test_a_sub_second_budget_still_times_out
                  TestTimeout::test_run_works_on_a_worker_thread
with the fix:  48 passed
```