### PR TITLE
feat(providers): add OrcaRouter as a named provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ GROQ_API_KEY=""
 ## Perplexity AI
 PPLX_API_KEY=""
 
+## OrcaRouter
+## OpenAI-compatible AI gateway. Model names use the ``orcarouter/`` prefix.
+ORCAROUTER_API_KEY=""
+
 ## AI21
 AI21_API_KEY=""
 

--- a/examples/models/README.md
+++ b/examples/models/README.md
@@ -59,6 +59,9 @@ Set the matching API key as an environment variable before running any example (
 - [glm_or.py](openrouter/glm_or.py) — GLM via OpenRouter
 - [hy3_or.py](openrouter/hy3_or.py) — Hunyuan 3 via OpenRouter
 
+### OrcaRouter
+- [qwen3_orca.py](orcarouter/qwen3_orca.py) — Qwen3 via OrcaRouter
+
 ### Qwen
 - [qwen_3_base.py](qwen/qwen_3_base.py) — Qwen 3 base model
 

--- a/examples/models/orcarouter/qwen3_orca.py
+++ b/examples/models/orcarouter/qwen3_orca.py
@@ -1,0 +1,23 @@
+from dotenv import load_dotenv
+
+from swarms import Agent
+
+load_dotenv()
+
+# Initialize a Qwen3 agent routed through OrcaRouter.
+# OrcaRouter exposes an OpenAI-compatible endpoint, so model names can be
+# prefixed with ``orcarouter/`` and are resolved via the ORCAROUTER_API_KEY
+# environment variable — no base URL wiring required.
+agent = Agent(
+    agent_name="Qwen3-OrcaRouter-Agent",
+    agent_description="Qwen3 VL model routed through OrcaRouter",
+    system_prompt="You are a helpful assistant that answers questions concisely.",
+    model_name="orcarouter/qwen/qwen3-vl-235b-a22b-instruct",
+    max_loops=1,
+)
+
+out = agent.run(
+    task="Explain the difference between a swarm and a single agent in two sentences.",
+)
+
+print(out)

--- a/swarms/cli/main.py
+++ b/swarms/cli/main.py
@@ -1825,6 +1825,11 @@ def handle_init(args: argparse.Namespace) -> None:
             "OpenRouter",
             "any model via openrouter.ai",
         ),
+        (
+            "ORCAROUTER_API_KEY",
+            "OrcaRouter",
+            "OpenAI-compatible gateway via orcarouter.ai",
+        ),
     ]
 
     table = Table(

--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -17,6 +17,7 @@ The main class `LiteLLM` provides a simple interface for running LLM tasks with 
 for various input modalities and output formats.
 """
 
+import os
 import socket
 import traceback
 from functools import lru_cache
@@ -1170,6 +1171,22 @@ class LiteLLM:
             "caching": self.caching,
             "temperature": self.temperature,
         }
+
+        # OrcaRouter is an OpenAI-compatible gateway. Model names can carry the
+        # ``orcarouter/`` provider prefix; route them to OrcaRouter's endpoint
+        # instead of letting litellm fail on the unknown provider.
+        if self.model_name.startswith("orcarouter/"):
+            completion_params["model"] = self.model_name[
+                len("orcarouter/") :
+            ]
+            completion_params["base_url"] = (
+                self.base_url or "https://api.orcarouter.ai/v1"
+            )
+            completion_params["api_key"] = (
+                self.api_key
+                or os.environ.get("ORCAROUTER_API_KEY", "")
+            )
+            completion_params["custom_llm_provider"] = "openai"
 
         # Only include top_p if explicitly set (not None)
         if self.top_p is not None:

--- a/tests/utils/test_litellm_wrapper.py
+++ b/tests/utils/test_litellm_wrapper.py
@@ -23,6 +23,8 @@ Still uncovered by any assertion, from the dropped script: streaming via
 image handling, and image message preparation.
 """
 
+import os
+
 import pytest
 from dotenv import load_dotenv
 
@@ -578,3 +580,59 @@ class TestGeminiProvider:
         )
         result = agent.run(SIMPLE_TASK)
         assert result is not None
