### PR TITLE
fix(autonomous-loop): run ContextCompressor between subtask iterations, rebuilding the transcript (#1962)

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -145,6 +145,42 @@ class AutonomousAgentLoop:
             formatter=format_data_structure,
         )
 
+    def _maybe_compress_context(self) -> bool:
+        """Compress the conversation when it nears the context limit.
+
+        ``ContextCompressor`` measures and compacts
+        ``agent.short_memory``, but the request body actually sent to
+        the model is ``self._transcript`` — so after a compaction the
+        transcript is rebuilt around the summary. Compressing only the
+        mirror would leave the payload growing unbounded, which is the
+        failure the compressor exists to prevent.
+
+        Returns:
+            bool: True when a compression ran and the transcript was
+            re-seeded. The caller must then restore whatever immediate
+            instruction the model needs (e.g. the prompt for the
+            subtask in flight).
+        """
+        compressor = getattr(self.agent, "_context_compressor", None)
+        if compressor is None:
+            return False
+        summary = compressor.maybe_compress(self.agent)
+        if summary is None:
+            return False
+
+        # compact() already re-seeded short_memory with the summary,
+        # so the transcript copy must not be mirrored back a second
+        # time.
+        self._transcript = Transcript()
+        self._say_user(
+            "[Compressed Memory Summary]\n"
+            "Earlier turns were compressed to stay within the "
+            "context window. Progress so far:\n\n"
+            f"{summary}",
+            mirror=False,
+        )
+        return True
+
     def _run_autonomous_loop(
         self,
         task: Optional[Union[str, Any]] = None,
@@ -673,6 +709,16 @@ class AutonomousAgentLoop:
                     and subtask_iterations < max_subtask_loops
                 ):
                     subtask_iterations += 1
