### PR TITLE
Fix CLI help text that advertised the wrong defaults

### DIFF
--- a/swarms/cli/main.py
+++ b/swarms/cli/main.py
@@ -854,11 +854,11 @@ class CustomHelpAction(argparse.Action):
             ),
             (
                 "--question-agent-model-name MODEL",
-                "Model for question generation agent (default: gpt-4o-mini)",
+                "Model for question generation agent (default: gpt-5.4)",
             ),
             (
                 "--worker-model-name MODEL",
-                "Model for worker agents (default: gpt-4o-mini)",
+                "Model for worker agents (default: gpt-5.4)",
             ),
             ("--context-length N", "Context length for the agent"),
             ("--retry-attempts N", "Number of retry attempts"),
@@ -877,7 +877,7 @@ class CustomHelpAction(argparse.Action):
                 "Fetch system prompt from Swarms marketplace",
             ),
             ("--verbose", "Enable verbose output"),
-            ("--interactive", "Enable interactive mode (default)"),
+            ("--interactive", "Enable interactive mode"),
             ("--no-interactive", "Disable interactive mode"),
             ("--streaming-on", "Enable streaming mode"),
             (
@@ -1015,7 +1015,7 @@ def setup_argument_parser() -> argparse.ArgumentParser:
         "--model-name",
         type=str,
         default=None,
-        help="Model name to use (e.g. gpt-5.4, gpt-4o, claude-opus-4-6). Defaults to gpt-5.4 for chat, gpt-4 for agent.",
+        help="Model name to use (e.g. gpt-5.4, gpt-4o, claude-opus-4-6). Defaults to gpt-5.1 for chat, gpt-5.4 for agent.",
     )
     parser.add_argument(
         "--task",
@@ -1025,7 +1025,7 @@ def setup_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--interactive",
         action="store_true",
-        help="Enable interactive mode for the agent (default: True)",
+        help="Enable interactive mode for the agent (default: False)",
     )
     parser.add_argument(
         "--no-interactive",
@@ -1129,13 +1129,13 @@ def setup_argument_parser() -> argparse.ArgumentParser:
         "--question-agent-model-name",
         type=str,
         default="gpt-5.4",
-        help="Model name for question generation agent (default: gpt-4o-mini)",
+        help="Model name for question generation agent (default: gpt-5.4)",
     )
     parser.add_argument(
         "--worker-model-name",
         type=str,
         default="gpt-5.4",
-        help="Model name for specialized worker agents (default: gpt-4o-mini)",
+        help="Model name for specialized worker agents (default: gpt-5.4)",
     )
     parser.add_argument(
         "--random-loops-per-agent",
@@ -1172,7 +1172,7 @@ def setup_argument_parser() -> argparse.ArgumentParser:
         "--dir",
         type=str,
         default=None,
-        help="Directory for 'swarms init' (default: prompted interactively)",
+        help="Directory for 'swarms init' (prompted interactively if omitted)",
     )
     # Tips command arguments
     parser.add_argument(
@@ -1420,8 +1420,8 @@ def handle_agent(args: argparse.Namespace) -> None:
             - system_prompt: Required unless marketplace_prompt_id is provided
             - marketplace_prompt_id: Optional prompt ID from Swarms marketplace
             - task: Optional task to execute immediately
-            - model_name: Model to use (default: "gpt-4")
-            - interactive: Enable interactive mode (default: True)
+            - model_name: Model to use (default: "gpt-5.4")
+            - interactive: Enable interactive mode (default: False)
             - temperature: Temperature setting (0.0-2.0)
             - max_loops: Maximum loops (integer or "auto")
             - And other optional agent configuration parameters

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,6 +76,61 @@ class TestSetupArgumentParser:
         parser = self.setup_argument_parser()
         assert isinstance(parser, argparse.ArgumentParser)
 
+    def test_help_text_matches_actual_defaults(self):
+        """Every '(default: X)' in a flag's help must be the real default.
+
+        Help text is the only place a user learns what a flag does when they
+        do not pass it, so a stale value there is actively misleading -- the
+        model flags in particular differ in cost. Walking the parser rather
+        than asserting on a fixed list means new flags are covered too.
+        """
+        import re
+
+        stated_default = re.compile(
+            r"\(default:\s*([^)]+)\)", re.IGNORECASE
+        )
+
+        parser = self.setup_argument_parser()
+        subparsers = [
+            action
+            for action in parser._actions
+            if isinstance(action, argparse._SubParsersAction)
+        ]
+        parsers = [parser] + [
+            sub
+            for action in subparsers
+            for sub in action.choices.values()
+        ]
+
+        mismatches = []
+        for parsed in parsers:
+            for action in parsed._actions:
+                if not action.help or not action.option_strings:
+                    continue
+                match = stated_default.search(action.help)
+                if not match:
+                    continue
+                claimed = match.group(1).strip().strip("\"'")
+                actual = action.default
+                if str(actual) != claimed:
+                    mismatches.append(
+                        f"{action.option_strings[0]}: help says "
+                        f"{claimed!r} but default is {actual!r}"
+                    )
+
+        assert (
+            not mismatches
+        ), "CLI help text disagrees with defaults: " + "; ".join(
+            mismatches
+        )
+
+    def test_heavy_swarm_model_defaults(self):
+        """The two HeavySwarm model flags resolve to the documented model."""
+        parser = self.setup_argument_parser()
+        args = parser.parse_args(["heavy-swarm", "--task", "t"])
+        assert args.question_agent_model_name == "gpt-5.4"
+        assert args.worker_model_name == "gpt-5.4"
+
     def test_valid_commands_parse(self):
         valid_commands = [
             "init",


### PR DESCRIPTION
`swarms/cli/main.py` advertised defaults that the parser doesn't actually use. The two HeavySwarm model flags are the expensive case:

```python
"--question-agent-model-name",
default="gpt-5.4",
help="Model name for question generation agent (default: gpt-4o-mini)",
```

Anyone reading `--help` and relying on the stated default gets `gpt-5.4` instead — a substantially different model in both cost and capability. The same stale text was duplicated in the hand-written help table that `CustomHelpAction` renders, so the wrong value appeared twice per flag.

While confirming that, I checked every other flag rather than just the two in the report, and the same drift existed elsewhere:

- `--interactive` is `action="store_true"`, so its default is `False`, but the help said `(default: True)` and the help table said `(default)`. That one is arguably worse than the model flags — it tells you the opposite of what happens.
- `--model-name` claimed "gpt-5.4 for chat, gpt-4 for agent". `handle_chat` falls back to `gpt-5.1`, and the agent path passes `None` through to `Agent`, whose own default is `gpt-5.4`. Both halves were wrong.
- The `handle_agent` docstring repeated the stale `gpt-4` / `interactive=True` pair.
- `--dir` said `(default: prompted interactively)`, which is accurate prose but uses the `(default: X)` form for something that isn't a literal value. Reworded to `(prompted interactively if omitted)` so the form consistently means "this is the actual default".

## What this changes

Help strings only — no default, no flag, and no runtime behaviour is touched. Every `(default: X)` in the CLI now states the value argparse will really use.

## Test

Rather than pin the four reported strings, `test_help_text_matches_actual_defaults` walks the parser and its subparsers, extracts any `(default: X)` from each action's help, and compares it against `action.default`. New flags are covered automatically, which is what stops this drifting again. `test_heavy_swarm_model_defaults` additionally asserts the two flags from the report resolve to `gpt-5.4`.

Confirmed the test actually pins the bug by reverting `main.py` and keeping the test:

```
AssertionError: CLI help text disagrees with defaults:
  --interactive: help says 'True' but default is False;
  --question-agent-model-name: help says 'gpt-4o-mini' but default is 'gpt-5.4';
  --worker-model-name: help says 'gpt-4o-mini' but default is 'gpt-5.4';
  --dir: help says 'prompted interactively' but default is None
```

With the fix applied, `pytest tests/test_cli.py`:

```
1 failed, 59 passed
```

against `57 passed` on pristine `master` — the delta is exactly the two tests added. The one failure is `TestMain::test_main_handles_bad_command_gracefully`, which fails identically on unmodified `master` and is unrelated to this change.

`ruff check` reports 46 errors on both files before and after (unchanged baseline). `black --line-length 70` leaves `tests/test_cli.py` unchanged; `main.py` is reformatted by black both before and after this change, so I left that pre-existing formatting alone rather than adding unrelated churn.

Fixes #2028
