### PR TITLE
fix(multi-agent): typed chat turns for the last four flattening structures

### DIFF
--- a/swarms/agents/agent_judge.py
+++ b/swarms/agents/agent_judge.py
@@ -2,6 +2,10 @@ import traceback
 from typing import Dict, List, Optional
 
 from swarms.structs.agent import Agent
+from swarms.structs.context_utils import (
+    agent_answer,
+    messages_for,
+)
 from swarms.structs.conversation import Conversation
 from swarms.utils.generate_id import generate_id
 
@@ -250,6 +254,7 @@ class AgentJudge:
         self,
         task: str = None,
         img: Optional[str] = None,
+        messages: Optional[List[Dict[str, str]]] = None,
     ) -> str:
         """
         Processes a single task and returns the agent's evaluation.
@@ -306,6 +311,7 @@ class AgentJudge:
             response = self.agent.run(
                 task=task_instruction,
                 img=img,
+                messages=messages,
             )
 
             return response
@@ -348,21 +354,23 @@ class AgentJudge:
             # The agent will run in a loop, remembering and updating the conversation context at each step.
             self.conversation.add(role="user", content=task)
             for _ in range(self.max_loops):
-                # Retrieve the full conversation context as a string
-                context = self.conversation.get_str()
-                # Build the contextualized task, always including the full conversation so far
-                contextualized_task = f"{context}\n"
-                # Get response for current iteration
+                # The judge's own earlier evaluations, as `assistant` turns.
+                # The seeded task turn is dropped because step() re-sends it
+                # wrapped in the evaluation prompt.
+                prior = messages_for(
+                    self.agent.agent_name, self.conversation
+                )[1:]
                 current_response = self.step(
-                    task=contextualized_task,
+                    task=task,
                     img=img,
+                    messages=prior,
                 )
-                # Add the agent's response to the conversation history
                 self.conversation.add(
                     role=self.agent.agent_name,
-                    content=current_response,
+                    content=agent_answer(
+                        self.agent, fallback=current_response
+                    ),
                 )
-                # The context will be updated automatically in the next loop iteration
 
             # After all loops, return either the reward or the full conversation
             if self.return_score:

--- a/swarms/agents/reasoning_duo.py
+++ b/swarms/agents/reasoning_duo.py
@@ -6,6 +6,11 @@ from swarms.structs.execution_utils import batched_run
 from swarms.prompts.reasoning_prompt import REASONING_PROMPT
 from swarms.structs.agent import Agent
 from swarms.utils.output_types import OutputType
+from swarms.structs.context_utils import (
+    agent_answer,
+    messages_for,
+    split_last_turn,
+)
 from swarms.structs.conversation import Conversation
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
@@ -55,8 +60,11 @@ class ReasoningDuo:
 
         self.conversation = Conversation()
 
+        # Distinct names: a shared one made both agents the same speaker in
+        # the conversation, so neither could tell its own turns from the
+        # other's.
         self.reasoning_agent = Agent(
-            agent_name=self.agent_name,
+            agent_name=f"{self.agent_name}-reasoning",
             description=self.agent_description,
             system_prompt=REASONING_PROMPT,
             max_loops=1,
@@ -67,7 +75,7 @@ class ReasoningDuo:
         )
 
         self.main_agent = Agent(
-            agent_name=self.agent_name,
+            agent_name=f"{self.agent_name}-main",
             description=self.agent_description,
             system_prompt=system_prompt,
             max_loops=1,
@@ -77,6 +85,39 @@ class ReasoningDuo:
             **kwargs,
         )
 
+    def _run_agent(
+        self,
+        agent,
+        task: Optional[str] = None,
+        img: Optional[str] = None,
+    ) -> str:
+        """Run one agent on the shared conversation and record its answer.
+
+        The conversation is delivered as typed chat turns, so each agent reads
+        its own prior output as ``assistant`` and its partner's as a labelled
+        ``user`` turn instead of one flattened block.
+
+        Args:
+            agent: The agent to run.
+            task (Optional[str]): A new instruction to append as this turn.
+                When None, the newest turn already in the conversation is used.
+            img (Optional[str]): Optional image input.
+
+        Returns:
+            str: The agent's answer.
+        """
+        if task is not None:
+            self.conversation.add(role="user", content=task)
+
+        prior, step_task = split_last_turn(
+            messages_for(agent.agent_name, self.conversation)
+        )
+        response = agent.run(task=step_task, messages=prior, img=img)
+
+        answer = agent_answer(agent, fallback=response)
+        self.conversation.add(role=agent.agent_name, content=answer)
+        return answer
+
     def step(self, task: str, img: Optional[str] = None):
         """
         Executes one step of reasoning and main agent processing.
