### PR TITLE
fix(SpreadSheetSwarm): record runtime timestamps correctly (#2117)

### DIFF
--- a/swarms/structs/spreadsheet_swarm.py
+++ b/swarms/structs/spreadsheet_swarm.py
@@ -15,13 +15,16 @@ from swarms.utils.workspace_utils import get_workspace_dir
 
 logger = initialize_logger(log_folder="spreadsheet_swarm")
 
-time = datetime.datetime.now().isoformat()
 uuid_hex = uuid.uuid4().hex
 
 # --------------- NEW CHANGE START ---------------
 # Format time variable to be compatible across operating systems
 formatted_time = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
 # --------------- NEW CHANGE END ---------------
+
+
+def _now() -> str:
+    return datetime.datetime.now().isoformat()
 
 
 class SpreadSheetSwarm:
@@ -197,7 +200,7 @@ class SpreadSheetSwarm:
         if not self.agents and self.load_path:
             self.load_from_csv()
 
-        start_time = time
+        start_time = _now()
 
         agent_task_pairs = [
             (agent, self.agent_tasks[agent.agent_name])
@@ -218,7 +221,7 @@ class SpreadSheetSwarm:
             ):
                 self._track_output(agent.agent_name, task, result)
 
-        end_time = time
+        end_time = _now()
 
         # Save outputs
         logger.info("Saving outputs to CSV...")
@@ -258,9 +261,9 @@ class SpreadSheetSwarm:
         if task is None and self.agent_tasks:
             return self.run_from_config()
         else:
-            start_time = time
+            start_time = _now()
             self._run_tasks(task, *args, **kwargs)
-            end_time = time
+            end_time = _now()
             self._save_metadata()
 
             if self.autosave:
@@ -336,7 +339,7 @@ class SpreadSheetSwarm:
                 "agent_name": agent_name,
                 "task": task,
                 "result": result,
-                "timestamp": time,
+                "timestamp": _now(),
             }
         )
 

--- a/tests/structs/test_spreadsheet.py
+++ b/tests/structs/test_spreadsheet.py
@@ -3,6 +3,8 @@ import json
 import csv
 import threading
 import time
+from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -782,3 +784,154 @@ def test_run_from_config_skips_agents_with_no_configured_task(
         (output["agent_name"], output["task"])
         for output in swarm.outputs
     ] == [("b", "task b"), ("b", "task b")]
