### PR TITLE
[Bug] ImageAgentBatchProcessor answers every image with the previous ones still in context

### DIFF
--- a/swarms/structs/image_batch_processor.py
+++ b/swarms/structs/image_batch_processor.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -106,6 +107,14 @@ class ImageAgentBatchProcessor:
                 f"Unsupported image format {path.suffix}. Supported formats: {self.supported_formats}"
             )
         return path
+
+    def _isolate(self, agent: Agent) -> Agent:
+        try:
+            isolated = copy.deepcopy(agent)
+        except Exception:
+            return agent
+        isolated.short_memory = isolated.short_memory_init()
+        return isolated
 
     def _process_single_image(
         self,
@@ -217,7 +226,10 @@ class ImageAgentBatchProcessor:
             for path in validated_paths:
                 for agent in self.agents:
                     future = executor.submit(
-                        self._process_single_image, path, tasks, agent
+                        self._process_single_image,
+                        path,
+                        tasks,
+                        self._isolate(agent),
                     )
                     future_to_path[future] = (path, agent)
 


### PR DESCRIPTION
Closes #2046.

## Why

`run()` submits the **same `Agent` object** once per image and nothing ever resets it:

```python
for path in validated_paths:
    for agent in self.agents:
        future = executor.submit(self._process_single_image, path, tasks, agent)
```

```console
$ grep -n "short_memory" swarms/structs/image_batch_processor.py
(no matches)
```

Three consequences, all silent:

- **Cross-contamination.** Image 40 is answered with images 1–39 in context. Results depend on batch order, which is the opposite of what a batch processor promises.
- **Cost grows quadratically.** The whole batch accumulates in `short_memory` and is re-sent on every later call.
- **Thread race.** Workers append to one `short_memory` concurrently, so an image can be answered against another image's task text.

## What

Hand each submission a private copy with empty short-term memory:

```python
def _isolate(self, agent: Agent) -> Agent:
    try:
        isolated = copy.deepcopy(agent)
    except Exception:
        return agent
    isolated.short_memory = isolated.short_memory_init()
    return isolated
```

Copying is what closes the race — no two workers touch the same object — and the reset is what makes each image independent.

**On the fallback.** Where the agent cannot be copied (a held `_thread.lock`, an HTTP connection pool) it returns the original, matching `AgentRearrange._clone_for_task`. It deliberately returns that agent **untouched rather than resetting it**: the issue suggests resetting inside `_process_single_image`, but a reset on a shared object that another worker is mid-run on would clear memory out from under it — a worse bug than the sharing. So the uncopyable case is left exactly as it is today rather than made newly unsafe.

13 lines. `AuctionSwarm` and `PlannerWorkerSwarm` already do the reset half of this; this adds the isolation the concurrency needs.

## Measured

Six images, one agent, `max_workers=1`, with a stub agent that reports how many earlier images were in memory when it ran:

```
master:    PRIOR-IMAGES-SEEN: [0, 1, 2, 3, 4, 5]     caller's agent left holding 6 entries
with fix:  PRIOR-IMAGES-SEEN: [0, 0, 0, 0, 0, 0]     caller's agent left untouched, 0 entries
```

The second line is the fix twice over: every image starts clean, and the caller's own `Agent` is no longer mutated as a side effect of running a batch.

## No test file

`image_batch_processor.py` has no test module and nothing in `tests/` references it, so a test means a new file for a 13-line change. The check above is a dozen lines and reproduces from the issue directly — happy to add `tests/structs/test_image_batch_processor.py` with it if you would rather have it in the suite.