### PR TITLE
[Bug] SpreadSheetSwarm max_loops runs one Agent object concurrently (#2045)

### DIFF
--- a/swarms/structs/spreadsheet_swarm.py
+++ b/swarms/structs/spreadsheet_swarm.py
@@ -308,25 +308,13 @@ class SpreadSheetSwarm:
         if not self.agents and self.load_path:
             self.load_from_csv()
 
-        # Prepare agents and tasks for concurrent execution
-        agents_to_run = []
-        tasks_to_run = []
-
         for _ in range(self.max_loops):
-            for agent in self.agents:
-                agents_to_run.append(agent)
-                tasks_to_run.append(task)
+            results = run_agents_with_different_tasks(
+                [(agent, task) for agent in self.agents]
+            )
 
-        # Run all tasks concurrently using the multi_agent_exec function
-        results = run_agents_with_different_tasks(
-            list(zip(agents_to_run, tasks_to_run))
-        )
-
-        # Process the results
-        for i, result in enumerate(results):
-            agent = agents_to_run[i]
-            task_str = tasks_to_run[i]
-            self._track_output(agent.agent_name, task_str, result)
+            for agent, result in zip(self.agents, results):
+                self._track_output(agent.agent_name, task, result)
 
     def _track_output(self, agent_name: str, task: str, result: str):
         """

--- a/tests/structs/test_spreadsheet.py
+++ b/tests/structs/test_spreadsheet.py
@@ -590,7 +590,9 @@ def test_max_loops_never_runs_one_agent_concurrently(temp_workspace):
             return "done"
 
     agents = [TrackingAgent("A"), TrackingAgent("B")]
-    swarm = SpreadSheetSwarm(agents=agents, max_loops=4, autosave=False)
+    swarm = SpreadSheetSwarm(
+        agents=agents, max_loops=4, autosave=False
+    )
 
     swarm.run("task")
 

--- a/tests/structs/test_spreadsheet.py
+++ b/tests/structs/test_spreadsheet.py
@@ -567,3 +567,32 @@ def test_reliability_check_verbose(temp_workspace):
     )
 
     assert swarm.verbose is True
+
+
+def test_max_loops_never_runs_one_agent_concurrently(temp_workspace):
+    import threading
+    import time
+
+    class TrackingAgent:
+        def __init__(self, name):
+            self.agent_name = name
+            self._live = 0
+            self.peak = 0
+            self._lock = threading.Lock()
+
+        def run(self, task=None, *args, **kwargs):
+            with self._lock:
+                self._live += 1
+                self.peak = max(self.peak, self._live)
+            time.sleep(0.05)
+            with self._lock:
+                self._live -= 1
+            return "done"
+
+    agents = [TrackingAgent("A"), TrackingAgent("B")]
+    swarm = SpreadSheetSwarm(agents=agents, max_loops=4, autosave=False)
+
+    swarm.run("task")
+
+    assert max(agent.peak for agent in agents) == 1
+    assert len(swarm.outputs) == 8


### PR DESCRIPTION
Closes #2045.

## What is wrong

With `max_loops > 1`, the same `Agent` object is appended to the executor list once per loop:

```python
for _ in range(self.max_loops):
    for agent in self.agents:
        agents_to_run.append(agent)
```

Several threads then call `run()` on one agent and mutate a single `short_memory` at the same time. Results interleave, writes are lost, output is nondeterministic.

The loops are also not iterations — nothing from loop 1 reaches loop 2. They are duplicate concurrent calls.

## What this does

Runs the loops sequentially, with the agents still concurrent **within** each loop. That keeps the parallelism worth having (different agents on one task) and removes the same-object concurrency entirely. Each loop records one output per agent, so the number of outputs is unchanged.

## Measured

An agent that counts overlapping calls on itself, `max_loops=4`, 2 agents:

```
before: peak concurrent calls on ONE agent object = 4
after:  peak concurrent calls on ONE agent object = 1
outputs recorded: 8 in both
```

## Note on the alternative

Giving each loop its own agent copy would preserve full parallelism, but `Agent` exposes no `copy`/`clone`, and deep-copying a live agent duplicates its model client and memory — a bigger change than this bug warrants. Sequential rounds fix the race with a smaller diff. Happy to take the copy approach instead if you would rather keep the wall-clock.

## Testing

One case appended to the existing `tests/structs/test_spreadsheet.py`, no new file. It fails on unfixed source. The three failures already present in that file on `master` are unaffected — verified by diffing failure sets rather than assuming.