### PR TITLE
Report unfinished subtasks in the autonomous loop's final summary

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -1227,14 +1227,28 @@ class AutonomousAgentLoop:
                         )
 
             # Phase 3: Final Summary
+            unfinished = self._unfinished_subtasks()
+
             if self.agent.print_on:
-                formatter.print_panel(
-                    "All subtasks completed. Generating final summary...",
-                    title="Autonomous Loop: Summary Phase",
-                )
+                if unfinished:
+                    names = ", ".join(
+                        s.get("step_id", "<unknown>")
+                        for s in unfinished
+                    )
+                    formatter.print_panel(
+                        f"{len(unfinished)} subtask(s) did not complete "
+                        f"({names}). Generating final summary...",
+                        title="Autonomous Loop: Summary Phase",
+                    )
+                else:
+                    formatter.print_panel(
+                        "All subtasks completed. Generating final summary...",
+                        title="Autonomous Loop: Summary Phase",
+                    )
 
             return self.agent._generate_final_summary(
-                streaming_callback=streaming_callback
+                streaming_callback=streaming_callback,
+                unfinished_subtasks=unfinished,
             )
 
         except Exception as error:
@@ -1803,6 +1817,26 @@ class AutonomousAgentLoop:
             )
         if self.agent.verbose:
             logger.warning(f"Subtask {step_id} skipped. {reason}")
+
+    def _unfinished_subtasks(self) -> List[Dict[str, Any]]:
+        """
+        Collect subtasks that never reached ``"completed"``.
+
+        This covers all three ways the execution loop can exit with work
+        outstanding: a subtask left ``"pending"`` when the loop hit the global
+        iteration cap or found nothing executable, one marked ``"failed"``
+        after exhausting its own iteration budget, and one ``"skipped"``
+        because a dependency did not complete successfully.
+
+        Returns:
+            List[Dict[str, Any]]: The unfinished subtasks, in plan order. Empty
+            when every subtask completed.
+        """
+        return [
+            subtask
+            for subtask in (self.agent.autonomous_subtasks or [])
+            if subtask.get("status") != "completed"
+        ]
 
     def _all_subtasks_complete(self) -> bool:
         """

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2161,6 +2161,7 @@ class Agent:
         self,
         streaming_callback: Optional[Callable[[str], None]] = None,
         messages: Optional[List[dict]] = None,
+        unfinished_subtasks: Optional[List[Dict[str, Any]]] = None,
     ) -> Any:
         """
         Generate a comprehensive final summary of the autonomous task execution.
@@ -2171,11 +2172,17 @@ class Agent:
                 the summary is requested against the real conversation - with
                 its tool calls and tool results intact - rather than against a
                 flattened string rendering of it.
+            unfinished_subtasks: Subtasks that never reached ``"completed"``.
+                When any are given, the summary prompt names them and requires
+                ``complete_task`` to be called with ``success=false``, so a
+                partial run is not reported to the user as a success.
 
         Returns:
             Any: The conversation shaped by ``output_type``, on every path.
         """
-        summary_prompt = get_summary_prompt()
+        summary_prompt = get_summary_prompt(
+            unfinished_subtasks=unfinished_subtasks
+        )
         self.short_memory.add(
             role=self.user_name, content=summary_prompt
         )

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -31,7 +31,7 @@ import re as _re
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
@@ -138,18 +138,45 @@ Instructions:
 """
 
 
-def get_summary_prompt() -> str:
+def get_summary_prompt(
+    unfinished_subtasks: Optional[List[Dict[str, Any]]] = None,
+) -> str:
     """
     Get the final summary phase prompt.
+
+    Args:
+        unfinished_subtasks: Subtasks that never reached ``"completed"`` -
+            those left ``"pending"`` when the loop hit its iteration cap, those
+            marked ``"failed"`` after exhausting their own budget, and those
+            ``"skipped"`` because a dependency did not complete. When any are
+            given the prompt stops asserting completion, names them, and
+            requires ``complete_task`` to be called with ``success=false``.
 
     Returns:
         str: Summary prompt
     """
