### PR TITLE
fix(self-moa-seq): draw each sample from a fresh proposer (#2042)

### DIFF
--- a/swarms/structs/self_moa_seq.py
+++ b/swarms/structs/self_moa_seq.py
@@ -84,6 +84,7 @@ class SelfMoASeq(SerializableMixin):
             max_loops=1,
             verbose=self.verbose,
             top_p=top_p,
+            output_type="final",
         )
 
         # Initialize aggregator agent (synthesizes outputs)
@@ -100,6 +101,7 @@ class SelfMoASeq(SerializableMixin):
             max_loops=1,
             verbose=self.verbose,
             top_p=top_p,
+            output_type="final",
         )
 
         # Metrics tracking
@@ -164,6 +166,9 @@ class SelfMoASeq(SerializableMixin):
             for i in range(num_samples):
                 self._log(
                     "debug", f"Generating sample {i+1}/{num_samples}"
+                )
+                self.proposer.short_memory = (
+                    self.proposer.short_memory_init()
                 )
                 sample = self.proposer.run(task)
                 samples.append(sample)
@@ -243,6 +248,9 @@ class SelfMoASeq(SerializableMixin):
                 best_so_far,
             )
 
+            self.aggregator.short_memory = (
+                self.aggregator.short_memory_init()
+            )
             aggregated = self.aggregator.run(prompt)
             self.metrics["total_aggregations"] += 1
 

--- a/tests/structs/test_self_moa_seq.py
+++ b/tests/structs/test_self_moa_seq.py
@@ -701,5 +701,105 @@ def test_large_configuration():
     assert seq.retry_max_delay == 300.0
 
 
