### PR TITLE
fix(spreadsheet-swarm): stop running one Agent in several threads (#2045)

### DIFF
--- a/swarms/structs/spreadsheet_swarm.py
+++ b/swarms/structs/spreadsheet_swarm.py
@@ -308,25 +308,16 @@ class SpreadSheetSwarm:
         if not self.agents and self.load_path:
             self.load_from_csv()
 
-        # Prepare agents and tasks for concurrent execution
-        agents_to_run = []
-        tasks_to_run = []
-
         for _ in range(self.max_loops):
             for agent in self.agents:
-                agents_to_run.append(agent)
-                tasks_to_run.append(task)
+                agent.short_memory = agent.short_memory_init()
 
-        # Run all tasks concurrently using the multi_agent_exec function
-        results = run_agents_with_different_tasks(
-            list(zip(agents_to_run, tasks_to_run))
-        )
+            results = run_agents_with_different_tasks(
+                [(agent, task) for agent in self.agents]
+            )
 
-        # Process the results
-        for i, result in enumerate(results):
-            agent = agents_to_run[i]
-            task_str = tasks_to_run[i]
-            self._track_output(agent.agent_name, task_str, result)
+            for agent, result in zip(self.agents, results):
+                self._track_output(agent.agent_name, task, result)
 
     def _track_output(self, agent_name: str, task: str, result: str):
         """

--- a/tests/structs/test_spreadsheet.py
+++ b/tests/structs/test_spreadsheet.py
@@ -1,6 +1,8 @@
 import os
 import json
 import csv
+import threading
+import time
 
 import pytest
 
@@ -567,3 +569,108 @@ def test_reliability_check_verbose(temp_workspace):
     )
 
     assert swarm.verbose is True
+
+
+class RecordingAgent(Agent):
+    def __init__(self, name, registry):
+        self.agent_name = name
+        self.registry = registry
+        self.short_memory = []
+        self.concurrent_peak = 0
+        self._live = 0
+        self._lock = threading.Lock()
+
+    def short_memory_init(self):
+        return []
+
+    def run(self, task=None, *args, **kwargs):
+        with self._lock:
+            self._live += 1
+            self.concurrent_peak = max(
+                self.concurrent_peak, self._live
+            )
+        self.short_memory.append(task)
+        time.sleep(0.02)
+        self.registry.append(
+            (self.agent_name, list(self.short_memory))
+        )
+        with self._lock:
+            self._live -= 1
+        return f"{self.agent_name}:{task}"
+
+
+def _recording_swarm(names, max_loops, temp_workspace):
+    registry = []
+    agents = [RecordingAgent(name, registry) for name in names]
+    swarm = SpreadSheetSwarm(
+        agents=agents,
+        max_loops=max_loops,
+        autosave_on=False,
+    )
+    return swarm, agents, registry
+
+
+def test_no_agent_is_run_by_two_threads_at_once(temp_workspace):
+    swarm, agents, _ = _recording_swarm(
+        ["a", "b", "c"], 3, temp_workspace
+    )
+
+    swarm._run_tasks("shared task")
+
+    assert [agent.concurrent_peak for agent in agents] == [1, 1, 1]
+
+
+def test_each_loop_starts_from_a_fresh_memory(temp_workspace):
+    swarm, agents, registry = _recording_swarm(
+        ["a"], 3, temp_workspace
+    )
+
+    swarm._run_tasks("shared task")
+
+    assert [memory for _, memory in registry] == [
+        ["shared task"],
+        ["shared task"],
+        ["shared task"],
+    ]
+
+
+def test_every_agent_runs_once_per_loop(temp_workspace):
+    swarm, agents, registry = _recording_swarm(
+        ["a", "b", "c"], 2, temp_workspace
+    )
+
+    swarm._run_tasks("shared task")
+
+    names = sorted(name for name, _ in registry)
+    assert names == ["a", "a", "b", "b", "c", "c"]
+    assert swarm.tasks_completed == 6
+
+
+def test_each_output_is_tracked_against_its_own_agent(temp_workspace):
+    swarm, agents, _ = _recording_swarm(["a", "b"], 2, temp_workspace)
+
+    swarm._run_tasks("shared task")
+
+    pairs = sorted(
+        (output["agent_name"], output["result"])
+        for output in swarm.outputs
+    )
+    assert pairs == [
+        ("a", "a:shared task"),
+        ("a", "a:shared task"),
+        ("b", "b:shared task"),
+        ("b", "b:shared task"),
+    ]
+
+
+def test_a_single_loop_still_runs_every_agent_concurrently(
+    temp_workspace,
+):
+    swarm, agents, registry = _recording_swarm(
+        ["a", "b", "c"], 1, temp_workspace
+    )
+
+    swarm._run_tasks("shared task")
+
+    assert sorted(name for name, _ in registry) == ["a", "b", "c"]
+    assert swarm.tasks_completed == 3


### PR DESCRIPTION
Closes #2045.

`SpreadSheetSwarm._run_tasks` dispatched the **same `Agent` object** into a thread pool once per loop, so with `max_loops > 1` several threads called `run()` on one agent and appended to one `short_memory` with no lock. **Three agents at `max_loops=3` meant nine concurrent calls across three instances — three threads per agent, sharing its memory.**

## Problem

`swarms/structs/spreadsheet_swarm.py:312-324`:

```python
        agents_to_run = []
        tasks_to_run = []

        for _ in range(self.max_loops):
            for agent in self.agents:
                agents_to_run.append(agent)
                tasks_to_run.append(task)

        results = run_agents_with_different_tasks(
            list(zip(agents_to_run, tasks_to_run))
        )
```

`run_agents_with_different_tasks` sends every pair into a thread pool, and the flat list repeats each agent `max_loops` times. Consequences:

- `short_memory` is appended to from several threads at once. Messages interleave, so an agent can answer using a sibling thread's transcript.
- Identical inputs give different outputs run to run.

## Fix

```python
        for _ in range(self.max_loops):
            for agent in self.agents:
                agent.short_memory = agent.short_memory_init()

            results = run_agents_with_different_tasks(
                [(agent, task) for agent in self.agents]
            )

            for agent, result in zip(self.agents, results):
                self._track_output(agent.agent_name, task, result)
```

Loops run one after another; each loop dispatches every agent **exactly once**, so no agent is ever held by two threads. Agents still run concurrently with each other inside a loop, which is the parallelism the structure exists for.

## Design decisions

- **Sequential loops rather than `deepcopy` per slot.** The issue offers three options: sequential loops, a deep copy per slot, or a memory reset. `copy.deepcopy(agent)` on an `Agent` would duplicate its LLM client and any tool objects it holds, which is both expensive and not obviously safe. Sequencing the loops removes the sharing outright and needs no copying.
- **Reset `short_memory` before each loop.** Without it, sequential reuse of one object would carry loop 1's transcript into loop 2 — the loops would silently stop being independent, which is a behavior change nobody asked for. `agent.short_memory = agent.short_memory_init()` is the idiom `auction_swarm.py` already uses for exactly this hazard.
- **Results are zipped against `self.agents`, not re-indexed.** The old code recovered the agent by index into a parallel list; one agent per slot means the pairing is now structural.
- **`max_loops` keeps its current meaning.** The issue also asks whether `max_loops` should be iterative refinement or repeated sampling. This PR does not answer that — it keeps today's meaning (repeated independent sampling) and only removes the race. Changing the semantics, or renaming it to `samples`/`repeats`, is a separate concern and a breaking one.

## Behavior-change note

With `max_loops > 1` a run now takes roughly `max_loops` times as long, because the loops are sequential rather than all in flight at once. That previous wall-clock came from racing a single object's memory, so it was never a real speedup — it was the bug. **Single-loop runs are completely unaffected**: every agent still goes out concurrently, which is the common case and is covered by a test below.

## Files

| File | Change |
|---|---|
| `swarms/structs/spreadsheet_swarm.py` | `_run_tasks` loops sequentially, one dispatch per loop, memory reset per loop |
| `tests/structs/test_spreadsheet.py` | 5 tests appended to the existing file |

## Verification

- **Unit**: 5 tests appended to the existing `tests/structs/test_spreadsheet.py`. No new test file.

  ```
  $ .venv/bin/python -m pytest tests/structs/test_spreadsheet.py -q \
      -k "two_threads or fresh_memory or once_per_loop or own_agent or single_loop"
  5 passed, 23 deselected in 1.96s
  ```

  The concurrency test is not a timing guess: `RecordingAgent.run` increments a lock-guarded counter on entry, records the high-water mark, sleeps 20ms to widen the window, and decrements on exit. The assertion is that every agent's peak concurrency is exactly **1**.

- **The tests fail on the unfixed base.** Same tests against `upstream/master`'s `spreadsheet_swarm.py`: **2 failed, 3 passed**. The two failures are precisely the defect — `test_no_agent_is_run_by_two_threads_at_once` (peak concurrency 3, not 1) and `test_each_loop_starts_from_a_fresh_memory` (loop 2 sees loop 1's task still in memory). The three that pass are the guards showing the working paths are unchanged.

- **The test file**, before and after:

  | | passed | failed |
  |---|---|---|
  | clean `upstream/master` | 20 | 3 |
  | this branch | **25** | 3 |

  The 3 are pre-existing (`test_swarm_save_file_path_generation`, `test_save_to_csv_data`, `test_save_to_csv_appends`) and fail identically on the clean base.

- **Full `tests/structs` suite**, both runs on this machine, same interpreter:

  | | passed | failed | skipped | xfailed | errors |
  |---|---|---|---|---|---|
  | clean `upstream/master` @ `cfc4366d` (git worktree) | 901 | 112 | 23 | 3 | 5 |
  | this branch | **906** | 112 | 23 | 3 | 5 |

  Identical failure and error sets; the +5 is exactly this PR's tests.

- **Lint**: `black --check` clean on both files; `ruff check` with the CI rule set reports no findings on either.

- **Not verified here**: no live-LLM path was exercised. `RecordingAgent` subclasses `Agent` (so the constructor's agent validation passes) and overrides `run` and `short_memory_init` without calling `super().__init__`, so no model is contacted. The threading behaviour under test is `run_agents_with_different_tasks`'s real thread pool, not a stub — only the agent body is fake.

## Note on `_track_output`

Still called from the collecting thread rather than the worker, so `self.outputs` and `self.tasks_completed` are appended from one thread per loop and need no lock. That was already true and is unchanged; the per-run reset of that state between `run()` calls, which the issue lists as related, is left as its own concern.
