### PR TITLE
fix(multi-agent): typed chat turns for the remaining structures

### DIFF
--- a/swarms/prompts/debate_with_judge_prompts.py
+++ b/swarms/prompts/debate_with_judge_prompts.py
@@ -1,0 +1,109 @@
+"""Prompts for the DebateWithJudge multi-agent structure."""
+
+PRO_AGENT_SYSTEM_PROMPT = """You are an expert debater specializing in arguing IN FAVOR of propositions.
+
+Your Role:
+- Present compelling, well-reasoned arguments supporting your assigned position
+- Use evidence, logic, and persuasive rhetoric to make your case
+- Anticipate and preemptively address potential counterarguments
+- Build upon previous arguments when refining your position
+
+Debate Guidelines:
+1. Structure your arguments clearly with main points and supporting evidence
+2. Use concrete examples and data when available
+3. Acknowledge valid opposing points while explaining why your position is stronger
+4. Maintain a professional, respectful tone throughout the debate
+5. Focus on the strongest aspects of your position
+
+Your goal is to present the most compelling case possible for the Pro position."""
+
+CON_AGENT_SYSTEM_PROMPT = """You are an expert debater specializing in arguing AGAINST propositions.
+
+Your Role:
+- Present compelling, well-reasoned counter-arguments opposing the given position
+- Identify weaknesses, flaws, and potential negative consequences
+- Challenge assumptions and evidence presented by the opposing side
+- Build upon previous arguments when refining your position
+
+Debate Guidelines:
+1. Structure your counter-arguments clearly with main points and supporting evidence
+2. Use concrete examples and data to support your opposition
+3. Directly address and refute the Pro's arguments
+4. Maintain a professional, respectful tone throughout the debate
+5. Focus on the most significant weaknesses of the opposing position
+
+Your goal is to present the most compelling case possible against the proposition."""
+
+JUDGE_AGENT_SYSTEM_PROMPT = """You are an impartial judge and critical evaluator of debates.
+
+Your Role:
+- Objectively evaluate arguments from both Pro and Con sides
+- Identify strengths and weaknesses in each position
+- Provide constructive feedback for improvement
+- Synthesize the best elements from both sides when appropriate
+- Render fair verdicts based on argument quality, not personal bias
+
+Evaluation Criteria:
+1. Logical coherence and reasoning quality
+2. Evidence and supporting data quality
+3. Persuasiveness and rhetorical effectiveness
+4. Responsiveness to opposing arguments
+5. Overall argument structure and clarity
+
+Judgment Guidelines:
+- Be specific about what makes arguments strong or weak
+- Provide actionable feedback for improvement
+- When synthesizing, explain how elements from both sides complement each other
+- In final rounds, provide clear conclusions with justification
+
+Your goal is to facilitate productive debate and arrive at well-reasoned conclusions."""
+
+PRO_AGENT_INTRO_PROMPT = """You are {pro_agent_name}, arguing in favor (Pro position) of the topic: {task}. Your role is to present strong, well-reasoned arguments supporting your position. You will debate against {con_agent_name}, who will argue against your position. A judge ({judge_agent_name}) will evaluate both arguments and provide synthesis. Present compelling evidence and reasoning."""
+
+CON_AGENT_INTRO_PROMPT = """You are {con_agent_name}, arguing against (Con position) of the topic: {task}. Your role is to present strong, well-reasoned counter-arguments. You will debate against {pro_agent_name}, who will argue in favor. A judge ({judge_agent_name}) will evaluate both arguments and provide synthesis. Present compelling counter-evidence and reasoning."""
+
+JUDGE_AGENT_INTRO_PROMPT = """You are {judge_agent_name}, an impartial judge evaluating a debate between {pro_agent_name} (Pro) and {con_agent_name} (Con) on the topic: {task}. Your role is to carefully evaluate both arguments, identify strengths and weaknesses, and provide a refined synthesis that incorporates the best elements from both sides. You may declare a winner or provide a balanced synthesis. Your output will be used to refine the discussion in subsequent loops."""
+
+PRO_FIRST_ROUND_PROMPT = """Present your argument in favor of: {topic}
+
+Provide a strong, well-reasoned argument with evidence and examples."""
+
+PRO_REFINEMENT_ROUND_PROMPT = """Loop {loop_number}: Based on the judge's previous evaluation, present an improved argument in favor of: {topic}
+
+Address any weaknesses identified and strengthen your position with additional evidence and reasoning."""
+
+CON_FIRST_ROUND_PROMPT = """Present your counter-argument against: {topic}
+
+Pro's argument:
+{pro_argument}
+
+Provide a strong, well-reasoned counter-argument that addresses the Pro's points and presents evidence against the position."""
+
+CON_REFINEMENT_ROUND_PROMPT = """Loop {loop_number}: Based on the judge's previous evaluation, present an improved counter-argument against: {topic}
+
+Pro's current argument:
+{pro_argument}
+
+Address any weaknesses identified and strengthen your counter-position with additional evidence and reasoning."""
+
+JUDGE_ROUND_PROMPT = """Loop {loop_number}/{max_loops}: Evaluate the debate on: {topic}
+
+Pro's argument ({pro_agent_name}):
+{pro_argument}
+
+Con's argument ({con_agent_name}):
+{con_argument}
+
+"""
+
+JUDGE_FINAL_ROUND_INSTRUCTIONS = """This is the final loop. Provide a comprehensive final evaluation:
+- Identify the strongest points from both sides
+- Determine a winner OR provide a balanced synthesis
+- Present a refined, well-reasoned answer that incorporates the best elements from both arguments
+- This will be the final output of the debate"""
+
+JUDGE_INTERMEDIATE_ROUND_INSTRUCTIONS = """Evaluate both arguments and provide:
+- Assessment of strengths and weaknesses in each argument
+- A refined synthesis that incorporates the best elements from both sides
+- Specific feedback for improvement in the next loop
+- Your synthesis will be used as the topic for the next loop"""

--- a/swarms/prompts/groupchat_prompt.py
+++ b/swarms/prompts/groupchat_prompt.py
@@ -1,7 +1,7 @@
 GROUPCHAT_DECIDE_PROMPT = """You are {agent_name} in a groupchat with: {other_agents}.
 
-Conversation so far:
-{history}
+The conversation so far is in the messages above; your own turns appear as
+your own replies.
 
 Latest message from {sender}:
 {message}

--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -1266,8 +1266,11 @@ class Conversation:
             return f"{self.conversation_history[-1]['role']}: {self.conversation_history[-1]['content']}"
         return ""
 
-    def return_messages_as_list(self):
+    def return_messages_as_strings(self):
         """Return the conversation messages as a list of formatted strings.
+
+        This is a rendering, not a message list. To build a request body use
+        :meth:`return_messages_as_dictionary`, which preserves roles.
 
         Returns:
             list: List of messages formatted as 'role: content'.
@@ -1277,11 +1280,14 @@ class Conversation:
             for message in self.conversation_history
         ]
 
-    def return_messages_as_dictionary(self):
-        """Return the conversation messages as a list of dictionaries.
+    def return_messages_as_list(self):
+        """Return the conversation as a list of message dictionaries.
+
+        For the ``'role: content'`` string rendering use
+        :meth:`return_messages_as_strings`.
 
         Returns:
-            list: List of dictionaries containing role and content of each message.
+            list: One ``{"role", "content"}`` dict per message.
         """
         return [
             {
@@ -1290,6 +1296,14 @@ class Conversation:
             }
             for message in self.conversation_history
         ]
+
+    def return_messages_as_dictionary(self):
+        """Return the conversation messages as a list of dictionaries.
+
+        Returns:
+            list: List of dictionaries containing role and content of each message.
+        """
+        return self.return_messages_as_list()
 
     def add_tool_output_to_agent(self, role: str, tool_output: dict):
         """
@@ -1338,7 +1352,7 @@ class Conversation:
         Returns:
             list: List of messages except the first one.
         """
-        return self.conversation_history[2:]
+        return self.conversation_history[1:]
 
     def return_all_except_first_string(self):
         """Return all messages except the first one as a string.
