### PR TITLE
[Bug] DebateWithJudge records transcripts as arguments, so the judge scores the setup text too

### DIFF
--- a/swarms/structs/debate_with_judge.py
+++ b/swarms/structs/debate_with_judge.py
@@ -4,6 +4,7 @@ from loguru import logger
 
 from swarms.structs.execution_utils import batched_run
 from swarms.structs.agent import Agent
+from swarms.structs.context_utils import agent_answer
 from swarms.structs.conversation import Conversation
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
@@ -296,6 +297,9 @@ class DebateWithJudge:
                 current_topic, round_num
             )
             pro_argument = self.pro_agent.run(task=pro_prompt)
+            pro_argument = agent_answer(
+                self.pro_agent, fallback=pro_argument
+            )
             self.conversation.add(
                 self.pro_agent.agent_name, pro_argument
             )
@@ -308,6 +312,9 @@ class DebateWithJudge:
                 current_topic, pro_argument, round_num
             )
             con_argument = self.con_agent.run(task=con_prompt)
+            con_argument = agent_answer(
+                self.con_agent, fallback=con_argument
+            )
             self.conversation.add(
                 self.con_agent.agent_name, con_argument
             )
@@ -320,6 +327,9 @@ class DebateWithJudge:
                 current_topic, pro_argument, con_argument, round_num
             )
             judge_synthesis = self.judge_agent.run(task=judge_prompt)
+            judge_synthesis = agent_answer(
+                self.judge_agent, fallback=judge_synthesis
+            )
             self.conversation.add(
                 self.judge_agent.agent_name, judge_synthesis
             )


### PR DESCRIPTION
Fixes #2052

### What was wrong

The three agents are constructed with no `output_type`, so they default to `"str-all-except-first"` — the agent's whole conversation. Their raw `run()` returns were then used as the arguments themselves:

```python
pro_argument = self.pro_agent.run(task=pro_prompt)
con_argument = self.con_agent.run(task=con_prompt)
judge_synthesis = self.judge_agent.run(task=judge_prompt)
```

Each of those is a transcript, not an argument. `_initialize_agents` primes every agent with an introduction whose response is deliberately discarded, so the transcript **starts with that setup text** — and `pro_argument` is then interpolated verbatim into the Con prompt and the Judge prompt, every round. The judge was scoring transcripts.

### The fix

The same three-line treatment used elsewhere in the codebase for this exact problem — `agent_answer(agent, fallback=raw)` — applied at the three capture sites. No new helper, no change to the priming, no change to the prompts.

### Verification

Stub agents that return their whole conversation, `max_loops=2`, counting prompts that contain intro or transcript text:

```
master : con 2, judge 2
branch : con 0, judge 0
```

So the Con agent and the Judge now receive the opponent's actual argument rather than a transcript with the discarded introduction glued to the front.

### Scope

I've left the intro-priming itself alone. It is a deliberate way to seed each agent's memory, and once the arguments are real arguments it no longer leaks into anyone else's prompt — which is the consequence the issue is about. Removing it would be a behavioural change on top of a bug fix.

No test file covers `debate_with_judge.py` — `test_multi_agent_debate.py` and `test_one_on_one_debate.py` both cover other modules — so rather than start one for a three-line change I verified directly against both branches, as above. Happy to add one if you want a home for it.