@@ -85,22 +126,8 @@ class ReasoningDuo:
             task (str): The task to be processed.
             img (Optional[str]): Optional image input.
         """
-        # For reasoning agent, use the current task (which may include conversation context)
-        output_reasoner = self.reasoning_agent.run(task, img=img)
-
-        self.conversation.add(
-            role=self.reasoning_agent.agent_name,
-            content=output_reasoner,
-        )
-
-        # For main agent, always use the full conversation context
-        output_main = self.main_agent.run(
-            task=self.conversation.get_str(), img=img
-        )
-
-        self.conversation.add(
-            role=self.main_agent.agent_name, content=output_main
-        )
+        self._run_agent(self.reasoning_agent, task, img=img)
+        self._run_agent(self.main_agent, img=img)
 
     def run(self, task: str, img: Optional[str] = None):
         """
@@ -116,19 +143,20 @@ class ReasoningDuo:
         logger.info(
             f"Running task: {task} with max_loops: {self.max_loops}"
         )
-        self.conversation.add(role="user", content=task)
-
+        # The task is appended by _run_agent on the first iteration; adding it
+        # here too would give the reasoning agent the same turn twice.
         for loop_iteration in range(self.max_loops):
             logger.info(
                 f"Loop iteration {loop_iteration + 1}/{self.max_loops}"
             )
 
-            if loop_iteration == 0:
-                # First iteration: use original task
-                current_task = task
-            else:
-                # Subsequent iterations: use task with context of previous reasoning
-                current_task = f"Continue reasoning and refining your analysis. Original task: {task}\n\nPrevious conversation context:\n{self.conversation.get_str()}"
+            # Prior turns reach the agents as messages, so a later loop only
+            # needs the new instruction rather than a re-rendered transcript.
+            current_task = (
+                task
+                if loop_iteration == 0
+                else "Continue reasoning and refining your analysis."
+            )
 
             self.step(task=current_task, img=img)
 

--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -132,7 +132,7 @@ class Conversation:
         self.output_metadata = output_metadata
         self.memory_md_path = memory_md_path
         self._memory_md_lock = threading.Lock()
-        
+
         # Suppressed so the static system_prompt and rules are not re-appended to MEMORY.md every construction.
         self._suppress_memory_md = True
 

--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -1749,9 +1749,9 @@ class GraphWorkflow:
         prev_outputs: Dict[str, Any],
         layer_idx: int,
         loop_idx: int = 0,
-    ) -> str:
+    ) -> tuple:
         """
-        Optimized prompt building with minimal string operations.
+        Build this node's instruction and the prior turns that precede it.
 
         Args:
             node_id (str): The node ID to build a prompt for.
@@ -1763,7 +1763,8 @@ class GraphWorkflow:
             loop_idx (int): The current loop iteration (0-based).
 
         Returns:
-            str: The built prompt.
+            tuple: ``(prompt, messages)`` - this turn's instruction, and the
+            predecessor outputs as typed chat turns to send alongside it.
         """
         if self.verbose:
             logger.debug(
@@ -1779,43 +1780,42 @@ class GraphWorkflow:
                 if pred in prev_outputs
             ]
 
+            messages = [{"role": "user", "content": str(task)}]
+
             if pred_outputs and layer_idx > 0:
