### PR TITLE
feat(social-algorithms): record agent messages in a Conversation

### DIFF
--- a/examples/multi_agent/social_algorithms_examples/social_algorithms_example.py
+++ b/examples/multi_agent/social_algorithms_examples/social_algorithms_example.py
@@ -1,0 +1,103 @@
+from dotenv import load_dotenv
+
+from swarms import Agent
+from swarms.structs.social_algorithms import SocialAlgorithms
+
+load_dotenv()
+
+researcher = Agent(
+    agent_name="Researcher",
+    agent_description="Gathers evidence and lays out the factual landscape",
+    system_prompt=(
+        "You are a research analyst. Given a question, lay out the key facts, "
+        "the main competing positions, and the evidence behind each. Be concrete "
+        "and cite the reasoning behind every claim. Keep it under 300 words."
+    ),
+    model_name="gpt-5.4",
+    max_loops=1,
+)
+
+critic = Agent(
+    agent_name="Critic",
+    agent_description="Attacks the research for gaps and weak reasoning",
+    system_prompt=(
+        "You are a skeptical reviewer. Given a piece of research, find its "
+        "weakest claims, its unstated assumptions, and anything important it "
+        "left out. Be specific and brief. Do not rewrite it yourself."
+    ),
+    model_name="gpt-5.4",
+    max_loops=1,
+)
+
+editor = Agent(
+    agent_name="Editor",
+    agent_description="Produces the final answer from the research and critique",
+    system_prompt=(
+        "You are an editor. Given research and a critique of it, write the "
+        "final answer that survives the critique. Address every objection "
+        "raised, or say plainly why it does not change the conclusion."
+    ),
+    model_name="gpt-5.4",
+    max_loops=1,
+)
+
+
+def peer_review(agents, task, rounds: int = 1, **kwargs):
+    """Research a question, critique the research, then edit past the critique.
+
+    This is the "social algorithm" — plain Python that decides who speaks, in
+    what order, and what each one sees. Anything callable with this signature
+    works, so the communication pattern is yours to define.
+
+    Args:
+        agents: The agents given to SocialAlgorithms, in declaration order.
+        task: The question to answer.
+        rounds: How many research/critique cycles to run before editing.
+        **kwargs: Ignored here; forwarded by SocialAlgorithms.
+
+    Returns:
+        The editor's final answer.
+    """
+    researcher, critic, editor = agents
+
+    draft = researcher.run(f"Research this question: {task}")
+
+    for _ in range(rounds):
+        critique = critic.run(
+            f"Critique this research on '{task}':\n\n{draft}"
+        )
+        draft = researcher.run(
+            f"Revise your research to answer this critique.\n\n"
+            f"Research:\n{draft}\n\nCritique:\n{critique}"
+        )
+
+    return editor.run(
+        f"Write the final answer to '{task}' from this research:\n\n{draft}"
+    )
+
+
+social_alg = SocialAlgorithms(
+    name="Peer-Review",
+    description="Research, critique, revise, then edit into a final answer",
+    agents=[researcher, critic, editor],
+    social_algorithm=peer_review,
+    max_execution_time=600,
+    verbose=True,
+)
+
+result = social_alg.run(
+    task="Are vector databases actually necessary for production RAG, or is Postgres with pgvector enough?",
+    algorithm_args={"rounds": 2},
+)
+
+print("\n=== FINAL ANSWER ===")
+print(result.final_outputs["result"])
+
+print("\n=== RUN STATS ===")
+print(f"agent messages: {result.total_steps}")
+print(f"elapsed:        {result.execution_time:.1f}s")
+
+# Every agent call is recorded automatically — the algorithm reports nothing.
+print("\n=== TRANSCRIPT ===")
+for message in social_alg.conversation.conversation_history:
+    print(f"\n[{message['role']}]\n{message['content']}")

--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -1,26 +1,17 @@
 import time
 import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
-from dataclasses import dataclass
 
 from swarms.structs.agent import Agent
+from swarms.structs.conversation import Conversation
 from swarms.structs.omni_agent_types import AgentType
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.output_types import OutputType
 
+
 logger = initialize_logger(log_folder="social_algorithms")
-
-
-@dataclass
-class CommunicationStep:
-    """Represents a single step in a social algorithm."""
-
-    step_id: str
-    sender_agent: str
-    receiver_agent: str
-    message: str
-    timestamp: float
-    metadata: Optional[Dict[str, Any]] = None
 
 
 @dataclass
@@ -32,9 +23,9 @@ class SocialAlgorithmResult:
     total_steps: int
     successful_steps: int
     failed_steps: int
