### PR TITLE
[Fix] MultiAgentRouter runs and bills every selected agent, then keeps only the first answer (#2044)

### DIFF
--- a/swarms/structs/multi_agent_router.py
+++ b/swarms/structs/multi_agent_router.py
@@ -292,14 +292,14 @@ class MultiAgentRouter:
         self, boss_response_str: dict, task: str
     ) -> None:
         """
-        Execute every agent selected by the boss and record the first response.
+        Execute every agent selected by the boss and record every response.
 
         Validates that every ``agent_name`` referenced in ``boss_response_str``
         exists before running anything. Each agent is run with its boss-supplied
         task (or the original ``task`` when the boss did not rewrite it). When
         ``skip_null_tasks`` is True, agents whose resolved task is empty or
-        ``None`` are skipped. After execution, the first selected agent's
-        response is appended to ``self.conversation``.
+        ``None`` are skipped. After execution, each selected agent's response is
+        appended to ``self.conversation`` under that agent's own name.
 
         Args:
             boss_response_str (dict): Parsed boss decision containing a
@@ -366,12 +366,12 @@ class MultiAgentRouter:
                     )
                 )
 
-            self.conversation.add(
-                role=selected_agents[0].agent_name,
-                content=agent_responses[0],
-            )
-
-        # return agent_responses
+            for agent, agent_response in zip(
+                selected_agents, agent_responses
+            ):
+                self.conversation.add(
+                    role=agent.agent_name, content=agent_response
+                )
 
     def route_task(self, task: str) -> dict:
         """

--- a/tests/structs/test_multi_agent_router.py
+++ b/tests/structs/test_multi_agent_router.py
@@ -5,6 +5,7 @@ import time
 import pytest
 
 from swarms.structs.agent import Agent
+from swarms.structs.conversation import Conversation
 from swarms.structs.multi_agent_router import MultiAgentRouter
 
 
@@ -544,6 +545,137 @@ def test_concurrent_batch_run_returns_results_in_input_order():
         "ok:a",
         "ok:c",
     ]
+
+
+def _stubbed_router(names=("Agent1", "Agent2", "Agent3")):
+    agents = []
+    for name in names:
+        agent = Agent.__new__(Agent)
+        agent.agent_name = name
+        agent.run = (
+            lambda task, _name=name: f"{_name} answered: {task}"
+        )
+        agents.append(agent)
+
+    router = MultiAgentRouter.__new__(MultiAgentRouter)
+    router.agents = agents
+    router.skip_null_tasks = True
+    router.print_on = False
+    router.conversation = Conversation()
+    return router
+
+
+def _handoffs(*pairs):
+    return {
+        "handoffs": [
+            {"agent_name": name, "task": task} for name, task in pairs
+        ]
+    }
+
+
+def _recorded(router):
+    return [
+        (message["role"], message["content"])
+        for message in router.conversation.conversation_history
+    ]
+
+
+def test_every_selected_agent_response_is_recorded():
+    router = _stubbed_router()
+
+    router.handle_multiple_handoffs(
+        _handoffs(
+            ("Agent1", "research it"),
+            ("Agent2", "code it"),
+            ("Agent3", "review it"),
+        ),
+        "original task",
+    )
+
+    assert _recorded(router) == [
+        ("Agent1", "Agent1 answered: research it"),
+        ("Agent2", "Agent2 answered: code it"),
+        ("Agent3", "Agent3 answered: review it"),
+    ]
+
+
+def test_no_agent_is_run_and_then_discarded():
+    router = _stubbed_router()
+
+    router.handle_multiple_handoffs(
+        _handoffs(("Agent1", "a"), ("Agent2", "b"), ("Agent3", "c")),
+        "original task",
+    )
+
+    assert len(router.conversation.conversation_history) == 3
+
+
+def test_each_response_is_recorded_under_its_own_agent_name():
+    router = _stubbed_router()
+
+    router.handle_multiple_handoffs(
+        _handoffs(("Agent2", "b"), ("Agent1", "a")), "original task"
+    )
+
+    roles = [role for role, _ in _recorded(router)]
+    assert roles == ["Agent2", "Agent1"]
+
+
+def test_a_single_handoff_is_unchanged():
+    router = _stubbed_router()
+
+    router.handle_multiple_handoffs(
+        _handoffs(("Agent2", "only task")), "original task"
+    )
+
+    assert _recorded(router) == [
+        ("Agent2", "Agent2 answered: only task")
+    ]
+
+
+def test_skipped_agents_are_not_recorded():
+    router = _stubbed_router()
+
+    router.handle_multiple_handoffs(
+        {
+            "handoffs": [
+                {"agent_name": "Agent1", "task": "real work"},
+                {"agent_name": "Agent2", "task": None},
+                {"agent_name": "Agent3", "task": ""},
+            ]
+        },
+        "",
+    )
+
+    assert _recorded(router) == [
+        ("Agent1", "Agent1 answered: real work")
+    ]
+
+
+def test_a_handoff_with_no_task_falls_back_to_the_original():
+    router = _stubbed_router()
+
+    router.handle_multiple_handoffs(
+        _handoffs(("Agent1", None), ("Agent2", "explicit")),
+        "original task",
+    )
+
+    assert _recorded(router) == [
+        ("Agent1", "Agent1 answered: original task"),
+        ("Agent2", "Agent2 answered: explicit"),
+    ]
+
+
+def test_an_unknown_agent_is_rejected_before_anything_runs():
+    router = _stubbed_router()
+
+    with pytest.raises(ValueError, match="unknown agent"):
+        router.handle_multiple_handoffs(
+            _handoffs(("Agent1", "a"), ("Nobody", "b")),
+            "original task",
+        )
+
+    assert router.conversation.conversation_history == []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2044.

