### PR TITLE
fix(multi-agent-router): honour skip_null_tasks, tolerate an absent task key, run selected agents concurrently

### DIFF
--- a/swarms/structs/multi_agent_router.py
+++ b/swarms/structs/multi_agent_router.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import json
 import traceback
 from typing import Callable, List, Optional
@@ -8,7 +7,6 @@ from pydantic import BaseModel, Field
 
 from swarms.structs.conversation import Conversation
 from swarms.structs.ma_blocks import find_agent_by_name
-from swarms.tools.base_tool import BaseTool
 from swarms.utils.formatter import formatter
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
@@ -50,21 +48,6 @@ class MultipleHandOffsResponse(BaseModel):
     handoffs: List[HandOffsResponse] = Field(
         description="A list of handoffs, each containing the reasoning, agent name, and task for each agent."
     )
-
-
-def get_agent_response_schema(model_name: str = None):
-    """
-    Return the JSON schema for the boss agent's structured handoff response.
-
-    Args:
-        model_name (str, optional): Reserved for future model-specific schema
-            tweaks. Currently unused.
-
-    Returns:
-        dict: A JSON schema dict derived from ``MultipleHandOffsResponse`` that
-        can be passed to a structured-output model as the response format.
-    """
-    return BaseTool().base_model_to_dict(MultipleHandOffsResponse)
 
 
 def agent_boss_router_prompt(agent_descriptions: any):
@@ -250,7 +233,7 @@ class MultiAgentRouter:
 
     def handle_single_handoff(
         self, boss_response_str: dict, task: str
-    ) -> dict:
+    ) -> None:
         """
         Execute the single agent selected by the boss and record its response.
 
@@ -268,9 +251,7 @@ class MultiAgentRouter:
                 boss did not supply a rewritten task.
 
         Returns:
-            dict: Currently returns ``None`` implicitly; the conversation is
-            mutated in place. Kept as ``dict`` in the signature for parity
-            with related methods.
+            None: The conversation is mutated in place.
 
         Raises:
             ValueError: If the boss selected an agent name that is not
@@ -286,7 +267,9 @@ class MultiAgentRouter:
         )
 
         # Use the modified task if provided, otherwise use original task
-        final_task = boss_response_str["handoffs"][0]["task"] or task
+        final_task = (
+            boss_response_str["handoffs"][0].get("task") or task
+        )
 
         # Skip execution if task is null/None and skip_null_tasks is True
         if self.skip_null_tasks and (
@@ -296,6 +279,7 @@ class MultiAgentRouter:
                 logger.info(
                     f"Skipping execution for agent {selected_agent.agent_name} - task is null/None"
                 )
+            return
 
         # Use the agent's run method directly
         agent_response = selected_agent.run(final_task)
@@ -304,11 +288,9 @@ class MultiAgentRouter:
             role=selected_agent.agent_name, content=agent_response
         )
 
-        # return agent_response
-
     def handle_multiple_handoffs(
         self, boss_response_str: dict, task: str
-    ) -> dict:
+    ) -> None:
         """
         Execute every agent selected by the boss and record the first response.
 
@@ -327,34 +309,34 @@ class MultiAgentRouter:
                 boss did not supply a rewritten task.
 
         Returns:
-            dict: Currently returns ``None`` implicitly; the conversation is
-            mutated in place. Kept as ``dict`` in the signature for parity
-            with related methods.
+            None: The conversation is mutated in place.
 
         Raises:
             ValueError: If any of the boss-selected agents is not registered
                 with this router.
         """
 
-        # Validate that the selected agents exist
+        # Resolve every agent up front so an unknown name fails before any
+        # agent runs and is paid for.
+        resolved = []
         for handoff in boss_response_str["handoffs"]:
             try:
-                find_agent_by_name(self.agents, handoff["agent_name"])
+                agent = find_agent_by_name(
+                    self.agents, handoff["agent_name"]
+                )
             except (TypeError, ValueError):
                 raise ValueError(
                     f"Boss selected unknown agent: {handoff['agent_name']}"
                 )
+            resolved.append((handoff, agent))
 
         # Get the selected agents and their tasks
         selected_agents = []
         final_tasks = []
         skipped_agents = []
 
-        for handoff in boss_response_str["handoffs"]:
-            agent = find_agent_by_name(
-                self.agents, handoff["agent_name"]
-            )
-            final_task = handoff["task"] or task
+        for handoff, agent in resolved:
+            final_task = handoff.get("task") or task
 
             # Skip execution if task is null/None and skip_null_tasks is True
             if self.skip_null_tasks and (
@@ -372,13 +354,17 @@ class MultiAgentRouter:
 
         # Execute agents only if there are valid tasks
         if selected_agents:
-            # Use the agents' run method directly
-            agent_responses = [
-                agent.run(final_task)
-                for agent, final_task in zip(
-                    selected_agents, final_tasks
+            # The boss is prompted for non-overlapping tasks, so these are
+            # independent; running them in series cost the sum of their latencies.
+            with ContextThreadPoolExecutor(
+                max_workers=len(selected_agents)
+            ) as executor:
+                agent_responses = list(
+                    executor.map(
+                        lambda pair: pair[0].run(pair[1]),
+                        zip(selected_agents, final_tasks),
+                    )
                 )
-            ]
 
             self.conversation.add(
                 role=selected_agents[0].agent_name,
@@ -462,9 +448,9 @@ class MultiAgentRouter:
         """
         Route a batch of tasks sequentially.
 
