### PR TITLE
[Bug] one_on_one_debate feeds each speaker the whole transcript, so context grows every turn

### DIFF
--- a/swarms/structs/deep_discussion.py
+++ b/swarms/structs/deep_discussion.py
@@ -1,6 +1,7 @@
 from typing import Callable, Union
 
 from swarms.structs.agent import Agent
+from swarms.structs.context_utils import agent_answer
 from swarms.structs.conversation import Conversation
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
@@ -53,10 +54,11 @@ def one_on_one_debate(
     for i in range(max_loops):
         # Current speaker responds
         response = speaker.run(task=message, img=img)
-        conversation.add(speaker.agent_name, response)
+        answer = agent_answer(speaker, fallback=response)
+        conversation.add(speaker.agent_name, answer)
 
         # Swap roles
-        message = response
+        message = answer
         speaker, other = other, speaker
 
     return history_output_formatter(

--- a/tests/structs/test_one_on_one_debate.py
+++ b/tests/structs/test_one_on_one_debate.py
@@ -633,3 +633,47 @@ def test_one_on_one_debate_class_multiple_loops(
             f"Failed to test OneOnOneDebate multiple loops: {e}"
         )
         raise
+
+
+def test_one_on_one_debate_forwards_the_answer_not_the_transcript():
+    """Each turn should receive the previous reply, not the whole transcript."""
+
+    class _Memory:
+        def __init__(self):
+            self.last = ""
+
+        def get_final_message_content(self):
+            return self.last
+
+    class _TranscriptAgent:
+        """Returns its whole conversation, as Agent does by default."""
+
+        def __init__(self, name):
+            self.agent_name = name
+            self.short_memory = _Memory()
+            self._transcript = []
+            self.prompts = []
+
+        def run(self, task=None, img=None):
+            self.prompts.append(str(task))
+            reply = f"{self.agent_name}-reply"
+            self.short_memory.last = reply
+            self._transcript.append(f"prev:{task}")
+            return "\n".join(self._transcript) + "\n" + reply
+
+    first = _TranscriptAgent("A")
+    second = _TranscriptAgent("B")
+
+    one_on_one_debate(
+        max_loops=6, task="seed", agents=[first, second]
+    )
+
+    for agent in (first, second):
+        assert not any(
+            "prev:" in prompt for prompt in agent.prompts[1:]
+        ), f"{agent.agent_name} was handed a transcript: {agent.prompts}"
+        assert agent.prompts[1:] == [
+            "B-reply" if agent.agent_name == "A" else "A-reply"
+        ] * len(
+            agent.prompts[1:]
+        ), f"{agent.agent_name} prompts: {agent.prompts}"


### PR DESCRIPTION
Fixes #2050

### What was wrong

`one_on_one_debate` used each speaker's `run()` return as the next speaker's message:

```python
response = speaker.run(task=message, img=img)
conversation.add(speaker.agent_name, response)
message = response
```

`Agent.run` returns according to `output_type`, which defaults to `"str-all-except-first"` — the agent's **entire conversation**, not its answer. So the whole transcript became the next prompt, and was also recorded as that speaker's contribution to the shared conversation.

### The fix

`agent_answer` already exists for precisely this, and its docstring says so: *"the right thing for a caller reading the result and the wrong thing to record as the agent's contribution to a shared conversation."* `agent_rearrange.py:735` already forwards the next task the same way. So this is three lines and no new helper:

```python
response = speaker.run(task=message, img=img)
answer = agent_answer(speaker, fallback=response)
conversation.add(speaker.agent_name, answer)
message = answer
```

### Verification

A stub agent that returns its growing transcript, `max_loops=4`, prompt sizes per turn:

```
master : A [4, 30]   B [17, 53]
branch : A [4, 7]    B [7, 7]
```

The new test in `tests/structs/test_one_on_one_debate.py` asserts no prompt after the first contains transcript content. It fails on master with *"A was handed a transcript"* and passes here.

Worth noting how I got that test right: my first version asserted that prompt sizes stopped growing, and it **passed on master** — with `max_loops=4` each agent only sees two prompts, so there was nothing to compare. It now runs six loops and asserts on content rather than length.

### One side effect worth flagging

Against the full file, master fails 10 tests and this branch fails 1. That is not nine bugs fixed — those are unmocked live-LLM tests that assert little more than `result is not None`, and without credentials a turn returns empty, master forwards the empty string, and the next turn raises:

```
ValueError: No task provided. Pass a non-empty `task`, or set interactive=True
```

Not feeding an empty message forward is a genuine robustness improvement, but the tests were only ever failing on that crash. The one remaining failure, `test_one_on_one_debate_none_task`, fails on master too.