+
+
+def test_track_output_timestamps_generated_at_call_time(temp_workspace):
+    """Test A: Output timestamps are generated dynamically at call time."""
+    agent = Agent(
+        agent_name="test_agent",
+        system_prompt="Test prompt",
+        model_name="gpt-5.4",
+        max_loops=1,
+    )
+    swarm = SpreadSheetSwarm(agents=[agent])
+
+    times = [
+        "2026-09-01T12:00:00.000000",
+        "2026-09-01T12:00:05.000000",
+    ]
+    with patch(
+        "swarms.structs.spreadsheet_swarm._now", side_effect=times
+    ):
+        swarm._track_output("test_agent", "Task 1", "Result 1")
+        swarm._track_output("test_agent", "Task 2", "Result 2")
+
+    t1 = swarm.outputs[0]["timestamp"]
+    t2 = swarm.outputs[1]["timestamp"]
+
+    assert t1 == "2026-09-01T12:00:00.000000"
+    assert t2 == "2026-09-01T12:00:05.000000"
+    assert t1 != t2
+    assert datetime.fromisoformat(t1) < datetime.fromisoformat(t2)
+
+
+def test_separate_runs_get_separate_start_times(temp_workspace):
+    """Test B: Separate swarm runs receive distinct start times."""
+    agent = Agent(
+        agent_name="test_agent",
+        system_prompt="Test prompt",
+        model_name="gpt-5.4",
+        max_loops=1,
+    )
+    swarm = SpreadSheetSwarm(agents=[agent], autosave=False)
+
+    times = [
+        # Run 1: start, output, end
+        "2026-09-01T10:00:00.000000",
+        "2026-09-01T10:00:01.000000",
+        "2026-09-01T10:00:02.000000",
+        # Run 2: start, output, end
+        "2026-09-01T11:00:00.000000",
+        "2026-09-01T11:00:01.000000",
+        "2026-09-01T11:00:02.000000",
+    ]
+
+    with patch(
+        "swarms.structs.spreadsheet_swarm.run_agents_with_different_tasks",
+        return_value=["ok"],
+    ):
+        with patch(
+            "swarms.structs.spreadsheet_swarm._now", side_effect=times
+        ):
+            run1 = swarm.run("task 1")
+            run2 = swarm.run("task 2")
+
+    assert run1["start_time"] == "2026-09-01T10:00:00.000000"
+    assert run2["start_time"] == "2026-09-01T11:00:00.000000"
+    assert run1["start_time"] != run2["start_time"]
+
+
+def test_end_time_occurs_after_start_time(temp_workspace):
+    """Test C: Swarm run end_time is greater than start_time when work completes."""
+    agent = Agent(
+        agent_name="test_agent",
+        system_prompt="Test prompt",
+        model_name="gpt-5.4",
+        max_loops=1,
+    )
+    swarm = SpreadSheetSwarm(agents=[agent], autosave=False)
+
+    times = [
+        "2026-09-01T12:00:00.000000",  # start_time
+        "2026-09-01T12:00:02.000000",  # output timestamp
+        "2026-09-01T12:00:05.000000",  # end_time
+    ]
+
+    with patch(
+        "swarms.structs.spreadsheet_swarm.run_agents_with_different_tasks",
+        return_value=["done"],
+    ):
+        with patch(
+            "swarms.structs.spreadsheet_swarm._now", side_effect=times
+        ):
+            summary = swarm.run("test task")
+
+    start_dt = datetime.fromisoformat(summary["start_time"])
+    end_dt = datetime.fromisoformat(summary["end_time"])
+
+    assert end_dt > start_dt
+    assert (end_dt - start_dt).total_seconds() == 5.0
+
+
+def test_output_timestamp_persisted_to_csv(temp_workspace):
+    """Test D: Output timestamp is correctly saved to CSV and matches tracked output."""
+    agent = Agent(
+        agent_name="test_agent",
+        system_prompt="Test prompt",
+        model_name="gpt-5.4",
+        max_loops=1,
+    )
+    swarm = SpreadSheetSwarm(agents=[agent])
+
+    expected_timestamp = "2026-09-01T15:30:45.123456"
+    with patch(
+        "swarms.structs.spreadsheet_swarm._now",
+        return_value=expected_timestamp,
+    ):
+        swarm._track_output("test_agent", "CSV task", "CSV result")
+        swarm._save_to_csv()
+
+    assert swarm.outputs[0]["timestamp"] == expected_timestamp
+
+    with open(swarm.save_file_path, "r", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["Timestamp"] == expected_timestamp
+
+
+def test_multiple_outputs_have_independent_timestamps(temp_workspace):
+    """Test E: Multiple outputs tracked over time do not share an import-time timestamp."""
+    agent = Agent(
+        agent_name="test_agent",
+        system_prompt="Test prompt",
+        model_name="gpt-5.4",
+        max_loops=1,
+    )
+    swarm = SpreadSheetSwarm(agents=[agent])
+
+    stamps = [
+        "2026-09-01T10:00:00",
+        "2026-09-01T10:05:00",
+        "2026-09-01T10:10:00",
+    ]
+    with patch(
+        "swarms.structs.spreadsheet_swarm._now", side_effect=stamps
+    ):
+        for i in range(3):
+            swarm._track_output("test_agent", f"Task {i}", f"Result {i}")
+
+    recorded_stamps = [output["timestamp"] for output in swarm.outputs]
+    assert recorded_stamps == stamps
+    assert len(set(recorded_stamps)) == 3

--- a/tests/structs/test_spreadsheet.py
+++ b/tests/structs/test_spreadsheet.py
@@ -786,7 +786,9 @@ def test_run_from_config_skips_agents_with_no_configured_task(
     ] == [("b", "task b"), ("b", "task b")]
 
 
-def test_track_output_timestamps_generated_at_call_time(temp_workspace):
+def test_track_output_timestamps_generated_at_call_time(
+    temp_workspace,
+):
     """Test A: Output timestamps are generated dynamically at call time."""
     agent = Agent(
         agent_name="test_agent",
@@ -930,8 +932,12 @@ def test_multiple_outputs_have_independent_timestamps(temp_workspace):
         "swarms.structs.spreadsheet_swarm._now", side_effect=stamps
     ):
         for i in range(3):
-            swarm._track_output("test_agent", f"Task {i}", f"Result {i}")
+            swarm._track_output(
+                "test_agent", f"Task {i}", f"Result {i}"
+            )
 
-    recorded_stamps = [output["timestamp"] for output in swarm.outputs]
+    recorded_stamps = [
+        output["timestamp"] for output in swarm.outputs
+    ]
     assert recorded_stamps == stamps
     assert len(set(recorded_stamps)) == 3


### PR DESCRIPTION
## Summary

Fixes #2117.

`SpreadSheetSwarm` was recording a frozen module-import timestamp for all execution runs and individual output rows because `datetime.datetime.now().isoformat()` was evaluated once at module load time.

This resulted in:
- `start_time` and `end_time` always returning identical timestamps (`start_time == end_time`).
- Multiple sequential or independent swarm runs appearing to take place at the exact same instant.
- Every recorded output and CSV row receiving the module import timestamp, making row ordering and time-series analysis impossible.

## Root Cause Analysis

In `swarms/structs/spreadsheet_swarm.py`:
- `time = datetime.datetime.now().isoformat()` was bound at the module top-level and evaluated once when Python imported the module.
- `run_from_config()` and `_run()` assigned `start_time = time` and `end_time = time` using this module-scoped string.
- `_track_output()` assigned `"timestamp": time` to every output entry, which was subsequently written into the `Timestamp` column during `_save_to_csv()`.

## Changes Made

1. **Runtime Timestamp Helper**: Added a lightweight helper function `_now() -> str` returning `datetime.datetime.now().isoformat()`.
2. **Dynamic Run Durations**:
   - Updated `run_from_config()` to set `start_time = _now()` right before execution begins and `end_time = _now()` immediately after completion.
   - Updated `_run()` to set `start_time = _now()` before task execution and `end_time = _now()` after completion.
3. **Dynamic Output Timestamps**: Updated `_track_output()` to set `"timestamp": _now()` whenever an output row is recorded.
4. **Removed Frozen Module State**: Completely removed the module-level `time` binding to prevent accidental reuse.
5. **Preserved Intended Filename Behavior**: Left process-scoped `formatted_time` untouched for OS-compatible filename generation per issue specifications.

## Regression Test Coverage

Added 5 comprehensive, deterministic test cases to `tests/structs/test_spreadsheet.py` using clock mocking to avoid test flakiness:

- `test_track_output_timestamps_generated_at_call_time`: Verifies output timestamps are dynamically captured at call time.
- `test_separate_runs_get_separate_start_times`: Verifies separate swarm runs receive distinct start timestamps.
- `test_end_time_occurs_after_start_time`: Verifies `end_time > start_time` for non-zero execution durations.
- `test_output_timestamp_persisted_to_csv`: Verifies the runtime timestamp persists into the CSV output under `"Timestamp"`.
- `test_multiple_outputs_have_independent_timestamps`: Ensures multiple tracked outputs over time receive independent timestamps rather than a shared value.

## Verification & Code Quality Checks

All targeted tests, formatting, and linting checks pass:

- **Targeted & Regression Tests**:
  ```bash
  uv run pytest tests/structs/test_spreadsheet.py -v