-        Each task is independently routed; failures are logged and the
-        corresponding result is omitted from the returned list (the batch
-        does not abort on a single failure).
+        Each task is independently routed; failures are logged with the task
+        that caused them and the corresponding result is omitted from the
+        returned list (the batch does not abort on a single failure).
 
         Args:
             tasks (List[str]): Tasks to route in order.
@@ -476,27 +462,29 @@ class MultiAgentRouter:
         results = []
         for task in tasks:
             try:
-                result = self.route_task(task)
-                results.append(result)
+                results.append(self.route_task(task))
             except Exception as e:
-                logger.error(f"Error routing task: {str(e)}")
+                logger.error(f"Error routing task {task!r}: {e}")
         return results
 
     def concurrent_batch_run(self, tasks: List[str] = []):
         """
         Route a batch of tasks in parallel using a thread pool.
 
-        Tasks are dispatched to a ``ThreadPoolExecutor`` and results are
-        collected as they complete. Order of returned results is **not
-        guaranteed** to match input order. Failures are logged and silently
-        dropped from the result list.
+        Tasks are dispatched to a ``ThreadPoolExecutor``. Failures are logged
+        with the task that caused them and omitted from the result list.
+
+        Note:
+            All tasks share this router's ``Conversation``, so their histories
+            interleave. Prefer :meth:`batch_run` when the per-task history
+            matters.
 
         Args:
             tasks (List[str]): Tasks to route concurrently.
 
         Returns:
-            List[Any]: Routed results for the tasks that succeeded, in
-            completion order.
+            List[Any]: Routed results for the tasks that succeeded, in input
+            order.
         """
         results = []
         with ContextThreadPoolExecutor() as executor:
@@ -504,10 +492,11 @@ class MultiAgentRouter:
                 executor.submit(self.route_task, task)
                 for task in tasks
             ]
-            for future in concurrent.futures.as_completed(futures):
+            # Read in submission order so element i belongs to tasks[i],
+            # matching batch_run.
+            for task, future in zip(tasks, futures):
                 try:
-                    result = future.result()
-                    results.append(result)
+                    results.append(future.result())
                 except Exception as e:
-                    logger.error(f"Error routing task: {str(e)}")
+                    logger.error(f"Error routing task {task!r}: {e}")
         return results

--- a/tests/structs/test_multi_agent_router.py
+++ b/tests/structs/test_multi_agent_router.py
@@ -1,5 +1,7 @@
 import os
 
+import time
+
 import pytest
 
 from swarms.structs.agent import Agent
@@ -427,6 +429,121 @@ def test_route_task_with_empty_task_raises():
     router = MultiAgentRouter(agents=_minimal_agents())
     with pytest.raises(ValueError):
         router.route_task("")