+
+
+# ===================================================================
+# OrcaRouter — parameter construction (no network)
+# ===================================================================
+
+
+class TestOrcaRouterProvider:
+    """OrcaRouter provider — parameter construction tests."""
+
+    def test_orcarouter_prefix_maps_to_gateway(self):
+        llm = LiteLLM(
+            model_name="orcarouter/qwen/qwen3-vl-235b-a22b-instruct",
+            system_prompt=SIMPLE_PROMPT,
+            max_tokens=50,
+        )
+        params = llm._build_completion_params(SIMPLE_TASK)
+        assert params["model"] == "qwen/qwen3-vl-235b-a22b-instruct"
+        assert params["base_url"] == "https://api.orcarouter.ai/v1"
+        assert params["custom_llm_provider"] == "openai"
+        assert params["api_key"] == os.environ.get(
+            "ORCAROUTER_API_KEY", ""
+        )
+
+    def test_orcarouter_prefix_respects_explicit_base_url(self):
+        llm = LiteLLM(
+            model_name="orcarouter/gpt-4o-mini",
+            system_prompt=SIMPLE_PROMPT,
+            max_tokens=50,
+            base_url="https://example.orca-proxy.test/v1",
+        )
+        params = llm._build_completion_params(SIMPLE_TASK)
+        assert params["model"] == "gpt-4o-mini"
+        assert (
+            params["base_url"] == "https://example.orca-proxy.test/v1"
+        )
+
+    def test_orcarouter_prefix_preserves_api_key(self):
+        llm = LiteLLM(
+            model_name="orcarouter/gpt-4o-mini",
+            system_prompt=SIMPLE_PROMPT,
+            max_tokens=50,
+            api_key="sk-orca-test-key",
+        )
+        params = llm._build_completion_params(SIMPLE_TASK)
+        assert params["api_key"] == "sk-orca-test-key"
+
+    def test_non_orcarouter_model_untouched(self):
+        llm = LiteLLM(
+            model_name=OPENAI_MODEL,
+            system_prompt=SIMPLE_PROMPT,
+            max_tokens=50,
+        )
+        params = llm._build_completion_params(SIMPLE_TASK)
+        assert params["model"] == OPENAI_MODEL
+        assert "custom_llm_provider" not in params


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class provider in Swarms.

Swarms already routes models through LiteLLM, where named providers such as `openrouter/...` resolve to the vendor's endpoint. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means Swarms users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`swarms/utils/litellm_wrapper.py`**: recognizes the `orcarouter/` model prefix and routes it to `https://api.orcarouter.ai/v1` (mirroring how LiteLLM maps `openrouter/`), using `ORCAROUTER_API_KEY` from the environment, with an explicit `custom_llm_provider="openai"` so the OpenAI-compatible endpoint is called directly.
- **`swarms/cli/main.py`**: adds `ORCAROUTER_API_KEY` to the `swarms init` provider table alongside OpenRouter.
- **`.env.example`**: documents the new `ORCAROUTER_API_KEY` variable.
- **`examples/models/orcarouter/qwen3_orca.py`**: runnable example using `orcarouter/qwen/qwen3-vl-235b-a22b-instruct`.
- **`examples/models/README.md`**: lists the new OrcaRouter example.
- **`tests/utils/test_litellm_wrapper.py`**: offline parameter-construction tests for the `orcarouter/` prefix (no network).

## Verification

- `pytest tests/utils/test_litellm_wrapper.py::TestOrcaRouterProvider` — 4 passed.
- `black --check` and `ruff check` clean on all touched files.
- Live test: `Agent(model_name="orcarouter/qwen/qwen3-vl-235b-a22b-instruct")` returned `OK` through the new provider path.

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
