### PR TITLE
fix(spreadsheet-swarm): stop run_from_config running one Agent in several threads (#2115)

### DIFF
--- a/swarms/structs/spreadsheet_swarm.py
+++ b/swarms/structs/spreadsheet_swarm.py
@@ -199,22 +199,24 @@ class SpreadSheetSwarm:
 
         start_time = time
 
-        # Prepare agent-task pairs for concurrent execution
-        agent_task_pairs = []
+        agent_task_pairs = [
+            (agent, self.agent_tasks[agent.agent_name])
+            for agent in self.agents
+            if self.agent_tasks.get(agent.agent_name)
+        ]
 
-        for agent in self.agents:
-            task = self.agent_tasks.get(agent.agent_name)
-            if task:
-                for _ in range(self.max_loops):
-                    agent_task_pairs.append((agent, task))
+        for _ in range(self.max_loops):
+            for agent, _task in agent_task_pairs:
+                agent.short_memory = agent.short_memory_init()
 
-        # Run all tasks concurrently using the multi_agent_exec function
-        results = run_agents_with_different_tasks(agent_task_pairs)
+            results = run_agents_with_different_tasks(
+                agent_task_pairs
+            )
 
-        # Process the results
-        for i, result in enumerate(results):
-            agent, task = agent_task_pairs[i]
-            self._track_output(agent.agent_name, task, result)
+            for (agent, task), result in zip(
+                agent_task_pairs, results
+            ):
+                self._track_output(agent.agent_name, task, result)
 
         end_time = time
 

--- a/tests/structs/test_spreadsheet.py
+++ b/tests/structs/test_spreadsheet.py
@@ -674,3 +674,111 @@ def test_a_single_loop_still_runs_every_agent_concurrently(
 
     assert sorted(name for name, _ in registry) == ["a", "b", "c"]
     assert swarm.tasks_completed == 3
+
+
+def _recording_config_swarm(agent_tasks, max_loops, temp_workspace):
+    registry = []
+    agents = [RecordingAgent(name, registry) for name in agent_tasks]
+    swarm = SpreadSheetSwarm(
+        agents=agents,
+        max_loops=max_loops,
+        autosave=False,
+    )
+    swarm.agent_tasks = dict(agent_tasks)
+    return swarm, agents, registry
+
+
+def test_run_from_config_never_runs_an_agent_in_two_threads(
+    temp_workspace,
+):
+    swarm, agents, _ = _recording_config_swarm(
+        {"a": "task a", "b": "task b", "c": "task c"},
+        3,
+        temp_workspace,
+    )
+
+    swarm.run_from_config()
+
+    assert [agent.concurrent_peak for agent in agents] == [1, 1, 1]
+
+
+def test_run_from_config_starts_each_loop_from_a_fresh_memory(
+    temp_workspace,
+):
+    swarm, _, registry = _recording_config_swarm(
+        {"a": "task a"}, 3, temp_workspace
+    )
+
+    swarm.run_from_config()
+
+    assert [memory for _, memory in registry] == [
+        ["task a"],
+        ["task a"],
+        ["task a"],
+    ]
+
+
+def test_run_from_config_runs_every_agent_once_per_loop(
+    temp_workspace,
+):
+    swarm, _, registry = _recording_config_swarm(
+        {"a": "task a", "b": "task b", "c": "task c"},
+        2,
+        temp_workspace,
+    )
+
+    swarm.run_from_config()
+
+    assert sorted(name for name, _ in registry) == [
+        "a",
+        "a",
+        "b",
+        "b",
+        "c",
+        "c",
+    ]
+    assert swarm.tasks_completed == 6
+
+
+def test_run_from_config_tracks_each_result_against_its_own_task(
+    temp_workspace,
+):
+    swarm, _, _ = _recording_config_swarm(
+        {"a": "task a", "b": "task b"}, 2, temp_workspace
+    )
+
+    swarm.run_from_config()
+
+    triples = sorted(
+        (output["agent_name"], output["task"], output["result"])
+        for output in swarm.outputs
+    )
+    assert triples == [
+        ("a", "task a", "a:task a"),
+        ("a", "task a", "a:task a"),
+        ("b", "task b", "b:task b"),
+        ("b", "task b", "b:task b"),
+    ]
+
+
+def test_run_from_config_skips_agents_with_no_configured_task(
+    temp_workspace,
+):
+    registry = []
+    agents = [RecordingAgent(name, registry) for name in ("a", "b")]
+    swarm = SpreadSheetSwarm(
+        agents=agents,
+        max_loops=2,
+        autosave=False,
+    )
+    swarm.agent_tasks = {"b": "task b"}
+
+    swarm.run_from_config()
+
+    assert [name for name, _ in registry] == ["b", "b"]
+    assert swarm.tasks_completed == 2
+    assert {output["agent_name"] for output in swarm.outputs} == {"b"}
+    assert [
+        (output["agent_name"], output["task"])
+        for output in swarm.outputs
+    ] == [("b", "task b"), ("b", "task b")]


### PR DESCRIPTION
Closes #2115.

#2096 fixed the shared-`Agent`-across-threads race in `SpreadSheetSwarm._run_tasks`. The identical race was still present one method away in `run_from_config`, which that PR did not touch. **This is the CSV-loaded, per-agent-task mode the structure is named for** — `_run` dispatches to `run_from_config` whenever `run()` is called without a task and `agent_tasks` is populated, which is exactly what `load_from_csv` sets up.

## Problem

`swarms/structs/spreadsheet_swarm.py:202-212` on `master` @ `64b5c3e1`:

```python
        agent_task_pairs = []

        for agent in self.agents:
            task = self.agent_tasks.get(agent.agent_name)
            if task:
                for _ in range(self.max_loops):
                    agent_task_pairs.append((agent, task))

        results = run_agents_with_different_tasks(agent_task_pairs)
```

The inner `for _ in range(self.max_loops)` appends the **same `Agent` object** into a flat pair list `max_loops` times. `run_agents_with_different_tasks` sends every pair into a thread pool, so with `max_loops > 1` several threads call `run()` on one instance and append to one unguarded `short_memory` — the defect #2045 described, in the method next door to where #2096 fixed it.

Measured with the `RecordingAgent` harness already in the test file, three agents at `max_loops=3`:

```
assert [agent.concurrent_peak for agent in agents] == [1, 1, 1]
E   assert [3, 3, 3] == [1, 1, 1]
```

Peak concurrency per agent equals `max_loops`, and each loop sees the previous loop's memory:

```
assert [memory for _, memory in registry] == [["task a"], ["task a"], ["task a"]]
E   At index 0 diff: ['task a', 'task a', 'task a'] != ['task a']
```

## Fix

The same transformation #2096 applied to `_run_tasks` — sequential loops, one dispatch per loop, memory reset before each — with the per-agent task lookup preserved:

```python
        agent_task_pairs = [
            (agent, self.agent_tasks[agent.agent_name])
            for agent in self.agents
            if self.agent_tasks.get(agent.agent_name)
        ]

        for _ in range(self.max_loops):
            for agent, _task in agent_task_pairs:
                agent.short_memory = agent.short_memory_init()

            results = run_agents_with_different_tasks(
                agent_task_pairs
            )

            for (agent, task), result in zip(
                agent_task_pairs, results
            ):
                self._track_output(agent.agent_name, task, result)
```

## Design decisions

- **Agents with no configured task are filtered out once, before the loop.** The old code's `if task:` guard means the pair list is not necessarily one entry per agent, so this path cannot zip against `self.agents` the way `_run_tasks` now does — zipping against the filtered pair list is what keeps each result matched to the agent and task that produced it. `test_run_from_config_skips_agents_with_no_configured_task` is the regression guard for exactly that alignment.
- **The `(agent, task)` pairs are built once and reused each loop**, rather than rebuilt per loop. The lookup is over `self.agent_tasks`, which does not change during the run, so rebuilding would only re-derive the same list.
- **Results are still tracked in dispatch order per loop**, so `self.outputs` ordering is unchanged for any single-loop run — the only behavioral difference is that loops no longer overlap.

## Behavior-change note

`max_loops=1` is unaffected end to end: one dispatch, the same pairs, the same tracking order. For `max_loops > 1` the loops now run sequentially instead of all at once, so a multi-loop `run_from_config` takes roughly `max_loops` times as long in wall-clock — that is the cost of each loop actually starting from a clean memory, and it matches what #2096 already did to `_run_tasks`.

## Verification

- **New tests**: 5, added to the existing `tests/structs/test_spreadsheet.py` — no new test file. They reuse the `RecordingAgent` harness and `temp_workspace` fixture #2096 added, driven through `run_from_config` with `agent_tasks` populated:

  | Test | Asserts |
  |---|---|
  | `test_run_from_config_never_runs_an_agent_in_two_threads` | `concurrent_peak == 1` for every agent at `max_loops=3` |
  | `test_run_from_config_starts_each_loop_from_a_fresh_memory` | each loop's recorded memory is exactly its own task |
  | `test_run_from_config_runs_every_agent_once_per_loop` | agents × loops runs, `tasks_completed == 6` |
  | `test_run_from_config_tracks_each_result_against_its_own_task` | every output triple pairs an agent with **its own** task and result |
  | `test_run_from_config_skips_agents_with_no_configured_task` | an untasked agent is never run and the zip stays aligned |

- **Shown to fail on the current code first**, as #2096 was asked to: with the source reverted to `upstream/master` and these tests kept, `2 failed, 3 passed` — `[3, 3, 3] == [1, 1, 1]` and the accumulated-memory diff quoted above. The other three pass on `master` too; they are alignment guards, not race detectors, and they are what stop the filtered-pair change from silently mismatching results to agents.

- **File suite**: `pytest tests/structs/test_spreadsheet.py -q` → **30 passed, 3 failed**. Clean `upstream/master` with no changes at all: **25 passed, 3 failed** — the same three, `test_swarm_save_file_path_generation`, `test_save_to_csv_data` and `test_save_to_csv_appends`. Pre-existing and unrelated to this change (they concern save-file paths); the delta is +5 passed, +0 failed.

- **Lint**: `black --check` clean on both files. `ruff check` reports **21 findings on this branch and the identical 21 on clean `upstream/master`** — this change adds none.

- **Not verified here**: no run against a real LLM. `RecordingAgent` subclasses `Agent` and overrides `run` and `short_memory_init`, so the threading behavior under test is the real `run_agents_with_different_tasks` dispatch and the real `run_from_config` control flow, with only the model call stubbed. The wall-clock cost noted above is inferred from the loop structure, not timed against a live provider.

## CI note

`lint` and `dependency-review` pass. `pyre` and `test-main-features` fail here and fail identically on the other open PRs (#2114, #2113) — `test-main-features` fails on `litellm.InternalServerError: Missing credentials. Please pass an api_key ... or set the OPENAI_API_KEY environment variable`, i.e. the secretless-job condition, not this change. Nothing in this diff is reachable from those jobs: it touches one method of `SpreadSheetSwarm` and one test file, and the local run of that test file is reported above.