@@ -1564,23 +1578,3 @@ class Conversation:
         except Exception as e:
             logger.error(f"Dynamic auto chunking failed: {e}")
             return self._return_history_as_string_worker()
-
-
-# Example usage
-# conversation = Conversation()
-# conversation = Conversation(token_count=True, context_length=14)
-# conversation.add("user", "Hello, how are you?")
-# conversation.add("assistant", "I am doing well, thanks.")
-# conversation.add("user", "What is the weather in Tokyo?")
-# print(conversation.dynamic_auto_chunking())
-# # conversation.add(
-# #     "assistant", {"name": "tool_1", "output": "Hello, how are you?"}
-# )
-# print(conversation.return_json())
-
-# # print(conversation.get_last_message_as_string())
-# print(conversation.return_json())
-# # conversation.add("assistant", "I am doing well, thanks.")
-# # # print(conversation.to_json())
-# print(type(conversation.to_dict()))
-# print(conversation.to_yaml())

--- a/swarms/structs/debate_with_judge.py
+++ b/swarms/structs/debate_with_judge.py
@@ -9,66 +9,21 @@ from swarms.utils.history_output_formatter import (
     history_output_formatter,
 )
 from swarms.telemetry.otel import capture_init, trace_run
-
-
-# Pre-built system prompts for debate agents
-PRO_AGENT_SYSTEM_PROMPT = """You are an expert debater specializing in arguing IN FAVOR of propositions.
-
-Your Role:
-- Present compelling, well-reasoned arguments supporting your assigned position
-- Use evidence, logic, and persuasive rhetoric to make your case
-- Anticipate and preemptively address potential counterarguments
-- Build upon previous arguments when refining your position
-
-Debate Guidelines:
-1. Structure your arguments clearly with main points and supporting evidence
-2. Use concrete examples and data when available
-3. Acknowledge valid opposing points while explaining why your position is stronger
-4. Maintain a professional, respectful tone throughout the debate
-5. Focus on the strongest aspects of your position
-
-Your goal is to present the most compelling case possible for the Pro position."""
-
-CON_AGENT_SYSTEM_PROMPT = """You are an expert debater specializing in arguing AGAINST propositions.
-
-Your Role:
-- Present compelling, well-reasoned counter-arguments opposing the given position
-- Identify weaknesses, flaws, and potential negative consequences
-- Challenge assumptions and evidence presented by the opposing side
-- Build upon previous arguments when refining your position
-
-Debate Guidelines:
-1. Structure your counter-arguments clearly with main points and supporting evidence
-2. Use concrete examples and data to support your opposition
-3. Directly address and refute the Pro's arguments
-4. Maintain a professional, respectful tone throughout the debate
-5. Focus on the most significant weaknesses of the opposing position
-
-Your goal is to present the most compelling case possible against the proposition."""
-
-JUDGE_AGENT_SYSTEM_PROMPT = """You are an impartial judge and critical evaluator of debates.
-
-Your Role:
-- Objectively evaluate arguments from both Pro and Con sides
-- Identify strengths and weaknesses in each position
-- Provide constructive feedback for improvement
-- Synthesize the best elements from both sides when appropriate
-- Render fair verdicts based on argument quality, not personal bias
-
-Evaluation Criteria:
-1. Logical coherence and reasoning quality
-2. Evidence and supporting data quality
-3. Persuasiveness and rhetorical effectiveness
-4. Responsiveness to opposing arguments
-5. Overall argument structure and clarity
-
-Judgment Guidelines:
-- Be specific about what makes arguments strong or weak
-- Provide actionable feedback for improvement
-- When synthesizing, explain how elements from both sides complement each other
-- In final rounds, provide clear conclusions with justification
-
-Your goal is to facilitate productive debate and arrive at well-reasoned conclusions."""
+from swarms.prompts.debate_with_judge_prompts import (
+    CON_AGENT_INTRO_PROMPT,
+    CON_AGENT_SYSTEM_PROMPT,
+    CON_FIRST_ROUND_PROMPT,
+    CON_REFINEMENT_ROUND_PROMPT,
+    JUDGE_AGENT_INTRO_PROMPT,
+    JUDGE_AGENT_SYSTEM_PROMPT,
+    JUDGE_FINAL_ROUND_INSTRUCTIONS,
+    JUDGE_INTERMEDIATE_ROUND_INSTRUCTIONS,
+    JUDGE_ROUND_PROMPT,
+    PRO_AGENT_INTRO_PROMPT,
+    PRO_AGENT_SYSTEM_PROMPT,
+    PRO_FIRST_ROUND_PROMPT,
+    PRO_REFINEMENT_ROUND_PROMPT,
+)
 
 
 class DebateWithJudge:
@@ -128,7 +83,7 @@ class DebateWithJudge:
         con_agent: Optional[Agent] = None,
         judge_agent: Optional[Agent] = None,
         agents: Optional[List[Agent]] = None,
-        preset_agents: bool = False,
+        preset_agents: bool = True,
         max_loops: int = 3,
         output_type: str = "str-all-except-first",
         verbose: bool = True,
@@ -389,40 +344,22 @@ class DebateWithJudge:
         Args:
             task (str): The initial task/topic for context.
         """
-        # Initialize Pro agent
-        pro_intro = (
-            f"You are {self.pro_agent.agent_name}, arguing in favor (Pro position) "
-            f"of the topic: {task}. Your role is to present strong, well-reasoned "
-            f"arguments supporting your position. You will debate against "
-            f"{self.con_agent.agent_name}, who will argue against your position. "
-            f"A judge ({self.judge_agent.agent_name}) will evaluate both arguments "
-            f"and provide synthesis. Present compelling evidence and reasoning."
-        )
-        self.pro_agent.run(task=pro_intro)
+        names = {
+            "task": task,
+            "pro_agent_name": self.pro_agent.agent_name,
+            "con_agent_name": self.con_agent.agent_name,
+            "judge_agent_name": self.judge_agent.agent_name,
+        }
 
-        # Initialize Con agent
-        con_intro = (
-            f"You are {self.con_agent.agent_name}, arguing against (Con position) "
-            f"of the topic: {task}. Your role is to present strong, well-reasoned "
-            f"counter-arguments. You will debate against {self.pro_agent.agent_name}, "
-            f"who will argue in favor. A judge ({self.judge_agent.agent_name}) will "
-            f"evaluate both arguments and provide synthesis. Present compelling "
-            f"counter-evidence and reasoning."
+        self.pro_agent.run(
+            task=PRO_AGENT_INTRO_PROMPT.format(**names)
         )
-        self.con_agent.run(task=con_intro)
-
-        # Initialize Judge agent
-        judge_intro = (
-            f"You are {self.judge_agent.agent_name}, an impartial judge evaluating "
-            f"a debate between {self.pro_agent.agent_name} (Pro) and "
-            f"{self.con_agent.agent_name} (Con) on the topic: {task}. "
-            f"Your role is to carefully evaluate both arguments, identify strengths "
-            f"and weaknesses, and provide a refined synthesis that incorporates the "
-            f"best elements from both sides. You may declare a winner or provide a "
-            f"balanced synthesis. Your output will be used to refine the discussion "
-            f"in subsequent loops."
+        self.con_agent.run(
+            task=CON_AGENT_INTRO_PROMPT.format(**names)
         )
-        self.judge_agent.run(task=judge_intro)
+        self.judge_agent.run(
+            task=JUDGE_AGENT_INTRO_PROMPT.format(**names)
+        )
 
     def _create_pro_prompt(self, topic: str, round_num: int) -> str:
         """
@@ -436,17 +373,11 @@ class DebateWithJudge:
             str: The prompt for the Pro agent.
         """
         if round_num == 0:
-            return (
-                f"Present your argument in favor of: {topic}\n\n"
-                f"Provide a strong, well-reasoned argument with evidence and examples."
-            )
-        else:
-            return (
-                f"Loop {round_num + 1}: Based on the judge's previous evaluation, "
-                f"present an improved argument in favor of: {topic}\n\n"
-                f"Address any weaknesses identified and strengthen your position "
-                f"with additional evidence and reasoning."
-            )
+            return PRO_FIRST_ROUND_PROMPT.format(topic=topic)
+
+        return PRO_REFINEMENT_ROUND_PROMPT.format(
+            loop_number=round_num + 1, topic=topic
+        )
 
     def _create_con_prompt(
         self, topic: str, pro_argument: str, round_num: int
@@ -463,20 +394,15 @@ class DebateWithJudge:
             str: The prompt for the Con agent.
         """
         if round_num == 0:
-            return (
-                f"Present your counter-argument against: {topic}\n\n"
-                f"Pro's argument:\n{pro_argument}\n\n"
-                f"Provide a strong, well-reasoned counter-argument that addresses "
-                f"the Pro's points and presents evidence against the position."
+            return CON_FIRST_ROUND_PROMPT.format(
+                topic=topic, pro_argument=pro_argument
             )
-        else:
-            return (
-                f"Loop {round_num + 1}: Based on the judge's previous evaluation, "
-                f"present an improved counter-argument against: {topic}\n\n"
-                f"Pro's current argument:\n{pro_argument}\n\n"
-                f"Address any weaknesses identified and strengthen your counter-position "
-                f"with additional evidence and reasoning."
-            )
+
+        return CON_REFINEMENT_ROUND_PROMPT.format(
+            loop_number=round_num + 1,
+            topic=topic,
+            pro_argument=pro_argument,
+        )
 
     def _create_judge_prompt(
         self,
@@ -499,49 +425,20 @@ class DebateWithJudge:
         """
         is_final_round = round_num == self.max_loops - 1
 
-        prompt = (
-            f"Loop {round_num + 1}/{self.max_loops}: Evaluate the debate on: {topic}\n\n"
-            f"Pro's argument ({self.pro_agent.agent_name}):\n{pro_argument}\n\n"
-            f"Con's argument ({self.con_agent.agent_name}):\n{con_argument}\n\n"
+        prompt = JUDGE_ROUND_PROMPT.format(
+            loop_number=round_num + 1,
+            max_loops=self.max_loops,
+            topic=topic,
+            pro_agent_name=self.pro_agent.agent_name,
+            pro_argument=pro_argument,
+            con_agent_name=self.con_agent.agent_name,
+            con_argument=con_argument,
         )
 
         if is_final_round:
-            prompt += (
-                "This is the final loop. Provide a comprehensive final evaluation:\n"
-                "- Identify the strongest points from both sides\n"
-                "- Determine a winner OR provide a balanced synthesis\n"
-                "- Present a refined, well-reasoned answer that incorporates the best "
-                "elements from both arguments\n"
-                "- This will be the final output of the debate"
-            )
-        else:
-            prompt += (
-                "Evaluate both arguments and provide:\n"
-                "- Assessment of strengths and weaknesses in each argument\n"
-                "- A refined synthesis that incorporates the best elements from both sides\n"
-                "- Specific feedback for improvement in the next loop\n"
-                "- Your synthesis will be used as the topic for the next loop"
-            )
+            return prompt + JUDGE_FINAL_ROUND_INSTRUCTIONS
 
-        return prompt
-
-    def get_conversation_history(self) -> List[dict]:
-        """
-        Get the full conversation history.
-
-        Returns:
-            List[dict]: List of message dictionaries containing the conversation history.
-        """
-        return self.conversation.return_messages_as_list()
-
-    def get_final_answer(self) -> str:
-        """
-        Get the final refined answer from the judge.
-
-        Returns:
-            str: The content of the final judge synthesis.
-        """
-        return self.conversation.get_final_message_content()
+        return prompt + JUDGE_INTERMEDIATE_ROUND_INSTRUCTIONS
 
     def batched_run(self, tasks: List[str]) -> List[str]:
         """

--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -1783,8 +1783,11 @@ class GraphWorkflow:
 
         try:
             preds = self._get_predecessors(node_id)
+            # Pair each name with its own output; zipping a filtered output
+            # list against the unfiltered names shifts every label when a
+            # predecessor is missing.
             pred_outputs = [
-                prev_outputs.get(pred)
+                (pred, prev_outputs[pred])
                 for pred in preds
                 if pred in prev_outputs
             ]
@@ -1793,7 +1796,7 @@ class GraphWorkflow:
                 # Use list comprehension and join for faster string building
                 predecessor_parts = [
                     f"Output from {pred}:\n{out}"
-                    for pred, out in zip(preds, pred_outputs)
+                    for pred, out in pred_outputs
                     if out is not None
                 ]
                 predecessor_context = "\n\n".join(predecessor_parts)

--- a/swarms/structs/groupchat.py
+++ b/swarms/structs/groupchat.py
@@ -57,6 +57,7 @@ Example:
     result = chat.run("Discuss the tradeoffs of autonomous multi-agent systems.")
 """
 
+import ast
 import asyncio
 import json
 from collections import deque
@@ -64,6 +65,7 @@ from typing import Any, Callable, List, Optional, Tuple
 
 from swarms.structs.execution_utils import batched_run
 from swarms.prompts.groupchat_prompt import GROUPCHAT_DECIDE_PROMPT
+from swarms.structs.context_utils import messages_for
 from swarms.structs.agent import Agent
 from swarms.structs.conversation import Conversation
 from swarms.structs.serialization import SerializableMixin
@@ -119,6 +121,15 @@ def _extract_args(tool_output: Any) -> Tuple[float, str]:
         silent decision: ``(0.0, "")``. Scores are clamped into the ``0..1``
         range and messages are stripped of surrounding whitespace.
     """
+    # An agent whose output_type renders to text hands back the repr of the
+    # tool-call list rather than the list, and every bid would parse as
+    # silence. Recover the structure before giving up.
+    if isinstance(tool_output, str):
+        try:
+            tool_output = ast.literal_eval(tool_output)
+        except (ValueError, SyntaxError):
+            return 0.0, ""
+
     if isinstance(tool_output, list):
         tool_output = tool_output[0] if tool_output else None
     if not tool_output:
@@ -241,7 +252,7 @@ class GroupChat(SerializableMixin):
         self.verbose = verbose
         self.auto_equip = auto_equip
 
-        self.conversation = Conversation(time_enabled=True)
+        self.conversation = Conversation(time_enabled=False)
 
         if len(self.agents) < 2:
             raise ValueError("GroupChat requires at least 2 agents.")
@@ -285,7 +296,7 @@ class GroupChat(SerializableMixin):
         )
 
     def _decide_sync(
-        self, agent: Agent, sender: str, message: str, history: str
+        self, agent: Agent, sender: str, message: str
     ) -> Tuple[float, str]:
         """Ask one agent whether it wants to respond to a message.
 
@@ -299,12 +310,19 @@ class GroupChat(SerializableMixin):
         prompt = GROUPCHAT_DECIDE_PROMPT.format(
             agent_name=agent.agent_name,
             other_agents=self._other_agents(agent.agent_name),
-            history=history,
             sender=sender,
             message=message,
         )
         try:
-            tool_output = agent.run(task=prompt)
+            # The room arrives as typed turns, so this agent can tell its own
+            # prior speech from a peer's; flattening it into the prompt made
+            # every speaker look like the user.
+            tool_output = agent.run(
+                task=prompt,
+                messages=messages_for(
+                    agent.agent_name, self.conversation
+                ),
+            )
             # print(f"Agent {agent.agent_name} response: {tool_output}")
         except Exception as e:
             # Surface failures unconditionally — a swallowed error here looks
@@ -385,7 +403,7 @@ class GroupChat(SerializableMixin):
         streaming_callback(sender, "", True)
 
     async def _collect_bids(
-        self, sender: str, message: str, history: str
+        self, sender: str, message: str
     ) -> List[Tuple[Agent, float, str]]:
         """Ask every agent, concurrently, for a speaking bid this turn.
 
@@ -399,7 +417,7 @@ class GroupChat(SerializableMixin):
         results = await asyncio.gather(
             *(
                 asyncio.to_thread(
-                    self._decide_sync, agent, sender, message, history
+                    self._decide_sync, agent, sender, message
                 )
                 for agent in self.agents
             )
@@ -451,7 +469,7 @@ class GroupChat(SerializableMixin):
     ) -> Any:
         """Run the turn-based groupchat and return formatted history.
 
-        Each turn: snapshot the shared history, collect a bid from every agent,
+        Each turn: collect a bid from every agent,
         let the single highest (recency-adjusted) bidder speak, and post only
         that reply. The loop stops at the first lull — a turn where no agent
         clears ``threshold`` — or once ``max_loops`` messages have been posted.
@@ -482,10 +500,7 @@ class GroupChat(SerializableMixin):
         message_count = 1  # the user task counts as the first message
 
         while message_count < self.max_loops:
-            history = self.conversation.return_history_as_string()
-            bids = await self._collect_bids(
-                last_sender, last_message, history
-            )
+            bids = await self._collect_bids(last_sender, last_message)
 
             selection = self._select_speaker(bids, set(recent))
             if selection is None:

--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -21,7 +21,11 @@ from swarms.prompts.multi_agent_collab_prompt import (
     MULTI_AGENT_COLLAB_PROMPT_TWO,
 )
 from swarms.structs.agent import Agent
-from swarms.structs.context_utils import new_context_for
+from swarms.structs.context_utils import (
+    messages_for,
+    new_context_for,
+    split_last_turn,
+)
 from swarms.structs.conversation import Conversation
 from swarms.utils.any_to_str import any_to_str
 from swarms.structs.ma_blocks import find_agent_by_name
@@ -661,6 +665,21 @@ class HierarchicalSwarm:
             empty_message="(no new messages)",
         )
 
+    def _messages_for(self, agent_name: str) -> tuple:
+        """
+        The shared conversation as typed turns for one agent.
+
+        Args:
+            agent_name: The agent about to run.
+
+        Returns:
+            ``(prior_messages, task)``.
+        """
+        return split_last_turn(
+            messages_for(agent_name, self.conversation),
+            fallback="(no new messages)",
+        )
+
     def run_director(
         self,
         task: str,
@@ -789,7 +808,10 @@ class HierarchicalSwarm:
 
             if self.agent_as_judge:
                 feedback = self.run_judge_agent(outputs)
-            elif self.director_feedback_on is True:
+            elif (
+                self.director_feedback_on is True
+                and self.max_loops > 1
+            ):
                 feedback = self.feedback_director(outputs)
             else:
                 feedback = outputs
@@ -847,6 +869,9 @@ class HierarchicalSwarm:
             # Handle interactive mode task input
             if task is None and self.interactive:
                 task = self._get_interactive_task()
+
+            if task is not None:
+                self.conversation.add(role="User", content=task)
 
             current_loop = 0
             last_output = None
@@ -1003,7 +1028,9 @@ class HierarchicalSwarm:
         Create a one-shot judge agent that scores each worker agent's output.
 
         Args:
-            outputs (list): List of agent outputs to evaluate.
+            outputs (list): Accepted for call-site compatibility. The outputs
+                scored are read from the shared conversation, where they carry
+                their author's name.
 
         Returns:
             str: The structured JudgeReport as a string, also added to conversation.
@@ -1025,12 +1052,11 @@ class HierarchicalSwarm:
                 output_type="final",
             )
 
-            task = (
-                f"Conversation history:\n{self.conversation.get_str()}\n\n"
-                f"Agent outputs to evaluate:\n{outputs}"
-            )
-
-            result = judge.run(task=task)
+            # The workers' outputs are already in the conversation under
+            # their own names; interpolating the raw list here dropped those
+            # names and handed the judge a Python repr to score.
+            prior, judge_task = self._messages_for(judge.agent_name)
+            result = judge.run(task=judge_task, messages=prior)
             self.conversation.add(role="JudgeAgent", content=result)
             logger.info(f"Judge agent completed scoring:\n{result}")
             return result
@@ -1089,7 +1115,17 @@ class HierarchicalSwarm:
                     agent_name, "RUNNING", task, "Executing task..."
                 )
 
-            worker_task = f"History: {self._context_for(agent_name)} \n\n Task: {task}"
+            # The order's task is this turn's instruction; the history it
+            # needs rides alongside it as typed turns. A nested orchestrator
+            # has no `messages` parameter, so it keeps the flattened form.
+            worker_task = task
+            worker_extra = {}
+            if self._agent_supports_messages(agent):
+                worker_extra["messages"] = messages_for(
+                    agent_name, self.conversation
+                )
+            else:
+                worker_task = f"History: {self._context_for(agent_name)} \n\n Task: {task}"
 
             # Handle streaming callback if provided and the worker's run()
             # actually supports it. A worker may be a leaf Agent or a nested
@@ -1140,9 +1176,10 @@ class HierarchicalSwarm:
                     agent.streaming_on = True
                 try:
                     output = agent.run(
+                        *args,
                         task=worker_task,
                         streaming_callback=agent_streaming_callback,
-                        *args,
+                        **worker_extra,
                         **kwargs,
                     )
                 finally:
@@ -1159,8 +1196,9 @@ class HierarchicalSwarm:
                     )
             else:
                 output = agent.run(
-                    task=worker_task,
                     *args,
+                    task=worker_task,
+                    **worker_extra,
                     **kwargs,
                 )
                 if streaming_callback is not None:
@@ -1278,6 +1316,27 @@ class HierarchicalSwarm:
             or getattr(agent, "name", None)
             or str(agent)
         )
+
+    @staticmethod
+    def _agent_supports_messages(agent: Any) -> bool:
+        """Check whether ``agent.run`` accepts a ``messages`` kwarg.
+
+        Leaf agents take typed turns; nested orchestrators do not, and
+        passing the kwarg to one would raise ``TypeError``.
+        """
+        run_method = getattr(agent, "run", None)
+        if run_method is None:
+            return False
+        try:
+            signature = inspect.signature(run_method)
+        except (TypeError, ValueError):
+            return False
+        for parameter in signature.parameters.values():
+            if parameter.name == "messages":
+                return True
+            if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+                return True
+        return False
 
     @staticmethod
     def _agent_supports_streaming_callback(agent: Any) -> bool:
@@ -1886,6 +1945,9 @@ class HierarchicalSwarm:
                 "loop": 0,
             }
 
+        if task is not None:
+            self.conversation.add(role="User", content=task)
+
         current_loop = 0
         last_output = None
 
@@ -1907,7 +1969,7 @@ class HierarchicalSwarm:
             # DIRECTOR PHASE
             # =============================================================
             director_task_str = (
-                f"History: {self.conversation.get_str()} "
+                f"History: {self._context_for(self.director.agent_name)} "
                 f"\n\n Task: {loop_task}"
             )
 
@@ -1924,7 +1986,7 @@ class HierarchicalSwarm:
                 )
                 # Refresh context after planning output was added
                 director_task_str = (
-                    f"History: {self.conversation.get_str()} "
+                    f"History: {self._context_for(self.director.agent_name)} "
                     f"\n\n Task: {loop_task}"
                 )
 
@@ -1994,7 +2056,7 @@ class HierarchicalSwarm:
                         self.agents, order.agent_name
                     )
                     w_task = (
-                        f"History: {self.conversation.get_str()} "
+                        f"History: {self._context_for(order.agent_name)} "
                         f"\n\n Task: {order.task}"
                     )
                     w_chunks: List[str] = []
@@ -2088,7 +2150,7 @@ class HierarchicalSwarm:
                         self.agents, order.agent_name
                     )
                     w_task = (
-                        f"History: {self.conversation.get_str()} "
+                        f"History: {self._context_for(order.agent_name)} "
                         f"\n\n Task: {order.task}"
                     )
 

--- a/swarms/structs/majority_voting.py
+++ b/swarms/structs/majority_voting.py
@@ -1,5 +1,5 @@
-import os
-from typing import Any, Callable, List, Optional
+from concurrent.futures import as_completed
+from typing import Any, Callable, Dict, List, Optional
 
 from swarms.structs.execution_utils import (
     batched_run,
@@ -7,14 +7,19 @@ from swarms.structs.execution_utils import (
 )
 from swarms.structs.agent import Agent
 from swarms.structs.conversation import Conversation
-from swarms.structs.multi_agent_exec import run_agents_concurrently
 from swarms.utils.formatter import formatter
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
 )
 from swarms.utils.output_types import OutputType
 from swarms.utils.workspace_manager import WorkspaceManager
+from swarms.structs.context_utils import (
+    agent_answer,
+    messages_for,
+    split_last_turn,
+)
 from swarms.telemetry.otel import (
+    ContextThreadPoolExecutor,
     capture_init,
     trace_run,
 )
@@ -183,6 +188,45 @@ class MajorityVoting:
             title="Majority Voting",
         )
 
+    def _run_voters(self) -> Dict[str, Any]:
+        """
+        Run every voter on the shared conversation, concurrently.
+
+        Each voter receives the history as typed turns and contributes its
+        answer. Recording ``run``'s return value instead would store the
+        voter's whole conversation - which already contains this history - so
+        the shared transcript would compound on every loop.
+
+        Returns:
+            Maps agent name to that voter's answer.
+        """
+        answers: Dict[str, Any] = {}
+        with ContextThreadPoolExecutor(
+            max_workers=len(self.agents)
+        ) as executor:
+            future_to_agent = {}
+            for agent in self.agents:
+                prior, vote_task = split_last_turn(
+                    messages_for(agent.agent_name, self.conversation)
+                )
+                future = executor.submit(
+                    agent.run, task=vote_task, messages=prior
+                )
+                future_to_agent[future] = agent
+
+            for future in as_completed(future_to_agent):
+                agent = future_to_agent[future]
+                try:
+                    result = future.result()
+                except Exception as error:
+                    answers[agent.agent_name] = error
+                    continue
+                answers[agent.agent_name] = agent_answer(
+                    agent, fallback=result
+                )
+
+        return answers
+
     @trace_run(
         "MajorityVoting.run",
         input_params=("task", "tasks", "img", "imgs"),
@@ -209,6 +253,10 @@ class MajorityVoting:
 
         """
 
+        # A reused instance would otherwise serve the previous task's votes
+        # as context for this one.
+        self.conversation = Conversation(time_enabled=False)
+
         self.conversation.add(
             role="user",
             content=task,
@@ -216,16 +264,12 @@ class MajorityVoting:
 
         for i in range(self.max_loops):
 
-            output = run_agents_concurrently(
-                agents=self.agents,
-                task=self.conversation.get_str(),
-                max_workers=os.cpu_count(),
-            )
+            outputs = self._run_voters()
 
-            for agent, output in zip(self.agents, output):
+            for agent in self.agents:
                 self.conversation.add(
                     role=agent.agent_name,
-                    content=output,
+                    content=outputs[agent.agent_name],
                 )
 
             # Set streaming_on for the consensus agent based on the provided streaming_callback
@@ -252,9 +296,18 @@ class MajorityVoting:
                 consensus_streaming_callback = None
 
             # Run the consensus agent with the streaming callback, if any
+            prior, consensus_task = split_last_turn(
+                messages_for(
+                    self.consensus_agent.agent_name, self.conversation
+                )
+            )
             consensus_output = self.consensus_agent.run(
-                task=(f"History: {self.conversation.get_str()}"),
+                task=consensus_task,
+                messages=prior,
                 streaming_callback=consensus_streaming_callback,
+            )
+            consensus_output = agent_answer(
+                self.consensus_agent, fallback=consensus_output
             )
 
             self.conversation.add(

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -27,6 +27,7 @@ from swarms.structs.heavy_swarm import HeavySwarm
 from swarms.structs.hiearchical_swarm import HierarchicalSwarm
 from swarms.structs.llm_council import LLMCouncil
 from swarms.structs.ma_utils import list_all_agents
+from swarms.utils.loguru_logger import initialize_logger
 from swarms.structs.majority_voting import MajorityVoting
 from swarms.structs.mixture_of_agents import MixtureOfAgents
 from swarms.structs.multi_agent_router import MultiAgentRouter
@@ -124,8 +125,25 @@ def _msg_autosave_enabled(workspace_dir: str) -> str:
     return f"Autosave enabled. Swarm workspace: {workspace_dir}"
 
 
+logger = initialize_logger(log_folder="swarm_router")
+
+
 def _msg_batch_run_error(err: Exception, tb: str) -> str:
     return f"SwarmRouter: Error executing batch task on swarm: {err} Traceback: {tb}"
+
+
+def _msg_collab_prompt_ignored(swarm_type: str) -> str:
+    return (
+        f"multi_agent_collab_prompt is ignored for swarm_type={swarm_type!r}; "
+        f"it is delivered only by {', '.join(sorted(_COLLAB_PROMPT_SWARM_TYPES))}."
+    )
+
+
+# Swarm types whose constructor carries the collaboration preamble through to
+# the agents. Everywhere else the flag has nothing to deliver it.
+_COLLAB_PROMPT_SWARM_TYPES = frozenset(
+    {"SequentialWorkflow", "AgentRearrange"}
+)
 
 
 SwarmType = Literal[
@@ -378,6 +396,8 @@ class SwarmRouter(SerializableMixin):
         # Initialize swarm factory for O(1) lookup performance
         self._swarm_factory = self._initialize_swarm_factory()
         self._swarm_cache = {}  # Cache for created swarms
+        # Built lazily on the first run.
+        self.swarm = None
 
         # Always built: a disabled manager no-ops, an absent one raises.
         self._setup_autosave()
@@ -472,15 +492,21 @@ class SwarmRouter(SerializableMixin):
     def setup(self):
         """Apply post-validation configuration to the agent roster.
 
-        Appends the multi-agent collaboration preamble and (if enabled) lists
-        every agent to every other agent. Called from
+        Warns when the collaboration preamble cannot be delivered for this
+        swarm type. The preamble itself is passed to the swarm at
+        construction, and the agent roster is seeded once the swarm exists
+        (see :meth:`list_agents_to_eachother`). Called from
         :meth:`reliability_check`; not intended to be called directly.
         """
-        if self.multi_agent_collab_prompt is True:
-            self.update_system_prompt_for_agent_in_swarm()
-
-        if self.list_all_agents is True:
-            self.list_agents_to_eachother()
+        if (
+            self.multi_agent_collab_prompt is True
+            and self.swarm_type not in _COLLAB_PROMPT_SWARM_TYPES
+        ):
+            # Not self._log: that is gated on verbose, and a flag that
+            # silently does nothing is the thing being warned about.
+            logger.warning(
+                _msg_collab_prompt_ignored(self.swarm_type)
+            )
 
     def fetch_message_history_as_string(self):
         """Return the underlying swarm's conversation history as a string.
@@ -584,7 +610,10 @@ class SwarmRouter(SerializableMixin):
         """Create an ``AgentRearrange`` using ``rearrange_flow``."""
         return AgentRearrange(
             *args,
-            **self._base_kwargs(flow=self.rearrange_flow),
+            **self._base_kwargs(
+                flow=self.rearrange_flow,
+                collab_prompt=self._collab_preamble(),
+            ),
             **kwargs,
         )
 
@@ -642,10 +671,45 @@ class SwarmRouter(SerializableMixin):
             output_type=self.output_type,
         )
 
+    def _collab_preamble(self) -> Optional[str]:
+        """Team context delivered to each agent as a system turn.
+
+        Built here rather than written into the shared conversation because
+        structures reset that conversation per task, which would discard
+        anything seeded before the run.
+
+        Returns:
+            The preamble, or ``None`` when neither option is enabled.
+        """
+        parts = []
+
+        if self.list_all_agents is True:
+            parts.append(
+                list_all_agents(
+                    agents=self.agents,
+                    name=self.name,
+                    description=self.description,
+                    add_collaboration_prompt=False,
+                    add_to_conversation=False,
+                )
+            )
+
+        if self.multi_agent_collab_prompt is True:
+            parts.append(MULTI_AGENT_COLLAB_PROMPT_TWO)
+
+        return "\n\n".join(part for part in parts if part) or None
+
     def _create_sequential_workflow(self, *args, **kwargs):
         """Create a ``SequentialWorkflow`` from the configured agents."""
         return SequentialWorkflow(
-            *args, **self._base_kwargs(), **kwargs
+            *args,
+            **self._base_kwargs(
+                multi_agent_collab_prompt=(
+                    self._collab_preamble() is not None
+                ),
+                collab_prompt=self._collab_preamble(),
+            ),
+            **kwargs,
         )
 
     def _create_concurrent_workflow(self, *args, **kwargs):
@@ -763,31 +827,22 @@ class SwarmRouter(SerializableMixin):
                 _msg_factory_failed(self.swarm_type, e)
             ) from e
 
-    def update_system_prompt_for_agent_in_swarm(self):
-        """Append the collaboration prompt to each configured agent."""
-        # Use list comprehension for faster iteration
-        for agent in self.agents:
-            if agent.system_prompt is None:
-                agent.system_prompt = ""
-            agent.system_prompt += MULTI_AGENT_COLLAB_PROMPT_TWO
-
     def list_agents_to_eachother(self):
-        """Add the configured agent roster to the swarm conversation."""
+        """Point ``self.conversation`` at the underlying swarm's conversation.
+
+        Called after each run, because the swarm is built lazily and several
+        structures replace their conversation object per task.
+        """
+        if self.swarm is None:
+            return
+
         if self.swarm_type == "SequentialWorkflow":
-            self.conversation = (
-                self.swarm.agent_rearrange.conversation
+            self.conversation = getattr(
+                self.swarm.agent_rearrange, "conversation", None
             )
         else:
-            self.conversation = self.swarm.conversation
-
-        if self.list_all_agents is True:
-            list_all_agents(
-                agents=self.agents,
-                conversation=self.swarm.conversation,
-                name=self.name,
-                description=self.description,
-                add_collaboration_prompt=True,
-                add_to_conversation=True,
+            self.conversation = getattr(
+                self.swarm, "conversation", None
             )
 
     def _run(
@@ -826,6 +881,8 @@ class SwarmRouter(SerializableMixin):
             args["img"] = img
 
         result = self.swarm.run(**args, **kwargs)
+
+        self.list_agents_to_eachother()
 
         # Config is written at init; overwriting it here would lose it.
         self.workspace.save_state()

--- a/tests/structs/test_conversation.py
+++ b/tests/structs/test_conversation.py
@@ -1089,6 +1089,74 @@ class TestDefaultConversationDoesNotResumeFromDisk:
         assert "explicit save" in contents
 
 
+# ============================================================================
+# MESSAGE ACCESSORS: STRINGS VS REAL MESSAGE DICTS
+# ============================================================================
+
+
+def _two_turn_conversation():
+    conv = Conversation()
+    conv.add("user", "Hello, world!")
+    conv.add("assistant", "Hello, user!")
+    return conv
+
+
+def test_return_messages_as_strings_formats_role_colon_content():
+    """The flattener returns renderings, not messages."""
+    conv = _two_turn_conversation()
+
+    strings = conv.return_messages_as_strings()
+
+    assert isinstance(strings, list)
+    assert all(isinstance(s, str) for s in strings)
+    assert strings == [
+        "user: Hello, world!",
+        "assistant: Hello, user!",
+    ]
+
+
+def test_return_messages_as_list_returns_message_dicts():
+    """The name promises a message list, so it returns dicts, not strings."""
+    conversation = Conversation()
+    conversation.add("user", "Hello, world!")
+    conversation.add("assistant", "Hello, user!")
+
+    messages = conversation.return_messages_as_list()
+
+    assert all(isinstance(message, dict) for message in messages)
+    assert [m["role"] for m in messages] == ["user", "assistant"]
+    assert [m["content"] for m in messages] == [
+        "Hello, world!",
+        "Hello, user!",
+    ]
+    # The string rendering lives under its own name.
+    assert conversation.return_messages_as_strings() == [
+        "user: Hello, world!",
+        "assistant: Hello, user!",
+    ]
+
+
+def test_return_messages_as_dictionary_preserves_roles():
+    """The real message-list accessor: dicts with exactly role and content.
+
+    Asserting the type and the role keeps a future rename from silently
+    swapping this with the "role: content" flattener.
+    """
+    conv = _two_turn_conversation()
+
+    messages = conv.return_messages_as_dictionary()
+
+    assert isinstance(messages, list)
+    for message in messages:
+        assert isinstance(message, dict)
+        assert set(message.keys()) == {"role", "content"}
+
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "Hello, world!"
+    assert messages[1]["role"] == "assistant"
+    assert messages[1]["content"] == "Hello, user!"
+
+
 if __name__ == "__main__":
     logger.info("Starting test execution")
     results = run_all_tests()

--- a/tests/structs/test_graph_workflow.py
+++ b/tests/structs/test_graph_workflow.py
@@ -1478,5 +1478,50 @@ def test_save_spec_round_trips_through_from_topology_spec(tmp_path):
     assert rebuilt.max_loops == wf.max_loops
 
 
+# ============================================================================
+# Fan-in attribution — each predecessor's output must carry its own name
+# ============================================================================
+
+
+def test_fan_in_attributes_outputs_to_the_correct_predecessor():
+    """A missing predecessor must not shift every remaining label.
+
+    ``pred_outputs`` is filtered by presence in ``prev_outputs``; zipping it
+    against the unfiltered predecessor list used to pair B's output with A's
+    name and drop the last output entirely.
+    """
+    wf = GraphWorkflow(auto_compile=False)
+    for name in ["A", "B", "C", "D"]:
+        wf.add_node(create_test_agent(name))
+    for parent in ["A", "B", "C"]:
+        wf.add_edge(parent, "D")
+
+    # A produced nothing this run - failed, skipped, or behind a false branch.
+    prev_outputs = {"B": "OUT_B", "C": "OUT_C"}
+    prompt = wf._build_prompt(
+        "D", "the task", prev_outputs, layer_idx=1
+    )
+
+    assert "Output from B:\nOUT_B" in prompt
+    assert "Output from C:\nOUT_C" in prompt
+    assert "Output from A:" not in prompt
+
+
+def test_fan_in_with_all_predecessors_present_is_unaffected():
+    """The all-present case keeps working."""
+    wf = GraphWorkflow(auto_compile=False)
+    for name in ["A", "B", "C"]:
+        wf.add_node(create_test_agent(name))
+    for parent in ["A", "B"]:
+        wf.add_edge(parent, "C")
+
+    prompt = wf._build_prompt(
+        "C", "the task", {"A": "OUT_A", "B": "OUT_B"}, layer_idx=1
+    )
+
+    assert "Output from A:\nOUT_A" in prompt
+    assert "Output from B:\nOUT_B" in prompt
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/structs/test_hierarchical_swarm.py
+++ b/tests/structs/test_hierarchical_swarm.py
@@ -1143,17 +1143,36 @@ class TestHierarchicalContextManagement:
             f"across one loop: {director_turns}"
         )
 
-    def test_a_worker_is_not_re_sent_the_whole_history(self):
+    def test_a_worker_sees_its_own_output_once_as_assistant(self):
+        """The compounding this guards against is the agent re-reading itself.
+
+        Typed turns carry the whole conversation every request, so raw growth
+        is linear and no longer the signal. What must not happen is the
+        worker's own output coming back a second time, mislabelled as
+        something someone else said - that is what compounded across loops.
+        """
         _, seen = self._run_two_loops()
-        worker_turns = [
-            sum(len(str(m.get("content"))) for m in messages)
-            for name, messages in seen
-            if name == "W1"
+        worker_calls = [
+            messages for name, messages in seen if name == "W1"
         ]
-        if len(worker_turns) >= 2:
-            assert (
-                worker_turns[1] < worker_turns[0] * 5
-            ), f"worker context grew too fast: {worker_turns}"
+        if len(worker_calls) < 2:
+            return
+
+        second = worker_calls[1]
+        # Turns that are the output, not ones quoting it inside a larger
+        # blob: the feedback director still interpolates a flattened history
+        # (#2033), which is a separate unconverted path.
+        own = [
+            message
+            for message in second
+            if str(message.get("content")).strip() == "[W1-out]"
+        ]
+        assert (
+            len(own) == 1
+        ), f"the worker saw its own output {len(own)} times: {own}"
+        assert (
+            own[0]["role"] == "assistant"
+        ), f"own output arrived as {own[0]['role']!r}, not 'assistant'"
 
     def test_the_director_tool_call_is_stored_readably(self):
         """

--- a/tests/structs/test_majority_voting.py
+++ b/tests/structs/test_majority_voting.py
@@ -274,3 +274,146 @@ def test_streaming_majority_voting():
         print("Error in test_streaming_majority_voting:", e)
         print("Logs so far:", logs)
         raise
+
+
+# ============================================================================
+# Context shape — voters receive typed chat turns, not one flattened blob
+# ============================================================================
+
+
+def _record(agent, calls):
+    """Replace an agent's run() with a stub that records the context it got."""
+    name = agent.agent_name
+    turns = [0]
+
+    def _run(task=None, messages=None, **kwargs):
+        turns[0] += 1
+        answer = f"{name}-answer-{turns[0]}"
+        calls.append(
+            {
+                "agent": name,
+                "task": task,
+                "messages": list(messages or []),
+                "answer": answer,
+            }
+        )
+        # Structures read the answer back through short_memory, not the
+        # return value, so the stub has to write it there too.
+        agent.short_memory.add(role=name, content=answer)
+        return answer
+
+    agent.run = _run
+    return agent
+
+
+def _recording_agents(names):
+    """Real agents whose run() records the context it was handed."""
+    calls = []
+    agents = []
+    for name in names:
+        agent = Agent(
+            agent_name=name,
+            agent_description=f"Recording voter {name}",
+            model_name="gpt-4o",
+            max_loops=1,
+            persistent_memory=False,
+            print_on=False,
+            autosave=False,
+        )
+        agents.append(_record(agent, calls))
+    return agents, calls
+
+
+def _voting_system(names, max_loops):
+    """A MajorityVoting whose voters and consensus agent are both recorded."""
+    agents, calls = _recording_agents(names)
+    mv = MajorityVoting(agents=agents, max_loops=max_loops)
+    _record(mv.consensus_agent, calls)
+    return mv, calls
+
+
+def test_voters_receive_typed_turns_not_one_user_blob():
+    """Shared history reaches a voter as chat turns, not concatenated onto the task."""
+    mv, calls = _voting_system(["Voter-A", "Voter-B"], max_loops=2)
+    mv.run("the original question")
+
+    a_calls = [c for c in calls if c["agent"] == "Voter-A"]
+    b_calls = [c for c in calls if c["agent"] == "Voter-B"]
+    assert len(a_calls) == 2 and len(b_calls) == 2
+
+    for call in a_calls + b_calls:
+        assert isinstance(call["messages"], list)
+        for message in call["messages"]:
+            assert isinstance(message, dict)
+            assert message["role"] in ("user", "assistant", "system")
+            assert isinstance(message["content"], str)
+        assert "History:" not in str(call["task"])
+
+    # The first round is the bare task: there is no history to send yet.
+    assert a_calls[0]["task"] == "the original question"
+    assert a_calls[0]["messages"] == []
+
+    # The second round carries the first round as turns, not as task text.
+    assert len(a_calls[1]["messages"]) >= 2
+    assert b_calls[0]["answer"] not in str(a_calls[1]["task"])
+    assert b_calls[0]["answer"] in "\n".join(
+        m["content"] for m in a_calls[1]["messages"]
+    )
+
+
+def test_votes_recorded_are_answers_not_transcripts():
+    """A voter contributes its answer to the shared conversation, not its transcript."""
+    task = "a very distinctive question about tungsten supply"
+    mv, calls = _voting_system(["Voter-A", "Voter-B"], max_loops=2)
+    mv.run(task)
+
+    for name in ("Voter-A", "Voter-B"):
+        expected = [c["answer"] for c in calls if c["agent"] == name]
+        recorded = [
+            m["content"]
+            for m in mv.conversation.conversation_history
+            if m["role"] == name
+        ]
+        assert recorded == expected, (
+            f"{name} recorded something other than its answers: "
+            f"{recorded}"
+        )
+        assert not any(
+            task in content for content in recorded
+        ), f"{name} echoed the task back into the shared conversation"
+
+
+def test_consensus_agent_sees_its_own_prior_consensus_as_assistant():
+    """The consensus agent's own turn must not come back labelled as the user's."""
+    mv, calls = _voting_system(["Voter-A", "Voter-B"], max_loops=2)
+    mv.run("go")
+
+    consensus_calls = [
+        c
+        for c in calls
+        if c["agent"] == mv.consensus_agent.agent_name
+    ]
+    assert len(consensus_calls) == 2
+    second = consensus_calls[1]
+
+    assistant = [
+        m["content"]
+        for m in second["messages"]
+        if m["role"] == "assistant"
+    ]
+    assert consensus_calls[0]["answer"] in assistant
+
+    user_text = "\n".join(
+        m["content"]
+        for m in second["messages"]
+        if m["role"] == "user"
+    )
+    for name in ("Voter-A", "Voter-B"):
+        for call in [c for c in calls if c["agent"] == name]:
+            labelled = f"{name}: {call['answer']}"
+            assert labelled in user_text or labelled == str(
+                second["task"]
+            ), f"{name}'s vote never reached the consensus agent as a user turn"
+            assert not any(
+                call["answer"] in content for content in assistant
+            ), f"{name}'s vote arrived as the consensus agent's own turn"

--- a/tests/structs/test_swarm_router.py
+++ b/tests/structs/test_swarm_router.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from typing import get_args
 
@@ -656,3 +658,176 @@ class TestConcurrentRun:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# ============================================================================
+# multi_agent_collab_prompt — delivered, not welded onto the caller's agents
+# ============================================================================
+
+
+def _collab_recording_agents(names):
+    """Agents whose run() records the system turns it was handed."""
+    from swarms import Agent
+
+    calls = []
+    agents = []
+    for name in names:
+        agent = Agent(
+            agent_name=name,
+            system_prompt=f"You are {name}.",
+            model_name="gpt-5.4",
+            max_loops=1,
+            verbose=False,
+        )
+
+        def _make(agent_obj, agent_name):
+            def _run(task=None, messages=None, **kwargs):
+                calls.append(
+                    {
+                        "agent": agent_name,
+                        "messages": list(messages or []),
+                    }
+                )
+                answer = f"{agent_name}-answer"
+                agent_obj.short_memory.add(
+                    role=agent_name, content=answer
+                )
+                return answer
+
+            return _run
+
+        agent.run = _make(agent, name)
+        agents.append(agent)
+    return agents, calls
+
+
+def test_collab_prompt_never_mutates_the_callers_agents():
+    """Building routers must not append to the caller's system_prompt.
+
+    The preamble used to be appended with ``+=`` at construction. It never
+    reached the model (the prompt is baked into the LLM when the agent is
+    built) and it accumulated once per router.
+    """
+    agents, _ = _collab_recording_agents(["A", "B"])
+    originals = [a.system_prompt for a in agents]
+
+    SwarmRouter(
+        agents=agents,
+        swarm_type="SequentialWorkflow",
+        multi_agent_collab_prompt=True,
+    )
+    SwarmRouter(
+        agents=agents,
+        swarm_type="SequentialWorkflow",
+        multi_agent_collab_prompt=True,
+    )
+
+    assert [a.system_prompt for a in agents] == originals
+
+
+def test_collab_prompt_is_delivered_as_a_system_turn():
+    """The preamble must actually reach the agent at run time."""
+    from swarms.prompts.multi_agent_collab_prompt import (
+        MULTI_AGENT_COLLAB_PROMPT_TWO,
+    )
+
+    agents, calls = _collab_recording_agents(["A", "B"])
+    router = SwarmRouter(
+        agents=agents,
+        swarm_type="SequentialWorkflow",
+        multi_agent_collab_prompt=True,
+    )
+    router.run("Go.")
+
+    delivered = [
+        m["content"]
+        for call in calls
+        for m in call["messages"]
+        if m["role"] == "system"
+    ]
+    assert any(
+        MULTI_AGENT_COLLAB_PROMPT_TWO in text for text in delivered
+    )
+    assert [a.system_prompt for a in agents] == [
+        "You are A.",
+        "You are B.",
+    ]
+
+
+def test_collab_prompt_warns_when_the_swarm_type_cannot_deliver_it():
+    """A flag that does nothing must say so, regardless of verbose."""
+    agents, _ = _collab_recording_agents(["A", "B"])
+
+    with patch("swarms.structs.swarm_router.logger.warning") as warn:
+        SwarmRouter(
+            agents=agents,
+            swarm_type="ConcurrentWorkflow",
+            multi_agent_collab_prompt=True,
+            verbose=False,
+        )
+
+    assert warn.called
+    assert "multi_agent_collab_prompt is ignored" in str(
+        warn.call_args
+    )
+
+
+def test_list_all_agents_does_not_crash_at_construction():
+    """The swarm is built lazily, so setup() must not reach for it.
+
+    ``setup()`` used to call ``list_agents_to_eachother()``, which reads
+    ``self.swarm`` — created only on the first ``run()`` — so constructing a
+    router with ``list_all_agents=True`` raised ``AttributeError``.
+    """
+    agents, _ = _collab_recording_agents(["A", "B"])
+
+    router = SwarmRouter(
+        agents=agents,
+        swarm_type="SequentialWorkflow",
+        list_all_agents=True,
+    )
+
+    assert router.swarm is None
+
+
+def test_list_all_agents_delivers_the_roster_as_a_system_turn():
+    """The roster reaches agents, and the caller's agents are untouched.
+
+    It cannot be seeded into the shared conversation: structures reset that
+    conversation per task, which would discard it before any agent ran.
+    """
+    agents, calls = _collab_recording_agents(["A", "B"])
+    originals = [a.system_prompt for a in agents]
+
+    router = SwarmRouter(
+        agents=agents,
+        swarm_type="SequentialWorkflow",
+        list_all_agents=True,
+        multi_agent_collab_prompt=False,
+    )
+    router.run("Go.")
+
+    delivered = [
+        m["content"]
+        for call in calls
+        for m in call["messages"]
+        if m["role"] == "system"
+    ]
+    assert any("Total Agents" in text for text in delivered)
+    assert [a.system_prompt for a in agents] == originals
+
+
+def test_conversation_points_at_the_live_swarm_conversation_after_run():
+    """``router.conversation`` must be the conversation the run actually used."""
+    agents, _ = _collab_recording_agents(["A", "B"])
+    router = SwarmRouter(
+        agents=agents, swarm_type="SequentialWorkflow", max_loops=1
+    )
+
+    assert router.conversation is None
+    router.run("Go.")
+
+    roles = [
+        m["role"] for m in router.conversation.conversation_history
+    ]
+    assert "A" in roles and "B" in roles


### PR DESCRIPTION
The rest of #2061. #2078 converted MixtureOfAgents and AgentRearrange; this finishes the structures that were left flattening the shared conversation.

Fixes #2031
Fixes #2032
Fixes #2034
Fixes #2038
Fixes #2039
Fixes #2048

## Why

These structures still rendered the shared conversation as `"role: content"` prose and passed it as `agent.run(task=<blob>)`, so the whole room arrived as a single `user` message — no role attribution, and no stable prefix to cache. They now use the `messages_for` / `split_last_turn` helpers added in #2078.

Converted: **GroupChat**, **HierarchicalSwarm**, **MajorityVoting**, **GraphWorkflow**, plus **SwarmRouter** moved off mutating the caller's agents.

## What each issue was

| Issue | Fix |
|---|---|
| #2048 | `SwarmRouter` appended the collaboration preamble to every agent's `system_prompt` **after the LLM was built**, so it never reached the model — while accumulating on the caller's live agents on every construction. It now rides in a system turn passed through the swarm constructor, which also survives the per-task conversation reset. A warning fires for swarm types that cannot deliver it |
| #2031 | `GraphWorkflow` fan-in filtered `pred_outputs` by presence but `zip`ped against the **unfiltered** predecessor list, so one missing predecessor shifted every label — B's output announced as A's, and the last output dropped |
| #2032 | `MajorityVoting` recorded each voter's whole conversation as its vote, compounding the shared conversation every loop |
| #2034 | `HierarchicalSwarm` never recorded the user's task, and its judge received worker outputs as a Python list repr with author names stripped |
| #2039 | `GroupChat` flattened the room into one timestamped user block that nested quadratically. Its conversations also drop timestamps, which were pure token cost and guaranteed a different prefix every turn |
| #2038 | `Conversation.return_messages_as_list` returned formatted strings, not messages. It now returns message dicts; the `"role: content"` rendering moved to `return_messages_as_strings` |

Two more defects fixed along the way:

- **`SwarmRouter(list_all_agents=True)` raised `AttributeError` at construction.** `setup()` reached for `self.swarm`, which is created lazily on the first `run()`. The roster moved into the same system turn and the conversation is rebound after the run.
- **GroupChat could never seat a speaker.** Agents bid correctly, but `_extract_args` could not parse a tool call returned as a string, so every bid scored `0.0`. Recovered with `ast.literal_eval` rather than mutating the caller's agents.

`DebateWithJudge`'s inline prompt constants also move to `swarms/prompts/debate_with_judge_prompts.py`.

## A regression this surfaced — and one #2061 still carries

`test_a_worker_is_not_re_sent_the_whole_history` failed after the HierarchicalSwarm conversion: worker context grew 174 → 1482 chars against a 5× ceiling.

That ceiling encoded the **old delivery-cursor contract**. Typed turns carry the whole conversation on every request by design — that is the point, since the history no longer lands in the agent's own memory to be re-sent on top. Growth is now linear in conversation size rather than compounding, so a raw ratio is no longer the signal. Inspecting the actual turns confirms the property that matters still holds: the worker's own prior output appears exactly once, as an `assistant` turn.

The test now asserts that invariant instead of the ratio.

**Worth flagging: #2061 has this same regression.** It changes `hiearchical_swarm.py` but never touches `test_hierarchical_swarm.py`, so the test is left failing there.

Chasing it also surfaced that the **feedback director still interpolates a flattened history** into its prompt, which then lands in the shared conversation — so a worker can still see its own output quoted inside that blob. That is an unconverted `get_str()` site and matches what #2061 lists as only partially addressed (#2033); it is out of scope here and the test comment says so.

## Verification

**No regressions**, from a detached worktree, run offline with empty API keys:

```
master:  14 failed  (9 failed + 5 errors)
this PR: 14 failed  (9 failed + 5 errors)   203 passed
```

Identical failure sets — `comm` reports nothing introduced. The pre-existing failures are live-LLM tests needing an API key, plus the `test_groupchat.py` collection errors.

**11 new tests fail against unpatched `master`:**

```
test_conversation.py::test_return_messages_as_list_returns_message_dicts
test_conversation.py::test_return_messages_as_strings_formats_role_colon_content
test_graph_workflow.py::test_fan_in_attributes_outputs_to_the_correct_predecessor
test_majority_voting.py::test_consensus_agent_sees_its_own_prior_consensus_as_assistant
test_majority_voting.py::test_voters_receive_typed_turns_not_one_user_blob
test_swarm_router.py::test_collab_prompt_is_delivered_as_a_system_turn
test_swarm_router.py::test_collab_prompt_never_mutates_the_callers_agents
test_swarm_router.py::test_collab_prompt_warns_when_the_swarm_type_cannot_deliver_it
test_swarm_router.py::test_conversation_points_at_the_live_swarm_conversation_after_run
test_swarm_router.py::test_list_all_agents_delivers_the_roster_as_a_system_turn
test_swarm_router.py::test_list_all_agents_does_not_crash_at_construction
```

Each headline fix also checked against its own reproduction:

```
#2048 construct with list_all_agents=True     -> FIXED
#2048 system_prompt unchanged: 10 -> 10       -> FIXED
#2038 return_messages_as_list -> dict         -> FIXED
#2038 return_messages_as_strings -> 'user: hi' -> FIXED
```

`black --line-length 70` and `ruff check .` clean across the repo.

## Behaviour changes worth a second opinion

1. **`Conversation.return_messages_as_list()` now returns message dicts**, not `"role: content"` strings. This is breaking for any external caller relying on the old type. `return_messages_as_dictionary` is kept as an alias.
2. **GroupChat conversations no longer carry timestamps** (`time_enabled=False`).

## Not converted here

#2029 / #2053 / #2041 / #2054 remain open — several structures still flatten or fail to reset per task. #2033 is partially addressed: the streaming director and worker paths now match the sync path, but four `get_str()` sites remain.