-    return (
-        "All subtasks are complete.\n"
+    if unfinished_subtasks:
+        lines = []
+        for subtask in unfinished_subtasks:
+            step_id = subtask.get("step_id", "<unknown>")
+            status = subtask.get("status", "pending")
+            summary = subtask.get("summary", "")
+            entry = f"- {step_id} ({status})"
+            if summary:
+                entry += f": {summary}"
+            lines.append(entry)
+        opening = (
+            f"Execution stopped with {len(unfinished_subtasks)} subtask(s) "
+            "unfinished. The task was NOT fully completed.\n"
+            "Unfinished subtasks:\n" + "\n".join(lines) + "\n"
+        )
+    else:
+        opening = "All subtasks are complete.\n"
+
+    body = (
         "Generate a clear, comprehensive final summary using the `complete_task` tool.\n"
         "Your summary should:\n"
-        "- Restate the original task and confirm completion.\n"
+        "- Restate the original task and state whether it was completed.\n"
         "- Outline major accomplishments and deliverables.\n"
         "- Present key results and findings (including important data or insights).\n"
         "- Briefly summarize each subtask's status (including any failures).\n"
@@ -158,6 +185,15 @@ def get_summary_prompt() -> str:
         "Use the `complete_task` tool with: task_id, summary, success (true/false), results (optional), and lessons_learned (optional).\n"
         "Be concise, well-organized, and thorough—this is the user's final deliverable."
     )
+
+    if unfinished_subtasks:
+        body += (
+            "\nBecause work was left unfinished, call `complete_task` with "
+            "success=false and name the unfinished subtasks above in the "
+            "summary. Do not report this task as a success."
+        )
+
+    return opening + body
 
 
 def get_autonomous_planning_tools() -> List[Dict[str, Any]]:

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -37,6 +37,7 @@ from swarms.agents.autonomous_loop import AutonomousAgentLoop
 from swarms.structs.autonomous_loop_utils import (
     MAX_SUBTASK_LOOPS,
     get_autonomous_planning_tools,
+    get_summary_prompt,
     glob_tool,
     TOOL_OUTPUT_CONTEXT_SHARE,
     read_file_tool,
@@ -1145,6 +1146,127 @@ class TestContextCompression:
 
         assert loop._maybe_compress_context() is False
         assert len(loop._transcript) == 1
+# #1974 — abandoned subtasks reported as a complete success
+# --------------------------------------------------------------------------
+
+
+class TestUnfinishedSubtasksReachTheSummary:
+    """A partial run must not be summarised as a success."""
+
+    def test_pending_failed_and_skipped_are_all_collected(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t",
+            [
+                {"step_id": "a"},
+                {"step_id": "b"},
+                {"step_id": "c"},
+                {"step_id": "d"},
+            ],
+        )
+
+        agent.autonomous_subtasks[0]["status"] = "completed"
+        agent.autonomous_subtasks[1]["status"] = "failed"
+        agent.autonomous_subtasks[2]["status"] = "skipped"
+        # 'd' stays pending — the loop hit its cap before reaching it.
+
+        unfinished = loop._unfinished_subtasks()
+
+        assert [s["step_id"] for s in unfinished] == ["b", "c", "d"]
+
+    def test_fully_completed_plan_has_nothing_unfinished(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a"}, {"step_id": "b"}]
+        )
+
+        for subtask in agent.autonomous_subtasks:
+            subtask["status"] = "completed"
+
+        assert loop._unfinished_subtasks() == []
+
+    def test_summary_prompt_claims_completion_only_when_earned(self):
+        done = get_summary_prompt()
+        assert done.startswith("All subtasks are complete.")
+
+        partial = get_summary_prompt(
+            unfinished_subtasks=[
+                {
+                    "step_id": "step2",
+                    "status": "failed",
+                    "summary": "Exhausted its budget.",
+                }
+            ]
+        )
+
+        assert "All subtasks are complete." not in partial
+        assert "NOT fully completed" in partial
+        assert "step2" in partial
+        assert "Exhausted its budget." in partial
+        assert "success=false" in partial
+
+    def test_empty_unfinished_list_is_the_completed_prompt(self):
+        assert (
+            get_summary_prompt(unfinished_subtasks=[])
+            == get_summary_prompt()
+        )
+
+    def test_abandoned_subtask_reaches_the_summary_call(
+        self, monkeypatch
+    ):
+        """
+        End to end: a subtask that burns its iteration budget must arrive at
+        ``_generate_final_summary`` as unfinished, and the prompt the model
+        actually receives must say so.
+        """
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+
+        captured = {}
+
+        def fake_summary(
+            streaming_callback=None,
+            messages=None,
+            unfinished_subtasks=None,
+        ):
+            captured["unfinished"] = unfinished_subtasks
+            captured["prompt"] = get_summary_prompt(
+                unfinished_subtasks=unfinished_subtasks
+            )
+            return "summary"
+
+        monkeypatch.setattr(
+            agent, "_generate_final_summary", fake_summary
+        )
+
+        # Plan two steps; 'a' completes, 'b' never calls subtask_done and so
+        # exhausts MAX_SUBTASK_LOOPS.
+        script_llm(
+            agent,
+            monkeypatch,
+            [plan(("a", []), ("b", []))]
+            + [
+                [
+                    tool_call(
+                        "subtask_done",
+                        task_id="a",
+                        summary="done",
+                        success=True,
+                    )
+                ]
+            ]
+            + ["thinking, no tool call"] * (MAX_SUBTASK_LOOPS + 2),
+        )
+
+        result = loop._run_autonomous_loop("t")
+
+        assert result == "summary"
+        assert captured["unfinished"], "abandoned subtask never reported"
+        assert [s["step_id"] for s in captured["unfinished"]] == ["b"]
+        assert "NOT fully completed" in captured["prompt"]
+        assert "success=false" in captured["prompt"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Report unfinished subtasks in the autonomous loop's final summary

Fixes #1974

## The problem

When `max_loops="auto"`, the execution loop in `AutonomousAgentLoop._run_autonomous_loop`
can exit with work outstanding in three different ways: the global iteration cap
(`total_iterations > max_subtask_iterations`), the "no executable subtasks found"
break, and an individual subtask exhausting its own `MAX_SUBTASK_LOOPS` budget and
being marked `failed`.

All three fall through to the same summary phase, which unconditionally printed

    All subtasks completed. Generating final summary...

and then called `_generate_final_summary()`, whose prompt opens with the literal
line `All subtasks are complete.` Nothing in the prompt told the model that a
subtask had been abandoned, so when it was asked to call `complete_task` with a
`success` flag it had no reason to report anything other than success.

The net effect is that a partial failure is reported to the user as a completed
task. Skipped subtasks (a dependency failed, so the dependent was cascaded to
`skipped`) hit exactly the same path.

Reproduced on `master` at `3977d78` with a two-step plan where `a` completes and
`b` never calls `subtask_done`:

    subtask statuses at summary time: [('a', 'completed'), ('b', 'failed')]
    kwargs passed to _generate_final_summary: ['streaming_callback']
    summary prompt opening line: 'All subtasks are complete.'

## The fix

Three small pieces, following the data from where it is known to where it is
needed:

- `AutonomousAgentLoop._unfinished_subtasks()` — a new helper next to the
  existing `_all_subtasks_complete()` that collects every subtask whose status
  is not `completed`. That single predicate covers all three exit paths:
  `pending` (loop capped out before reaching it), `failed` (own budget
  exhausted), and `skipped` (blocked dependency). I deliberately keyed on "not
  completed" rather than enumerating the failure statuses, so a future status
  cannot silently slip through as a success.

- `get_summary_prompt(unfinished_subtasks=None)` — when given a non-empty list,
  the prompt stops asserting completion, names each unfinished subtask with its
  status and stored reason, and explicitly instructs the model to call
  `complete_task` with `success=false`. With no argument (or an empty list) it
  returns exactly the prompt it always did, so the all-complete path is
  byte-identical.

- `Agent._generate_final_summary(..., unfinished_subtasks=None)` forwards the
  list through to the prompt builder, and the loop's summary phase passes it
  along and prints an accurate panel naming the unfinished steps.

One deliberate non-change: the early `return self.agent._generate_final_summary(...)`
that fires when the model itself calls `complete_task` is left alone. That is
the model asserting the work is done, which is a different thing from the
framework asserting it on the model's behalf.

## Testing

Added `TestUnfinishedSubtasksReachTheSummary` to
`tests/agents/test_autonomous_loop.py`, following the existing offline pattern
in that file (real `Agent`, real loop, `call_llm` monkeypatched with a scripted
sequence). Five tests: the pending/failed/skipped collection, the fully-complete
case, the two prompt shapes, and an end-to-end run where a subtask burns its
iteration budget and must arrive at the summary call flagged as unfinished.

    $ python -m pytest tests/agents/test_autonomous_loop.py -q -p no:randomly
    41 passed, 1 warning in 2.70s

That is the 36 tests already in the file plus the 5 added — nothing was skipped
or broken.

Wider run over the neighbouring suites:

    $ python -m pytest tests/agents/test_autonomous_loop.py tests/structs/test_agent.py \
        tests/structs/test_conversation.py -q -p no:randomly
    1 failed, 186 passed, 32 warnings in 10.50s

The single failure is `test_agent.py::TestAgentFeatures::test_async_operations`,
which fails identically on pristine `master` before this change — I checked by
stashing the diff and re-running it alone.

I also confirmed the new tests actually pin the bug rather than passing for
free. Stashing only the three source files and running the original logic
reproduces the defect:

    AssertionError: BUG REPRODUCED: subtask 'b' was abandoned (status=failed)
    yet the summary prompt still opens with 'All subtasks are complete.' and no
    unfinished-work signal reaches the model.

Lint: `ruff check` and `black --line-length 70` show no new rule classes against
the pristine baseline for the touched files (the repo has a large pre-existing
count on these paths; the before/after rule-code breakdown is unchanged apart
from `UP006`/`UP045`, which are the `List`/`Dict`/`Optional` annotations the rest
of these modules already use).
