### PR TITLE
[Bug] Evaluation scores are hardcoded to 7.5, so the score-based early-stop is dead code

### DIFF
--- a/swarms/structs/hierarchical_structured_communication_framework.py
+++ b/swarms/structs/hierarchical_structured_communication_framework.py
@@ -20,6 +20,7 @@ Key Features:
 - Flexible model support (OpenAI and Ollama)
 """
 
+import re
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Union
 from dataclasses import dataclass
@@ -99,6 +100,31 @@ class HierarchicalOrder(BaseModel):
     )
     intermediate_output: str = Field(
         default="", description="Intermediate output to pass along"
+    )
+
+
+def _parse_evaluation(response: str) -> tuple:
+    text = response if isinstance(response, str) else str(response)
+    text = re.sub(
+        r"\(\s*\d+(?:\.\d+)?\s*-\s*\d+(?:\.\d+)?\s*\)", " ", text
+    )
+
+    def _last_in_range(label, low, high, default):
+        for found in reversed(
+            re.findall(
+                rf"{label}\D{{0,20}}?(\d+(?:\.\d+)?)",
+                text,
+                re.IGNORECASE,
+            )
+        ):
+            value = float(found)
+            if low <= value <= high:
+                return value
+        return default
+
+    return (
+        _last_in_range("score", 0.0, 10.0, 7.5),
+        _last_in_range("confidence", 0.0, 1.0, 0.8),
     )
 
 
@@ -1559,7 +1585,9 @@ Always explain your refinements and how they address the evaluation feedback.
                         f"Evaluate this content for {criterion}:\n{content}\n\nProvide: 1) Score (0-10), 2) Detailed feedback, 3) Confidence (0-1)"
                     )
 
-                    # Parse evaluation result (simplified parsing)
+                    score, confidence = _parse_evaluation(
+                        eval_response
+                    )
                     result = EvaluationResult(
                         evaluator_name=(
                             evaluator.agent_name
@@ -1567,9 +1595,9 @@ Always explain your refinements and how they address the evaluation feedback.
                             else f"Evaluator_{i}"
                         ),
                         criterion=criterion,
-                        score=7.5,  # Default score, would need proper parsing
+                        score=score,
                         feedback=eval_response,
-                        confidence=0.8,  # Default confidence
+                        confidence=confidence,
                     )
                     results.append(result)
 


### PR DESCRIPTION
Fixes #2043

### What was wrong

Every `EvaluationResult` carried a hardcoded `score=7.5` and `confidence=0.8`, with a comment saying parsing "would need proper parsing". The refinement loop stops on:

```python
if avg_score >= 8.0:
```

`avg_score` was the mean of a constant 7.5, so the condition was unreachable, the loop always ran the full `max_loops`, and anyone tuning that threshold was tuning nothing.

The evaluator was already being asked for the numbers:

```python
f"Evaluate this content for {criterion}:\n{content}\n\n"
"Provide: 1) Score (0-10), 2) Detailed feedback, 3) Confidence (0-1)"
```

The model answered; the code threw the answer away and kept the feedback text only.

### The fix

`_parse_evaluation` pulls the score and confidence out of the response, keeping the existing 7.5 / 0.8 as fallbacks so a response that omits them behaves exactly as before. Out-of-range values fall back too, rather than feeding a nonsense score into the average.

Two things the naive version got wrong, both found by testing it:

- **The prompt's own `(0-10)` was being parsed as the score.** `Score (0-10): 4` returned `0.0`, because the first digits after "score" are the range, not the answer — and that is the exact format this prompt asks for. Parenthesized ranges are stripped first.
- **Models echo the instruction.** When a response repeats `Provide: 1) Score (0-10), 2) feedback...` before answering, the first match is the echo. It now takes the *last* in-range match, which is the actual answer.

### Verification

```
Score: 9.2 / Confidence: 0.95            -> (9.2, 0.95)
Score (0-10): 4 / Confidence (0-1): 0.6  -> (4.0, 0.6)
**Score**: 8.5 out of 10 / Confidence - 0.7 -> (8.5, 0.7)
echoed instructions, then Score: 6.5     -> (6.5, 0.4)
no numbers at all                        -> (7.5, 0.8)   fallback
Score: 42 / Confidence: 5  (out of range)-> (7.5, 0.8)   fallback
None                                     -> (7.5, 0.8)   fallback
```

No test file owns `hierarchical_structured_communication_framework.py` and the suite has no general catch-all for it, so rather than add a file for one private helper I verified it directly against the cases above.