`MultiAgentRouter.handle_multiple_handoffs` ran every agent the boss selected and then recorded only the first one's answer. **Whenever the boss selected more than one agent, the caller paid for N completions and received one**, with nothing logged or warned about the rest.

## Problem

`swarms/structs/multi_agent_router.py:371-386`:

```python
        # Execute agents only if there are valid tasks
        if selected_agents:
            # Use the agents' run method directly
            agent_responses = [
                agent.run(final_task)
                for agent, final_task in zip(
                    selected_agents, final_tasks
                )
            ]

            self.conversation.add(
                role=selected_agents[0].agent_name,
                content=agent_responses[0],
            )

        # return agent_responses
```

`agent_responses[1:]` is never read. Two consequences:

- **Spend is silently discarded.** Each dropped agent has already made a completion call by the time the list comprehension finishes.
- **It is invisible.** Nothing distinguishes "the boss picked one agent" from "the boss picked four and three answers were thrown away" — the conversation looks identical.

The dangling `# return agent_responses` on the following line is the remnant of the refactor that left it this way; the method's own docstring said "record the first response", so the code and its documentation agreed on the wrong behavior.

## Fix

```python
            for agent, agent_response in zip(
                selected_agents, agent_responses
            ):
                self.conversation.add(
                    role=agent.agent_name, content=agent_response
                )
```

Every response is recorded under **its own** agent's name, in the order the agents were run. The docstring is corrected to match, and the commented-out return — which described exactly the discarded values — is removed.

## Files

| File | Change |
|---|---|
| `swarms/structs/multi_agent_router.py` | record all responses; docstring corrected; dead commented-out return removed |
| `tests/structs/test_multi_agent_router.py` | 7 tests appended to the existing file |

## Design decisions

- **Record all, rather than run one.** The issue notes the alternative: if returning a single answer is intended, only one agent should be run. That would be a behavior change to the boss contract — `handoffs` is a list and the boss prompt actively invites multiple entries — so the conservative reading is that running all of them was intended and the recording was the half left unfinished.
- **Attribute each message to its own agent.** Recording all four answers under `selected_agents[0].agent_name` would have been a smaller diff and is wrong: a downstream reader filtering the conversation by agent would attribute three agents' work to the first.
- **Order follows execution order.** `zip(selected_agents, agent_responses)` reuses the list built alongside `final_tasks`, so the recorded order matches the order the agents actually ran, not the boss's original list — which can differ once `skip_null_tasks` drops entries.

## Deliberately not in this PR

The issue lists two neighbours in the same file. Both are left alone, each its own concern:

- **Raw transcripts recorded rather than answers** (`:301-305` has the same shape) — `Agent.run` honours `output_type`, defaulting to `"str-all-except-first"`. Fixing that means routing through `context_utils.agent_answer` at both sites and changes what every existing caller reads out of the conversation.
- **`concurrent_batch_run` races on one shared `Conversation`** (`:485`) — that is the per-task conversation isolation work, not this.

## Behavior-change note

Callers reading `self.conversation` after a multi-agent handoff now see **one message per agent** instead of one message total. Anything that indexed `conversation_history[-1]` expecting the sole handoff result will now get the last agent's answer rather than the first's. Single-agent handoffs, `skip_null_tasks` skipping, and the up-front unknown-agent validation are all unchanged — each is covered by a test below.

## Verification

- **Unit**: 7 tests appended to the existing `tests/structs/test_multi_agent_router.py`. No new test file.

  ```
  $ .venv/bin/python -m pytest tests/structs/test_multi_agent_router.py -q \
      -k "every_selected or run_and_then_discarded or own_agent_name or \
          single_handoff_is_unchanged or skipped_agents or falls_back or \
          unknown_agent_is_rejected"
  7 passed, 24 deselected in 2.39s
  ```

  Covered: all three answers kept; one message per agent run; each recorded under its own name; a single handoff unchanged; skipped null-task agents contribute nothing; a handoff with no rewritten task falls back to the original; an unknown agent raises before anything runs and leaves the conversation empty.

- **The tests fail on the unfixed base.** Same tests against `upstream/master`'s `multi_agent_router.py`: **4 failed, 3 passed**. The four that fail are exactly the multi-agent ones; the three that pass are the single-agent and validation guards, which is the point — they prove the fix did not change those paths.

- **The test file**, before and after:

  | | passed | failed | skipped |
  |---|---|---|---|
  | clean `upstream/master` @ `ff8a60e0` (git worktree) | 1 | 22 | 1 |
  | this branch | **8** | 22 | 1 |

- **Full `tests/structs` suite**, both runs on this machine, same interpreter:

  | | passed | failed | skipped | xfailed | errors |
  |---|---|---|---|---|---|
  | clean `upstream/master` (git worktree) | 866 | 112 | 23 | 3 | 5 |
  | this branch | **873** | 112 | 23 | 3 | 5 |

  Identical failure and error sets; the +7 is exactly this PR's tests. The 112 pre-existing failures — including the 22 in this very file — are live-LLM tests that construct real `Agent`s and need an API key; they fail identically on the clean base.

- **Lint**: `black --check` clean on both files; `ruff check` with the CI rule set (`ruff==0.2.1` defaults, per `.github/workflows/lint.yml`) reports no findings on either.

- **Not verified here**: no live-LLM path was exercised. The new tests build the router with `MultiAgentRouter.__new__` and agents via `Agent.__new__`, setting only the attributes `handle_multiple_handoffs` reads (`agents`, `skip_null_tasks`, `print_on`, `conversation`), so no model is contacted and no API key is needed. The boss call itself is not exercised — these tests drive `handle_multiple_handoffs` with a boss response directly, which is the method the defect lives in.
