### PR TITLE
Honour output_type on the complete_task path of _generate_final_summary

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2139,7 +2139,7 @@ class Agent:
         self,
         streaming_callback: Optional[Callable[[str], None]] = None,
         messages: Optional[List[dict]] = None,
-    ) -> str:
+    ) -> Any:
         """
         Generate a comprehensive final summary of the autonomous task execution.
 
@@ -2151,7 +2151,9 @@ class Agent:
                 flattened string rendering of it.
 
         Returns:
-            str: Comprehensive summary
+            Any: The conversation rendered according to ``self.output_type``.
+                The shape does not depend on whether the model finished by
+                calling ``complete_task`` or by answering in prose.
         """
         summary_prompt = get_summary_prompt()
         self.short_memory.add(
@@ -2215,7 +2217,18 @@ class Agent:
                                 title="Task Completion Summary",
                             )
 
-                        return result
+                        # Record the summary as the agent's own final turn so
+                        # that output_type is honoured here exactly as it is on
+                        # the fallback path below. Returning `result` directly
+                        # would hand back a bare string no matter what the
+                        # caller asked for.
+                        self.short_memory.add(
+                            role=self.agent_name, content=result
+                        )
+
+                        return history_output_formatter(
+                            self.short_memory, type=self.output_type
+                        )
 
             # If complete_task wasn't called, generate summary manually
             comprehensive_summary = f"""Task Execution Summary

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1375,3 +1375,74 @@ class TestEmptyToolsList:
         agent = self._agent(tools=[sample])
         assert agent.tools_list_dictionary
         assert "tool_search" in agent.system_prompt
+
+
+COMPLETE_TASK_CALL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "complete_task",
+            "arguments": json.dumps(
+                {
+                    "task_id": "task-1",
+                    "summary": "did the thing",
+                    "success": True,
+                }
+            ),
+        },
+    }
+]
+
+
+class TestFinalSummaryOutputType:
+    """`_generate_final_summary` must honour `output_type` on every path.
+
+    The `complete_task` branch returned the tool's raw string while the two
+    other paths returned `history_output_formatter(...)`, so the shape a
+    caller got depended on whether the model called the tool.
+    """
+
+    @staticmethod
+    def _summarise(output_type, llm_response):
+        agent = Agent(
+            agent_name="summary_agent",
+            model_name="gpt-4o-mini",
+            max_loops=1,
+            output_type=output_type,
+            print_on=False,
+        )
+        agent.short_memory.add(role="User", content="original task")
+        with patch.object(
+            Agent, "call_llm", return_value=llm_response
+        ), patch.object(
+            Agent,
+            "parse_llm_output",
+            side_effect=lambda response: response,
+        ):
+            return agent._generate_final_summary()
+
+    @pytest.mark.parametrize(
+        "output_type",
+        [
+            "list",
+            "dict",
+            "str",
+            "final",
+            "dict-final",
+            "str-all-except-first",
+        ],
+    )
+    def test_complete_task_path_matches_fallback_path(
+        self, output_type
+    ):
+        fallback = self._summarise(output_type, "plain text answer")
+        completed = self._summarise(output_type, COMPLETE_TASK_CALL)
+        assert type(completed) is type(fallback)
+
+    def test_list_output_type_is_not_a_bare_string(self):
+        completed = self._summarise("list", COMPLETE_TASK_CALL)
+        assert isinstance(completed, list)
+
+    def test_summary_text_survives_into_the_conversation(self):
+        completed = self._summarise("str", COMPLETE_TASK_CALL)
+        assert "did the thing" in completed


### PR DESCRIPTION
`_generate_final_summary` has three exit points and only two of them respect `output_type`.

When the model finishes by calling `complete_task`, the method returns the tool's return value directly — a plain string. The fallback path (model answered in prose) and the exception path both return `history_output_formatter(self.short_memory, type=self.output_type)`. So the shape a caller gets back from `agent.run()` in `max_loops="auto"` mode depends on whether the model happened to invoke the tool, and it's the *success* path that's wrong. A caller who set `output_type="list"` gets a `list` when the run muddles through and a `str` when it goes well.

That's awkward for anything downstream that indexes the result — `SwarmRouter` and the swarm structures consume this.

## The change

On the `complete_task` branch, add the completion summary to `short_memory` as the agent's own final turn, then return through `history_output_formatter` like the other two paths do. The summary text isn't lost — it's now in the conversation, so it shows up in whatever rendering the caller asked for.

Also widened the annotation from `-> str` to `-> Any`; it was never accurate for the two formatter paths, which return lists, dicts and tuples depending on `output_type`.

## Testing

Added `TestFinalSummaryOutputType` to `tests/structs/test_agent.py`. It stubs `call_llm` and `parse_llm_output`, so it needs no provider or API key, and asserts that the `complete_task` path and the fallback path return the same type across six `output_type` values.

```
$ python -m pytest tests/structs/test_agent.py::TestFinalSummaryOutputType -q -p no:randomly
8 passed in 2.67s
```

Confirmed the test actually pins the bug by reverting only `swarms/structs/agent.py` and re-running:

```
>       assert type(completed) is type(fallback)
E       AssertionError: assert <class 'str'> is <class 'list'>
E       AssertionError: assert <class 'str'> is <class 'tuple'>
>       assert isinstance(completed, list)
E       AssertionError: assert False
4 failed, 4 passed
```

Full file, before and after:

```
pristine origin/master:  1 failed, 87 passed
this branch:             1 failed, 95 passed
```

`+8` is exactly the number of tests added. The one failure, `TestAgentFeatures::test_async_operations`, fails identically on pristine `master` and is unrelated to this change.

Lint: `ruff check` reports 277 errors on `swarms/structs/agent.py` + `tests/structs/test_agent.py` both before and after — no new ones. `black --check` leaves the test file unchanged; the single `agent.py` reformat it wants is at ~line 4289, pre-existing and nowhere near this change.

Fixes #1972
