### PR TITLE
[Bug] ExpertPanelDiscussion sends the moderator a Python list repr instead of the experts' answers

### DIFF
--- a/swarms/structs/multi_agent_debates.py
+++ b/swarms/structs/multi_agent_debates.py
@@ -167,7 +167,16 @@ class ExpertPanelDiscussion:
                 conversation.add(expert.agent_name, expert_response)
 
             # Moderator synthesizes and asks follow-up
-            synthesis_prompt = f"Synthesize the expert responses and ask a follow-up question: {[msg['content'] for msg in conversation.conversation_history[-len(self.agents):]]}"
+            panel = conversation.conversation_history[
+                -len(self.agents) :
+            ]
+            transcript = "\n\n".join(
+                f"{msg['role']}: {msg['content']}" for msg in panel
+            )
+            synthesis_prompt = (
+                "Synthesize the expert responses below and ask a "
+                f"follow-up question.\n\n{transcript}"
+            )
             synthesis = self.moderator.run(task=synthesis_prompt)
             conversation.add(self.moderator.agent_name, synthesis)
 

--- a/tests/structs/test_multi_agent_debate.py
+++ b/tests/structs/test_multi_agent_debate.py
@@ -176,3 +176,33 @@ def test_expert_panel_discussion_output_types(
             f"Failed to test ExpertPanelDiscussion output types: {e}"
         )
         raise
+
+
+class _RecordingAgent(Agent):
+    def __init__(self, name, reply):
+        self.agent_name = name
+        self.reply = reply
+        self.tasks = []
+
+    def run(self, task=None, *args, **kwargs):
+        self.tasks.append(task)
+        return self.reply
+
+
+def test_moderator_synthesis_names_each_expert_and_is_not_a_list_repr():
+    moderator = _RecordingAgent("Moderator", "A follow-up question.")
+    experts = [
+        _RecordingAgent("Economist", "Rates will hold."),
+        _RecordingAgent("Historian", 'Precedent says "no".'),
+    ]
+
+    ExpertPanelDiscussion(
+        agents=experts, moderator=moderator, max_rounds=1
+    ).run(task="Where do rates go?")
+
+    synthesis = moderator.tasks[-1]
+
+    assert "Economist: Rates will hold." in synthesis
+    assert 'Historian: Precedent says "no".' in synthesis
+    assert "['" not in synthesis
+    assert "\\n" not in synthesis


### PR DESCRIPTION
Closes #2051 — the list-repr defect. The other three in that issue are noted at the bottom.

## Why

`swarms/structs/multi_agent_debates.py:170` interpolates a list comprehension straight into the prompt:

```python
synthesis_prompt = f"Synthesize the expert responses and ask a follow-up question: {[msg['content'] for msg in conversation.conversation_history[-len(self.agents):]]}"
```

The moderator is asked to synthesise the panel, and this is what it actually receives — captured from a real run:

```
Synthesize the expert responses and ask a follow-up question: ['Rates will hold.', 'Precedent says "no".']
```

Bracket syntax, Python string quoting, `\n` escaped into literal backslash-n on any multi-line answer — and, worst of the four, **no expert names**. The one thing a panel synthesis needs is who said what, and the list carries only contents. With three experts the moderator cannot attribute a single claim.

## What

```python
panel = conversation.conversation_history[-len(self.agents):]
transcript = "\n\n".join(f"{msg['role']}: {msg['content']}" for msg in panel)
synthesis_prompt = (
    "Synthesize the expert responses below and ask a "
    f"follow-up question.\n\n{transcript}"
)
```

Attribution is free here: `conversation.add(expert.agent_name, expert_response)` already stores the agent name as the message role, so it was being discarded rather than being unavailable.

Now:

```
Synthesize the expert responses below and ask a follow-up question.

Economist: Rates will hold.

Historian: Precedent says "no".
```

## Test

Added to `tests/structs/test_multi_agent_debate.py`, which already owns this class.

`test_moderator_synthesis_names_each_expert_and_is_not_a_list_repr` captures the prompt the moderator is handed and asserts each expert's line is present and attributed, that no `['` appears, and that no literal `\n` escape does.

On `master` it fails with the defect printed in full:

```
assert 'Economist: Rates will hold.' in
       'Synthesize the expert responses and ask a follow-up question: [\'Rates will hold.\', \'Precedent says "no".\']'
```

The test uses stub agents and needs no API key, unlike its neighbours in that file, so it runs in CI rather than skipping.

## Not in scope

The issue bundles three more defects:

- **Intro-priming contamination** (`:64-65`, `:139`, `:147`) — agents are primed with a throwaway `run()`, and because `output_type` defaults to `str-all-except-first`, every later return starts with that setup text. Real, but the fix is a behavioural change to what `run()` returns for every caller of this module, not a formatting fix.
- **Transcripts recorded as contributions** (`:74`, `:159`, `:167`, `:172`) — downstream of the above; fixing priming first changes what these record.
- **`:165`** builds the expert prompt from `moderator_response`, which carries the same contamination.

All three share one root cause and want one PR that changes how this module calls `run()`. Keeping them out means this diff is nine lines and the review is about one thing. Happy to take that second PR next if you want it.