+class _TranscriptAgent:
+    def __init__(self, name):
+        self.agent_name = name
+        self.short_memory = []
+        self.calls = 0
+        self.inits = 0
+
+    def short_memory_init(self):
+        self.inits += 1
+        return []
+
+    def run(self, task, *args, **kwargs):
+        self.calls += 1
+        self.short_memory.append(f"{self.agent_name}#{self.calls}")
+        return " | ".join(self.short_memory)
+
+
+def _bare_seq(num_samples=3):
+    seq = SelfMoASeq.__new__(SelfMoASeq)
+    seq.verbose = False
+    seq.proposer = _TranscriptAgent("proposer")
+    seq.aggregator = _TranscriptAgent("aggregator")
+    seq.metrics = {
+        "total_samples_generated": 0,
+        "total_aggregations": 0,
+    }
+    seq.num_samples = num_samples
+    return seq
+
+
+def test_each_sample_starts_from_a_fresh_proposer_memory():
+    seq = _bare_seq()
+
+    seq._generate_samples("write a haiku", 3)
+
+    assert seq.proposer.inits == 3
+
+
+def test_a_sample_never_contains_an_earlier_sample():
+    seq = _bare_seq()
+
+    samples = seq._generate_samples("write a haiku", 3)
+
+    assert samples == ["proposer#1", "proposer#2", "proposer#3"]
+    for index, sample in enumerate(samples):
+        for earlier in samples[:index]:
+            assert earlier not in sample
+
+
+def test_sample_count_metric_still_increments():
+    seq = _bare_seq()
+
+    samples = seq._generate_samples("write a haiku", 4)
+
+    assert len(samples) == 4
+    assert seq.metrics["total_samples_generated"] == 4
+
+
+def test_the_unreset_agent_would_accumulate():
+    agent = _TranscriptAgent("proposer")
+
+    agent.run("t")
+    second = agent.run("t")
+
+    assert second == "proposer#1 | proposer#2"
+
+
+def test_each_window_starts_from_a_fresh_aggregator_memory():
+    seq = _bare_seq()
+
+    seq._aggregate_window("task", ["a", "b"])
+    seq._aggregate_window("task", ["c", "d"], best_so_far="a")
+
+    assert seq.aggregator.inits == 2
+
+
+def test_a_window_aggregation_never_carries_the_previous_window():
+    seq = _bare_seq()
+
+    first = seq._aggregate_window("task", ["a"])
+    second = seq._aggregate_window("task", ["b"], best_so_far=first)
+
+    assert first == "aggregator#1"
+    assert second == "aggregator#2"
+    assert first not in second
+    assert seq.metrics["total_aggregations"] == 2
+
+
+def test_both_agents_are_built_to_return_an_answer_not_a_transcript():
+    with patch("swarms.structs.self_moa_seq.Agent") as agent_cls:
+        SelfMoASeq(num_samples=2, window_size=4, reserved_slots=2)
+
+    output_types = [
+        call.kwargs.get("output_type")
+        for call in agent_cls.call_args_list
+    ]
+
+    assert output_types == ["final", "final"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #2042.

`SelfMoASeq` is meant to draw **N independent samples** from one model and aggregate them. It reused a single `self.proposer` across every sample and never reset it, so **sample *i* was generated with samples 1..*i*-1 already in context** — which removes the independence the whole method rests on.

## Problem

`swarms/structs/self_moa_seq.py:164-170` (before this change):

```python
for i in range(num_samples):
    self._log("debug", f"Generating sample {i+1}/{num_samples}")
    sample = self.proposer.run(task)
    samples.append(sample)
```

`self.proposer` is built once at `:76`. Nothing reset it:

```console
$ grep -n "short_memory" swarms/structs/self_moa_seq.py
(no matches)
```

Two compounding failures:

1. **Samples are conditioned on each other.** Variance reduction through sampling assumes independent draws. By sample 10 the model has seen its own nine previous attempts and converges on them or deliberately diverges — either way, not an independent draw.
2. **Each sample's text contains the previous ones.** Neither agent set `output_type`, so both defaulted to `"str-all-except-first"` (`swarms/structs/agent.py:349`) — the agent's *entire conversation*. So `samples[i]` literally contained samples 0..*i*-1 as text. Those strings are then concatenated into the aggregation prompt at `:205-207`, so with the default `num_samples=30` the last samples are enormous near-duplicates and cost grows quadratically.

## Fix

| Site | Change |
|---|---|
| `_generate_samples` | reset the proposer's `short_memory` before each `run` |
| `_aggregate_window` | reset the aggregator's `short_memory` before each `run` |
| proposer + aggregator construction | `output_type="final"` |

`agent.short_memory = agent.short_memory_init()` is the idiom `auction_swarm.py` already uses for exactly this hazard.

## Design decisions

- **The aggregator is reset too, which the issue does not ask for.** It is reused across sliding windows with no reset, so every window re-sent everything it had already seen — the same defect as the proposer's, one layer up, and leaving it would have left the quadratic growth in place on the aggregation side. Covered by its own test.
- **`output_type="final"` rather than `context_utils.agent_answer()`.** The issue offers both. Setting it at construction fixes the return value at the one place the agents are built, and applies to every call site including any future one; `agent_answer` would have to be remembered at each `run()`. These agents are internal to `SelfMoASeq` and not exposed, so changing their output type cannot surprise a caller.
- **Both agents changed together.** Fixing only the proposer would leave the aggregator returning a transcript, so `run()`'s final result would still carry the prompt back to the caller.

## Not in this PR

Passing the samples to the aggregator as typed turns via `messages=` instead of the `"\n[Response i]:\n"` concatenation. That is the third change #2042 lists, it is tracked in #2029, and it is a different concern from making a sample independent.

## Behavior-change note

`run()`'s output no longer carries the prompt and prior transcript back to the caller — it returns the synthesised answer. Anything that was parsing the old blob to recover the answer will now find the answer already on its own. Sample and aggregation **counts** are unchanged, and both metrics are asserted below.

## Verification

- **Unit**: 7 tests appended to the existing `tests/structs/test_self_moa_seq.py`. **No new test file.**

  ```
  $ .venv/bin/python -m pytest tests/structs/test_self_moa_seq.py -q \
      -k "fresh_proposer or never_contains_an_earlier or count_metric or \
          unreset_agent or fresh_aggregator or previous_window or answer_not_a_transcript"
  7 passed, 35 deselected in 2.39s
  ```

  `_TranscriptAgent` reproduces the defect mechanically rather than describing it: its `run` appends a unique marker to `short_memory` and returns the **whole memory joined**, which is what `"str-all-except-first"` does. With the reset in place each sample is `proposer#1`, `proposer#2`, `proposer#3`; without it, sample 3 is `proposer#1 | proposer#2 | proposer#3`. One test asserts the unreset agent *does* accumulate, so the fake is pinned to the behaviour it is standing in for.

- **The tests fail on the unfixed base.** Same tests against `upstream/master`'s `self_moa_seq.py`: **5 failed, 2 passed** — the two that pass are the metric count and the fake's own accumulation check, which is exactly right: they are the guards showing the counts did not change.

- **Full `tests/structs` suite**, both runs on this machine, same interpreter:

  | | passed | failed | skipped | xfailed | errors |
  |---|---|---|---|---|---|
  | clean `upstream/master` @ `cfc4366d` (git worktree) | 901 | 112 | 23 | 3 | 5 |
  | this branch | **908** | 112 | 23 | 3 | 5 |

  Identical failure and error sets; the +7 is exactly this PR's tests. The 112 pre-existing failures include 8 in this very file (retry-decorator and log-summary tests) that fail identically on the clean base.

- **Lint**: `black --check` clean on both files; `ruff check` with the CI rule set reports no findings on either.

- **Not verified here**: no live-LLM path was exercised. The tests build the structure with `SelfMoASeq.__new__` and set only the attributes `_generate_samples` and `_aggregate_window` read (`proposer`, `aggregator`, `metrics`, `verbose`), so no model is contacted and no API key is needed. The `output_type="final"` assertion patches `swarms.structs.self_moa_seq.Agent` and inspects the constructor kwargs, so it verifies what is passed, not what `Agent` then does with it — that behaviour belongs to `Agent` and is covered there.
