### PR TITLE
fix(social-algorithms): enforce the timeout by joining a worker thread, not SIGALRM (#2070)

### DIFF
--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -1,5 +1,7 @@
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
@@ -320,25 +322,30 @@ class SocialAlgorithms:
 
         Raises:
             TimeoutError: If the function execution exceeds max_execution_time.
-        """
-        import signal
 
-        def timeout_handler(signum, frame):
+        Note:
+            The deadline is enforced by joining a worker thread rather than
+            with ``signal.SIGALRM``, which only worked on the main thread of
+            Unix platforms (``AttributeError`` on Windows, ``ValueError``
+            from any worker thread) and truncated sub-second budgets to
+            ``alarm(0)``, which cancels the timeout entirely. On timeout the
+            algorithm cannot be safely interrupted — it is arbitrary user
+            code — so its thread is left to finish in the background while
+            the caller receives the ``TimeoutError`` immediately.
+        """
+        executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=f"{self.name}-timeout",
+        )
+        future = executor.submit(func, *args, **kwargs)
+        try:
+            return future.result(timeout=self.max_execution_time)
+        except FuturesTimeoutError:
             raise TimeoutError(
                 f"Algorithm execution exceeded {self.max_execution_time} seconds"
-            )
-
-        # Set up timeout
-        old_handler = signal.signal(signal.SIGALRM, timeout_handler)
-        signal.alarm(int(self.max_execution_time))
-
-        try:
-            result = func(*args, **kwargs)
-            return result
+            ) from None
         finally:
-            # Restore original handler
-            signal.alarm(0)
-            signal.signal(signal.SIGALRM, old_handler)
+            executor.shutdown(wait=False, cancel_futures=True)
 
     def _format_output(self, result: Any) -> Any:
         """

--- a/tests/structs/test_social_algorithms.py
+++ b/tests/structs/test_social_algorithms.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 import time
 
@@ -459,7 +460,12 @@ class TestAlgorithmArgs:
 
 
 class TestTimeout:
-    """The timeout is SIGALRM-based, so it only works on the main thread."""
+    """The timeout joins a worker thread, so it works anywhere.
+
+    The previous SIGALRM implementation only worked on the main thread of
+    Unix platforms; the three formerly-xfailed tests below pin down the
+    portability and precision it lacked.
+    """
 
     def test_a_generous_timeout_does_not_interfere(self):
         swarm = _swarm(_pipeline, max_execution_time=30)
@@ -472,10 +478,6 @@ class TestTimeout:
 
         assert swarm.run("t").total_steps == 2
 
-    @pytest.mark.xfail(
-        reason="signal.alarm truncates to int, so alarm(0) cancels the timeout",
-        strict=False,
-    )
     def test_a_sub_second_budget_still_times_out(self):
         def slow(agents, task, **kwargs):
             time.sleep(2)
@@ -486,10 +488,19 @@ class TestTimeout:
         with pytest.raises(TimeoutError):
             swarm.run("t")
 
-    @pytest.mark.xfail(
-        reason="signal.signal cannot be called off the main thread",
-        strict=False,
-    )
+    def test_a_timeout_does_not_block_until_the_algorithm_ends(self):
+        def slow(agents, task, **kwargs):
+            time.sleep(5)
+            return "never"
+
+        swarm = _swarm(slow, max_execution_time=0.2)
+        started = time.monotonic()
+
+        with pytest.raises(TimeoutError):
+            swarm.run("t")
+
+        assert time.monotonic() - started < 4
+
     def test_run_works_on_a_worker_thread(self):
         swarm = _swarm(_pipeline)
         outcome = {}
@@ -506,12 +517,14 @@ class TestTimeout:
 
         assert outcome.get("steps") == 2
 
-    @pytest.mark.xfail(
-        reason="run_async runs on a worker thread, where SIGALRM is unavailable",
-        strict=False,
-    )
-    def test_run_async_works_on_the_default_configuration(self):
-        assert _swarm(_pipeline).run_async("t").total_steps == 2
+    def test_run_works_under_asyncio_to_thread(self):
+        """The default configuration must survive the common async pattern."""
+        swarm = _swarm(_pipeline)
+
+        async def main():
+            return await asyncio.to_thread(swarm.run, "t")
+
+        assert asyncio.run(main()).total_steps == 2
 
 
 class TestAlgorithmInfo:


### PR DESCRIPTION
## Description

`SocialAlgorithms._execute_with_timeout` enforced its deadline with `signal.SIGALRM`, which is mutually exclusive with almost every way the class is actually used:

- **Windows:** `signal.SIGALRM` does not exist, so the default configuration of `run()` raised `AttributeError: module 'signal' has no attribute 'SIGALRM'` on every call. Since `_validate_inputs` rejects `max_execution_time <= 0`, the signal path was unconditional — there was **no argument combination that let `run()` complete on Windows at all**.
- **Any worker thread** (e.g. `asyncio.to_thread(swarm.run, ...)`): `signal.signal` raised `ValueError: signal only works in main thread of the main interpreter`.
- **Sub-second budgets:** `signal.alarm(int(0.5))` is `alarm(0)`, which *cancels* the pending alarm — a tighter budget silently disabled the timeout.

Reproduced on `master` (win32, Python 3.12): running the existing `tests/structs/test_social_algorithms.py` suite fails 32 of its tests with the `SIGALRM AttributeError` before this change and passes 50/50 after it.

**The fix:** `_execute_with_timeout` now submits the algorithm to a single-thread `ThreadPoolExecutor` and joins it with the fractional deadline (`future.result(timeout=...)`). This works from any thread, on any platform, and honours sub-second budgets.

**Tradeoff stated in the docstring:** `signal.alarm` interrupted the running call; a timed-out future keeps running in the background (`shutdown(wait=False, cancel_futures=True)` never blocks the caller). The algorithm is arbitrary user code that cannot be safely killed either way, so reporting the timeout accurately from any thread is the better half of that trade — this matches the resolution suggested in the issue.

**Tests:**
- Removed the three `xfail` markers that pinned the old behaviour (`test_a_sub_second_budget_still_times_out`, `test_run_works_on_a_worker_thread`, and the `run_async` one) — the first two now pass as regular tests.
- `run_async` no longer exists on the struct, so its xfailed test is replaced with `test_run_works_under_asyncio_to_thread`, the pattern users reach for today and the exact configuration the issue reported.
- Added `test_a_timeout_does_not_block_until_the_algorithm_ends`, which pins the non-blocking guarantee of the new implementation.

`ruff check` and `black --check` (CI versions) are clean on both changed files.

## Issue

Fixes #2070

## Dependencies

None — `concurrent.futures` is stdlib.

## Tag maintainer

@kyegomez

## Twitter handle

—