+
+                    # Between iterations every recorded tool call has
+                    # been answered, so this is the one point the
+                    # transcript can be replaced without orphaning a
+                    # tool_call id.
+                    if self._maybe_compress_context():
+                        # The rebuilt transcript holds only the
+                        # summary; restore the instruction for the
+                        # subtask in flight.
+                        self._say_user(execution_prompt)
 
                     try:
                         response = self.agent.call_llm(

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -10,7 +10,7 @@ to a provider — ``Agent.call_llm`` — is monkeypatched per-test with a script
 sequence of canned responses, so the loop's real control flow, real tool
 dispatch, and real state transitions are exercised end to end.
 
-Covers three fixed defects:
+Covers four fixed defects:
 
 * #1963 — tool errors were logged and discarded, so the model never learned a
   call had failed and re-emitted it until the iteration budget was gone.
@@ -18,6 +18,9 @@ Covers three fixed defects:
   every call the model batched after it, while still marking the subtask done.
 * #1966 — a *failed* dependency satisfied its dependents, and an unknown
   ``step_id`` defaulted to satisfied.
+* #1962 — ``ContextCompressor.maybe_compress`` was never called on the
+  ``max_loops="auto"`` path, so history grew unbounded in exactly the mode
+  that needs compression most.
 
 Run:
     cd /Users/swarms_wd/Desktop/research/swarms
@@ -950,6 +953,159 @@ class TestHandoffPromptIsNotReappended:
         self._run_setup_only(agent, monkeypatch)
 
         assert agent.system_prompt == before
+
+
+# --------------------------------------------------------------------------
+# #1962 — context compression in the auto loop
+# --------------------------------------------------------------------------
+
+
+class TestContextCompression:
+    """#1962 — ``maybe_compress`` was never called on the auto path.
+
+    The compressor measures and compacts ``short_memory``, but the body
+    sent to the model is the loop's ``Transcript`` — so the fix both
+    triggers the compressor between subtask iterations and rebuilds the
+    transcript from the summary it returns. Compressing only the mirror
+    would leave the request payload growing unbounded.
+    """
+
+    class _StubCompressor:
+        """Always compresses, returning a fixed summary."""
+
+        def __init__(self, summary):
+            self.summary = summary
+            self.calls = 0
+
+        def maybe_compress(self, agent):
+            self.calls += 1
+            return self.summary
+
+    def test_no_compressor_is_a_no_op(self):
+        agent = build_agent()  # context_compression=False
+        loop = AutonomousAgentLoop(agent)
+        loop._say_user("seed")
+
+        assert loop._maybe_compress_context() is False
+        assert len(loop._transcript) == 1
+
+    def test_below_threshold_leaves_the_transcript_alone(self):
+        agent = build_agent(
+            context_compression=True, context_length=1_000_000
+        )
+        loop = AutonomousAgentLoop(agent)
+        loop._say_user("seed")
+
+        assert loop._maybe_compress_context() is False
+        assert len(loop._transcript) == 1
+
+    def test_compression_rebuilds_the_transcript(self):
+        agent = build_agent()
+        stub = self._StubCompressor("CANNED SUMMARY")
+        agent._context_compressor = stub
+        loop = AutonomousAgentLoop(agent)
+        for i in range(6):
+            loop._say_user(f"turn {i}")
+        memory_before = history(agent)
+
+        assert loop._maybe_compress_context() is True
+        assert stub.calls == 1
+
+        # The request body is now a single user turn holding the
+        # summary, not the six accumulated turns.
+        assert len(loop._transcript) == 1
+        seeded = loop._transcript[0]
+        assert seeded["role"] == "user"
+        assert "[Compressed Memory Summary]" in seeded["content"]
+        assert "CANNED SUMMARY" in seeded["content"]
+
+        # The compressor owns the short_memory compaction; the
+        # transcript re-seed must not mirror the summary there a
+        # second time.
+        assert history(agent) == memory_before
+
+    def test_compression_fires_during_a_run(self, monkeypatch):
+        """End to end: a run over a tiny context budget compresses
+        between subtask iterations, and the next request body is the
+        summary plus the re-issued subtask prompt — not the
+        accumulated planning transcript.
+        """
+        agent = build_agent(
+            context_compression=True, context_length=120
+        )
+        monkeypatch.setattr(
+            agent._context_compressor,
+            "_summarize",
+            lambda agent, history: "CANNED SUMMARY",
+        )
+
+        bodies = []
+        queue = [
+            plan(("step1", [])),
+            [
+                tool_call(
+                    "subtask_done",
+                    task_id="step1",
+                    summary="done",
+                    success=True,
+                )
+            ],
+            [
+                tool_call(
+                    "complete_task",
+                    task_id="main",
+                    summary="all done",
+                    success=True,
+                )
+            ],
+        ]
+
+        def fake_call_llm(task=None, *args, **kwargs):
+            bodies.append(list(kwargs.get("messages") or []))
+            if queue:
+                return queue.pop(0)
+            return "no further action"
+
+        monkeypatch.setattr(agent, "call_llm", fake_call_llm)
+
+        agent.run("test task")
+
+        # bodies[0] is the planning request; bodies[1] is the first
+        # subtask iteration, which crossed the 90% threshold and was
+        # compressed down to [summary, execution prompt].
+        assert len(bodies) >= 2
+        first_exec = bodies[1]
+        assert len(first_exec) == 2
+        assert (
+            "[Compressed Memory Summary]" in first_exec[0]["content"]
+        )
+        assert "CANNED SUMMARY" in first_exec[0]["content"]
+        assert "step1" in first_exec[1]["content"]
+
+    def test_compression_failure_does_not_break_the_loop(
+        self, monkeypatch
+    ):
+        """maybe_compress swallows summarizer errors and returns None;
+        the loop must treat that as "no compression" and carry on.
+        """
+        agent = build_agent(
+            context_compression=True, context_length=10
+        )
+
+        def boom(agent, history):
+            raise RuntimeError("summarizer unavailable")
+
+        monkeypatch.setattr(
+            agent._context_compressor, "_summarize", boom
+        )
+
+        loop = AutonomousAgentLoop(agent)
+        loop._say_user(
+            "a turn long enough to cross a 10-token budget"
+        )
+
+        assert loop._maybe_compress_context() is False
+        assert len(loop._transcript) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`Agent.run()` dispatches `max_loops="auto"` straight to `_run_autonomous_loop` (`agent.py:3327`), which never enters the `_run()` while-loop holding the only `maybe_compress` call site (`agent.py:1379`). So `ContextCompressor` was constructed when `context_compression=True`, documented in `CLAUDE.md` as firing "automatically when token usage crosses 90% of `context_length`" — and completely dead in exactly the mode that re-sends the whole history every iteration and can run for hundreds of them. Long autonomous runs fail with a context-length error instead of compacting. (P0, as tagged on the issue.)

**Why the one-line fix suggested in the issue wouldn't have been enough:** the compressor measures and compacts `agent.short_memory`, but the request body the auto loop actually sends is its `Transcript` (`messages=self._transcript.messages`), of which `short_memory` is explicitly only a mirror (see `transcript.py`'s module docstring). Calling `maybe_compress` alone would summarize the mirror while the real payload kept growing unbounded — the failure the compressor exists to prevent would still happen, just with a misleadingly compacted `short_memory` on the side.

**The fix** (`_maybe_compress_context`, called at the top of each subtask iteration):

1. Runs `maybe_compress` **between iterations** — the one point where every recorded tool call has been answered, so the transcript can be replaced without orphaning a `tool_call` id (an assistant `tool_calls` turn with no matching tool result makes the next request invalid).
2. When compression runs, rebuilds the transcript as `[summary block, re-issued subtask prompt]`. The summary is not mirrored back into `short_memory` (compaction already re-seeded it there — mirroring again would duplicate it); the re-issued subtask prompt is mirrored, keeping the two views consistent.
3. A summarizer failure is already converted to `None` inside `maybe_compress`; the loop treats that as "no compression" and carries on.

**Tests** (following the existing `script_llm` pattern in `tests/agents/test_autonomous_loop.py` — real `Agent`, real loop, scripted `call_llm`, fully offline):

- End to end: a run with `context_length=120` crosses the 90% threshold after planning; the captured request body for the first subtask iteration is **exactly two messages** — the `[Compressed Memory Summary]` block and the re-issued `step1` prompt — instead of the accumulated planning transcript.
- No compressor configured → no-op, transcript untouched.
- Below threshold → no-op, transcript untouched.
- Stub compressor → transcript rebuilt to a single user turn containing the summary, and `short_memory` not written a second time.
- Summarizer raising → treated as no compression, loop continues.

`tests/agents/test_autonomous_loop.py` (41) and `tests/agents/test_context_compressor.py` (32) all pass; `ruff check` and `black --check` (CI versions) clean.

## Issue

Fixes #1962

## Dependencies

None.

## Tag maintainer

@kyegomez

## Twitter handle

—