-    communication_history: List[CommunicationStep]
-    final_outputs: Dict[str, Any]
-    metadata: Optional[Dict[str, Any]] = None
+    communication_history: List[Dict[str, Any]]
+    final_outputs: Any
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 class SocialAlgorithmError(Exception):
@@ -57,60 +48,43 @@ class AgentNotFoundError(SocialAlgorithmError):
 
 class SocialAlgorithms:
     """
-    A flexible framework for defining and executing custom social algorithms
-    that control how agents communicate and interact with each other.
+    Run an arbitrary callable that decides how a group of agents talk to each other.
 
-    This class allows users to upload any arbitrary social algorithm as a callable
-    that defines the sequence of communication between agents. The algorithm should
-    specify how agents talk to each other, in what order, and what information
-    should be shared.
+    The algorithm receives ``(agents, task, **kwargs)`` and may call the agents in
+    any order. Every agent call made while it runs is recorded into
+    ``self.conversation``, so the transcript is available without the algorithm
+    having to report anything itself.
 
-    Attributes:
-        algorithm_id (str): Unique identifier for the algorithm instance.
+    Args:
+        algorithm_id (str, optional): Unique identifier. Generated if omitted.
         name (str): Human-readable name for the algorithm.
         description (str): Description of what the algorithm does.
-        agents (List[AgentType]): List of agents that will participate in the algorithm.
-        social_algorithm (Callable): The callable that defines the communication sequence.
-        max_execution_time (float): Maximum time allowed for algorithm execution.
-        output_type (OutputType): Format of the output from the algorithm.
-        verbose (bool): Whether to enable verbose logging.
+        agents (List[AgentType]): Agents that participate in the algorithm.
+        social_algorithm (Callable): Callable defining the communication
+            sequence. Must accept ``(agents, task, **kwargs)``.
+        max_execution_time (float): Seconds allowed for execution.
+        output_type (OutputType): Format of ``final_outputs``.
+        verbose (bool): Whether to log progress.
+
+    Attributes:
+        conversation (Conversation): Transcript of every agent message, kept
+            across runs.
+
+    Raises:
+        InvalidAlgorithmError: If ``social_algorithm`` is not callable.
+        ValueError: If no agents are given, or ``max_execution_time`` is not positive.
 
     Example:
-        >>> from swarms import Agent, SocialAlgorithms
+        >>> def pipeline(agents, task, **kwargs):
+        ...     research = agents[0].run(f"Research: {task}")
+        ...     return agents[1].run(f"Analyze: {research}")
         >>>
-        >>> # Define a custom social algorithm
-        >>> def custom_communication_algorithm(agents, task, **kwargs):
-        ...     # Agent 1 researches the topic
-        ...     research_result = agents[0].run(f"Research: {task}")
-        ...
-        ...     # Agent 2 analyzes the research
-        ...     analysis = agents[1].run(f"Analyze this research: {research_result}")
-        ...
-        ...     # Agent 3 synthesizes the findings
-        ...     synthesis = agents[2].run(f"Synthesize: {research_result} + {analysis}")
-        ...
-        ...     return {
-        ...         "research": research_result,
-        ...         "analysis": analysis,
-        ...         "synthesis": synthesis
-        ...     }
-        >>>
-        >>> # Create agents
-        >>> researcher = Agent(agent_name="Researcher", model_name="gpt-5.4")
-        >>> analyst = Agent(agent_name="Analyst", model_name="gpt-5.4")
-        >>> synthesizer = Agent(agent_name="Synthesizer", model_name="gpt-5.4")
-        >>>
-        >>> # Create social algorithm
         >>> social_alg = SocialAlgorithms(
-        ...     name="Research-Analysis-Synthesis",
-        ...     agents=[researcher, analyst, synthesizer],
-        ...     social_algorithm=custom_communication_algorithm,
-        ...     verbose=True
+        ...     agents=[researcher, analyst],
+        ...     social_algorithm=pipeline,
         ... )
-        >>>
-        >>> # Run the algorithm
         >>> result = social_alg.run("The impact of AI on healthcare")
-        >>> print(result)
+        >>> print(social_alg.conversation.get_str())
     """
 
     def __init__(
@@ -120,39 +94,12 @@ class SocialAlgorithms:
         description: str = "A custom social algorithm for agent communication",
         agents: List[AgentType] = None,
         social_algorithm: Callable = None,
-        max_execution_time: float = 300.0,  # 5 minutes default
+        max_execution_time: float = 300.0,
         output_type: OutputType = "dict",
         verbose: bool = False,
-        enable_communication_logging: bool = False,
-        parallel_execution: bool = False,
-        max_workers: int = None,
         *args,
         **kwargs,
     ):
-        """
-        Initialize a SocialAlgorithms instance.
-
-        Args:
-            algorithm_id (str, optional): Unique identifier for the algorithm.
-                If None, a UUID will be generated.
-            name (str): Human-readable name for the algorithm.
-            description (str): Description of what the algorithm does.
-            agents (List[AgentType]): List of agents that will participate in the algorithm.
-            social_algorithm (Callable): The callable that defines the communication sequence.
-                Must accept (agents, task, **kwargs) as parameters.
-            max_execution_time (float): Maximum time allowed for algorithm execution in seconds.
-            output_type (OutputType): Format of the output from the algorithm.
-            verbose (bool): Whether to enable verbose logging.
-            enable_communication_logging (bool): Whether to log communication steps.
-            parallel_execution (bool): Whether to enable parallel execution where possible.
-            max_workers (int, optional): Maximum number of workers for parallel execution.
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
-
-        Raises:
-            InvalidAlgorithmError: If the social_algorithm is not callable or invalid.
-            ValueError: If agents list is empty or invalid.
-        """
         self.algorithm_id = algorithm_id or str(uuid.uuid4())
         self.name = name
         self.description = description
@@ -161,31 +108,26 @@ class SocialAlgorithms:
         self.max_execution_time = max_execution_time
         self.output_type = output_type
         self.verbose = verbose
-        self.enable_communication_logging = (
-            enable_communication_logging
-        )
-        self.parallel_execution = parallel_execution
-        self.max_workers = max_workers
 
-        # Communication tracking
-        self.communication_history: List[CommunicationStep] = []
         self.execution_metadata: Dict[str, Any] = {}
+        self.conversation = Conversation(
+            name=f"{name}-Conversation", time_enabled=True
+        )
 
-        # Validate inputs
         self._validate_inputs()
 
         if self.verbose:
             logger.info(
-                f"Initialized SocialAlgorithm: {self.name} with {len(self.agents)} agents"
+                f"Initialized {self.name} with {len(self.agents)} agents"
             )
 
     def _validate_inputs(self) -> None:
         """
-        Validate the inputs provided to the SocialAlgorithms constructor.
+        Validate the constructor inputs.
 
         Raises:
             InvalidAlgorithmError: If the social_algorithm is not callable.
-            ValueError: If agents list is empty or invalid.
+            ValueError: If the agents list is empty or invalid.
         """
         if not self.agents:
             raise ValueError("At least one agent must be provided")
@@ -205,70 +147,162 @@ class SocialAlgorithms:
         if self.max_execution_time <= 0:
             raise ValueError("max_execution_time must be positive")
 
