### PR TITLE
fix(agent-rearrange): isolate concurrent tasks

### DIFF
--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -944,7 +944,7 @@ class AgentRearrange(SerializableMixin):
         return self.run(task=task, *args, **kwargs)
 
     def _clone_for_task(self) -> "AgentRearrange":
-        """Build an isolated clone of this orchestrator for one batch_run task.
+        """Build an isolated clone of this orchestrator for one task.
 
         Each clone gets:
         - A fresh ``Conversation`` so per-task history does not bleed across
@@ -1088,8 +1088,14 @@ class AgentRearrange(SerializableMixin):
             The number of concurrent executions is limited by max_workers parameter.
             Each task runs independently through the full agent workflow.
         """
+
+        def run_isolated(task, *run_args, **run_kwargs):
+            return self._clone_for_task().run(
+                task, *run_args, **run_kwargs
+            )
+
         return run_concurrently(
-            self.run,
+            run_isolated,
             tasks,
             *args,
             img=img,

--- a/tests/structs/test_agent_rearrange.py
+++ b/tests/structs/test_agent_rearrange.py
@@ -1371,5 +1371,70 @@ class TestAgentContextManagement:
         ), f"the second task never reached the agent: {messages}"
 
 
+# ============================================================================
+# concurrent_run — per-task isolation
+# ============================================================================
+
+
+class TestConcurrentRunIsolation:
+    def test_each_task_gets_own_clone_conversation(self):
+        pipeline = _make_pipeline("AgentA", "AgentB")
+        tasks = ["alpha", "beta", "gamma"]
+        seen_conversations = []
+        parent_conversation = pipeline.conversation
+        parent_message_count = len(
+            parent_conversation.conversation_history
+        )
+
+        def _mock_run(self_inner, task=None, img=None, *a, **kw):
+            seen_conversations.append(self_inner.conversation)
+            self_inner.conversation.add("user", task)
+            return f"result:{task}"
+
+        with patch.object(AgentRearrange, "_run", _mock_run):
+            results = pipeline.concurrent_run(
+                tasks=tasks, max_workers=1
+            )
+
+        assert results == [f"result:{task}" for task in tasks]
+        assert len(seen_conversations) == len(tasks)
+        assert all(
+            conversation is not parent_conversation
+            for conversation in seen_conversations
+        )
+        assert len({id(c) for c in seen_conversations}) == len(tasks)
+        assert (
+            len(parent_conversation.conversation_history)
+            == parent_message_count
+        )
+
+    def test_img_pairing_survives_isolated_closure(self):
+        pipeline = _make_pipeline("AgentA", "AgentB")
+        tasks = ["t1", "t2", "t3"]
+        images = ["img1.png", "img2.png", "img3.png"]
+        received = []
+        parent_conversation = pipeline.conversation
+
+        def _mock_run(self_inner, task=None, img=None, *a, **kw):
+            received.append((task, img, self_inner.conversation))
+            return f"{task}:{img}"
+
+        with patch.object(AgentRearrange, "_run", _mock_run):
+            results = pipeline.concurrent_run(
+                tasks=tasks, img=images, max_workers=1
+            )
+
+        assert results == [
+            f"{task}:{img}" for task, img in zip(tasks, images)
+        ]
+        assert [(task, img) for task, img, _ in received] == list(
+            zip(tasks, images)
+        )
+        assert all(
+            conversation is not parent_conversation
+            for _, _, conversation in received
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Replacement for #1954, opened with fresh commit history per maintainer request.

Keeps `AgentRearrange.concurrent_run()` on the shared `run_concurrently(...)` abstraction while ensuring each task executes through a fresh `_clone_for_task()` orchestrator, giving each task an isolated Conversation.

`execution_utils` continues to own image pairing, validation, ordering, concurrency, and argument forwarding.

## Tests

- `uv run --no-sync python -m pytest tests/structs/test_agent_rearrange.py::TestConcurrentRunIsolation -q` - 2 passed, 1 warning
- `uv run --no-sync python -m pytest tests/structs/test_agent_rearrange.py -q --tb=short -ra` - 9 failed, 63 passed, 1 warning
- upstream `master` baseline for `tests/structs/test_agent_rearrange.py` - same 9 failures, 61 passed, 1 warning
- `uv run --no-sync python -m pytest tests/structs/test_execution_utils.py -q --tb=short -ra` - 43 passed, 1 warning
- `uv run --no-sync black --check swarms/structs/agent_rearrange.py tests/structs/test_agent_rearrange.py` - passed
- `uv run --no-sync ruff check swarms/structs/agent_rearrange.py tests/structs/test_agent_rearrange.py` - passed
- `git diff --check` - passed
- `git show --check --stat HEAD` - passed

The AgentRearrange module failures are existing upstream baseline failures, not introduced here.

Replaces #1954.
