### PR TITLE
cleanup: compact the comments added by #2085 to one line each

### DIFF
--- a/swarms/agents/agent_judge.py
+++ b/swarms/agents/agent_judge.py
@@ -354,9 +354,7 @@ class AgentJudge:
             # The agent will run in a loop, remembering and updating the conversation context at each step.
             self.conversation.add(role="user", content=task)
             for _ in range(self.max_loops):
-                # The judge's own earlier evaluations, as `assistant` turns.
-                # The seeded task turn is dropped because step() re-sends it
-                # wrapped in the evaluation prompt.
+                # Prior verdicts as assistant turns; [1:] drops the task, which step() re-sends.
                 prior = messages_for(
                     self.agent.agent_name, self.conversation
                 )[1:]

--- a/swarms/agents/reasoning_duo.py
+++ b/swarms/agents/reasoning_duo.py
@@ -60,9 +60,7 @@ class ReasoningDuo:
 
         self.conversation = Conversation()
 
-        # Distinct names: a shared one made both agents the same speaker in
-        # the conversation, so neither could tell its own turns from the
-        # other's.
+        # Distinct names: a shared one made both agents the same speaker.
         self.reasoning_agent = Agent(
             agent_name=f"{self.agent_name}-reasoning",
             description=self.agent_description,
@@ -143,15 +141,13 @@ class ReasoningDuo:
         logger.info(
             f"Running task: {task} with max_loops: {self.max_loops}"
         )
-        # The task is appended by _run_agent on the first iteration; adding it
-        # here too would give the reasoning agent the same turn twice.
+        # _run_agent appends the task on the first iteration; adding it here would duplicate it.
         for loop_iteration in range(self.max_loops):
             logger.info(
                 f"Loop iteration {loop_iteration + 1}/{self.max_loops}"
             )
 
-            # Prior turns reach the agents as messages, so a later loop only
-            # needs the new instruction rather than a re-rendered transcript.
+            # Prior turns arrive as messages, so later loops need only the new instruction.
             current_task = (
                 task
                 if loop_iteration == 0

--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -1783,8 +1783,7 @@ class GraphWorkflow:
             messages = [{"role": "user", "content": str(task)}]
 
             if pred_outputs and layer_idx > 0:
-                # One turn per predecessor, labelled with its node id, rather
-                # than every output joined into a single user block.
+                # One turn per predecessor rather than every output joined into one block.
                 messages += [
                     {"role": "user", "content": f"{pred}: {out}"}
                     for pred, out in pred_outputs

--- a/swarms/structs/swarming_architectures.py
+++ b/swarms/structs/swarming_architectures.py
@@ -41,8 +41,7 @@ def _run_on_conversation(
     )
     response = agent.run(task=task, messages=prior)
 
-    # run() honours the agent's own output_type, which by default is its
-    # whole conversation rather than its answer.
+    # run() honours output_type, which by default is the whole conversation, not the answer.
     answer = agent_answer(agent, fallback=response)
     conversation.add(agent.agent_name, answer)
     return answer
@@ -83,8 +82,7 @@ def circular_swarm(
     conversation = Conversation()
 
     for task in tasks:
-        # Once per task, not once per agent: the turn is already in the
-        # conversation every agent reads.
+        # Once per task, not once per agent: every agent reads the same turn.
         conversation.add(
             role="User",
             content=task,

--- a/tests/agents/test_agent_judge.py
+++ b/tests/agents/test_agent_judge.py
@@ -44,8 +44,7 @@ def test_context_does_not_compound_across_loops():
     judge, calls = _judge(max_loops=3)
     judge.run(task="rate this answer")
 
-    # call_llm receives the whole transcript: the prior turns plus the
-    # instruction appended last. The cacheable part is everything before it.
+    # call_llm receives the whole transcript: prior turns plus the instruction, appended last.
     priors = [
         [m["content"] for m in call["messages"][:-1]]
         for call in calls

--- a/tests/structs/test_graph_workflow.py
+++ b/tests/structs/test_graph_workflow.py
@@ -1081,8 +1081,7 @@ def test_subgraph_executes_and_output_reaches_downstream():
     inner_agent.run.assert_called_once()
     # Downstream agent must have been called with the inner graph's output
     downstream.run.assert_called_once()
-    # The subgraph's output now arrives as its own turn rather than being
-    # joined into the prompt string.
+    # The subgraph's output arrives as its own turn, not joined into the prompt.
     call_kwargs = downstream.run.call_args.kwargs
     delivered = [
         m["content"] for m in call_kwargs.get("messages") or []
@@ -1550,7 +1549,6 @@ def test_predecessor_outputs_are_typed_turns_not_one_user_blob():
         "A: OUT_A",
         "B: OUT_B",
     ]
-    # The instruction no longer carries the outputs.
     assert "OUT_A" not in prompt and "OUT_B" not in prompt
 
 

--- a/tests/structs/test_swarming_architectures.py
+++ b/tests/structs/test_swarming_architectures.py
@@ -50,8 +50,7 @@ def test_circular_swarm_delivers_typed_turns_not_one_blob():
     assert first["messages"] == []
 
     assert second["agent"] == "B"
-    # split_last_turn hands the newest turn over as the task, so A's answer
-    # is either the task or one of the prior turns - never inside a blob.
+    # split_last_turn hands the newest turn over as the task, so A's answer is task or prior.
     seen = _contents(second) + [second["task"]]
     assert any(
         "A-answer" in str(c) for c in seen


### PR DESCRIPTION
Follow-up to #2085, which introduced ten two- and three-line comment blocks. The repo's rule is one line: if it needs a paragraph it belongs in the docstring.

**7 files, +10 / −23. Every line in this diff is a comment or a blank.**

## What changed

Each block is now a single line keeping the fact a reader could otherwise get wrong, and dropping the part the surrounding code already states:

```python
# before
# The judge's own earlier evaluations, as `assistant` turns.
# The seeded task turn is dropped because step() re-sends it
# wrapped in the evaluation prompt.

# after
# Prior verdicts as assistant turns; [1:] drops the task, which step() re-sends.
```

```python
# before
# Distinct names: a shared one made both agents the same speaker in
# the conversation, so neither could tell its own turns from the
# other's.

# after
# Distinct names: a shared one made both agents the same speaker.
```

The full set, one line each now:

| File | Comment |
|---|---|
| `agent_judge.py` | `Prior verdicts as assistant turns; [1:] drops the task, which step() re-sends.` |
| `reasoning_duo.py` | `Distinct names: a shared one made both agents the same speaker.` |
| `reasoning_duo.py` | `_run_agent appends the task on the first iteration; adding it here would duplicate it.` |
| `reasoning_duo.py` | `Prior turns arrive as messages, so later loops need only the new instruction.` |
| `graph_workflow.py` | `One turn per predecessor rather than every output joined into one block.` |
| `swarming_architectures.py` | `run() honours output_type, which by default is the whole conversation, not the answer.` |
| `swarming_architectures.py` | `Once per task, not once per agent: every agent reads the same turn.` |
| `test_agent_judge.py` | `call_llm receives the whole transcript: prior turns plus the instruction, appended last.` |
| `test_graph_workflow.py` | `The subgraph's output arrives as its own turn, not joined into the prompt.` |
| `test_swarming_architectures.py` | `split_last_turn hands the newest turn over as the task, so A's answer is task or prior.` |

One comment was deleted rather than compacted: `# The instruction no longer carries the outputs.` at the end of the `GraphWorkflow` typed-turns test, where the assert immediately below already says it.

## Verification

- `87 passed` across the four suites #2085 touched
- `black --line-length 70` and `ruff check .` clean
- Comments-only, verified mechanically:

```
git diff -U0 | grep -E "^[-+]" | grep -vE "^(\+\+\+|---)" \
  | sed -E 's/^[-+][[:space:]]*//' | grep -vE '^#|^$'
```

returns nothing.

## Note

Separate from #2080, which compacts the 202 pre-existing comment blocks across the repo. This one only covers the ten I added in #2085, so the two do not overlap.
