### PR TITLE
[FIX][Agent.arun][Stop binding a third positional to run()'s imgs parameter]

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2264,7 +2264,6 @@ Subtask Breakdown:
         self,
         task: Optional[str] = None,
         img: Optional[str] = None,
-        *args,
         **kwargs,
     ) -> Any:
         """
@@ -2273,9 +2272,7 @@ Subtask Breakdown:
         Args:
             task (Optional[str]): The task to be performed. Defaults to None.
             img (Optional[str]): The image to be processed. Defaults to None.
-            is_last (bool): Indicates if this is the last task. Defaults to False.
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
+            **kwargs: Additional keyword arguments, forwarded to run().
 
         Returns:
             Any: The result of the asynchronous operation.
@@ -2284,12 +2281,10 @@ Subtask Breakdown:
             Exception: If an error occurs during the asynchronous operation.
         """
         try:
-            # Positional, in run()'s order: keywords plus *args made every extra positional collide with task.
             return await asyncio.to_thread(
                 self.run,
-                task,
-                img,
-                *args,
+                task=task,
+                img=img,
                 **kwargs,
             )
         except Exception as error:
@@ -2300,7 +2295,6 @@ Subtask Breakdown:
         self,
         task: Optional[str] = None,
         img: Optional[str] = None,
-        *args,
         **kwargs,
     ) -> Any:
         """Call the agent
@@ -2308,12 +2302,12 @@ Subtask Breakdown:
         Args:
             task (Optional[str]): The task to be performed. Defaults to None.
             img (Optional[str]): The image to be processed. Defaults to None.
+            **kwargs: Additional keyword arguments, forwarded to run().
         """
         try:
             return self.run(
                 task=task,
                 img=img,
-                *args,
                 **kwargs,
             )
         except Exception as error:

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1028,25 +1028,53 @@ class TestArunForwarding:
         agent.to_dict = lambda: {}
         return agent
 
-    def test_extra_positional_args_reach_run(self):
-        """`task=`/`img=` as keywords alongside *args made every extra
-        positional collide with `task`: arun(task, img, extra) raised
-        `TypeError: got multiple values for argument 'task'`.
-        """
+    def test_task_and_img_reach_run_with_kwargs(self):
+        """The forwarding arun is actually able to do."""
+        import asyncio
+
         agent = self._bare_agent()
         seen = {}
 
-        def fake_run(*args, **kwargs):
-            seen["args"] = args
+        def fake_run(task=None, img=None, **kwargs):
+            seen["task"] = task
+            seen["img"] = img
             seen["kwargs"] = kwargs
             return "ok"
 
         agent.run = fake_run
 
-        result = asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
+        result = asyncio.run(
+            Agent.arun(agent, "T", "I", streaming_callback=None)
+        )
 
         assert result == "ok"
-        assert seen["args"] == ("T", "I", "EXTRA")
+        assert seen["task"] == "T"
+        assert seen["img"] == "I"
+        assert seen["kwargs"] == {"streaming_callback": None}
+
+    def test_a_third_positional_is_refused_not_bound_to_imgs(self):
+        """It has to fail loudly, because there is no correct place for it.
+
+        run()'s positionals after `img` are imgs/correct_answer/
+        streaming_callback/n, so forwarding a third positional through does
+        not reach run()'s own *args -- it lands on `imgs`, a List[str] of
+        image paths:
+
+            >>> inspect.signature(Agent.run).bind_partial(
+            ...     None, "T", "I", "EXTRA").arguments
+            {'task': 'T', 'img': 'I', 'imgs': 'EXTRA'}
+
+        A stub declared as ``fake_run(*args, **kwargs)`` cannot see that --
+        it accepts anything positionally -- which is why the real signature
+        is used here.
+        """
+        import asyncio
+
+        agent = self._bare_agent()
+        agent.run = lambda task=None, img=None, imgs=None, **kw: "ok"
+
+        with pytest.raises(TypeError):
+            asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
 
     def test_error_path_does_not_await_a_sync_handler(self):
         """`_handle_run_error` is sync and re-raises; the await was harmless


### PR DESCRIPTION
Replaces #1879.

## What is wrong

`master` forwards positionally. `run()`'s parameters after `img` are `imgs`, `correct_answer`, `streaming_callback`, `n` — so a third positional lands on `imgs` long before it could reach `run()`'s own `*args`:

```py
def real_shaped_run(task=None, img=None, imgs=None, correct_answer=None,
                    streaming_callback=None, n=None, *args, **kwargs): ...
agent.run = real_shaped_run
asyncio.run(Agent.arun(agent, "T", "I", "EXTRA"))
```
```
EXTRA landed on: [imgs]
run()'s own *args: ()
```

## What this does

`*args` on these two forwarders could never carry a value through to `run()`'s `*args` under either forwarding scheme, so the signature was promising something it cannot keep. Dropped it; `task`/`img` go by keyword plus `**kwargs`. An extra positional now fails at the call rather than binding silently to the wrong parameter:

```
TypeError: Agent.arun() takes from 1 to 3 positional arguments but 4 were given
```

Same reasoning as #1891 and #1893.

## On the replaced test

`test_extra_positional_args_reach_run` asserted the binding this PR removes, and its stub was a catch-all `fake_run(*args, **kwargs)` which absorbs any binding — so it passed against the misbind it was written to catch. The replacement mirrors `run()`'s real parameter list, so a wrong bind shows up as a wrong parameter name.

If you would rather keep positional forwarding and accept the `imgs` binding, say so and I will close this.

## Why a new PR

I force-pushed #1879 to rebase it, which moves the diff under a reviewer mid-read. Fresh branch off current `master`, and I will not force-push this one. `tests/structs/test_agent.py`: 89 passed.