### PR TITLE
[Bug] MixtureOfAgents gives the aggregator nine unlabelled answers with no layer attribution

### DIFF
--- a/swarms/structs/mixture_of_agents.py
+++ b/swarms/structs/mixture_of_agents.py
@@ -250,7 +250,11 @@ class MixtureOfAgents:
 
             for agent_name, agent_output in step_output.items():
                 self.conversation.add(
-                    role=agent_name,
+                    role=(
+                        f"{agent_name} (layer {i + 1}/{self.layers})"
+                        if self.layers > 1
+                        else agent_name
+                    ),
                     content=agent_output,
                 )
 

--- a/tests/structs/test_moa.py
+++ b/tests/structs/test_moa.py
@@ -449,7 +449,8 @@ def test_aggregator_receives_typed_turns_per_worker():
     contents = [m["content"] for m in turns]
     for worker in ("W1", "W2"):
         assert any(
-            text.startswith(f"{worker}: ") for text in contents
+            text.startswith(worker) and ": " in text
+            for text in contents
         ), f"no turn attributed to {worker}: {contents}"
 
     # Four worker outputs across two layers, plus the task - not one blob.
@@ -484,3 +485,25 @@ def test_team_roster_does_not_reach_aggregator_as_user_prose():
             "These are the agents in your team"
             not in message["content"]
         )
+
+
+def test_aggregator_can_tell_which_layer_produced_each_answer():
+    """With layers > 1 each contribution carries the round that produced it."""
+    agents, _ = _recording_agents(["W1", "W2"])
+    aggregator, agg_calls = _recording_agents(["Agg"])
+
+    MixtureOfAgents(
+        agents=agents,
+        aggregator_agent=aggregator[0],
+        layers=3,
+    ).run("Question?")
+
+    turns = agg_calls[0]["messages"] + [
+        {"role": "user", "content": agg_calls[0]["task"]}
+    ]
+    contents = " ".join(m["content"] for m in turns)
+
+    for layer in (1, 2, 3):
+        assert (
+            f"layer {layer}/3" in contents
+        ), f"layer {layer} not attributed: {contents}"

--- a/tests/structs/test_moa.py
+++ b/tests/structs/test_moa.py
@@ -489,7 +489,6 @@ def test_team_roster_does_not_reach_aggregator_as_user_prose():
 
 
 def test_aggregator_can_tell_which_layer_produced_each_answer():
-    """With layers > 1 each contribution carries the round that produced it."""
     agents, _ = _recording_agents(["W1", "W2"])
     aggregator, agg_calls = _recording_agents(["Agg"])
 

--- a/tests/structs/test_moa.py
+++ b/tests/structs/test_moa.py
@@ -1,3 +1,4 @@
+import re
 from swarms.structs.mixture_of_agents import MixtureOfAgents
 from swarms.structs.agent import Agent
 
@@ -449,7 +450,7 @@ def test_aggregator_receives_typed_turns_per_worker():
     contents = [m["content"] for m in turns]
     for worker in ("W1", "W2"):
         assert any(
-            text.startswith(worker) and ": " in text
+            re.match(rf"^{worker}(?: \(layer \d+/\d+\))?: ", text)
             for text in contents
         ), f"no turn attributed to {worker}: {contents}"
 
@@ -498,6 +499,7 @@ def test_aggregator_can_tell_which_layer_produced_each_answer():
         layers=3,
     ).run("Question?")
 
+    assert agg_calls, "aggregator was never invoked"
     turns = agg_calls[0]["messages"] + [
         {"role": "user", "content": agg_calls[0]["task"]}
     ]


### PR DESCRIPTION
Part of #2040 — the layer-marker half.

### What was wrong

`MixtureOfAgents` runs `layers` rounds of the same workers, then asks the aggregator to synthesise. Each contribution was recorded under `role=agent_name` with nothing to say which round produced it, so with the default `layers=3` and three workers the aggregator received **nine contributions, three per name, indistinguishable from each other**. A first pass and a later refinement read identically.

### The fix

The speaker label now carries the round when there is more than one:

```python
role=(
    f"{agent_name} (layer {i + 1}/{self.layers})"
    if self.layers > 1
    else agent_name
)
```

`layers=1` is untouched, and worker **content is byte-identical** — nothing is prefixed or wrapped.

### Two dead ends worth recording, since both look right and neither works

**A `System` marker row does not reach the aggregator.** My first attempt added `--- Layer N/M ---` as a `role="System"` row. It is filtered out by design — `messages_for` drops `_STRUCTURE_ROLES`, and its docstring says why: *"Structure bookkeeping (system rows such as team rosters) is omitted — it belongs in a system prompt, not in the conversation body."* Measured against the aggregator's actual turns, that version delivered **0** markers. I only caught it because I checked what the aggregator receives rather than what the conversation contains.

**A content prefix breaks a stronger invariant.** Prefixing `[Layer N/M]` onto the output does reach the aggregator, but it fails `test_workers_record_only_their_answer`, which pins worker content exactly. That test guards the transcript-flattening bug, and I would rather not loosen it — hence putting the label in the role, where `messages_for` already renders `f"{role}: {content}"`.

### One existing assertion I did widen, deliberately

`test_aggregator_receives_typed_turns_per_worker` asserted `text.startswith(f"{worker}: ")`. With the layer in the label that becomes `"W1 (layer 1/2): ..."`, so I relaxed it to require the worker name *and* a `": "` separator. The test's stated intent — *"each worker contribution reaches the aggregator as its own labelled turn"* — is preserved and arguably strengthened; only the exact-prefix form changed. Flagging it because it is an existing test and you should see that rather than find it.

### Verification

Aggregator's actual turns, three layers and two workers:

```
master : []                                                          0 markers
branch : ['layer 1/3','layer 1/3','layer 2/3','layer 2/3','layer 3/3','layer 3/3']
```

`tests/structs/test_moa.py`: 11 passed on this branch, 10 on master (the extra is the new regression test, which fails on master as it should).

The other half of #2040 — the roster and task arriving as prose in the same message as the answers — is already fixed on master by `messages_for` / `split_last_turn`, so it is not in scope here.
