### PR TITLE
fix(multi-agent): deliver context as typed chat turns, not one user blob

### DIFF
--- a/swarms/prompts/prompt.py
+++ b/swarms/prompts/prompt.py
@@ -118,25 +118,13 @@ class Prompt(BaseModel):
                 "New content must be different from the current content."
             )
 
-        # logger.info(
-        #     f"Editing prompt {self.id}. Current content: '{self.content}'"
-        # )
         self.edit_history.append(new_content)
         self.content = new_content
         self.edit_count += 1
         self.last_modified_at = time.strftime("%Y-%m-%d %H:%M:%S")
 
-        # logger.debug(
-        #     f"Prompt {self.id} updated. Edit count: {self.edit_count}. New content: '{self.content}'"
-        # )
-
         if self.autosave:
             self._autosave()
-
-    # def log_telemetry(self):
-    #     system_data = capture_system_data()
-    #     merged_data = {**system_data, **self.model_dump()}
-    #     log_agent_data(merged_data)
 
     def rollback(self, version: int) -> None:
         """
@@ -181,9 +169,6 @@ class Prompt(BaseModel):
         Returns:
             str: The current prompt content.
         """
-        # logger.debug(f"Returning prompt {self.id} as a string.")
-        # self.log_telemetry()
-
         return self.content
 
     def save_to_storage(self) -> None:
@@ -194,7 +179,6 @@ class Prompt(BaseModel):
         Raises:
             NotImplementedError: This method is a placeholder for storage integration.
         """
-        # logger.info(f"Saving prompt {self.id} to persistent storage.")
         raise NotImplementedError(
             "Persistent storage integration is required."
         )
@@ -212,9 +196,6 @@ class Prompt(BaseModel):
         Raises:
             NotImplementedError: This method is a placeholder for storage integration.
         """
-        # logger.info(
-        #     f"Loading prompt {prompt_id} from persistent storage."
-        # )
         raise NotImplementedError(
             "Persistent storage integration is required."
         )
@@ -250,19 +231,6 @@ class Prompt(BaseModel):
         )
         with open(file_path, "w") as file:
             json.dump(self.model_dump(), file)
-        # logger.info(f"Autosaved prompt {self.id} to {file_path}.")
-
-        # return "Prompt autosaved successfully."
-
-    # def auto_generate_prompt(self):
-    #     logger.info(f"Auto-generating prompt for {self.name}")
-    #     task = self.name + " " + self.description + " " + self.content
-    #     prompt = auto_generate_prompt(task, llm=self.llm, max_tokens=4000, use_second_sys_prompt=True)
-    #     logger.info("Generated prompt successfully, updating content")
-    #     self.edit_prompt(prompt)
-    #     logger.info("Prompt content updated")
-
-    #     return "Prompt auto-generated successfully."
 
     class Config:
         """Pydantic configuration for better JSON serialization."""

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -505,22 +505,11 @@ class Agent:
         self.reasoning_effort = reasoning_effort
         self.thinking_tokens = thinking_tokens
 
-        # Defer tool schemas and let the agent search for what it needs.
         self.dynamic_tools = dynamic_tools
         self.tool_loader: Optional[DynamicToolLoader] = None
-        # MCP schemas are fetched over the network, so they are folded into
-        # the catalog once rather than on every LLM rebuild.
         self._mcp_tools_deferred = False
-        # Fetched MCP schemas, kept so a rebuilt loader can be repopulated
-        # without another network call. The autonomous loop constructs a fresh
-        # loader per run, so a boolean "already deferred" flag is not enough.
         self._mcp_schemas_cache: Optional[List[dict]] = None
 
-        # Whether the autonomous loop offers the `think` tool. Off by default:
-        # a think call costs a full round-trip to produce reasoning the model
-        # could have emitted alongside its actions in the same response. Turn
-        # it on for models that do not reason natively, or when an explicit
-        # analysis step is worth the extra turn.
         self.think_tool = think_tool
         self.reasoning_enabled = reasoning_enabled
         self.fallback_model_name = fallback_model_name
@@ -530,9 +519,6 @@ class Agent:
         self.publish_to_marketplace = publish_to_marketplace
         self.marketplace_prompt_id = marketplace_prompt_id
 
-        # All MCP (Model Context Protocol) behaviour — connection handling,
-        # API key / bearer token / OAuth authentication, transport selection,
-        # tool discovery and tool execution — lives in MCPManager.
         self.mcp_manager = MCPManager(
             mcp_url=self.mcp_url,
             mcp_urls=self.mcp_urls,
@@ -1250,6 +1236,7 @@ class Agent:
         img: Optional[str] = None,
         imgs: Optional[List[str]] = None,
         streaming_callback: Optional[Callable[[str], None]] = None,
+        messages: Optional[List[Dict[str, Any]]] = None,
         *args,
         **kwargs,
     ) -> Any:
@@ -1432,12 +1419,6 @@ class Agent:
                     self.dynamic_temperature()
 
                 # Task prompt with optional transforms.
-                #
-                # `transforms` rewrites the whole history into a single string
-                # by design, so that path keeps the legacy flattened prompt.
-                # Everything else sends a real message list, which preserves
-                # assistant `tool_calls` turns and `tool` results instead of
-                # collapsing them into prose.
                 task_prompt = None
                 use_transcript = self.transforms is None
 
@@ -1448,7 +1429,9 @@ class Agent:
                         model_name=self.model_name,
                     )
                 elif transcript is None:
-                    transcript = self._transcript_from_memory()
+                    transcript = self._transcript_from_messages(
+                        messages, task
+                    )
 
                 # Parameters
                 attempt = 0
@@ -4461,3 +4444,29 @@ Summary: {summary}
             f"Agent '{self.agent_name}' failed to execute tools in loop "
             f"{loop_count} after {attempts} attempt(s): {last_error}"
         ) from last_error
+
+    def _transcript_from_messages(
+        self,
+        messages: Optional[List[Dict[str, Any]]],
+        task: Optional[Any],
+    ) -> Transcript:
+        """
+        Build this run's transcript, preferring caller-supplied turns.
+
+        Args:
+            messages: Prior conversation as typed chat messages. When given,
+                these replace the memory-derived prefix and ``task`` is
+                appended as the new user turn. ``None`` falls back to
+                :meth:`_transcript_from_memory`.
+            task: The instruction for this turn.
+
+        Returns:
+            The transcript to send with the next request.
+        """
+        if messages is None:
+            return self._transcript_from_memory()
+
+        transcript = Transcript(list(messages))
+        if task is not None:
+            transcript.append_user(task)
+        return transcript