+
+
+def _local_router(agents=None, delay=0.0):
+    """A router whose agents answer locally, so no model is contacted."""
+    from swarms.structs.conversation import Conversation
+
+    ran = []
+
+    class LocalAgent(Agent):
+        def __init__(self, name):
+            self.agent_name = name
+            self.description = name
+
+        def run(self, task, *args, **kwargs):
+            if delay:
+                time.sleep(delay)
+            ran.append((self.agent_name, task))
+            return f"{self.agent_name}-out"
+
+    router = MultiAgentRouter.__new__(MultiAgentRouter)
+    router.agents = [LocalAgent(n) for n in (agents or ["A1", "A2"])]
+    router.skip_null_tasks = True
+    router.print_on = False
+    router.conversation = Conversation()
+    router.output_type = "dict"
+    return router, ran
+
+
+def test_skip_null_tasks_actually_skips_on_the_single_path():
+    """The single path logged "Skipping" and then ran the agent anyway."""
+    router, ran = _local_router()
+
+    router.handle_single_handoff(
+        {"handoffs": [{"agent_name": "A1", "task": None}]}, ""
+    )
+
+    assert ran == [], f"the agent ran despite a null task: {ran}"
+
+
+def test_a_handoff_without_a_task_key_falls_back_to_the_original():
+    """HandOffsResponse.task is Optional, so the key may be absent."""
+    router, ran = _local_router()
+
+    router.handle_single_handoff(
+        {"handoffs": [{"agent_name": "A1"}]}, "the original task"
+    )
+
+    assert ran == [("A1", "the original task")]
+
+
+def test_multiple_handoffs_without_a_task_key_fall_back():
+    router, ran = _local_router()
+
+    router.handle_multiple_handoffs(
+        {"handoffs": [{"agent_name": "A1"}, {"agent_name": "A2"}]},
+        "the original task",
+    )
+
+    assert [task for _, task in ran] == [
+        "the original task",
+        "the original task",
+    ]
+
+
+def test_selected_agents_run_concurrently():
+    """Independent agents used to run one after another."""
+    router, ran = _local_router(agents=["S0", "S1", "S2"], delay=0.35)
+    handoffs = {
+        "handoffs": [
+            {"agent_name": f"S{i}", "task": f"t{i}"} for i in range(3)
+        ]
+    }
+
+    started = time.time()
+    router.handle_multiple_handoffs(handoffs, "x")
+    elapsed = time.time() - started
+
+    assert len(ran) == 3
+    assert (
+        elapsed < 0.35 * 3 * 0.7
+    ), f"three 0.35s agents took {elapsed:.2f}s, so they ran in series"
+
+
+def test_an_unknown_agent_raises_before_any_agent_runs():
+    router, ran = _local_router()
+
+    with pytest.raises(ValueError, match="unknown agent"):
+        router.handle_multiple_handoffs(
+            {
+                "handoffs": [
+                    {"agent_name": "A1", "task": "a"},
+                    {"agent_name": "NOPE", "task": "b"},
+                ]
+            },
+            "x",
+        )
+
+    assert ran == [], f"an agent ran before validation failed: {ran}"
+
+
+def test_concurrent_batch_run_returns_results_in_input_order():
+    """Results used to come back in completion order, unlike batch_run."""
+    router, _ = _local_router()
+
+    def flaky(task):
+        if task == "bad":
+            raise RuntimeError("boom")
+        return f"ok:{task}"
+
+    router.route_task = flaky
+
+    assert router.concurrent_batch_run(["a", "bad", "c"]) == [
+        "ok:a",
+        "ok:c",
+    ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Six contained fixes to `MultiAgentRouter`, no restructuring.

## Correctness

**`skip_null_tasks` did nothing on the single-agent path.** `handle_single_handoff` logged *"Skipping execution"* and then ran the agent anyway — the guard had no `return`. `route_task:414` sends every single-handoff decision there, so the documented flag was inert for the common case and the agent was run on an empty task.

```
before:  1 single-path skip_null_tasks: agent ran? True   [('A1', '')]
after:   1 single-path skip honoured: True  []
```

**An absent `task` key raised `KeyError`.** `HandOffsResponse.task` is `Optional`, but both handlers read `handoff["task"]` rather than `.get("task")`, so a boss that omits the field instead of nulling it took the run down.

## Efficiency

**Selected agents ran in series.** The boss prompt asks for *"non-overlapping tasks"*, so they are independent by construction; N agents cost the sum of their latencies rather than the maximum. They now run on a thread pool:

```
three 0.35s agents: 1.05s -> 0.41s
```

**`handle_multiple_handoffs` resolved every agent twice** — once in the validation loop, again in the build loop. It now resolves once and keeps the pair, preserving the guarantee that an unknown name fails before any agent runs and is paid for.

## Consistency

**`concurrent_batch_run` returned completion order** while `batch_run` returned input order, so the two were not interchangeable. Futures are now read in submission order, so element *i* belongs to `tasks[i]`. Both helpers log the task that failed rather than only the exception.

**Removed `get_agent_response_schema`** — no callers in `swarms/`, `tests/` or `examples/` — along with the two imports it was the last user of (`concurrent.futures`, `BaseTool`). Corrected both handler annotations from `-> dict` to `-> None`; their docstrings already admitted they return `None`.

## Verification

6 tests appended to the existing `tests/structs/test_multi_agent_router.py`. **5 of the 6 fail against unpatched `master`** (the sixth is the unknown-agent guard, which already worked and is there to prove the resolve-once change did not weaken it).

**No regressions**, run offline from a detached worktree:

```
master:  27 failed
branch:  22 failed
```

`comm` reports nothing introduced; the five that flip are the ones these fixes address. The remaining 22 are pre-existing live-LLM tests needing an API key.

`black --line-length 70` and `ruff check .` clean.

## Deliberately not here

- **The "only the first response is recorded" bug** is #2044, already fixed by the open #2076. I left `handle_multiple_handoffs`'s recording block untouched so that PR stays mergeable — but note both PRs edit that method, so whichever lands second will need a small conflict resolution.
- **`concurrent_batch_run` still shares one `Conversation` across threads**, so histories interleave. Making that per-task means threading a conversation through both handlers, which is the work in #2041 / #2054 rather than a contained fix. The behaviour is now documented on the method instead of being silent.
- **The two handlers are still separate.** `handle_single_handoff` is `handle_multiple_handoffs` with `[0]` hardcoded, and that duplication is what let the missing `return` diverge in the first place. Collapsing them is the right structural change but not a minimal one.
