### PR TITLE
docs(examples): add a MultiAgentRouter specialist-routing example

### DIFF
--- a/examples/multi_agent/mar/README.md
+++ b/examples/multi_agent/mar/README.md
@@ -7,6 +7,7 @@ This directory contains examples demonstrating Multi-Agent Router patterns for i
 - [model_router_example.py](model_router_example.py) - Model routing example
 - [multi_agent_router_example.py](multi_agent_router_example.py) - Multi-agent router implementation
 - [multi_agent_router_minimal.py](multi_agent_router_minimal.py) - Minimal router setup
+- [multi_agent_router_specialist_routing.py](multi_agent_router_specialist_routing.py) - Routing to one specialist vs. several, driven by each agent's description
 
 ## Overview
 

--- a/examples/multi_agent/mar/multi_agent_router_specialist_routing.py
+++ b/examples/multi_agent/mar/multi_agent_router_specialist_routing.py
@@ -1,0 +1,72 @@
+from dotenv import load_dotenv
+
+from swarms import Agent
+from swarms.structs.multi_agent_router import MultiAgentRouter
+
+load_dotenv()
+
+# The boss routes on these descriptions, so they carry the weight here - the
+# system_prompt only shapes the answer once an agent has been chosen.
+researcher = Agent(
+    agent_name="Researcher",
+    agent_description="Finds and explains facts, prior art, and how something works. Use for 'what is', 'how does', and background questions.",
+    system_prompt=(
+        "You are a research analyst. Answer with concrete facts and the "
+        "reasoning behind them. Keep it under 200 words."
+    ),
+    model_name="gpt-5.4",
+    max_loops=1,
+)
+
+coder = Agent(
+    agent_name="Coder",
+    agent_description="Writes and debugs code. Use for anything that should produce a function, script, or fix.",
+    system_prompt=(
+        "You are a Python engineer. Return working code with a short "
+        "explanation. Prefer the standard library."
+    ),
+    model_name="gpt-5.4",
+    max_loops=1,
+)
+
+writer = Agent(
+    agent_name="Writer",
+    agent_description="Turns material into clear prose for a stated audience. Use for summaries, docs, and explanations for non-experts.",
+    system_prompt=(
+        "You are a technical writer. Write plainly for a non-expert reader. "
+        "No filler."
+    ),
+    model_name="gpt-5.4",
+    max_loops=1,
+)
+
+router = MultiAgentRouter(
+    name="engineering-router",
+    description="Routes engineering questions to the right specialist",
+    agents=[researcher, coder, writer],
+    model="gpt-5.4",
+    # Print the boss's routing decision, including its reasoning.
+    print_on=True,
+    # Do not run an agent the boss handed an empty task.
+    skip_null_tasks=True,
+)
+
+# One clear task, so the boss picks a single agent.
+print("\n=== SINGLE AGENT ===")
+single = router.run(
+    "Write a Python function that validates an email address."
+)
+print(single)
+
+# Several distinct pieces of work, so the boss picks several agents. They run
+# concurrently, so this costs roughly one agent's latency rather than three.
+print("\n=== MULTIPLE AGENTS ===")
+multiple = router.run(
+    "Explain what a vector database is, write a Python snippet that queries "
+    "one, and summarise both for a non-technical reader."
+)
+print(multiple)
+
+print("\n=== WHO ANSWERED ===")
+for message in router.conversation.conversation_history:
+    print(f"[{message['role']}] {str(message['content'])[:100]}")


### PR DESCRIPTION
Adds `examples/multi_agent/mar/multi_agent_router_specialist_routing.py` and indexes it in the folder README.

## Why another one

`mar/` already has `multi_agent_router_minimal.py` and `multi_agent_router_example.py`, but neither shows the thing that actually decides whether this structure works: **the boss routes on each agent's `description`, not on its `system_prompt`**. That is the part people get wrong, so the descriptions here are written as routing hints —

```python
agent_description="Finds and explains facts, prior art, and how something works. "
                  "Use for 'what is', 'how does', and background questions.",
```

— while `system_prompt` only shapes the answer once an agent has been picked.

## What it demonstrates

Two runs against the same router, covering both branches of `route_task`:

- **One clear task** → the boss selects a single agent (`handle_single_handoff`).
- **A task with three distinct pieces** → the boss selects three (`handle_multiple_handoffs`), which now run concurrently after #2087.

`print_on=True` so the boss's reasoning panel is visible, `skip_null_tasks=True` (which actually works now, also #2087), and the run ends by printing the conversation so it is clear who answered.

## Verified without a model

The example was checked by stubbing the boss decision and `Agent.call_llm`, so the API usage is exercised end to end with no API call:

```
=== SINGLE AGENT ===
[user]  Write a Python function that validates an email address.
[Coder] <Coder answered>
```

`black --line-length 70` and `ruff` clean.

## One caveat a reviewer should know

The multi-agent run currently prints **one** answer for a three-part task. All three agents run, but only the first response is recorded — that is #2044, fixed by the open **#2076**.

So until #2076 merges, this example demonstrates the bug rather than the feature. The example itself is correct; nothing here needs changing when that lands. It is arguably a good reason to merge #2076 first.