--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -1,5 +1,6 @@
 import copy
 import os
+from concurrent.futures import as_completed
 from typing import (
     Any,
     Callable,
@@ -20,14 +21,11 @@ from swarms.telemetry.otel import (
 )
 from swarms.structs.context_utils import (
     agent_answer,
-    new_context_for,
+    messages_for,
+    split_last_turn,
 )
 from swarms.structs.conversation import Conversation
 from swarms.structs.ma_blocks import find_agent_by_name
-from swarms.structs.multi_agent_exec import (
-    run_agents_concurrently,
-    run_agents_with_different_tasks,
-)
 from swarms.structs.serialization import SerializableMixin
 from swarms.utils.any_to_str import any_to_str
 from swarms.utils.history_output_formatter import (
@@ -120,6 +118,7 @@ class AgentRearrange(SerializableMixin):
         team_awareness: bool = False,
         time_enabled: bool = False,
         message_id_on: bool = False,
+        collab_prompt: Optional[str] = None,
     ):
         """
         Initialize the AgentRearrange system.
@@ -153,6 +152,9 @@ class AgentRearrange(SerializableMixin):
                 Defaults to False.
             message_id_on (bool): Whether to include message IDs in conversations.
                 Defaults to False.
+            collab_prompt (str, optional): Guidance prepended as a system turn
+                for every agent. Not written to the shared conversation.
+                Defaults to None.
 
         Raises:
             ValueError: If agents list is None or empty, max_loops is 0,
@@ -174,21 +176,10 @@ class AgentRearrange(SerializableMixin):
         self.autosave = autosave
         self.time_enabled = time_enabled
         self.message_id_on = message_id_on
+        self.team_awareness = team_awareness
+        self.collab_prompt = collab_prompt
 
-        # How much of the shared conversation each agent has already been
-        # given. Without this an agent receives the entire history on every
-        # invocation, that history lands in its own short_memory, and the next
-        # invocation re-sends it on top - so context grows exponentially across
-        # loops and the agent sees its own output twice, the second time
-        # mislabelled as something the user said.
-        self._delivered: Dict[str, int] = {}
-
-        self.conversation = Conversation(
-            name=f"{self.name}-Conversation",
-            time_enabled=self.time_enabled,
-            token_count=False,
-            message_id_on=self.message_id_on,
-        )
+        self._reset_conversation()
 
         if team_awareness is True:
             # agents_info = get_agents_info(agents=self.agents, team_name=self.name)
@@ -547,11 +538,49 @@ class AgentRearrange(SerializableMixin):
         """
         return self._get_sequential_flow_info()
 
-    def _context_for(self, agent_name: str) -> str:
-        """What this agent has not been given yet. See context_utils."""
-        return new_context_for(
-            agent_name, self.conversation, self._delivered
+    def _reset_conversation(self) -> None:
+        """Start a fresh shared conversation, re-seeding team awareness."""
+        self.conversation = Conversation(
+            name=f"{self.name}-Conversation",
+            time_enabled=self.time_enabled,
+            token_count=False,
+            message_id_on=self.message_id_on,
         )
+
+        if self.team_awareness is True:
+            sequential_info = self._get_sequential_flow_info()
+            if sequential_info:
+                self.conversation.add("system", sequential_info)
+
+    def _messages_for(
+        self, agent_name: str, extra_system: Optional[str] = None
+    ) -> tuple:
+        """
+        The shared conversation as typed turns for one agent.
+
+        Args:
+            agent_name: The agent about to run.
+            extra_system: Per-agent guidance - collaboration rules, flow
+                position - prepended as a system turn. It is not written to
+                the shared conversation, so other agents never see it.
+
+        Returns:
+            ``(prior_messages, task)`` - the conversation prefix as chat
+            messages, and the newest turn as this run's task.
+        """
+        prior, task = split_last_turn(
+            messages_for(agent_name, self.conversation)
+        )
+
+        preamble = "\n\n".join(
+            part
+            for part in (self.collab_prompt, extra_system)
+            if part
+        )
+        if preamble:
+            prior = [{"role": "system", "content": preamble}] + prior
+
+        return prior, task
 
     def _run_concurrent_workflow(
         self,
@@ -599,30 +628,44 @@ class AgentRearrange(SerializableMixin):
                 f"Agent(s) {missing} not registered in this AgentRearrange instance."
             )
 
-        # Concurrent agents in the same flow step each get their own slice of
-        # what is new for them; a shared task string would re-send history the
-        # agent already holds, which is what compounded across loops.
-        contexts = [self._context_for(name) for name in agent_names]
+        # Every agent in the step sees the same history, but each sees its own
+        # turns as `assistant`, so the message list is built per agent rather
+        # than shared.
+        results = [None] * len(agents_to_run)
+        with ContextThreadPoolExecutor(
+            max_workers=len(agents_to_run)
+        ) as executor:
+            future_to_index = {}
+            for index, (agent, name) in enumerate(
+                zip(agents_to_run, agent_names)
+            ):
+                prior, step_task = self._messages_for(name)
+                future = executor.submit(
+                    agent.run,
+                    task=step_task,
+                    messages=prior,
+                    img=img,
+                    **kwargs,
+                )
+                future_to_index[future] = index
 
-        if len(set(contexts)) == 1:
-            # Identical context for everyone (the common case on the first
-            # step) - the cheaper shared-task path still applies.
-            results = run_agents_concurrently(
-                agents=agents_to_run,
-                task=contexts[0],
-                img=img,
-            )
-        else:
-            results = run_agents_with_different_tasks(
-                list(zip(agents_to_run, contexts))
-            )
+            for future in as_completed(future_to_index):
+                index = future_to_index[future]
+                try:
+                    results[index] = future.result()
+                except Exception as error:
+                    results[index] = error
 
-        # Process results and update conversation
         response_dict = {}
         for i, agent_name in enumerate(agent_names):
             result = results[i]
 
-            # print(f"Result: {result}")
+            # `run` honours the agent's own output_type, which by default is
+            # its whole conversation; record the answer instead.
+            if not isinstance(result, Exception):
+                result = agent_answer(
+                    agents_to_run[i], fallback=result
+                )
 
             self.conversation.add(agent_name, result)
             response_dict[agent_name] = result
@@ -674,39 +717,27 @@ class AgentRearrange(SerializableMixin):
                 f"Agent '{agent_name}' is not registered in this AgentRearrange instance."
             )
 
-        # Sequential awareness is delivered through a temporary extension
-        # of the agent's system prompt rather than being added to the
-        # shared conversation. Two reasons:
-        #   1. The shared transcript stays clean — downstream agents do
-        #      not see other agents' private awareness payloads.
-        #   2. System-prompt content is excluded from the agent's default
-        #      response format ("str-all-except-first"), so the awareness
-        #      text cannot leak back into the conversation through the
-        #      agent's echo of its prompt.
-        # Mutation is safe here because sequential agents run one at a
-        # time, and batch_run gives each task its own orchestrator clone.
+        # Awareness rides in the message list rather than the agent's
+        # system_prompt: the prompt is baked into the LLM when it is built,
+        # so assigning to it here would never reach the request.
         awareness_info = self._get_sequential_awareness(
             agent_name, tasks, task_idx=task_idx
         )
-        original_system_prompt = getattr(agent, "system_prompt", None)
-        try:
-            if awareness_info and original_system_prompt is not None:
-                agent.system_prompt = (
-                    f"{original_system_prompt}\n\n{awareness_info}"
-                )
-                logger.info(
-                    f"Added sequential awareness for {agent_name}: {awareness_info}"
-                )
-
-            current_task = agent.run(
-                task=self._context_for(agent_name),
-                img=img,
-                *args,
-                **kwargs,
+        if awareness_info:
+            logger.info(
+                f"Added sequential awareness for {agent_name}: {awareness_info}"
             )
-        finally:
-            if awareness_info and original_system_prompt is not None:
-                agent.system_prompt = original_system_prompt
+
+        prior, step_task = self._messages_for(
+            agent_name, extra_system=awareness_info
+        )
+        current_task = agent.run(
+            task=step_task,
+            messages=prior,
+            img=img,
+            *args,
+            **kwargs,
+        )
 
         if not isinstance(current_task, str):
             current_task = any_to_str(current_task)
@@ -767,10 +798,9 @@ class AgentRearrange(SerializableMixin):
             based on the flow syntax. It also supports custom task injection
             and multiple execution loops as configured.
         """
-        # A new task starts a new delivery window. Without this the cursor
-        # carries over between tasks on a reused instance (batch_run), so the
-        # second task's agents are told there is nothing new and never see it.
-        self._delivered = {}
+        # A reused instance would otherwise serve the previous task's whole
+        # transcript as context for this one.
+        self._reset_conversation()
 
         self.conversation.add("User", task)
 
@@ -904,10 +934,6 @@ class AgentRearrange(SerializableMixin):
             The result from executing the task through the agent rearrange system.
             The format depends on the configured output_type.
 
-        Note:
-            This method automatically logs agent data before and after execution
-            for telemetry and debugging purposes. Any exceptions are caught and
-            handled by the _catch_error method.
         """
         try:
             out = self._run(
@@ -928,18 +954,6 @@ class AgentRearrange(SerializableMixin):
 
         Enables the AgentRearrange instance to be called directly as a function,
         providing a convenient interface for task execution.
-
-        Args:
-            task (str): The task to execute through the agent workflow.
-            *args: Additional positional arguments passed to run().
-            **kwargs: Additional keyword arguments passed to run().
-
-        Returns:
-            The result from executing the task through the agent rearrange system.
-
-        Example:
-            >>> rearrange_system = AgentRearrange(agents=[agent1, agent2], flow="agent1 -> agent2")
-            >>> result = rearrange_system("Process this data")
         """
         return self.run(task=task, *args, **kwargs)
 
@@ -1173,7 +1187,8 @@ class AgentRearrange(SerializableMixin):
             yield {"type": "agent_start", "agent": agent_name}
 
         chunks: List[str] = []
-        run_kwargs = {"task": self._context_for(agent_name)}
+        prior, step_task = self._messages_for(agent_name)
+        run_kwargs = {"task": step_task, "messages": prior}
         if img is not None:
             run_kwargs["img"] = img
         run_kwargs.update(kwargs)
@@ -1219,7 +1234,7 @@ class AgentRearrange(SerializableMixin):
         DONE = object()
         ERROR = object()
         base_inputs = {
-            name: self._context_for(name) for name in agent_names
+            name: self._messages_for(name) for name in agent_names
         }
         results: Dict[str, List[str]] = {
             name: [] for name in agent_names
@@ -1232,7 +1247,11 @@ class AgentRearrange(SerializableMixin):
         async def producer(name: str):
             try:
                 agent = find_agent_by_name(self.agents, name)
-                run_kwargs = {"task": base_inputs[name]}
+                prior, step_task = base_inputs[name]
+                run_kwargs = {
+                    "task": step_task,
+                    "messages": prior,
+                }
                 if img is not None:
                     run_kwargs["img"] = img
                 run_kwargs.update(kwargs)
@@ -1312,10 +1331,9 @@ class AgentRearrange(SerializableMixin):
         Not yet supported in streaming mode: ``max_loops > 1``,
         ``custom_tasks``. Use ``run()`` for those.
         """
-        # A new task starts a new delivery window. Without this the cursor
-        # carries over between tasks on a reused instance (batch_run), so the
-        # second task's agents are told there is nothing new and never see it.
-        self._delivered = {}
+        # A reused instance would otherwise serve the previous task's whole
+        # transcript as context for this one.
+        self._reset_conversation()
 
         self.conversation.add("User", task)
 
@@ -1413,39 +1431,6 @@ def rearrange(
     instance and immediately executing a task with it. It's useful for quick
     prototyping or when you don't need to reuse the rearrange system.
 
-    Parameters:
-        name (str, optional): Name for the agent rearrange system.
-            Defaults to None (uses AgentRearrange default).
-        description (str, optional): Description of the system.
-            Defaults to None (uses AgentRearrange default).
-        agents (List[Agent]): The list of agents to be included in the system.
-        flow (str): The flow pattern defining agent execution order.
-            Uses '->' for sequential and ',' for concurrent execution.
-        task (str, optional): The task to be performed during rearrangement.
-            Defaults to None.
-        img (str, optional): Image input for agents that support it.
-            Defaults to None.
-        *args: Additional positional arguments passed to AgentRearrange constructor.
-        **kwargs: Additional keyword arguments passed to AgentRearrange constructor.
-
-    Returns:
-        The result of running the agent system with the specified task.
-        The format depends on the output_type configuration.
-
-    Example:
-        >>> from swarms import Agent, rearrange
-        >>>
-        >>> # Create agents
-        >>> agent1 = Agent(name="researcher", ...)
-        >>> agent2 = Agent(name="writer", ...)
-        >>> agent3 = Agent(name="reviewer", ...)
-        >>>
-        >>> # Execute task with flow
-        >>> result = rearrange(
-        ...     agents=[agent1, agent2, agent3],
-        ...     flow="researcher -> writer, reviewer",
-        ...     task="Research and write a report"
-        ... )
     """
     agent_system = AgentRearrange(
         name=name,

--- a/swarms/structs/context_utils.py
+++ b/swarms/structs/context_utils.py
@@ -28,6 +28,107 @@ NO_NEW_MESSAGES = (
     "previous response."
 )
 
+# Roles a structure writes for its own bookkeeping - rosters, flow diagrams,
+# loop markers. They are not turns any agent took, so they are not rendered.
+_STRUCTURE_ROLES = frozenset({"system"})
+
+_USER_ROLES = frozenset({"user", "human"})
+
+
+def messages_for(
+    agent_name: str,
+    conversation: Any,
+) -> List[Dict[str, str]]:
+    """
+    A shared conversation as typed chat turns, from one agent's point of view.
+
+    The string form built by :func:`new_context_for` collapses every speaker
+    into one ``user`` message, so the model cannot tell its own prior output
+    from a peer's, and the request has no stable prefix to cache. This returns
+    the same history as real turns instead: the recipient's own messages
+    become ``assistant`` turns and everyone else's become ``user`` turns
+    labelled with the speaker's name.
+
+    Unlike :func:`new_context_for` there is no delivery cursor. A chat request
+    carries the whole conversation every time; sending only the delta is what
+    the flattened form had to do because it was writing into the agent's own
+    memory.
+
+    Args:
+        agent_name: The agent about to run. Its own messages in the shared
+            conversation carry this as their role.
+        conversation: A :class:`~swarms.structs.conversation.Conversation`.
+
+    Returns:
+        Chat-completions messages, oldest first. Structure bookkeeping
+        (``system`` rows such as team rosters) is omitted - it belongs in a
+        system prompt, not in the conversation body.
+
+    Example:
+        >>> messages_for("Writer", conversation)
+        [{'role': 'user', 'content': 'draft it'},
+         {'role': 'assistant', 'content': 'here is a draft'},
+         {'role': 'user', 'content': 'Editor: needs a stronger opening'}]
+    """
+    history = (
+        getattr(conversation, "conversation_history", None) or []
+    )
+
+    messages: List[Dict[str, str]] = []
+    for message in history:
+        if not isinstance(message, dict):
+            continue
+
+        role = message.get("role")
+        content = message.get("content")
+        if content is None:
+            continue
+        content = str(content)
+
+        if role == agent_name:
+            messages.append({"role": "assistant", "content": content})
+            continue
+
+        role_key = str(role).lower()
+        if role_key in _STRUCTURE_ROLES:
+            continue
+
+        if role_key in _USER_ROLES:
+            messages.append({"role": "user", "content": content})
+        else:
+            messages.append(
+                {"role": "user", "content": f"{role}: {content}"}
+            )
+
+    return messages
+
+
+def split_last_turn(
+    messages: List[Dict[str, str]],
+    fallback: str = NO_NEW_MESSAGES,
+) -> tuple:
+    """
+    Split typed turns into a prefix and the instruction for this run.
+
+    ``Agent.run`` still takes a ``task``, so the newest turn is handed over
+    separately rather than being duplicated at the end of ``messages``.
+
+    Args:
+        messages: Turns from :func:`messages_for`, oldest first.
+        fallback: Task text used when there are no turns to split.
+
+    Returns:
+        ``(prior_messages, task)``.
+    """
+    if not messages:
+        return [], fallback
+    # A blank newest turn would reach Agent.run as an empty task, which it
+    # rejects; the flattened form used to smuggle one through as "User: ".
+    task = messages[-1]["content"]
+    if not str(task).strip():
+        return messages[:-1], fallback
+    return messages[:-1], task
+
 
 def new_context_for(
     agent_name: str,

--- a/swarms/structs/mixture_of_agents.py
+++ b/swarms/structs/mixture_of_agents.py
@@ -1,26 +1,30 @@
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
+from swarms.prompts.ag_prompt import AGGREGATOR_SYSTEM_PROMPT_MAIN
+from swarms.structs.agent import Agent
+from swarms.structs.context_utils import (
+    agent_answer,
+    get_final_agent_answer,
+    messages_for,
+    split_last_turn,
+)
+from swarms.structs.conversation import Conversation
 from swarms.structs.execution_utils import (
     batched_run,
     run_concurrently,
 )
-from swarms.prompts.ag_prompt import AGGREGATOR_SYSTEM_PROMPT_MAIN
-from swarms.structs.agent import Agent
-from swarms.structs.conversation import Conversation
 from swarms.structs.ma_utils import list_all_agents
 from swarms.structs.multi_agent_exec import run_agents_concurrently
+from swarms.telemetry.otel import (
+    capture_init,
+    trace_run,
+)
+from swarms.utils.generate_id import generate_id
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
 )
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.output_types import OutputType
-from swarms.telemetry.otel import (
-    capture_init,
-    trace_run,
-)
-from typing import Dict, Any
-from swarms.utils.generate_id import generate_id
-from swarms.structs.context_utils import get_final_agent_answer
 
 logger = initialize_logger(log_folder="mixture_of_agents")
 
@@ -118,6 +122,20 @@ class MixtureOfAgents:
 
         self.reliability_check()
 
+        self._reset_conversation()
+
+        if self.aggregator_agent is None:
+            self.aggregator_agent = self.aggregator_agent_setup()
+
+        # Capture the full __init__ configuration if telemetry is enabled.
+        capture_init(self)
+
+    def _reset_conversation(self) -> None:
+        """Start a fresh shared conversation, re-seeding the team roster.
+
+        A reused instance would otherwise carry the previous task's layers
+        into the next one's aggregation.
+        """
         self.conversation = Conversation()
 
         list_all_agents(
@@ -127,12 +145,6 @@ class MixtureOfAgents:
             name=self.name,
             add_to_conversation=True,
         )
-
-        if self.aggregator_agent is None:
-            self.aggregator_agent = self.aggregator_agent_setup()
-
-        # Capture the full __init__ configuration if telemetry is enabled.
-        capture_init(self)
 
     def reliability_check(self) -> None:
         """Validate required configuration before the workflow starts.
@@ -219,6 +231,8 @@ class MixtureOfAgents:
             The conversation formatted according to ``self.output_type``.
         """
 
+        self._reset_conversation()
+
         self.conversation.add(role="User", content=task)
 
         # Workers receive only the original task on the first layer, and
@@ -238,17 +252,25 @@ class MixtureOfAgents:
 
             for agent_name, agent_output in step_output.items():
                 self.conversation.add(
-                    role=agent_name, content=agent_output
+                    role=agent_name,
+                    content=agent_output,
                 )
 
-            # Summarise the layer as the concatenation of worker outputs so
-            # the next layer has a compact view of what was produced.
+            # Summarize this layer by concatenating worker outputs for the next layer's input.
             prev_layer_output = "\n\n".join(
                 f"{name}: {out}" for name, out in step_output.items()
             )
 
+        prior, aggregator_task = split_last_turn(
+            messages_for(
+                self.aggregator_agent.agent_name, self.conversation
+            )
+        )
         aggregator_output = self.aggregator_agent.run(
-            task=self.conversation.get_str()
+            task=aggregator_task, messages=prior
+        )
+        aggregator_output = agent_answer(
+            self.aggregator_agent, fallback=aggregator_output
         )
 
         self.conversation.add(

--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -87,6 +87,7 @@ class SequentialWorkflow:
         output_type: OutputType = "dict",
         shared_memory_system: callable = None,
         multi_agent_collab_prompt: bool = False,
+        collab_prompt: Optional[str] = None,
         team_awareness: bool = False,
         autosave: bool = True,
         verbose: bool = False,
@@ -108,7 +109,10 @@ class SequentialWorkflow:
             max_loops (int, optional): Maximum number of times to execute the workflow. Defaults to 1.
             output_type (OutputType, optional): Output format for the workflow. Defaults to "dict".
             shared_memory_system (callable, optional): Callable for shared memory management. Defaults to None.
-            multi_agent_collab_prompt (bool, optional): If True, appends a collaborative prompt to each agent.
+            multi_agent_collab_prompt (bool, optional): If True, each agent receives a collaboration
+                preamble as a system turn for the duration of the run.
+            collab_prompt (str, optional): Overrides the default preamble text. Ignored unless
+                multi_agent_collab_prompt is True.
             autosave (bool, optional): Whether to enable autosaving of conversation history. Defaults to False.
             verbose (bool, optional): Whether to enable verbose logging. Defaults to False.
             drift_detection (bool, optional): If True, a judge agent scores the final output's semantic
@@ -135,6 +139,7 @@ class SequentialWorkflow:
         self.output_type = output_type
         self.shared_memory_system = shared_memory_system
         self.multi_agent_collab_prompt = multi_agent_collab_prompt
+        self.collab_prompt = collab_prompt
         self.team_awareness = team_awareness
         self.autosave = autosave
         self.verbose = verbose
@@ -172,6 +177,11 @@ class SequentialWorkflow:
             max_loops=self.max_loops,
             output_type=self.output_type,
             team_awareness=self.team_awareness,
+            collab_prompt=(
+                (self.collab_prompt or AGENT_COLLAB_PROMPT)
+                if self.multi_agent_collab_prompt
+                else None
+            ),
         )
 
         # Capture the full __init__ configuration if telemetry is enabled.
@@ -197,11 +207,7 @@ class SequentialWorkflow:
 
         if self.multi_agent_collab_prompt is True:
             for agent in self.agents:
-                if hasattr(agent, "system_prompt"):
-                    if agent.system_prompt is None:
-                        agent.system_prompt = ""
-                    agent.system_prompt += AGENT_COLLAB_PROMPT
-                else:
+                if not hasattr(agent, "system_prompt"):
                     logger.warning(
                         f"Agent {getattr(agent, 'name', str(agent))} does not have a 'system_prompt' attribute."
                     )

--- a/tests/structs/test_agent_rearrange.py
+++ b/tests/structs/test_agent_rearrange.py
@@ -576,11 +576,23 @@ def test_missing_agent_raises():
         r.run("test")
 
 
-def test_broken_conversation_raises():
-    """run() must raise when conversation is corrupted."""
+def test_broken_conversation_raises(monkeypatch):
+    """run() must raise when the conversation it uses is corrupted.
+
+    Corrupting the conversation before ``run()`` no longer works: each task
+    starts from a fresh conversation, so the damage is discarded. Corrupt the
+    one the run actually builds instead.
+    """
     agents = create_sample_agents()
     r = _make_rearrange(agents, "ResearchAgent -> WriterAgent")
-    r.conversation.conversation_history = None
+
+    original_reset = r._reset_conversation
+
+    def reset_then_corrupt():
+        original_reset()
+        r.conversation.conversation_history = None
+
+    monkeypatch.setattr(r, "_reset_conversation", reset_then_corrupt)
 
     with pytest.raises((TypeError, AttributeError)):
         r.run("test")
@@ -862,27 +874,29 @@ def test_awareness_not_in_shared_conversation():
     ), f"Sequential awareness leaked into the shared conversation: {leaked}"
 
 
-def test_awareness_delivered_per_agent_via_system_prompt():
-    """Each repeated occurrence of an agent should observe a DIFFERENT
-    system_prompt during its run() call (because awareness is injected
-    there), and the original system_prompt must be restored after."""
+def test_awareness_delivered_per_agent_as_system_message():
+    """Awareness rides in the message list, not the agent's system_prompt.
+
+    The prompt is baked into the LLM when it is built, so assigning to
+    ``agent.system_prompt`` mid-run never reaches the request. Each repeated
+    occurrence of an agent should receive its own awareness system turn, and
+    the caller's agents must be left unmutated.
+    """
     agents = create_repeated_flow_agents()
-    observed_system_prompts: List = []
+    observed_messages: List = []
     originals = {a.agent_name: a.system_prompt for a in agents}
 
     for agent in agents:
         name = agent.agent_name
 
-        def _make_tracker(agent_obj, agent_name):
-            def _track(task=None, *a, **kw):
-                observed_system_prompts.append(
-                    (agent_name, agent_obj.system_prompt)
-                )
+        def _make_tracker(agent_name):
+            def _track(task=None, messages=None, *a, **kw):
+                observed_messages.append((agent_name, messages or []))
                 return f"{agent_name} acknowledged"
 
             return _track
 
-        agent.run = _make_tracker(agent, name)
+        agent.run = _make_tracker(name)
 
     rearrange = AgentRearrange(
         agents=agents,
@@ -891,19 +905,27 @@ def test_awareness_delivered_per_agent_via_system_prompt():
     )
     rearrange.run("Write about thunder.")
 
-    writer_prompts = [
-        sp for name, sp in observed_system_prompts if name == "Writer"
+    writer_awareness = [
+        "\n".join(
+            m["content"]
+            for m in messages
+            if m.get("role") == "system"
+        )
+        for name, messages in observed_messages
+        if name == "Writer"
     ]
-    assert len(writer_prompts) == 2
-    assert all("Sequential awareness" in sp for sp in writer_prompts)
+    assert len(writer_awareness) == 2
+    assert all(
+        "Sequential awareness" in text for text in writer_awareness
+    )
     assert (
-        writer_prompts[0] != writer_prompts[1]
+        writer_awareness[0] != writer_awareness[1]
     ), "Repeated Writer invocations received identical awareness"
-    # System prompt must be restored after the run completes
+    # Awareness is per-run context, never a mutation of the caller's agent.
     for agent in agents:
         assert (
             agent.system_prompt == originals[agent.agent_name]
-        ), f"system_prompt for {agent.agent_name} was not restored"
+        ), f"system_prompt for {agent.agent_name} was mutated"
 
 
 # ============================================================================
@@ -1438,3 +1460,148 @@ class TestConcurrentRunIsolation:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# ============================================================================
+# Context shape — agents receive typed chat turns, not one flattened blob
+# ============================================================================
+
+
+def _recording_agents(names):
+    """Agents whose run() records the context it was handed."""
+    calls = []
+    agents = []
+    for name in names:
+        agent = Agent(
+            agent_name=name,
+            system_prompt=f"You are {name}.",
+            model_name="gpt-5.4",
+            max_loops=1,
+            verbose=False,
+        )
+
+        def _make(agent_obj, agent_name):
+            def _run(task=None, messages=None, **kwargs):
+                calls.append(
+                    {
+                        "agent": agent_name,
+                        "task": task,
+                        "messages": list(messages or []),
+                    }
+                )
+                answer = f"{agent_name}-answer"
+                agent_obj.short_memory.add(
+                    role=agent_name, content=answer
+                )
+                return answer
+
+            return _run
+
+        agent.run = _make(agent, name)
+        agents.append(agent)
+    return agents, calls
+
+
+def test_agents_receive_typed_turns_not_one_user_blob():
+    """Peers arrive as separate messages, not concatenated into the task."""
+    agents, calls = _recording_agents(["A", "B", "C"])
+    AgentRearrange(
+        agents=agents, flow="A -> B -> C", max_loops=1
+    ).run("the original task")
+
+    first, last = calls[0], calls[-1]
+
+    # The first agent gets the raw task, not a "User: ..." rendering of it.
+    assert first["task"] == "the original task"
+    assert not [m for m in first["messages"] if m["role"] != "system"]
+
+    # The last agent sees each prior speaker as its own message.
+    assert last["agent"] == "C"
+    contents = [m["content"] for m in last["messages"]] + [
+        last["task"]
+    ]
+    assert "the original task" in contents
+    assert any("A-answer" in c for c in contents)
+    assert any("B-answer" in c for c in contents)
+
+    # None of it is crammed into a single string.
+    assert len(last["messages"]) >= 2
+
+
+def test_agent_sees_its_own_output_as_assistant():
+    """An agent's own prior turn must not come back labelled as the user's."""
+    agents, calls = _recording_agents(["A", "B"])
+    AgentRearrange(agents=agents, flow="A -> B", max_loops=2).run(
+        "go"
+    )
+
+    second_a = [c for c in calls if c["agent"] == "A"][1]
+    assistant = [
+        m["content"]
+        for m in second_a["messages"]
+        if m["role"] == "assistant"
+    ]
+    assert "A-answer" in assistant
+
+    # B's contribution reaches A as a user turn, attributed to B.
+    user_text = " ".join(
+        m["content"]
+        for m in second_a["messages"]
+        if m["role"] == "user"
+    )
+    assert "B-answer" in user_text or "B-answer" in second_a["task"]
+
+
+def test_team_awareness_is_a_system_turn_not_user_prose():
+    """Flow structure must not be rendered as 'system: ...' inside a user turn."""
+    agents, calls = _recording_agents(["A", "B"])
+    AgentRearrange(
+        agents=agents, flow="A -> B", max_loops=1, team_awareness=True
+    ).run("go")
+
+    first = calls[0]
+    user_text = " ".join(
+        m["content"] for m in first["messages"] if m["role"] == "user"
+    ) + str(first["task"])
+    assert "system:" not in user_text.lower()
+
+    system_text = " ".join(
+        m["content"]
+        for m in first["messages"]
+        if m["role"] == "system"
+    )
+    assert "Sequential" in system_text
+
+
+def test_conversation_does_not_leak_between_runs():
+    """A reused instance must not serve the previous task's transcript."""
+    agents, calls = _recording_agents(["A", "B"])
+    rearrange = AgentRearrange(
+        agents=agents, flow="A -> B", max_loops=1
+    )
+    rearrange.run("first task")
+    calls.clear()
+    rearrange.run("second task")
+
+    everything = " ".join(
+        [str(c["task"]) for c in calls]
+        + [m["content"] for c in calls for m in c["messages"]]
+    )
+    assert "second task" in everything
+    assert "first task" not in everything
+
+
+def test_concurrent_step_records_answers_not_transcripts():
+    """A parallel step must contribute each agent's answer to the transcript."""
+    agents, _ = _recording_agents(["A", "B", "C"])
+    rearrange = AgentRearrange(
+        agents=agents, flow="A -> B, C", max_loops=1
+    )
+    rearrange.run("go")
+
+    recorded = {
+        m["role"]: m["content"]
+        for m in rearrange.conversation.conversation_history
+    }
+    assert recorded["B"] == "B-answer"
+    assert recorded["C"] == "C-answer"

--- a/tests/structs/test_moa.py
+++ b/tests/structs/test_moa.py
@@ -310,7 +310,7 @@ class TestWorkerContributions:
         worker_messages = [
             m["content"]
             for m in moa.conversation.conversation_history
-            if m["role"] in ("W1", "W2")
+            if m["role"].startswith(("W1", "W2"))
         ]
         assert worker_messages == [
             "[W1-out]",
@@ -357,3 +357,130 @@ class TestWorkerContributions:
         assert (
             "user" not in roles
         ), f"stale messages loaded from disk: {roles}"
+
+
+# ============================================================================
+# Context shape — the aggregator receives typed chat turns, not one blob
+# ============================================================================
+
+
+def _recording_agents(names):
+    """Real agents whose run() records the context it was handed."""
+    calls = []
+    agents = []
+    for name in names:
+        agent = Agent(
+            agent_name=name,
+            model_name="gpt-4o-mini",
+            max_loops=1,
+            persistent_memory=False,
+            print_on=False,
+            autosave=False,
+        )
+
+        def _make(agent_obj, agent_name):
+            turns = [0]
+
+            def _run(task=None, messages=None, **kwargs):
+                turns[0] += 1
+                answer = f"{agent_name}-answer-{turns[0]}"
+                calls.append(
+                    {
+                        "agent": agent_name,
+                        "task": task,
+                        "messages": list(messages or []),
+                        "answer": answer,
+                    }
+                )
+                # The mixture reads the answer back through short_memory,
+                # not the return value, so the stub writes it there too.
+                agent_obj.short_memory.add(
+                    role=agent_name, content=answer
+                )
+                return answer
+
+            return _run
+
+        agent.run = _make(agent, name)
+        agents.append(agent)
+    return agents, calls
+
+
+def _aggregator_call(calls, name="Aggregator"):
+    """The single call handed to the aggregator, plus its turns as one list."""
+    aggregator_calls = [c for c in calls if c["agent"] == name]
+    assert (
+        len(aggregator_calls) == 1
+    ), f"the aggregator ran {len(aggregator_calls)} times"
+    call = aggregator_calls[0]
+    # split_last_turn hands the newest turn over as the task instead of
+    # repeating it at the end of messages.
+    turns = call["messages"] + [
+        {"role": "user", "content": str(call["task"])}
+    ]
+    return call, turns
+
+
+def test_aggregator_receives_typed_turns_per_worker():
+    """Each worker contribution reaches the aggregator as its own labelled turn.
+
+    The flattened form collapsed every worker into one user string, so the
+    aggregator could not tell one contributor from another.
+    """
+    agents, calls = _recording_agents(["W1", "W2"])
+    aggregator, agg_calls = _recording_agents(["Agg"])
+
+    MixtureOfAgents(
+        agents=agents,
+        aggregator_agent=aggregator[0],
+        layers=2,
+    ).run("Question?")
+
+    assert len(agg_calls) == 1
+    turns = agg_calls[0]["messages"] + [
+        {"role": "user", "content": agg_calls[0]["task"]}
+    ]
+
+    for message in turns:
+        assert isinstance(message, dict)
+        assert message["role"] in ("user", "assistant", "system")
+        assert isinstance(message["content"], str)
+
+    contents = [m["content"] for m in turns]
+    for worker in ("W1", "W2"):
+        assert any(
+            text.startswith(f"{worker}: ") for text in contents
+        ), f"no turn attributed to {worker}: {contents}"
+
+    # Four worker outputs across two layers, plus the task - not one blob.
+    assert len(turns) == 5
+
+
+def test_team_roster_does_not_reach_aggregator_as_user_prose():
+    """The roster is structure bookkeeping and belongs in a system prompt."""
+    agents, calls = _recording_agents(["W1", "W2", "Aggregator"])
+    moa = MixtureOfAgents(
+        name="Team Name",
+        agents=agents[:2],
+        aggregator_agent=agents[2],
+        layers=1,
+    )
+    moa.run("Question?")
+
+    roster = [
+        m
+        for m in moa.conversation.conversation_history
+        if str(m["role"]).lower() == "system"
+    ]
+    assert roster, "expected list_all_agents to add a System row"
+
+    _, turns = _aggregator_call(calls)
+    for message in turns:
+        if message["role"] != "user":
+            continue
+        assert not message["content"].startswith("System: Team Name")
+        assert "System: Team Name" not in message["content"]
+        assert (
+            "These are the agents in your team"
+            not in message["content"]
+        )

--- a/tests/structs/test_sequential_workflow.py
+++ b/tests/structs/test_sequential_workflow.py
@@ -4,6 +4,9 @@ from unittest.mock import patch
 import pytest
 
 from swarms import Agent, SequentialWorkflow
+from swarms.prompts.agent_acknowledgement_prompt import (
+    AGENT_COLLAB_PROMPT,
+)
 from swarms.structs.sequential_workflow import DRIFT_DETECTION_PROMPT
 from swarms.utils.workspace_utils import get_workspace_dir
 
@@ -639,3 +642,97 @@ def test_run_omits_imgs_when_not_supplied():
         wf.run("plain task")
 
     assert "imgs" not in pipeline.call_args.kwargs
+
+
+# ============================================================================
+# MULTI-AGENT COLLAB PROMPT: DELIVERED, NOT WELDED ONTO THE AGENTS
+# ============================================================================
+
+
+def _recording_agents(names):
+    """Agents whose run() records the context it was handed."""
+    calls = []
+    agents = []
+    for name in names:
+        agent = Agent(
+            agent_name=name,
+            system_prompt=f"You are {name}.",
+            model_name="gpt-4o",
+            max_loops=1,
+        )
+
+        def _make(agent_obj, agent_name):
+            def _run(task=None, messages=None, **kwargs):
+                calls.append(
+                    {
+                        "agent": agent_name,
+                        "task": task,
+                        "messages": list(messages or []),
+                    }
+                )
+                answer = f"{agent_name}-answer"
+                agent_obj.short_memory.add(
+                    role=agent_name, content=answer
+                )
+                return answer
+
+            return _run
+
+        agent.run = _make(agent, name)
+        agents.append(agent)
+    return agents, calls
+
+
+def test_collab_prompt_never_mutates_the_callers_agents():
+    """Construction used to do `agent.system_prompt += AGENT_COLLAB_PROMPT`.
+
+    It was never restored and it was cumulative, so building two workflows
+    over the same agents appended 13,433 chars twice.
+    """
+    agents, _ = _recording_agents(["A1", "A2"])
+    originals = [agent.system_prompt for agent in agents]
+
+    SequentialWorkflow(
+        agents=agents,
+        max_loops=1,
+        autosave=False,
+        multi_agent_collab_prompt=True,
+    )
+    SequentialWorkflow(
+        agents=agents,
+        max_loops=1,
+        autosave=False,
+        multi_agent_collab_prompt=True,
+    )
+
+    for agent, original in zip(agents, originals):
+        assert agent.system_prompt == original
+
+
+def test_collab_prompt_is_delivered_as_a_system_turn_at_run_time():
+    """Not mutating the agents must not mean losing the guidance."""
+    agents, calls = _recording_agents(["A1", "A2"])
+    originals = [agent.system_prompt for agent in agents]
+
+    workflow = SequentialWorkflow(
+        agents=agents,
+        max_loops=1,
+        autosave=False,
+        multi_agent_collab_prompt=True,
+    )
+    workflow.run("the task")
+
+    assert calls, "no agent was run"
+    system_turns = [
+        message["content"]
+        for call in calls
+        for message in call["messages"]
+        if message["role"] == "system"
+    ]
+    assert any(
+        AGENT_COLLAB_PROMPT in content for content in system_turns
+    )
+
+    # ...and the caller's agents are still untouched afterwards.
+    for agent, original in zip(agents, originals):
+        assert agent.system_prompt == original


### PR DESCRIPTION
A smaller slice of #2061, limited to **MixtureOfAgents** and **AgentRearrange** (and therefore SequentialWorkflow). The remaining structures from that PR are not touched here.

Fixes #2030
Fixes #2035
Fixes #2036
Fixes #2037

## Why

The `Agent` side already builds a `Transcript` and sends real typed turns. **That fix never reached the multi-agent structures.** Each one rendered the shared conversation as `"role: content"` prose and passed it as `agent.run(task=<blob>)`, so the entire room arrived as a single `user` message — role attribution lost, and no stable prefix for prompt caching.

The blocker was that a structure had nowhere to put typed turns: `Agent.run(messages=...)` accepted the kwarg through `**kwargs` and then silently overwrote it with the memory-derived transcript (#2030). That is fixed first; everything else builds on it.

## Approach

`context_utils` gains two helpers:

- **`messages_for(agent_name, conversation)`** renders a shared conversation from one agent's point of view — its own turns as `assistant`, everyone else's as `user` turns labelled with the speaker — and omits structure bookkeeping (`system` rows such as team rosters, which belong in a system prompt, not the conversation body).
- **`split_last_turn(messages)`** hands the newest turn over as the run's `task`, since `Agent.run` still takes one.

`Agent._run` now declares `messages` explicitly, and `_transcript_from_messages` prefers caller-supplied turns, falling back to `_transcript_from_memory` when none are given.

## What each issue was

| Issue | Fix |
|---|---|
| #2030 | `Agent.run(messages=...)` was silently discarded, so no structure could pass typed turns |
| #2035 | `SequentialWorkflow(multi_agent_collab_prompt=True)` appended 13,433 chars to the caller's live agents on **every** construction. The preamble now goes through the `AgentRearrange` constructor and is delivered as a system turn at run time |
| #2036 | `team_awareness` wrote a `"system"` row that `new_context_for` rendered as prose, so the first agent's task literally began `"system: ..."`. `messages_for` excludes structure roles, and awareness is delivered as a real system turn |
| #2037 | The concurrent path recorded the raw `run()` value — the agent's whole conversation by default — instead of its answer. It now records `agent_answer`, matching the sequential path |

Both structures also reset their conversation per task, so a reused instance no longer serves the previous task's transcript as context for the next one.

Guidance no longer reaches agents by mutating them. Sequential awareness and the collaboration preamble ride in the message list as `system` turns — assigning to `agent.system_prompt` never reached the model anyway, since the prompt is baked in when the LLM is built.

## Verified on the wire

Captured through the real `Agent` path at `call_llm`, a 3-agent `SequentialWorkflow`:

```
A: messages=2   [system] Sequential awareness: Agent behind: B
                [user]   the task
B: messages=3   [system] Sequential awareness: Agent ahead: A | Agent behind: C
                [user]   the task
                [user]   A: ANSWER_A
C: messages=4   [system] Sequential awareness: Agent ahead: B
                [user]   the task
                [user]   A: ANSWER_A
                [user]   B: ANSWER_B
```

Each speaker is its own labelled turn, awareness is a `system` turn rather than user prose, and 2 → 3 → 4 is a **strict prefix** — which is what prompt caching requires. The old single blob was re-rendered every turn and could never cache.

Each closed issue also checked against its own reproduction:

```
#2035 system_prompt len: base=10 after1=10 after2=10   -> FIXED
#2030 caller turns preserved: 2/2                      -> FIXED
#2037 recorded 2 msgs, longest=2 chars                 -> FIXED
```

## Tests

11 tests added across `test_moa.py`, `test_agent_rearrange.py`, `test_sequential_workflow.py` — typed turns per worker, an agent seeing its own output as `assistant`, awareness as a system message, no conversation leak between runs, the concurrent path recording answers, and the collab prompt never mutating the caller's agents.

**10 of the 11 fail against unpatched `master`.** (The eleventh, `test_concurrent_step_records_answers_not_transcripts`, passes there because `agent_answer` already exists.)

**No regressions**, from a detached worktree, run offline:

```
master:  9 failed,  98 passed
this PR: 9 failed, 107 passed
```

Identical failure sets — `comm` reports nothing introduced and nothing fixed. The 9 are pre-existing.

`black --line-length 70` and `ruff check .` clean across the repo.

## Deliberately not here

- **#2029 / #2053** — the remaining structures still flatten. Only MoA, AgentRearrange and SequentialWorkflow are converted, so those stay open.
- **#2040 (MixtureOfAgents)** — the "System roster rendered as user prose" half is fixed, and the aggregator now receives one labelled turn per worker per layer instead of one blob. Explicit **layer markers** are not added, so it is referenced rather than closed.
- **#2048 (SwarmRouter)** — the equivalent `multi_agent_collab_prompt` bug there needs `AgentRearrange(collab_prompt=...)`, which this PR adds; the SwarmRouter side is left for a follow-up.

## Not mine to review

The diff also removes commented-out code from `swarms/structs/agent.py` and `swarms/prompts/prompt.py` — a separate cleanup pass made in the same working tree, included here at the maintainer's request.