-    def _log_communication(
-        self,
-        sender_agent: str,
-        receiver_agent: str,
-        message: str,
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> None:
-        """
-        Log a communication step between agents.
+    def add_agent(self, agent: Agent) -> None:
+        if not isinstance(agent, Agent):
+            raise ValueError(
+                "Agent must be an instance of the Agent class"
+            )
 
-        Args:
-            sender_agent (str): Name of the sending agent.
-            receiver_agent (str): Name of the receiving agent.
-            message (str): The message being sent.
-            metadata (Dict[str, Any], optional): Additional metadata about the communication.
-        """
-        if not self.enable_communication_logging:
-            return
-
-        step = CommunicationStep(
-            step_id=str(uuid.uuid4()),
-            sender_agent=sender_agent,
-            receiver_agent=receiver_agent,
-            message=message,
-            timestamp=time.time(),
-            metadata=metadata,
-        )
-
-        self.communication_history.append(step)
+        self.agents.append(agent)
 
         if self.verbose:
             logger.info(
-                f"Communication: {sender_agent} -> {receiver_agent}: {message[:100]}..."
+                f"Added agent: {agent.agent_name} to {self.name}"
             )
 
-    def _log_execution_step(
+    def remove_agent(self, agent_name: str) -> None:
+        for index, agent in enumerate(self.agents):
+            if agent.agent_name == agent_name:
+                del self.agents[index]
+                break
+        else:
+            raise AgentNotFoundError(
+                f"No agent found with name: {agent_name}"
+            )
+
+        if self.verbose:
+            logger.info(f"Removed agent: {agent_name}")
+
+    def get_communication_history(self) -> List[Dict[str, Any]]:
+        """
+        Get the recorded agent messages.
+
+        Returns:
+            List[Dict[str, Any]]: The conversation messages, oldest first.
+        """
+        return list(self.conversation.conversation_history)
+
+    def clear_communication_history(self) -> None:
+        """Clear the recorded agent messages."""
+        self.conversation.conversation_history.clear()
+
+    def _log_communication(
         self,
-        step: str,
-        details: Optional[Dict[str, Any]] = None,
-        level: str = "info",
+        sender_agent: str,
+        message: Any,
+        receiver_agent: Optional[str] = None,
     ) -> None:
         """
-        Log a key execution step with optional details.
+        Record one agent message into the conversation.
 
         Args:
-            step (str): Description of the execution step.
-            details (Dict[str, Any], optional): Additional details about the step.
-            level (str): Log level ('info', 'debug', 'warning', 'error').
+            sender_agent (str): Name of the agent that produced the message.
+            message (Any): The message content.
+            receiver_agent (str, optional): Name of the receiving agent, for
+                agent-to-agent messages.
         """
-        if not self.verbose:
-            return
+        self.conversation.add(
+            role=sender_agent,
+            content=message,
+            metadata=(
+                {"receiver_agent": receiver_agent}
+                if receiver_agent
+                else None
+            ),
+        )
 
-        message = f"[{self.name}] {step}"
-        if details:
-            message += f" - Details: {details}"
+        if self.verbose:
+            logger.info(
+                f"{sender_agent} -> {receiver_agent or sender_agent}: {str(message)[:100]}"
+            )
 
-        if level == "debug":
-            logger.debug(message)
-        elif level == "warning":
-            logger.warning(message)
-        elif level == "error":
-            logger.error(message)
+    @contextmanager
+    def _recording_agents(self):
+        """
+        Route every agent's ``run`` and ``talk_to`` through the conversation log.
+
+        Patches the agent instances rather than the ``Agent`` class, so agents
+        outside this swarm and concurrent runs elsewhere are unaffected.
+
+        Yields:
+            None: For the duration of the algorithm call.
+        """
+        saved = [
+            (
+                agent,
+                agent.__dict__.get("run"),
+                agent.__dict__.get("talk_to"),
+            )
+            for agent in self.agents
+        ]
+
+        for agent in self.agents:
+            agent.run = self._recorded_run(agent)
+            agent.talk_to = self._recorded_talk_to(agent)
+
+        try:
+            yield
+        finally:
+            for agent, original_run, original_talk_to in saved:
+                self._restore(agent, "run", original_run)
+                self._restore(agent, "talk_to", original_talk_to)
+
+    @staticmethod
+    def _restore(agent: Agent, name: str, original: Any) -> None:
+        """
+        Undo one patched attribute on an agent.
+
+        Args:
+            agent (Agent): The agent to restore.
+            name (str): Attribute name that was patched.
+            original (Any): The prior instance attribute, or None if the agent
+                had none and should fall back to the class method.
+        """
+        if original is None:
+            agent.__dict__.pop(name, None)
         else:
-            logger.info(message)
+            agent.__dict__[name] = original
+
+    def _recorded_run(self, agent: Agent) -> Callable:
+        """
+        Build a ``run`` replacement that logs the agent's output.
+
+        Args:
+            agent (Agent): The agent being wrapped, before it is patched.
+
+        Returns:
+            Callable: A drop-in replacement for ``agent.run``.
+        """
+        # Whatever is bound now, so an instance override or an enclosing
+        # recorder still runs rather than being skipped for the class method.
+        original = agent.run
+
+        def run(task, *args, **kwargs):
+            result = original(task, *args, **kwargs)
+            self._log_communication(agent.agent_name, result)
+            return result
+
+        return run
+
+    def _recorded_talk_to(self, agent: Agent) -> Callable:
+        """
+        Build a ``talk_to`` replacement that logs the outgoing message.
+
+        Args:
+            agent (Agent): The agent being wrapped, before it is patched.
+
+        Returns:
+            Callable: A drop-in replacement for ``agent.talk_to``.
+        """
+        original = agent.talk_to
+
+        def talk_to(other, task, *args, **kwargs):
+            self._log_communication(
+                agent.agent_name, task, other.agent_name
+            )
+            return original(other, task, *args, **kwargs)
+
+        return talk_to
 
     def _execute_with_timeout(
         self, func: Callable, *args, **kwargs
@@ -331,58 +365,6 @@ class SocialAlgorithms:
 
         return result
 
-    def add_agent(self, agent: Agent) -> None:
-        """
-        Add an agent to the social algorithm.
-
-        Args:
-            agent (Agent): The agent to add.
-        """
-        if not isinstance(agent, Agent):
-            raise ValueError(
-                "Agent must be an instance of the Agent class"
-            )
-
-        self.agents.append(agent)
-
-        if self.verbose:
-            logger.info(f"Added agent: {agent.agent_name}")
-
-    def remove_agent(self, agent_name: str) -> None:
-        """
-        Remove an agent from the social algorithm.
-
-        Args:
-            agent_name (str): Name of the agent to remove.
-
-        Raises:
-            AgentNotFoundError: If no agent with the given name is found.
-        """
-        for index, agent in enumerate(self.agents):
-            if agent.agent_name == agent_name:
-                del self.agents[index]
-                break
-        else:
-            raise AgentNotFoundError(
-                f"No agent found with name: {agent_name}"
-            )
-
-        if self.verbose:
-            logger.info(f"Removed agent: {agent_name}")
-
-    def get_communication_history(self) -> List[CommunicationStep]:
-        """
-        Get the communication history for this algorithm execution.
-
-        Returns:
-            List[CommunicationStep]: List of communication steps.
-        """
-        return self.communication_history.copy()
-
-    def clear_communication_history(self) -> None:
-        """Clear the communication history."""
-        self.communication_history.clear()
-
     def run(
         self,
         task: str,
@@ -394,228 +376,84 @@ class SocialAlgorithms:
 
         Args:
             task (str): The task to execute using the social algorithm.
-            algorithm_args (Dict[str, Any], optional): Additional arguments for the algorithm.
-            **kwargs: Additional keyword arguments.
+            algorithm_args (Dict[str, Any], optional): Additional arguments for
+                the algorithm. Never mutated.
+            **kwargs: Additional keyword arguments, which win on conflict.
 
         Returns:
             SocialAlgorithmResult: The result of executing the social algorithm.
 
         Raises:
             InvalidAlgorithmError: If no social algorithm is defined.
-            TimeoutError: If the algorithm execution exceeds max_execution_time.
-            Exception: If the algorithm execution fails.
+            TimeoutError: If execution exceeds max_execution_time.
+            Exception: Whatever the algorithm raises.
         """
         if self.social_algorithm is None:
             raise InvalidAlgorithmError(
                 "No social algorithm defined. Please provide a callable algorithm."
             )
 
-        self._log_execution_step(
-            "Starting social algorithm execution",
-            {
-                "algorithm_name": self.name,
-                "task": task,
-                "agent_count": len(self.agents),
-                "agent_names": [
-                    agent.agent_name for agent in self.agents
-                ],
-                "max_execution_time": self.max_execution_time,
-            },
-        )
+        if self.verbose:
+            logger.info(
+                f"[{self.name}] Running {len(self.agents)} agents on: {task}"
+            )
 
-        # Clear previous communication history
-        self._log_execution_step(
-            "Clearing previous communication history"
-        )
-        self.clear_communication_history()
-
-        # Prepare algorithm arguments
-        self._log_execution_step(
-            "Preparing algorithm arguments",
-            {
-                "algorithm_args": algorithm_args,
-                "additional_kwargs": kwargs,
-            },
-        )
+        self.conversation.add(role="User", content=task)
+        opening_steps = len(self.conversation.conversation_history)
         algorithm_kwargs = {**(algorithm_args or {}), **kwargs}
 
-        # Add communication logging wrapper if enabled
-        if self.enable_communication_logging:
-            self._log_execution_step(
-                "Wrapping algorithm with communication logging"
-            )
-            wrapped_algorithm = self._wrap_algorithm_with_logging()
-            wrapped_algorithm.social_algorithms_instance = self
-        else:
-            self._log_execution_step(
-                "Using algorithm without communication logging"
-            )
-            wrapped_algorithm = self.social_algorithm
-
         start_time = time.time()
-        successful_steps = 0
         failed_steps = 0
 
         try:
-            # Execute the algorithm with timeout
-            if self.max_execution_time > 0:
-                self._log_execution_step(
-                    "Executing algorithm with timeout",
-                    {"timeout_seconds": self.max_execution_time},
-                )
-                result = self._execute_with_timeout(
-                    wrapped_algorithm,
-                    self.agents,
-                    task,
-                    **algorithm_kwargs,
-                )
-            else:
-                self._log_execution_step(
-                    "Executing algorithm without timeout"
-                )
-                result = wrapped_algorithm(
-                    self.agents, task, **algorithm_kwargs
-                )
-
-            successful_steps = len(self.communication_history)
-            self._log_execution_step(
-                "Algorithm execution completed successfully",
-                {
-                    "successful_steps": successful_steps,
-                    "communication_steps": len(
-                        self.communication_history
-                    ),
-                },
-            )
-
+            with self._recording_agents():
+                if self.max_execution_time > 0:
+                    result = self._execute_with_timeout(
+                        self.social_algorithm,
+                        self.agents,
+                        task,
+                        **algorithm_kwargs,
+                    )
+                else:
+                    result = self.social_algorithm(
+                        self.agents, task, **algorithm_kwargs
+                    )
         except TimeoutError:
-            self._log_execution_step(
-                "Algorithm execution timed out",
-                {"timeout_seconds": self.max_execution_time},
-                level="error",
+            logger.warning(
+                f"[{self.name}] Timed out after {self.max_execution_time}s"
             )
             raise
         except Exception as e:
-            self._log_execution_step(
-                "Algorithm execution failed",
-                {"error": str(e), "error_type": type(e).__name__},
-                level="error",
+            logger.error(
+                f"[{self.name}] Failed: {type(e).__name__}: {e}"
             )
             failed_steps = 1
             raise
         finally:
             execution_time = time.time() - start_time
 
-        # Format the output
-        self._log_execution_step(
-            "Formatting output", {"output_type": self.output_type}
+        successful_steps = (
+            len(self.conversation.conversation_history)
+            - opening_steps
         )
-        formatted_result = self._format_output(result)
+        self.conversation.add(role=self.name, content=result)
+        history = self.get_communication_history()
 
-        # Create result object
-        self._log_execution_step("Creating algorithm result object")
-        algorithm_result = SocialAlgorithmResult(
-            algorithm_id=self.algorithm_id,
-            execution_time=execution_time,
-            total_steps=len(self.communication_history),
-            successful_steps=successful_steps,
-            failed_steps=failed_steps,
-            communication_history=self.communication_history.copy(),
-            final_outputs=formatted_result,
-            metadata=self.execution_metadata,
-        )
-
-        self._log_execution_step(
-            "Algorithm execution completed",
-            {
-                "execution_time": f"{execution_time:.2f} seconds",
-                "total_communication_steps": len(
-                    self.communication_history
-                ),
-                "successful_steps": successful_steps,
-                "failed_steps": failed_steps,
-            },
-        )
-
-        return algorithm_result
-
-    def _wrap_algorithm_with_logging(self) -> Callable:
-        """
-        Wrap the social algorithm with communication logging.
-
-        Returns:
-            Callable: The wrapped algorithm with logging capabilities.
-        """
-
-        def wrapped_algorithm(agents, task, **kwargs):
-            # Store original agent methods
-            original_talk_to = Agent.talk_to
-            original_run = Agent.run
-
-            def logged_talk_to(
-                agent_self, agent, task, img=None, *args, **kwargs
-            ):
-                # Log the communication
-                self._log_communication(
-                    agent_self.agent_name, agent.agent_name, task
-                )
-                # Call original method
-                return original_talk_to(
-                    agent_self, agent, task, img, *args, **kwargs
-                )
-
-            def logged_run(
-                agent_self, task, img=None, *args, **kwargs
-            ):
-                # Log the communication (self-communication)
-                self._log_communication(
-                    agent_self.agent_name, agent_self.agent_name, task
-                )
-                # Call original method
-                return original_run(
-                    agent_self, task, img, *args, **kwargs
-                )
-
-            # Temporarily replace methods
-            Agent.talk_to = logged_talk_to
-            Agent.run = logged_run
-
-            try:
-                # Execute the algorithm
-                result = self.social_algorithm(agents, task, **kwargs)
-                return result
-            finally:
-                # Restore original methods
-                Agent.talk_to = original_talk_to
-                Agent.run = original_run
-
-        return wrapped_algorithm
-
-    def run_async(
-        self,
-        task: str,
-        algorithm_args: Optional[Dict[str, Any]] = None,
-        **kwargs,
-    ) -> SocialAlgorithmResult:
-        """
-        Execute the social algorithm asynchronously.
-
-        Args:
-            task (str): The task to execute using the social algorithm.
-            algorithm_args (Dict[str, Any], optional): Additional arguments for the algorithm.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            SocialAlgorithmResult: The result of executing the social algorithm.
-        """
-        import asyncio
-
-        async def async_execution():
-            return await asyncio.to_thread(
-                self.run, task, algorithm_args, **kwargs
+        if self.verbose:
+            logger.info(
+                f"[{self.name}] Completed in {execution_time:.2f}s over {successful_steps} messages"
             )
 
-        return asyncio.run(async_execution())
+        return SocialAlgorithmResult(
+            algorithm_id=self.algorithm_id,
+            execution_time=execution_time,
+            total_steps=successful_steps,
+            successful_steps=successful_steps,
+            failed_steps=failed_steps,
+            communication_history=history,
+            final_outputs=self._format_output(result),
+            metadata=self.execution_metadata,
+        )
 
     def get_algorithm_info(self) -> Dict[str, Any]:
         """
@@ -636,15 +474,4 @@ class SocialAlgorithms:
             "max_execution_time": self.max_execution_time,
             "output_type": self.output_type,
             "verbose": self.verbose,
-            "enable_communication_logging": self.enable_communication_logging,
-            "parallel_execution": self.parallel_execution,
-            "max_workers": self.max_workers,
         }
-
-    def __str__(self) -> str:
-        """String representation of the SocialAlgorithms instance."""
-        return f"SocialAlgorithms(name='{self.name}', agents={len(self.agents)}, algorithm_id='{self.algorithm_id}')"
-
-    def __repr__(self) -> str:
-        """Detailed string representation of the SocialAlgorithms instance."""
-        return f"SocialAlgorithms(algorithm_id='{self.algorithm_id}', name='{self.name}', agents={self.agents})"

--- a/tests/structs/test_social_algorithms.py
+++ b/tests/structs/test_social_algorithms.py
@@ -1,10 +1,27 @@
+import threading
+import time
+
 import pytest
 
 from swarms.structs.agent import Agent
 from swarms.structs.social_algorithms import (
     AgentNotFoundError,
+    InvalidAlgorithmError,
     SocialAlgorithms,
 )
+
+
+class FakeAgent(Agent):
+    """An Agent that answers locally, so tests need no model or API key."""
+
+    def __init__(self, name):
+        self.agent_name = name
+
+    def run(self, task, *args, **kwargs):
+        return f"{self.agent_name} handled: {task}"
+
+    def talk_to(self, other, task, *args, **kwargs):
+        return other.run(task)
 
 
 def _agent(name):
@@ -13,72 +30,510 @@ def _agent(name):
     return agent
 
 
-def _social_algorithm_with_agents(agent_names):
+def _bare(agent_names):
+    """Build an instance without __init__, for cases __init__ would reject."""
     social_algorithm = SocialAlgorithms.__new__(SocialAlgorithms)
     social_algorithm.agents = [_agent(name) for name in agent_names]
     social_algorithm.verbose = False
     return social_algorithm
 
 
-def test_remove_agent_removes_matching_agent_by_name():
-    social_algorithm = _social_algorithm_with_agents(
-        ["researcher", "critic"]
-    )
-
-    social_algorithm.remove_agent("researcher")
-
-    assert [
-        agent.agent_name for agent in social_algorithm.agents
-    ] == ["critic"]
-
-
-def test_remove_agent_preserves_remaining_agent_order():
-    social_algorithm = _social_algorithm_with_agents(
-        ["planner", "researcher", "critic", "writer"]
-    )
-
-    social_algorithm.remove_agent("critic")
-
-    assert [
-        agent.agent_name for agent in social_algorithm.agents
-    ] == ["planner", "researcher", "writer"]
-
-
-def test_remove_agent_raises_agent_not_found_for_unknown_name():
-    social_algorithm = _social_algorithm_with_agents(["researcher"])
-
-    with pytest.raises(AgentNotFoundError):
-        social_algorithm.remove_agent("critic")
-
-
-def test_remove_agent_raises_agent_not_found_for_empty_agent_list():
-    social_algorithm = _social_algorithm_with_agents([])
-
-    with pytest.raises(AgentNotFoundError):
-        social_algorithm.remove_agent("researcher")
-
-
-def test_run_does_not_write_kwargs_into_the_callers_algorithm_args():
-    seen = {}
-
-    def algorithm(agents, task, **kwargs):
-        seen.clear()
-        seen.update(kwargs)
-        return "ok"
-
-    social_algorithm = SocialAlgorithms(
-        agents=[_agent("worker")],
+def _swarm(algorithm, names=("Researcher", "Analyst"), **kwargs):
+    return SocialAlgorithms(
+        name="Demo",
+        agents=[FakeAgent(name) for name in names],
         social_algorithm=algorithm,
-    )
-    shared = {"depth": 3}
-
-    social_algorithm.run(
-        "first", algorithm_args=shared, temperature=0.2
+        **kwargs,
     )
 
-    assert shared == {"depth": 3}
-    assert seen == {"depth": 3, "temperature": 0.2}
 
-    social_algorithm.run("second", algorithm_args=shared)
+def _roles(swarm):
+    return [
+        message["role"]
+        for message in swarm.conversation.conversation_history
+    ]
 
-    assert seen == {"depth": 3}
+
+def _pipeline(agents, task, **kwargs):
+    research = agents[0].run(f"Research: {task}")
+    return agents[1].run(f"Analyze: {research}")
+
+
+class TestValidation:
+    def test_empty_agent_list_is_rejected(self):
+        with pytest.raises(ValueError, match="At least one agent"):
+            SocialAlgorithms(agents=[], social_algorithm=len)
+
+    def test_non_agent_members_are_rejected(self):
+        with pytest.raises(
+            ValueError, match="instances of the Agent"
+        ):
+            SocialAlgorithms(
+                agents=["not-an-agent"], social_algorithm=len
+            )
+
+    def test_non_callable_algorithm_is_rejected(self):
+        with pytest.raises(InvalidAlgorithmError):
+            SocialAlgorithms(
+                agents=[FakeAgent("A")], social_algorithm="nope"
+            )
+
+    def test_non_positive_max_execution_time_is_rejected(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            SocialAlgorithms(
+                agents=[FakeAgent("A")],
+                social_algorithm=len,
+                max_execution_time=0,
+            )
+
+    def test_run_without_an_algorithm_is_rejected(self):
+        swarm = SocialAlgorithms(agents=[FakeAgent("A")])
+
+        with pytest.raises(InvalidAlgorithmError):
+            swarm.run("t")
+
+    def test_unknown_constructor_kwargs_are_tolerated(self):
+        """Retired parameters must not break callers that still pass them."""
+        swarm = _swarm(
+            _pipeline,
+            enable_communication_logging=False,
+            parallel_execution=True,
+        )
+
+        assert swarm.run("t").total_steps == 2
+
+
+class TestAgentRoster:
+    def test_add_agent_appends(self):
+        swarm = _swarm(_pipeline)
+
+        swarm.add_agent(FakeAgent("Writer"))
+
+        assert [a.agent_name for a in swarm.agents] == [
+            "Researcher",
+            "Analyst",
+            "Writer",
+        ]
+
+    def test_add_agent_rejects_non_agents(self):
+        swarm = _swarm(_pipeline)
+
+        with pytest.raises(ValueError):
+            swarm.add_agent("not-an-agent")
+
+    def test_agent_added_after_construction_is_recorded(self):
+        swarm = _swarm(
+            lambda agents, task, **kwargs: agents[-1].run(task)
+        )
+        swarm.add_agent(FakeAgent("Writer"))
+
+        swarm.run("t")
+
+        assert "Writer" in _roles(swarm)
+
+    def test_remove_agent_removes_matching_agent_by_name(self):
+        swarm = _bare(["researcher", "critic"])
+
+        swarm.remove_agent("researcher")
+
+        assert [a.agent_name for a in swarm.agents] == ["critic"]
+
+    def test_remove_agent_preserves_remaining_agent_order(self):
+        swarm = _bare(["planner", "researcher", "critic", "writer"])
+
+        swarm.remove_agent("critic")
+
+        assert [a.agent_name for a in swarm.agents] == [
+            "planner",
+            "researcher",
+            "writer",
+        ]
+
+    def test_remove_agent_raises_agent_not_found_for_unknown_name(
+        self,
+    ):
+        with pytest.raises(AgentNotFoundError):
+            _bare(["researcher"]).remove_agent("critic")
+
+    def test_remove_agent_raises_agent_not_found_for_empty_agent_list(
+        self,
+    ):
+        with pytest.raises(AgentNotFoundError):
+            _bare([]).remove_agent("researcher")
+
+
+class TestConversationRecording:
+    def test_task_agents_and_result_are_recorded_in_order(self):
+        swarm = _swarm(_pipeline)
+
+        swarm.run("AI in healthcare")
+
+        assert _roles(swarm) == [
+            "User",
+            "Researcher",
+            "Analyst",
+            "Demo",
+        ]
+
+    def test_agent_output_is_the_recorded_content(self):
+        swarm = _swarm(_pipeline)
+
+        swarm.run("t")
+
+        contents = [
+            m["content"]
+            for m in swarm.conversation.conversation_history
+        ]
+        assert contents[0] == "t"
+        assert contents[1] == "Researcher handled: Research: t"
+        assert contents[2].startswith("Analyst handled: Analyze:")
+        assert contents[3] == contents[2]
+
+    def test_talk_to_records_the_receiver(self):
+        swarm = _swarm(
+            lambda agents, task, **kwargs: agents[0].talk_to(
+                agents[1], task
+            )
+        )
+
+        swarm.run("question")
+
+        sender = swarm.conversation.conversation_history[1]
+        assert sender["role"] == "Researcher"
+        assert sender["content"] == "question"
+
+    def test_repeated_agent_calls_are_all_recorded(self):
+        def chatty(agents, task, **kwargs):
+            for i in range(3):
+                agents[0].run(f"{task}-{i}")
+            return "done"
+
+        swarm = _swarm(chatty)
+
+        swarm.run("t")
+
+        assert _roles(swarm).count("Researcher") == 3
+
+    def test_conversation_accumulates_across_runs(self):
+        swarm = _swarm(_pipeline)
+
+        swarm.run("first")
+        swarm.run("second")
+
+        assert len(swarm.conversation.conversation_history) == 8
+
+    def test_clear_communication_history_empties_the_transcript(self):
+        swarm = _swarm(_pipeline)
+        swarm.run("t")
+
+        swarm.clear_communication_history()
+
+        assert swarm.get_communication_history() == []
+
+    def test_get_communication_history_returns_a_copy(self):
+        swarm = _swarm(_pipeline)
+        swarm.run("t")
+
+        swarm.get_communication_history().clear()
+
+        assert len(swarm.conversation.conversation_history) == 4
+
+    def test_a_nested_swarm_does_not_hide_calls_from_the_outer_one(
+        self,
+    ):
+        """The inner recorder must chain to the outer one, not replace it."""
+        shared = FakeAgent("Shared")
+        inner = SocialAlgorithms(
+            name="Inner",
+            agents=[shared],
+            social_algorithm=lambda agents, task, **kwargs: agents[
+                0
+            ].run(task),
+        )
+        outer = SocialAlgorithms(
+            name="Outer",
+            agents=[shared],
+            social_algorithm=lambda agents, task, **kwargs: inner.run(
+                "nested"
+            ),
+        )
+
+        outer.run("t")
+
+        assert "Shared" in _roles(outer)
+
+
+class TestAgentRestoration:
+    def test_agents_are_unpatched_after_a_successful_run(self):
+        swarm = _swarm(_pipeline)
+
+        swarm.run("t")
+
+        for agent in swarm.agents:
+            assert "run" not in agent.__dict__
+            assert "talk_to" not in agent.__dict__
+
+    def test_agents_are_unpatched_after_the_algorithm_raises(self):
+        def boom(agents, task, **kwargs):
+            agents[0].run(task)
+            raise RuntimeError("boom")
+
+        swarm = _swarm(boom)
+
+        with pytest.raises(RuntimeError):
+            swarm.run("t")
+
+        assert "run" not in swarm.agents[0].__dict__
+
+    def test_agents_still_work_normally_after_a_run(self):
+        swarm = _swarm(_pipeline)
+        swarm.run("t")
+
+        assert (
+            swarm.agents[0].run("ping") == "Researcher handled: ping"
+        )
+
+    def test_a_pre_existing_instance_override_is_used_and_restored(
+        self,
+    ):
+        agent = FakeAgent("Custom")
+        agent.run = lambda task, *a, **k: f"override:{task}"
+        swarm = SocialAlgorithms(
+            name="Demo",
+            agents=[agent],
+            social_algorithm=lambda agents, task, **kwargs: agents[
+                0
+            ].run(task),
+        )
+
+        swarm.run("t")
+
+        assert (
+            swarm.conversation.conversation_history[1]["content"]
+            == "override:t"
+        )
+        assert agent.run("x") == "override:x"
+
+    def test_the_other_agents_class_is_untouched(self):
+        """Patching is per instance, so bystander agents must be unaffected."""
+        bystander = FakeAgent("Bystander")
+        swarm = _swarm(_pipeline)
+
+        swarm.run("t")
+
+        assert bystander.run("x") == "Bystander handled: x"
+        assert "run" not in bystander.__dict__
+
+
+class TestOutputFormatting:
+    def test_dict_output_wraps_a_non_dict_result(self):
+        assert _swarm(lambda a, t, **k: "plain").run(
+            "t"
+        ).final_outputs == {"result": "plain"}
+
+    def test_dict_output_passes_a_dict_through(self):
+        payload = {"a": 1}
+
+        assert (
+            _swarm(lambda a, t, **k: payload).run("t").final_outputs
+            is payload
+        )
+
+    def test_list_output_wraps_a_non_list_result(self):
+        swarm = _swarm(lambda a, t, **k: "plain", output_type="list")
+
+        assert swarm.run("t").final_outputs == ["plain"]
+
+    def test_str_output_stringifies(self):
+        swarm = _swarm(lambda a, t, **k: 42, output_type="str")
+
+        assert swarm.run("t").final_outputs == "42"
+
+    def test_a_none_result_is_handled(self):
+        assert _swarm(lambda a, t, **k: None).run(
+            "t"
+        ).final_outputs == {"result": None}
+
+
+class TestResultAccounting:
+    def test_total_steps_counts_only_agent_messages(self):
+        result = _swarm(_pipeline).run("t")
+
+        assert result.total_steps == 2
+        assert result.successful_steps == 2
+
+    def test_step_counts_are_per_run_not_cumulative(self):
+        swarm = _swarm(_pipeline)
+        swarm.run("first")
+
+        assert swarm.run("second").total_steps == 2
+
+    def test_failed_steps_is_zero_on_success(self):
+        assert _swarm(_pipeline).run("t").failed_steps == 0
+
+    def test_execution_time_is_recorded(self):
+        assert _swarm(_pipeline).run("t").execution_time >= 0
+
+    def test_algorithm_id_is_carried_into_the_result(self):
+        swarm = _swarm(_pipeline)
+
+        assert swarm.run("t").algorithm_id == swarm.algorithm_id
+
+    def test_communication_history_matches_the_conversation(self):
+        swarm = _swarm(_pipeline)
+
+        result = swarm.run("t")
+
+        assert (
+            result.communication_history
+            == swarm.conversation.conversation_history
+        )
+
+
+class TestErrorHandling:
+    def test_the_algorithms_exception_propagates(self):
+        swarm = _swarm(
+            lambda a, t, **k: (_ for _ in ()).throw(KeyError("nope"))
+        )
+
+        with pytest.raises(KeyError):
+            swarm.run("t")
+
+    def test_no_result_message_is_recorded_on_failure(self):
+        def boom(agents, task, **kwargs):
+            agents[0].run(task)
+            raise RuntimeError("boom")
+
+        swarm = _swarm(boom)
+
+        with pytest.raises(RuntimeError):
+            swarm.run("t")
+
+        assert _roles(swarm) == ["User", "Researcher"]
+
+
+class TestAlgorithmArgs:
+    def test_run_does_not_write_kwargs_into_the_callers_dict(self):
+        seen = {}
+
+        def algorithm(agents, task, **kwargs):
+            seen.clear()
+            seen.update(kwargs)
+            return "ok"
+
+        swarm = _swarm(algorithm)
+        shared = {"depth": 3}
+
+        swarm.run("first", algorithm_args=shared, temperature=0.2)
+
+        assert shared == {"depth": 3}
+        assert seen == {"depth": 3, "temperature": 0.2}
+
+        swarm.run("second", algorithm_args=shared)
+
+        assert seen == {"depth": 3}
+
+    def test_kwargs_win_over_algorithm_args_on_conflict(self):
+        seen = {}
+
+        def algorithm(agents, task, **kwargs):
+            seen.update(kwargs)
+            return "ok"
+
+        _swarm(algorithm).run(
+            "t", algorithm_args={"depth": 1}, depth=9
+        )
+
+        assert seen == {"depth": 9}
+
+    def test_the_task_reaches_the_algorithm(self):
+        seen = {}
+
+        def algorithm(agents, task, **kwargs):
+            seen["task"] = task
+            return "ok"
+
+        _swarm(algorithm).run("the actual task")
+
+        assert seen["task"] == "the actual task"
+
+
+class TestTimeout:
+    """The timeout is SIGALRM-based, so it only works on the main thread."""
+
+    def test_a_generous_timeout_does_not_interfere(self):
+        swarm = _swarm(_pipeline, max_execution_time=30)
+
+        assert swarm.run("t").total_steps == 2
+
+    def test_disabling_the_timeout_still_runs(self):
+        swarm = _swarm(_pipeline)
+        swarm.max_execution_time = 0
+
+        assert swarm.run("t").total_steps == 2
+
+    @pytest.mark.xfail(
+        reason="signal.alarm truncates to int, so alarm(0) cancels the timeout",
+        strict=False,
+    )
+    def test_a_sub_second_budget_still_times_out(self):
+        def slow(agents, task, **kwargs):
+            time.sleep(2)
+            return "never"
+
+        swarm = _swarm(slow, max_execution_time=0.2)
+
+        with pytest.raises(TimeoutError):
+            swarm.run("t")
+
+    @pytest.mark.xfail(
+        reason="signal.signal cannot be called off the main thread",
+        strict=False,
+    )
+    def test_run_works_on_a_worker_thread(self):
+        swarm = _swarm(_pipeline)
+        outcome = {}
+
+        def worker():
+            try:
+                outcome["steps"] = swarm.run("t").total_steps
+            except BaseException as exc:
+                outcome["error"] = exc
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+        assert outcome.get("steps") == 2
+
+    @pytest.mark.xfail(
+        reason="run_async runs on a worker thread, where SIGALRM is unavailable",
+        strict=False,
+    )
+    def test_run_async_works_on_the_default_configuration(self):
+        assert _swarm(_pipeline).run_async("t").total_steps == 2
+
+
+class TestAlgorithmInfo:
+    def test_reports_the_current_roster(self):
+        swarm = _swarm(_pipeline)
+        swarm.add_agent(FakeAgent("Writer"))
+
+        info = swarm.get_algorithm_info()
+
+        assert info["agent_count"] == 3
+        assert info["agent_names"] == [
+            "Researcher",
+            "Analyst",
+            "Writer",
+        ]
+        assert info["has_algorithm"] is True
+
+    def test_reports_no_algorithm_when_unset(self):
+        swarm = SocialAlgorithms(agents=[FakeAgent("A")])
+
+        assert swarm.get_algorithm_info()["has_algorithm"] is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Why

`SocialAlgorithms` tracked agent communication by hand: a `CommunicationStep` dataclass, a `communication_history` list, and a `_log_communication` method — all gated behind `enable_communication_logging`, which **defaulted to `False`**. Out of the box the structure recorded nothing, and there was no way to read the transcript through the API every other structure uses.

Every other multi-agent structure in `swarms/structs` already owns a `Conversation` for exactly this. This adopts it.

## What

**`Conversation` is now the transcript.** The task lands as `User`, every agent call is recorded under that agent's own `agent_name`, and the final result under the swarm name — with no cooperation from the algorithm itself:

```
User: AI in healthcare
Researcher: Researcher handled: Research: AI in healthcare
Analyst:    Analyst handled: Analyze: ...
Demo:       Analyst handled: Analyze: ...
```

`talk_to` records the receiver in the message metadata. The conversation accumulates across runs; `clear_communication_history()` resets it.

**Instance patching instead of class patching.** The old `_wrap_algorithm_with_logging` replaced `Agent.talk_to` and `Agent.run` on the **class**, so a single run monkeypatched every agent in the process for its duration. That was survivable while logging was off by default; it is not something to leave permanently on. `_recording_agents()` now patches only the instances in `self.agents` and restores them in a `finally`. Bystander agents and other swarms are untouched.

Recorders capture whatever is currently bound rather than reaching for `type(agent).run`, so a nested swarm chains to the outer one instead of shadowing it, and a caller's own `agent.run = ...` override still runs.

**`_log_execution_step` is gone**, along with its 13 call sites. They narrated the code — `"Clearing previous communication history"`, `"Preparing algorithm arguments"`, `"Creating algorithm result object"`. What remains is two `logger.info` calls gated on `verbose`, plus `logger.warning` on timeout and `logger.error` on failure. Those two no longer depend on `verbose`: previously the helper's early return swallowed every error unless you had opted into verbose logging.

**Dead weight removed:** `CommunicationStep` (the conversation stores messages), and `parallel_execution` / `max_workers`, which were stored and echoed in `get_algorithm_info` but never used for anything.

`swarms/structs/social_algorithms.py`: **650 → 514 lines.**

## Behaviour changes worth a second opinion

1. **`enable_communication_logging` is retired and recording is unconditional.** Leaving it off by default would have meant integrating `Conversation` and then recording nothing. Callers still passing it are swallowed by `**kwargs` rather than raising — covered by `test_unknown_constructor_kwargs_are_tolerated`. Say the word if you want it kept as a real switch.
2. **`communication_history` is now `List[Dict]`**, not `List[CommunicationStep]`. Nothing in the repo or the 13 examples read it.
3. The public surface the examples actually use — `final_outputs`, `total_steps`, `execution_time`, and the constructor kwargs — is unchanged.

## Tests

`tests/structs/test_social_algorithms.py`: **5 tests → 49**, in 10 classes covering validation, roster changes, conversation recording, agent restoration, output formatting, result accounting, error handling, algorithm args, timeouts and `get_algorithm_info`.

Agents are a local `FakeAgent(Agent)` subclass that answers without a model, so the suite needs no API key and no mocking.

Shown to fail against unpatched `master` (run from a detached worktree, not the working tree):

```
master:   16 failed, 30 passed, 3 xfailed
this PR:  46 passed, 3 xfailed
```

The 16 baseline failures are the recording, accounting, restoration and tolerance tests — the behaviour this PR adds.

## Known-broken, marked xfail

Three tests are `xfail(strict=False)` for the pre-existing `SIGALRM` timeout bugs in #2070, so they document the breakage now and flip to passing when #2073 lands:

- `test_a_sub_second_budget_still_times_out` — `signal.alarm(int(0.2))` is `alarm(0)`, which *cancels* the alarm; a 2s sleep runs to completion under a 0.2s budget
- `test_run_works_on_a_worker_thread` — `ValueError: signal only works in main thread`
- `test_run_async_works_on_the_default_configuration` — same, via `asyncio.to_thread`

`_execute_with_timeout` is left **byte-identical to master** so this does not collide with #2073's fix.

## Example

`examples/multi_agent/social_algorithms_examples/social_algorithms_example.py` — a peer-review pattern (research → critique → revise → edit) where the algorithm loops back to the researcher after each critique, which is the thing that distinguishes this structure from `SequentialWorkflow`. Drives the loop count through `algorithm_args={"rounds": 2}` and prints the auto-recorded transcript.

Verified by parsing `peer_review` out of the file and running it against stand-in agents, so no API call:

```
final_outputs['result'] -> <Editor output>
total_steps -> 6
roles -> ['User', 'Researcher', 'Critic', 'Researcher', 'Critic', 'Researcher', 'Editor', 'Peer-Review']
```

## Validation

- `python3 -m black --line-length 70` — unchanged
- `python3 -m ruff check .` — all checks passed
- Tests run offline with `OPENAI_API_KEY=""` / `ANTHROPIC_API_KEY=""`