-                # Use list comprehension and join for faster string building
-                predecessor_parts = [
-                    f"Output from {pred}:\n{out}"
+                # One turn per predecessor, labelled with its node id, rather
+                # than every output joined into a single user block.
+                messages += [
+                    {"role": "user", "content": f"{pred}: {out}"}
                     for pred, out in pred_outputs
                     if out is not None
                 ]
-                predecessor_context = "\n\n".join(predecessor_parts)
-
                 prompt = (
-                    f"Original Task: {task}\n\n"
-                    f"Previous Agent Outputs:\n{predecessor_context}\n\n"
-                    f"Instructions: Please carefully review the work done by your predecessor agents above. "
-                    f"Acknowledge their contributions, verify their findings, and build upon their work. "
-                    f"If you agree with their analysis, say so and expand on it. "
-                    f"If you disagree or find gaps, explain why and provide corrections or improvements. "
-                    f"Your goal is to collaborate and create a comprehensive response that builds on all previous work."
+                    "Instructions: Please carefully review the work done by your predecessor agents above. "
+                    "Acknowledge their contributions, verify their findings, and build upon their work. "
+                    "If you agree with their analysis, say so and expand on it. "
+                    "If you disagree or find gaps, explain why and provide corrections or improvements. "
+                    "Your goal is to collaborate and create a comprehensive response that builds on all previous work."
                 )
             elif loop_idx > 0 and layer_idx == 0 and prev_outputs:
                 # Entry-point nodes in subsequent loops receive end-point
                 # outputs from the previous loop as refinement context.
-                prior_parts = [
-                    f"Output from {nid} (previous iteration):\n{out}"
+                messages += [
+                    {
+                        "role": "user",
+                        "content": f"{nid} (previous iteration): {out}",
+                    }
                     for nid, out in prev_outputs.items()
                     if out is not None
                 ]
-                prior_context = "\n\n".join(prior_parts)
-
                 prompt = (
-                    f"Original Task: {task}\n\n"
-                    f"Previous Iteration Outputs:\n{prior_context}\n\n"
                     f"Instructions: This is iteration {loop_idx + 1} of the workflow. "
-                    f"Review the outputs from the previous iteration above. "
-                    f"Refine, correct, or expand upon the previous results. "
-                    f"Focus on improving accuracy, filling gaps, and strengthening the analysis."
+                    "Review the outputs from the previous iteration above. "
+                    "Refine, correct, or expand upon the previous results. "
+                    "Focus on improving accuracy, filling gaps, and strengthening the analysis."
                 )
             else:
+                messages = []
                 prompt = (
                     f"{task}\n\n"
                     f"You are starting the workflow analysis. Please provide your best comprehensive response to this task."
@@ -1823,10 +1823,10 @@ class GraphWorkflow:
 
             if self.verbose:
                 logger.debug(
-                    f"Built prompt for node {node_id} ({len(prompt)} characters)"
+                    f"Built {len(messages)} prior turns for node {node_id}"
                 )
 
-            return prompt
+            return prompt, messages
 
         except Exception as e:
             logger.exception(
@@ -2098,12 +2098,14 @@ class GraphWorkflow:
                         agent_name,
                     ) in layer:
                         try:
-                            prompt = self._build_prompt(
-                                node_id,
-                                task,
-                                prev_outputs,
-                                layer_idx,
-                                loop,
+                            prompt, prior_messages = (
+                                self._build_prompt(
+                                    node_id,
+                                    task,
+                                    prev_outputs,
+                                    layer_idx,
+                                    loop,
+                                )
                             )
                         except Exception as e:
                             logger.exception(
@@ -2111,6 +2113,7 @@ class GraphWorkflow:
                             )
                             # Continue with an error prompt as fallback
                             prompt = f"Error building prompt: {e}"
+                            prior_messages = []
                         layer_data.append(
                             (
                                 node_id,
@@ -2118,11 +2121,19 @@ class GraphWorkflow:
                                 node_type,
                                 agent_name,
                                 prompt,
+                                prior_messages,
                             )
                         )
 
-                    def _make_call(node_id, agent, node_type, prompt):
+                    def _make_call(
+                        node_id,
+                        agent,
+                        node_type,
+                        prompt,
+                        messages=None,
+                    ):
                         """Bind one node's invocation into a zero-arg callable."""
+                        messages = messages or []
                         if node_type == NodeType.SUBGRAPH:
                             # Subgraphs take the prompt as their task and checkpoint under a per-parent directory.
                             inner: GraphWorkflow = agent
@@ -2136,9 +2147,14 @@ class GraphWorkflow:
                                     / node_id
                                 )
 
+                            flattened = "\n\n".join(
+                                [m["content"] for m in messages]
+                                + [prompt]
+                            )
+
                             def _run_inner(
                                 _inner=inner,
-                                _prompt=prompt,
+                                _prompt=flattened,
                                 _prev=_prev_cp,
                             ):
                                 try:
@@ -2156,10 +2172,16 @@ class GraphWorkflow:
                         if _streaming_callback is None:
                             # Common path: no per-node kwargs copy needed.
                             def _run_agent(
-                                _agent=agent, _prompt=prompt
+                                _agent=agent,
+                                _prompt=prompt,
+                                _messages=messages,
                             ):
                                 return _agent.run(
-                                    _prompt, img, *args, **kwargs
+                                    task=_prompt,
+                                    img=img,
+                                    messages=_messages,
+                                    *args,
+                                    **kwargs,
                                 )
 
                             return _run_agent
@@ -2168,6 +2190,7 @@ class GraphWorkflow:
                             _agent=agent,
                             _prompt=prompt,
                             _nid=node_id,
+                            _messages=messages,
                         ):
                             call_kwargs = dict(kwargs)
                             call_kwargs["streaming_callback"] = (
@@ -2176,7 +2199,11 @@ class GraphWorkflow:
                                 )
                             )
                             return _agent.run(
-                                _prompt, img, *args, **call_kwargs
+                                task=_prompt,
+                                img=img,
+                                messages=_messages,
+                                *args,
+                                **call_kwargs,
                             )
 
                         return _run_agent_streaming
@@ -2225,11 +2252,16 @@ class GraphWorkflow:
                             node_type,
                             agent_name,
                             prompt,
+                            prior_messages,
                         ) = layer_data[0]
                         _, output = self._safe_output(
                             agent_name,
                             _make_call(
-                                node_id, agent, node_type, prompt
+                                node_id,
+                                agent,
+                                node_type,
+                                prompt,
+                                prior_messages,
                             ),
                         )
                         _record(
@@ -2246,6 +2278,7 @@ class GraphWorkflow:
                             node_type,
                             agent_name,
                             prompt,
+                            prior_messages,
                         ) in layer_data:
                             try:
                                 future = pool.submit(
@@ -2254,6 +2287,7 @@ class GraphWorkflow:
                                         agent,
                                         node_type,
                                         prompt,
+                                        prior_messages,
                                     )
                                 )
                                 future_to_data[future] = (

--- a/swarms/structs/swarming_architectures.py
+++ b/swarms/structs/swarming_architectures.py
@@ -2,6 +2,11 @@ from typing import List, Union, Dict, Any
 
 
 from swarms.structs.agent import Agent
+from swarms.structs.context_utils import (
+    agent_answer,
+    messages_for,
+    split_last_turn,
+)
 from swarms.structs.omni_agent_types import AgentListType
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.structs.conversation import Conversation
@@ -11,6 +16,36 @@ from swarms.utils.history_output_formatter import (
 from swarms.utils.output_types import OutputType
 
 logger = initialize_logger(log_folder="swarming_architectures")
+
+
+def _run_on_conversation(
+    agent: Agent, conversation: Conversation
+) -> str:
+    """Run ``agent`` on the shared conversation and record its answer.
+
+    The conversation is delivered as typed chat turns - the agent's own
+    messages as ``assistant``, everyone else's as labelled ``user`` turns -
+    so the model can tell its own prior output from a peer's and the request
+    keeps a stable prefix for caching.
+
+    Args:
+        agent (Agent): The agent to run.
+        conversation (Conversation): The shared conversation, appended to
+            in place with the agent's answer.
+
+    Returns:
+        str: The agent's answer.
+    """
+    prior, task = split_last_turn(
+        messages_for(agent.agent_name, conversation)
+    )
+    response = agent.run(task=task, messages=prior)
+
+    # run() honours the agent's own output_type, which by default is its
+    # whole conversation rather than its answer.
+    answer = agent_answer(agent, fallback=response)
+    conversation.add(agent.agent_name, answer)
+    return answer
 
 
 def circular_swarm(
@@ -48,16 +83,15 @@ def circular_swarm(
     conversation = Conversation()
 
     for task in tasks:
+        # Once per task, not once per agent: the turn is already in the
+        # conversation every agent reads.
+        conversation.add(
+            role="User",
+            content=task,
+        )
+
         for agent in flat_agents:
-            conversation.add(
-                role="User",
-                content=task,
-            )
-            response = agent.run(conversation.get_str())
-            conversation.add(
-                role=agent.agent_name,
-                content=response,
-            )
+            _run_on_conversation(agent, conversation)
 
     return history_output_formatter(conversation, output_type)
 
@@ -140,11 +174,7 @@ def star_swarm(
             role="User",
             content=task,
         )
-        center_response = center_agent.run(conversation.get_str())
-        conversation.add(
-            role=center_agent.agent_name,
-            content=center_response,
-        )
+        _run_on_conversation(center_agent, conversation)
 
         # Other agents process the same task
         for agent in agents[1:]:
@@ -338,20 +368,11 @@ async def broadcast(
 
     try:
         # First get the sender's broadcast message
-        broadcast_message = sender.run(conversation.get_str())
-
-        conversation.add(
-            role=sender.agent_name,
-            content=broadcast_message,
-        )
+        _run_on_conversation(sender, conversation)
 
         # Then have all agents process it
         for agent in agents:
-            response = agent.run(conversation.get_str())
-            conversation.add(
-                role=agent.agent_name,
-                content=response,
-            )
+            _run_on_conversation(agent, conversation)
 
         return history_output_formatter(conversation, output_type)
 

--- a/tests/agents/test_agent_judge.py
+++ b/tests/agents/test_agent_judge.py
@@ -1,0 +1,83 @@
+"""Context delivery for ``AgentJudge``."""
+
+import pytest
+
+from swarms.agents.agent_judge import AgentJudge
+from swarms.structs.agent import Agent
+
+
+def _judge(max_loops=1):
+    """A judge whose LLM answers locally, recording what it received."""
+    calls = []
+    judge = AgentJudge(
+        agent_name="Judge", model_name="gpt-5.4", max_loops=max_loops
+    )
+
+    def fake_call_llm(self, task=None, *args, **kwargs):
+        calls.append(
+            {"task": task, "messages": kwargs.get("messages") or []}
+        )
+        return f"verdict-{len(calls)}"
+
+    Agent.call_llm = fake_call_llm
+    return judge, calls
+
+
+def test_the_judge_reads_its_own_prior_verdict_as_assistant():
+    """A previous evaluation is the judge's own turn, not more material."""
+    judge, calls = _judge(max_loops=2)
+    judge.run(task="rate this answer")
+
+    assert len(calls) == 2
+
+    own = [
+        m
+        for m in calls[1]["messages"]
+        if str(m["content"]).startswith("verdict-")
+    ]
+    assert len(own) == 1, f"expected one prior verdict: {own}"
+    assert own[0]["role"] == "assistant"
+
+
+def test_context_does_not_compound_across_loops():
+    """Each loop must be a strict prefix of the next, not a re-flattening."""
+    judge, calls = _judge(max_loops=3)
+    judge.run(task="rate this answer")
+
+    # call_llm receives the whole transcript: the prior turns plus the
+    # instruction appended last. The cacheable part is everything before it.
+    priors = [
+        [m["content"] for m in call["messages"][:-1]]
+        for call in calls
+    ]
+
+    assert priors[0] == []
+    for earlier, later in zip(priors, priors[1:]):
+        assert (
+            later[: len(earlier)] == earlier
+        ), f"loop context was rebuilt rather than extended: {priors}"
+        assert len(later) == len(earlier) + 1
+
+
+def test_the_conversation_is_not_flattened_into_the_task():
+    """The old form passed the whole transcript as one user string."""
+    judge, calls = _judge(max_loops=2)
+    judge.run(task="rate this answer")
+
+    for call in calls:
+        assert "Judge:" not in str(
+            call["task"]
+        ), f"the judge received flattened prose: {call['task']}"
+
+
+def test_a_single_loop_sends_only_the_instruction():
+    judge, calls = _judge(max_loops=1)
+    judge.run(task="rate this answer")
+
+    assert len(calls) == 1
+    assert len(calls[0]["messages"]) == 1
+    assert "rate this answer" in calls[0]["messages"][0]["content"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/agents/test_reasoning_duo.py
+++ b/tests/agents/test_reasoning_duo.py
@@ -1,0 +1,95 @@
+"""Context delivery for ``ReasoningDuo``."""
+
+import pytest
+
+from swarms.agents.reasoning_duo import ReasoningDuo
+from swarms.structs.agent import Agent
+
+
+def _duo(max_loops=1):
+    """A duo whose LLM answers locally, recording what each agent received."""
+    calls = []
+    duo = ReasoningDuo(
+        model_names=["gpt-5.4", "gpt-5.4"], max_loops=max_loops
+    )
+
+    def fake_call_llm(self, task=None, *args, **kwargs):
+        calls.append(
+            {
+                "agent": self.agent_name,
+                "messages": kwargs.get("messages") or [],
+            }
+        )
+        return f"{self.agent_name}-out"
+
+    Agent.call_llm = fake_call_llm
+    return duo, calls
+
+
+def test_the_two_agents_have_distinct_names():
+    """A shared name made both agents the same speaker in the conversation."""
+    duo, _ = _duo()
+
+    assert (
+        duo.reasoning_agent.agent_name != duo.main_agent.agent_name
+    ), "both agents answer to one name, so neither can be attributed"
+
+
+def test_the_main_agent_sees_the_reasoner_as_a_labelled_turn():
+    duo, calls = _duo()
+    duo.run("think about it")
+
+    main = [c for c in calls if c["agent"].endswith("-main")][0]
+    contents = [m["content"] for m in main["messages"]]
+
+    assert any(
+        "-reasoning-out" in c for c in contents
+    ), f"the main agent never saw the reasoner: {contents}"
+    assert any(
+        "think about it" in c for c in contents
+    ), f"the main agent never saw the task: {contents}"
+
+
+def test_each_agent_reads_its_own_output_as_assistant():
+    duo, calls = _duo(max_loops=2)
+    duo.run("think about it")
+
+    second_reasoning = [
+        c for c in calls if c["agent"].endswith("-reasoning")
+    ][1]
+    own = [
+        m
+        for m in second_reasoning["messages"]
+        if m["content"].endswith("-reasoning-out")
+    ]
+
+    assert len(own) == 1, f"expected one own turn: {own}"
+    assert own[0]["role"] == "assistant"
+
+
+def test_the_task_is_not_duplicated_across_the_loop():
+    """run() used to seed the task and then step() appended it again."""
+    duo, calls = _duo(max_loops=2)
+    duo.run("think about it")
+
+    first = calls[0]
+    contents = [m["content"] for m in first["messages"]]
+
+    assert contents.count("think about it") == 1, contents
+
+
+def test_no_agent_receives_a_flattened_transcript():
+    """The old form passed conversation.get_str() as the task."""
+    duo, calls = _duo(max_loops=2)
+    duo.run("think about it")
+
+    for call in calls:
+        for message in call["messages"]:
+            assert (
+                "Previous conversation context:"
+                not in message["content"]
+            ), f"{call['agent']} received a flattened transcript"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/structs/test_graph_workflow.py
+++ b/tests/structs/test_graph_workflow.py
@@ -1081,8 +1081,13 @@ def test_subgraph_executes_and_output_reaches_downstream():
     inner_agent.run.assert_called_once()
     # Downstream agent must have been called with the inner graph's output
     downstream.run.assert_called_once()
-    call_prompt = downstream.run.call_args[0][0]
-    assert "inner result" in call_prompt
+    # The subgraph's output now arrives as its own turn rather than being
+    # joined into the prompt string.
+    call_kwargs = downstream.run.call_args.kwargs
+    delivered = [
+        m["content"] for m in call_kwargs.get("messages") or []
+    ] + [str(call_kwargs.get("task"))]
+    assert any("inner result" in c for c in delivered), delivered
 
 
 def test_subgraph_result_in_outer_output():
@@ -1498,13 +1503,14 @@ def test_fan_in_attributes_outputs_to_the_correct_predecessor():
 
     # A produced nothing this run - failed, skipped, or behind a false branch.
     prev_outputs = {"B": "OUT_B", "C": "OUT_C"}
-    prompt = wf._build_prompt(
+    _, messages = wf._build_prompt(
         "D", "the task", prev_outputs, layer_idx=1
     )
 
-    assert "Output from B:\nOUT_B" in prompt
-    assert "Output from C:\nOUT_C" in prompt
-    assert "Output from A:" not in prompt
+    contents = [m["content"] for m in messages]
+    assert "B: OUT_B" in contents
+    assert "C: OUT_C" in contents
+    assert not any(c.startswith("A: ") for c in contents)
 
 
 def test_fan_in_with_all_predecessors_present_is_unaffected():
@@ -1515,12 +1521,37 @@ def test_fan_in_with_all_predecessors_present_is_unaffected():
     for parent in ["A", "B"]:
         wf.add_edge(parent, "C")
 
-    prompt = wf._build_prompt(
+    _, messages = wf._build_prompt(
         "C", "the task", {"A": "OUT_A", "B": "OUT_B"}, layer_idx=1
     )
 
-    assert "Output from A:\nOUT_A" in prompt
-    assert "Output from B:\nOUT_B" in prompt
+    contents = [m["content"] for m in messages]
+    assert "A: OUT_A" in contents
+    assert "B: OUT_B" in contents
+
+
+def test_predecessor_outputs_are_typed_turns_not_one_user_blob():
+    """Each predecessor is its own labelled turn, not joined into the prompt."""
+    wf = GraphWorkflow(auto_compile=False)
+    for name in ["A", "B", "C"]:
+        wf.add_node(create_test_agent(name))
+    for parent in ["A", "B"]:
+        wf.add_edge(parent, "C")
+
+    prompt, messages = wf._build_prompt(
+        "C", "the task", {"A": "OUT_A", "B": "OUT_B"}, layer_idx=1
+    )
+
+    assert all(
+        isinstance(m, dict) and m["role"] == "user" for m in messages
+    )
+    assert [m["content"] for m in messages] == [
+        "the task",
+        "A: OUT_A",
+        "B: OUT_B",
+    ]
+    # The instruction no longer carries the outputs.
+    assert "OUT_A" not in prompt and "OUT_B" not in prompt
 
 
 if __name__ == "__main__":

--- a/tests/structs/test_swarming_architectures.py
+++ b/tests/structs/test_swarming_architectures.py
@@ -1,0 +1,141 @@
+"""Context delivery for the helpers in ``swarms.structs.swarming_architectures``."""
+
+import asyncio
+
+import pytest
+
+from swarms.structs.agent import Agent
+from swarms.structs.swarming_architectures import (
+    broadcast,
+    circular_swarm,
+    star_swarm,
+)
+
+
+class RecordingAgent(Agent):
+    """An Agent that answers locally and records what it was handed."""
+
+    def __init__(self, name, calls):
+        self.agent_name = name
+        self._calls = calls
+
+    def run(self, task=None, messages=None, *args, **kwargs):
+        self._calls.append(
+            {
+                "agent": self.agent_name,
+                "task": task,
+                "messages": messages or [],
+            }
+        )
+        return f"{self.agent_name}-answer"
+
+
+def _agents(names, calls):
+    return [RecordingAgent(name, calls) for name in names]
+
+
+def _contents(call):
+    return [m["content"] for m in call["messages"]]
+
+
+def test_circular_swarm_delivers_typed_turns_not_one_blob():
+    """Each speaker is its own labelled turn, not a flattened string."""
+    calls = []
+    circular_swarm(agents=_agents(["A", "B"], calls), tasks=["do it"])
+
+    first, second = calls[0], calls[1]
+
+    assert first["agent"] == "A"
+    assert first["task"] == "do it"
+    assert first["messages"] == []
+
+    assert second["agent"] == "B"
+    # split_last_turn hands the newest turn over as the task, so A's answer
+    # is either the task or one of the prior turns - never inside a blob.
+    seen = _contents(second) + [second["task"]]
+    assert any(
+        "A-answer" in str(c) for c in seen
+    ), f"B never saw A's answer: {second}"
+    assert "do it" in seen
+    assert all(
+        isinstance(m, dict) and m["role"] in ("user", "assistant")
+        for m in second["messages"]
+    )
+
+
+def test_an_agent_sees_its_own_prior_output_as_assistant():
+    """Two tasks means A speaks twice; the second time it reads itself back."""
+    calls = []
+    circular_swarm(
+        agents=_agents(["A", "B"], calls), tasks=["one", "two"]
+    )
+
+    second_turn_for_a = [c for c in calls if c["agent"] == "A"][1]
+    own = [
+        m
+        for m in second_turn_for_a["messages"]
+        if m["content"] == "A-answer"
+    ]
+
+    assert len(own) == 1, f"expected one own turn: {own}"
+    assert own[0]["role"] == "assistant"
+
+
+def test_the_task_is_recorded_once_per_task_not_once_per_agent():
+    """The shared turn is added for the task, not re-added for every agent."""
+    calls = []
+    circular_swarm(
+        agents=_agents(["A", "B", "C"], calls), tasks=["do it"]
+    )
+
+    last = calls[-1]
+    assert (
+        _contents(last).count("do it") + [last["task"]].count("do it")
+        == 1
+    ), f"the task appears more than once: {last}"
+
+
+def test_star_swarm_centre_receives_typed_turns():
+    calls = []
+    star_swarm(agents=_agents(["Centre", "X"], calls), tasks=["go"])
+
+    centre = calls[0]
+    assert centre["agent"] == "Centre"
+    assert centre["task"] == "go"
+    assert isinstance(centre["messages"], list)
+
+
+def test_broadcast_agents_see_the_sender_as_a_labelled_turn():
+    calls = []
+    sender = RecordingAgent("Sender", calls)
+    asyncio.run(
+        broadcast(
+            sender=sender,
+            agents=_agents(["R1", "R2"], calls),
+            task="announce",
+        )
+    )
+
+    receiver = [c for c in calls if c["agent"] == "R1"][0]
+    seen = _contents(receiver) + [receiver["task"]]
+
+    assert any(
+        "Sender-answer" in str(c) for c in seen
+    ), f"R1 did not see the sender's turn: {receiver}"
+
+
+def test_nothing_is_handed_a_flattened_role_colon_blob():
+    """The old form rendered the whole room as 'Role: content' prose."""
+    calls = []
+    circular_swarm(
+        agents=_agents(["A", "B"], calls), tasks=["one", "two"]
+    )
+
+    for call in calls:
+        assert "User: " not in str(
+            call["task"]
+        ), f"{call['agent']} received flattened prose: {call['task']}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes the four structures found by the audit in #2053's comments — the last of the flattening class.

Fixes #2081
Fixes #2082
Fixes #2083
Fixes #2084

Each rendered the shared conversation as `"role: content"` prose and passed it as `agent.run(task=<blob>)`, so every speaker arrived as one `user` message with no role attribution and no cacheable prefix. All four now use the `messages_for` / `split_last_turn` / `agent_answer` helpers.

## What each was

**#2081 `swarming_architectures`** passed the conversation as the positional task with no wrapper at all, in `circular_swarm`, `star_swarm` and both halves of `broadcast`. A single `_run_on_conversation` helper now delivers typed turns and records `agent_answer` rather than the raw `run()` return.

**#2082 `AgentJudge`** built each iteration's task from the flattened conversation and appended the response back into it, so with `max_loops > 1` the input grew superlinearly and the judge re-read its own verdicts as material to evaluate. Prior verdicts now arrive as `assistant` turns.

**#2083 `ReasoningDuo`** handed the main agent `conversation.get_str()` on every step and re-interpolated the transcript into the reasoning agent's task from the second loop on.

**#2084 `GraphWorkflow._build_prompt`** joined predecessor outputs into one user string. It now returns `(prompt, messages)` — the standing instruction as the task, each predecessor as its own labelled turn. Subgraph nodes are nested orchestrators with no `messages` parameter, so they keep the flattened form.

## Three further defects the conversion exposed

Typed turns made these visible; none were in the issues:

1. **`ReasoningDuo` built both agents with the same `agent_name`** (`:64`, `:75`). Neither could be attributed in the shared conversation, and each read the other's output as its own `assistant` turn — fatal for a structure whose whole premise is that the two roles differ. Now suffixed `-reasoning` and `-main`.
2. **`circular_swarm` added the user task once per agent** rather than once per task, so every agent saw it twice. Invisible inside a flattened blob; obvious as duplicate turns.
3. **`AgentJudge` could not use `split_last_turn`.** The newest turn is the judge's own last verdict, not a new instruction, so splitting would have handed it back as the task. It passes the prior verdicts as `messages` and re-sends the original task as the instruction instead.

## Verified on the wire

Captured at `call_llm` through real `Agent` objects:

```
#2081 circular_swarm
  A: 1 prior turn  ['user:do it']
  B: 2 prior turns ['user:do it', 'user:A: <A-ans>']

#2082 AgentJudge max_loops=2
  Judge: ['user:<evaluation prompt>']
  Judge: ['assistant:<Judge-ans>', 'user:<evaluation prompt>']

#2083 ReasoningDuo max_loops=2
  ...-reasoning: ['user:think']
  ...-main:      ['user:think', 'user:...-reasoning: <ans>']

#2084 GraphWorkflow fan-in
  Merger: ['user:merge it', 'user:Alpha: <Alpha-ans>', 'user:Beta: <Beta-ans>', 'user:Instructions: ...']
```

## Tests

**15 new tests** across `tests/structs/test_swarming_architectures.py` (new), `tests/agents/test_agent_judge.py` (new), `tests/agents/test_reasoning_duo.py` (new), and `tests/structs/test_graph_workflow.py`.

Against unpatched `master`: **10 of the 11 new-file tests fail**, plus all 4 targeted `test_graph_workflow.py` tests.

**Three existing tests updated, not deleted.** Two asserted the old `"Output from B:\nOUT_B"` rendering and one read the prompt from `call_args[0][0]`; each now asserts the same invariant — correct predecessor attribution — against typed turns. Worth a look in review, since changing a test to match new behaviour is exactly where a real regression can hide.

**No regressions:** master and this branch both report `8 failed` on the pre-existing suites, identical sets (`comm` reports nothing introduced).

`black --line-length 70` and `ruff check .` clean.

## Note on the diff

`swarms/structs/conversation.py` carries a one-line trailing-whitespace fix that `black` applied while formatting; it is not a behaviour change.
