### PR TITLE
[Bug] SocialAlgorithms.run_async always raises: the timeout path is main-thread only (#2070)

### DIFF
--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -1,5 +1,7 @@
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
@@ -321,24 +323,16 @@ class SocialAlgorithms:
         Raises:
             TimeoutError: If the function execution exceeds max_execution_time.
         """
-        import signal
-
-        def timeout_handler(signum, frame):
+        executor = ThreadPoolExecutor(max_workers=1)
+        future = executor.submit(func, *args, **kwargs)
+        try:
+            return future.result(timeout=self.max_execution_time)
+        except FuturesTimeoutError:
             raise TimeoutError(
                 f"Algorithm execution exceeded {self.max_execution_time} seconds"
             )
-
-        # Set up timeout
-        old_handler = signal.signal(signal.SIGALRM, timeout_handler)
-        signal.alarm(int(self.max_execution_time))
-
-        try:
-            result = func(*args, **kwargs)
-            return result
         finally:
-            # Restore original handler
-            signal.alarm(0)
-            signal.signal(signal.SIGALRM, old_handler)
+            executor.shutdown(wait=False)
 
     def _format_output(self, result: Any) -> Any:
         """

--- a/tests/structs/test_social_algorithms.py
+++ b/tests/structs/test_social_algorithms.py
@@ -535,5 +535,36 @@ class TestAlgorithmInfo:
         assert swarm.get_algorithm_info()["has_algorithm"] is False
 
 
+class TestTimeoutOffMainThread:
+    def test_timeout_path_runs_off_the_main_thread(self):
+        swarm = SocialAlgorithms(agents=[FakeAgent("A")])
+        swarm.max_execution_time = 5.0
+        results = {}
+
+        def worker():
+            try:
+                results["value"] = swarm._execute_with_timeout(
+                    lambda: "ok"
+                )
+            except Exception as exc:
+                results["value"] = f"{type(exc).__name__}: {exc}"
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+        assert results["value"] == "ok"
+
+    def test_sub_second_timeout_still_fires(self):
+        swarm = SocialAlgorithms(agents=[FakeAgent("A")])
+        swarm.max_execution_time = 0.2
+
+        def slow():
+            time.sleep(2)
+
+        with pytest.raises(TimeoutError):
+            swarm._execute_with_timeout(slow)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #2070.

## What is wrong

`_execute_with_timeout` installs a `SIGALRM` handler, which can only be done from the main thread. `run_async` hands `self.run` to a worker thread via `asyncio.to_thread`, and `run()` takes the timeout path whenever `max_execution_time > 0` — which the default `300.0` satisfies. The two are mutually exclusive by construction, so `run_async` fails on the default configuration:

```
off main thread, quick call -> ValueError: signal only works in main thread of the main interpreter
```

Two smaller defects rode along:

- `signal.alarm` takes whole seconds, so any `max_execution_time` below `1.0` truncated to `0` and scheduled **no timeout at all**
- `signal.SIGALRM` does not exist on Windows, so the default path raised `AttributeError` there

## What this does

A single-worker `ThreadPoolExecutor` with `future.result(timeout=...)`: works from any thread, accepts floats, cross-platform. `shutdown(wait=False)` so a timed-out call returns immediately instead of blocking on the thread it just gave up on.

Same probe after the change:

```
off main thread, quick call -> ok
off main thread, sub-second timeout -> TimeoutError: Algorithm execution exceeded 0.3 seconds
```

## One behaviour difference, stated rather than buried

`SIGALRM` interrupted the running function; this cannot. A timed-out call raises `TimeoutError` while its thread runs to completion in the background. That only changes behaviour where the old path worked at all — the main thread — and interrupting arbitrary code mid-call was never safe for a function holding locks or a network handle.

## Testing

Two cases appended to the existing `tests/structs/test_social_algorithms.py`, no new file. Both fail on unfixed source and pass with the change; the file is 48 passed.