### PR TITLE
[Bug] reasoning_effort is annotated with a function call, which is not valid Literal typing

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -101,7 +101,7 @@ from swarms.utils.file_processing import create_file_in_folder
 from swarms.utils.formatter import formatter
 from swarms.utils.generate_id import generate_id
 from swarms.utils.generate_keys import generate_api_key
-from swarms.utils.get_reasoning_efforts import get_reasoning_efforts
+from swarms.utils.get_reasoning_efforts import ReasoningEffort
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
 )
@@ -391,7 +391,7 @@ class Agent:
         reasoning_prompt_on: bool = True,
         dynamic_context_window: bool = True,
         show_tool_execution_output: bool = True,
-        reasoning_effort: Literal[get_reasoning_efforts()] = None,
+        reasoning_effort: Optional[ReasoningEffort] = None,
         thinking_tokens: int = 1024,
         think_tool: bool = False,
         dynamic_tools: bool = True,

--- a/swarms/utils/get_reasoning_efforts.py
+++ b/swarms/utils/get_reasoning_efforts.py
@@ -14,7 +14,6 @@ ReasoningEffort = Literal[
     "None",
 ]
 
-# Fallback set, unioned with installed litellm's values so supported efforts are never reduced.
 REASONING_EFFORTS: Tuple[str, ...] = get_args(ReasoningEffort)
 
 

--- a/swarms/utils/get_reasoning_efforts.py
+++ b/swarms/utils/get_reasoning_efforts.py
@@ -1,9 +1,8 @@
 import inspect
 from functools import lru_cache
-from typing import Tuple, get_args
+from typing import Literal, Tuple, get_args
 
-# Fallback set, unioned with installed litellm's values so supported efforts are never reduced.
-REASONING_EFFORTS: Tuple[str, ...] = (
+ReasoningEffort = Literal[
     "none",
     "minimal",
     "low",
@@ -13,7 +12,10 @@ REASONING_EFFORTS: Tuple[str, ...] = (
     "ultra",
     "max",
     "None",
-)
+]
+
+# Fallback set, unioned with installed litellm's values so supported efforts are never reduced.
+REASONING_EFFORTS: Tuple[str, ...] = get_args(ReasoningEffort)
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
The follow-up you suggested on #1773 — but smaller than proposed, and for a different reason than I expected. Details below.

## The bug

`swarms/structs/agent.py:394` on master:

```python
reasoning_effort: Literal[get_reasoning_efforts()] = None,
```

`Literal` takes literal members. A **function call** there is rejected by every type checker, so `reasoning_effort` has effectively been unannotated for tooling purposes. It happens to work at runtime only because annotations are evaluated as ordinary expressions.

And it is evaluated — at class-body execution, i.e. when `agent.py` is imported. `get_reasoning_efforts()` does this:

```python
try:
    import litellm
    annotation = inspect.signature(litellm.completion).parameters["reasoning_effort"].annotation
```

So an annotation reaches into litellm's signature at import time.

## The fix

Spell the members out once as a `Literal`, and derive the tuple from it:

```python
ReasoningEffort = Literal["none", "minimal", ..., "None"]

REASONING_EFFORTS: Tuple[str, ...] = get_args(ReasoningEffort)
```

```python
reasoning_effort: Optional[ReasoningEffort] = None,
```

The static type and the runtime tuple now come from one source, so they cannot disagree. **`get_reasoning_efforts()` is untouched** and still unions whatever the installed litellm advertises, so no accepted value is narrowed — that behaviour was the point of the helper and it is preserved.

## Verified

```
ReasoningEffort members:                       9
REASONING_EFFORTS == get_args(ReasoningEffort): True
get_reasoning_efforts() still unions litellm:   True
agent annotation: Optional[Literal['none','minimal','low','medium','high','xhigh','ultra','max','None']]

tests/structs/test_agent.py                     88 passed
```

## Why this is smaller than you proposed

You suggested salvaging two files from #1773. I checked both and only one survives contact:

- **`get_reasoning_efforts.py`** — real, and it turned out to be a correctness bug rather than only a perf one. That is this PR.
- **`swarms/tools/mcp_manager.py`** — I built the leaf deferral (`from __future__ import annotations`, `TYPE_CHECKING` for the two annotations, local imports at the two genuine runtime sites `isinstance(tool, MCPTool)` and `async with ClientSession(...)`, plus `lru_cache` on `_mcp_is_v2`) and then **measured it, and it changes nothing today**:

```
importing swarms.tools.mcp_manager
  master:      mcp in sys.modules: True
  with my fix: mcp in sys.modules: True
```

Because importing `swarms.tools.mcp_manager` executes `swarms/__init__.py` first, which pulls the package in regardless. The leaf deferral only pays off once the package boundary is handled — which is #2090's PEP 562 work. So it is not "helps anyone importing mcp_manager directly" yet, and I would rather not ship a change whose stated benefit I cannot demonstrate. Happy to send it as a one-file follow-up the moment #2090 lands, when it will actually compose.

One correction to the framing on #1773: **#2090 has not landed** — it is still open as of now, and master still has `from litellm import model_list` at `agent.py:21`. Nothing here depends on it either way; this PR stands alone.