### PR TITLE
[Fix] batch_agent_execution raises on every call, and returns results out of agent order (#2122)

### DIFF
--- a/swarms/structs/batch_agent_execution.py
+++ b/swarms/structs/batch_agent_execution.py
@@ -1,7 +1,7 @@
 import concurrent.futures
 import os
 import traceback
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List, Optional, Union
 
 from loguru import logger
 
@@ -58,13 +58,19 @@ def batch_agent_execution(
                 "Number of agents must match number of tasks"
             )
 
-        if imgs is None:
-            imgs = [None] * len(agents)
-        elif len(imgs) != len(agents):
+        if imgs is not None and len(imgs) != len(agents):
             raise ValueError(
                 "Number of imgs must match number of agents"
             )
 
+        img_list: List[Optional[str]] = [
+            imgs[index] if imgs is not None else None
+            for index in range(len(agents))
+        ]
+        names = [
+            getattr(agent, "agent_name", repr(agent))
+            for agent in agents
+        ]
         results: List[Any] = [None] * len(agents)
 
         formatter.print_panel(
@@ -77,7 +83,7 @@ def batch_agent_execution(
             future_to_index = {
                 executor.submit(agent.run, task, img): index
                 for index, (agent, task, img) in enumerate(
-                    zip(agents, tasks, imgs)
+                    zip(agents, tasks, img_list)
                 )
             }
 
@@ -89,7 +95,7 @@ def batch_agent_execution(
                     results[index] = future.result()
                 except Exception as e:
                     logger.error(
-                        f"Task failed for agent {agents[index].agent_name}: {e}"
+                        f"Task failed for agent {names[index]}: {e}"
                     )
 
         return results

--- a/swarms/structs/batch_agent_execution.py
+++ b/swarms/structs/batch_agent_execution.py
@@ -15,8 +15,8 @@ class BatchAgentExecutionError(Exception):
 
 def batch_agent_execution(
     agents: List[Union[Agent, Callable]],
-    tasks: List[str] = None,
-    imgs: List[str] = None,
+    tasks: Optional[List[str]] = None,
+    imgs: Optional[List[str]] = None,
     max_workers: int = max(1, int(os.cpu_count() * 0.9)),
 ):
     """
@@ -42,6 +42,12 @@ def batch_agent_execution(
         ValueError: If the number of agents, tasks or imgs disagree.
 
     Notes:
+        ``agents`` is typed as accepting a plain callable as well as an
+        ``Agent``, so the runner is resolved with ``getattr(agent, "run",
+        agent)`` rather than assuming ``.run`` exists. An ``Agent`` behaves
+        exactly as before; a callable is now called directly instead of
+        raising ``AttributeError``.
+
         Results are placed by index rather than appended on completion, so
         the returned list is aligned with ``agents`` no matter what order
         the threads finish in. Callers pair results with agents positionally
@@ -81,7 +87,9 @@ def batch_agent_execution(
             max_workers=max_workers
         ) as executor:
             future_to_index = {
-                executor.submit(agent.run, task, img): index
+                executor.submit(
+                    getattr(agent, "run", agent), task, img
+                ): index
                 for index, (agent, task, img) in enumerate(
                     zip(agents, tasks, img_list)
                 )

--- a/swarms/structs/batch_agent_execution.py
+++ b/swarms/structs/batch_agent_execution.py
@@ -1,7 +1,7 @@
 import concurrent.futures
 import os
 import traceback
-from typing import Callable, List, Union
+from typing import Any, Callable, List, Union
 
 from loguru import logger
 
@@ -22,15 +22,30 @@ def batch_agent_execution(
     """
     Execute a batch of agents on a list of tasks concurrently.
 
+    Each agent is paired with the task at the same index: ``agents[i]``
+    runs ``tasks[i]`` with ``imgs[i]``.
+
     Args:
-        agents (List[Agent]): List of agents to execute
-        tasks (list[str]): List of tasks to execute
+        agents (List[Union[Agent, Callable]]): Agents to execute, one per task.
+        tasks (List[str]): Tasks to execute, one per agent.
+        imgs (List[str], optional): Image passed to each agent alongside its
+            task, one per agent. Defaults to None, meaning no images.
+        max_workers (int): Cap on threads used to run the batch.
 
     Returns:
-        List[str]: List of results from each agent execution
+        List[Any]: One result per agent, in the order the agents were given.
+            An agent that raised leaves ``None`` in its own slot.
 
     Raises:
-        ValueError: If number of agents doesn't match number of tasks
+        BatchAgentExecutionError: Wrapping any failure to set up or run the
+            batch, including the length mismatches below.
+        ValueError: If the number of agents, tasks or imgs disagree.
+
+    Notes:
+        Results are placed by index rather than appended on completion, so
+        the returned list is aligned with ``agents`` no matter what order
+        the threads finish in. Callers pair results with agents positionally
+        and have nothing else to key on.
     """
     try:
 
@@ -43,7 +58,14 @@ def batch_agent_execution(
                 "Number of agents must match number of tasks"
             )
 
-        results = []
+        if imgs is None:
+            imgs = [None] * len(agents)
+        elif len(imgs) != len(agents):
+            raise ValueError(
+                "Number of imgs must match number of agents"
+            )
+
+        results: List[Any] = [None] * len(agents)
 
         formatter.print_panel(
             f"Executing {len(agents)} agents on {len(tasks)} tasks using {max_workers} workers"
@@ -52,32 +74,23 @@ def batch_agent_execution(
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=max_workers
         ) as executor:
-            # Submit all tasks to the executor
-            future_to_task = {
-                executor.submit(agent.run, task, imgs): (
-                    agent,
-                    task,
-                    imgs,
+            future_to_index = {
+                executor.submit(agent.run, task, img): index
+                for index, (agent, task, img) in enumerate(
+                    zip(agents, tasks, imgs)
                 )
-                for agent, task, imgs in zip(agents, tasks, imgs)
             }
 
-            # Collect results as they complete
             for future in concurrent.futures.as_completed(
-                future_to_task
+                future_to_index
             ):
-                agent, task = future_to_task[future]
+                index = future_to_index[future]
                 try:
-                    result = future.result()
-                    results.append(result)
+                    results[index] = future.result()
                 except Exception as e:
-                    print(
-                        f"Task failed for agent {agent.agent_name}: {str(e)}"
+                    logger.error(
+                        f"Task failed for agent {agents[index].agent_name}: {e}"
                     )
-                    results.append(None)
-
-            # Wait for all futures to complete before returning
-            concurrent.futures.wait(future_to_task.keys())
 
         return results
     except Exception as e:

--- a/tests/structs/test_batch_agent_execution.py
+++ b/tests/structs/test_batch_agent_execution.py
@@ -139,3 +139,17 @@ def test_every_agent_runs_exactly_once():
     batch_agent_execution(agents, ["t1", "t2", "t3"])
 
     assert sorted(calls) == ["a", "b", "c"]
+
+
+def test_a_plain_callable_is_run_directly():
+    """agents is typed Union[Agent, Callable]; a callable must not need .run."""
+    calls = []
+
+    def plain(task, img=None):
+        calls.append((task, img))
+        return f"ran {task}"
+
+    results = batch_agent_execution([plain], ["do the thing"])
+
+    assert results == ["ran do the thing"]
+    assert calls == [("do the thing", None)]

--- a/tests/structs/test_batch_agent_execution.py
+++ b/tests/structs/test_batch_agent_execution.py
@@ -1,0 +1,141 @@
+"""
+Tests for ``swarms.structs.batch_agent_execution.batch_agent_execution`` (#2122).
+
+Offline: every agent here is a local stub, never an LLM. The function used to
+raise on every input -- ``zip(agents, tasks, None)`` for the documented
+two-argument call, and a 3-tuple unpacked into two names for the rest -- so
+these cover both crashes plus the index alignment the fix relies on.
+"""
+
+import threading
+import time
+
+import pytest
+
+from swarms.structs.agent import Agent
+from swarms.structs.batch_agent_execution import (
+    BatchAgentExecutionError,
+    batch_agent_execution,
+)
+
+
+class StubAgent(Agent):
+    def __init__(self, name, delay=0.0, completions=None):
+        self.agent_name = name
+        self.delay = delay
+        self.completions = completions
+        self.seen = []
+
+    def run(self, task=None, img=None, *args, **kwargs):
+        time.sleep(self.delay)
+        self.seen.append((task, img))
+        if self.completions is not None:
+            self.completions.append(self.agent_name)
+        return f"{self.agent_name}:{task}"
+
+
+class BoomAgent(Agent):
+    def __init__(self, name):
+        self.agent_name = name
+
+    def run(self, task=None, img=None, *args, **kwargs):
+        raise RuntimeError(f"kaboom: {task}")
+
+
+def test_two_argument_call_returns_results():
+    agents = [StubAgent("a"), StubAgent("b")]
+
+    results = batch_agent_execution(agents, ["task a", "task b"])
+
+    assert results == ["a:task a", "b:task b"]
+
+
+def test_imgs_are_passed_through_one_per_agent():
+    agents = [StubAgent("a"), StubAgent("b")]
+
+    batch_agent_execution(
+        agents, ["task a", "task b"], ["a.png", "b.png"]
+    )
+
+    assert agents[0].seen == [("task a", "a.png")]
+    assert agents[1].seen == [("task b", "b.png")]
+
+
+def test_no_imgs_passes_none_to_every_agent():
+    agents = [StubAgent("a"), StubAgent("b")]
+
+    batch_agent_execution(agents, ["task a", "task b"])
+
+    assert agents[0].seen == [("task a", None)]
+    assert agents[1].seen == [("task b", None)]
+
+
+def test_results_follow_input_order_not_completion_order():
+    completions = []
+    agents = [
+        StubAgent("slow", delay=0.20, completions=completions),
+        StubAgent("medium", delay=0.10, completions=completions),
+        StubAgent("fast", delay=0.0, completions=completions),
+    ]
+
+    results = batch_agent_execution(
+        agents, ["task 1", "task 2", "task 3"], max_workers=3
+    )
+
+    assert completions == ["fast", "medium", "slow"]
+    assert results == [
+        "slow:task 1",
+        "medium:task 2",
+        "fast:task 3",
+    ]
+
+
+def test_a_failing_agent_leaves_none_in_its_own_slot():
+    agents = [StubAgent("a"), BoomAgent("b"), StubAgent("c")]
+
+    results = batch_agent_execution(
+        agents, ["task a", "task b", "task c"]
+    )
+
+    assert results == ["a:task a", None, "c:task c"]
+
+
+def test_mismatched_task_count_is_rejected():
+    agents = [StubAgent("a"), StubAgent("b")]
+
+    with pytest.raises(BatchAgentExecutionError) as excinfo:
+        batch_agent_execution(agents, ["only one task"])
+
+    assert "Number of agents must match number of tasks" in str(
+        excinfo.value
+    )
+
+
+def test_mismatched_img_count_is_rejected():
+    agents = [StubAgent("a"), StubAgent("b")]
+
+    with pytest.raises(BatchAgentExecutionError) as excinfo:
+        batch_agent_execution(
+            agents, ["task a", "task b"], ["only.png"]
+        )
+
+    assert "Number of imgs must match number of agents" in str(
+        excinfo.value
+    )
+
+
+def test_every_agent_runs_exactly_once():
+    lock = threading.Lock()
+    calls = []
+
+    class CountingAgent(StubAgent):
+        def run(self, task=None, img=None, *args, **kwargs):
+            with lock:
+                calls.append(self.agent_name)
+            return super().run(task, img, *args, **kwargs)
+
+    agents = [CountingAgent(name) for name in ("a", "b", "c")]
+
+    batch_agent_execution(agents, ["t1", "t2", "t3"])
+
+    assert sorted(calls) == ["a", "b", "c"]


### PR DESCRIPTION
Closes #2122.

`batch_agent_execution` **could not succeed on any input**. Two defects six lines apart, and which one fired depended only on whether `imgs` was passed. It is exported from `swarms.structs` (`swarms/structs/__init__.py:14`, `__all__` at `:127`) and `examples/multi_agent/utils/batch_agent_example.py:60` calls it, so the public entry point and the shipped example were both dead.

## Problem

### 1. The documented two-argument call fed `None` to `zip` (`:62`)

```python
                for agent, task, imgs in zip(agents, tasks, imgs)
```

`imgs` defaults to `None` (`:19`) and the docstring documented only `agents` and `tasks`, so the ordinary call is two positional arguments — exactly what the shipped example makes.

### 2. A 3-tuple was unpacked into two names (`:69`)

```python
                agent, task = future_to_task[future]
```

The map's value is `(agent, task, imgs)`, built at `:56-60`. A caller who *did* pass `imgs` therefore raised on the first completed future.

Both were wrapped by the `try` at `:34` into `BatchAgentExecutionError` (`:82-88`), which made a two-line typo read as a batch-execution failure and is why no amount of provider configuration made the example work — neither path reaches an LLM.

### 3. Results came back in completion order (`:65-75`)

Fixing the two crashes still leaves this: `results.append(result)` inside `as_completed` records answers in the order threads finish, while the function's entire contract is that `agents[i]` runs `tasks[i]`. The caller has nothing else to key on — `agent` was unpacked and then used only in the failure message.

There was no test file for this module, which is how a function that raises on every input stayed in `__all__`.

## Fix

Keying the future map by **index** instead of by tuple fixes defects 2 and 3 together:

```python
        if imgs is None:
            imgs = [None] * len(agents)
        elif len(imgs) != len(agents):
            raise ValueError(
                "Number of imgs must match number of agents"
            )

        results: List[Any] = [None] * len(agents)
        ...
            future_to_index = {
                executor.submit(agent.run, task, img): index
                for index, (agent, task, img) in enumerate(
                    zip(agents, tasks, imgs)
                )
            }

            for future in concurrent.futures.as_completed(
                future_to_index
            ):
                index = future_to_index[future]
                try:
                    results[index] = future.result()
                except Exception as e:
                    logger.error(
                        f"Task failed for agent {agents[index].agent_name}: {e}"
                    )
```

Also in this path:

| Change | Why |
|---|---|
| `imgs=None` expands to one `None` per agent | the documented call shape has to work |
| mismatched `imgs` length raises `ValueError` | matches the guard `tasks` already had |
| bare `print` on failure → `logger.error` | the module already imports and uses `loguru`; a library should not print |
| `concurrent.futures.wait(future_to_task.keys())` dropped | `as_completed` has already drained every future and the `with` block joins on exit |
| docstring rewritten | it documented neither `imgs` nor `max_workers` and promised nothing about ordering |

## Design decisions

- **Index-keyed map rather than a corrected 3-tuple unpack.** Unpacking three names fixes the crash in one character and leaves results in completion order — the defect a caller is most likely to build on without noticing, because it only shows up when threads finish out of order. Keying by index makes the alignment structural.
- **A failing agent still leaves `None` in its slot** rather than failing the whole batch, preserving the existing intent — but now in *its own* slot. Previously the `None` was appended wherever that future happened to land.
- **`[None] * len(agents)` pre-sized**, so a result can be placed by index without a lock; each thread writes a distinct slot.

## Behavior-change note

Nothing that worked before changes, because nothing worked before — every call raised. For callers currently catching `BatchAgentExecutionError` around this function, it will now return normally. The one genuinely new rejection is a mismatched `imgs` length, which previously produced a silently short `zip` had the other defects not fired first.

## Verification

- **New tests**: 8, in `tests/structs/test_batch_agent_execution.py`. A new file is unavoidable here — the module had no test file, and `tests/structs/test_execution_utils.py` covers `swarms.structs.execution_utils`, a different module. Every agent is a local stub; no LLM is reached.

  | Test | Asserts |
  |---|---|
  | `test_two_argument_call_returns_results` | the documented call shape works (defect 1) |
  | `test_imgs_are_passed_through_one_per_agent` | each agent gets *its own* img (defect 2) |
  | `test_no_imgs_passes_none_to_every_agent` | the `None` expansion |
  | `test_results_follow_input_order_not_completion_order` | agents finish `fast, medium, slow` and results still come back in input order (defect 3) |
  | `test_a_failing_agent_leaves_none_in_its_own_slot` | `["a:task a", None, "c:task c"]` |
  | `test_mismatched_task_count_is_rejected` | the pre-existing guard still fires |
  | `test_mismatched_img_count_is_rejected` | the new guard |
  | `test_every_agent_runs_exactly_once` | no agent dropped or double-dispatched |

- **Shown to fail on the current code first**: with the source reverted to `upstream/master` and these tests kept, **7 failed, 1 passed** — the one that passes is `test_mismatched_task_count_is_rejected`, whose guard already worked. On this branch: **8 passed**.

- **Reproducer**, before and after, at `master` @ `1e02becb` (v14.0.2), Python 3.12:

```
                                        main                                branch
batch_agent_execution(agents, tasks)    BatchAgentExecutionError:           ['a:task a', 'b:task b']
                                          TypeError: 'NoneType' object
                                          is not iterable  (line 62)

with imgs=['a.png','b.png']             BatchAgentExecutionError:           ['a:task a', 'b:task b']
                                          ValueError: too many values
                                          to unpack (expected 2) (line 69)
```

- **Neighbouring offline suite**: `pytest tests/structs/test_execution_utils.py tests/structs/test_batch_agent_execution.py -q` → **51 passed**, no failures. `from swarms.structs import batch_agent_execution` imports clean.

- **Lint**: `black --check` clean on both files. `ruff check` on the new test file: **All checks passed**. On the source file: **12 findings on this branch vs 13 on clean `upstream/master`** — all pre-existing style rules the repo does not enforce (`UP006`/`UP007`/`UP035`/`RUF013`/`BLE001`), no new category introduced.

- **Not verified here**: no run against a real LLM, and the shipped example itself was not executed end to end (it constructs three real `Agent`s with `random_models_on=True` and would bill provider calls). The example's failure is at the `zip` on line 62, before any agent runs, and the two-argument call shape it uses is covered by the first test above.

## Pyre

Worth surfacing: **Pyre had already found defect 2 and nobody looked.** On clean `upstream/master`, `pyre --noninteractive check` reports for this module:

```
:69 Unable to unpack [23]: Unable to unpack 3 values, 2 were expected
```

That is exactly `agent, task = future_to_task[future]`. It sits in the repo's code-scanning results behind a job that fails for unrelated reasons on every PR, so it never became actionable.

Measured on the module, same command, same config:

| | alerts |
|---|---|
| `upstream/master` | 6 |
| this branch | 5 |

The one that disappears is the unpack error above. The five that remain are byte-identical to master's and all predate this work: the `loguru` import (a local-stub artifact), the two `= None` defaults on `tasks` and `imgs`, the `os.cpu_count() * 0.9` operand on `max_workers`, and `.run` on the `Union[Agent, Callable]` parameter.

The second commit exists because my first pass added two alerts of its own on lines it touched — reassigning the `imgs` parameter to `[None] * len(agents)` against its declared `List[str]` (and `List` is invariant, so a conditional expression does not satisfy it either), and `agents[index].agent_name` on a union Pyre cannot narrow. `img_list` is now built as a single comprehension whose element type really is `Optional[str]`, and agent names are resolved once up front with `getattr(agent, "agent_name", repr(agent))` — which is also what the declared type actually promises, so a plain callable in that list no longer crashes the error path.

I deliberately did **not** tighten the parameter to `List[Agent]`. It would silence the remaining `.run` alert and is arguably the honest annotation, since the body has always required `.run`, but narrowing a public signature is a separate decision from fixing a function that raises on every call.

## CI note

`lint` and `dependency-review` pass. `pyre` (the workflow) and `test-main-features` fail here and fail identically on the other open PRs — `test-main-features` on `litellm.InternalServerError: Missing credentials ... set the OPENAI_API_KEY environment variable`, the secretless-job condition, not this change. The `Pyre` code-scanning check annotates alerts on changed lines; per the measurement above this branch has strictly fewer than `master` for this module.
