### PR TITLE
fix(mcp): restore compatibility with mcp 2.x

### DIFF
--- a/swarms/tools/mcp_manager.py
+++ b/swarms/tools/mcp_manager.py
@@ -1084,7 +1084,12 @@ class MCPManager:
             "tool": name,
             "server": self.label(connection),
             "arguments": arguments,
-            "is_error": bool(getattr(result, "isError", False)),
+            # mcp 2.x renamed `isError` to `is_error`; reading only the
+            # old name reports every failed call as a success.
+            "is_error": bool(
+                getattr(result, "isError", None)
+                or getattr(result, "is_error", None)
+            ),
             "result": self._extract_result(result),
         }
 
@@ -1144,7 +1149,10 @@ class MCPManager:
         if texts or others:
             return {"text": "\n".join(texts), "content": others}
 
-        structured = getattr(result, "structuredContent", None)
+        # mcp 2.x renamed `structuredContent` to `structured_content`.
+        structured = getattr(
+            result, "structuredContent", None
+        ) or getattr(result, "structured_content", None)
         if structured:
             return structured
 
@@ -1408,14 +1416,18 @@ class MCPManager:
                 callback_server.wait, float(oauth.callback_timeout)
             )
 
-        provider = OAuthClientProvider(
-            server_url=_server_origin(connection.url or ""),
-            client_metadata=client_metadata,
-            storage=storage,
-            redirect_handler=redirect_handler,
-            callback_handler=callback_handler,
-            timeout=float(oauth.callback_timeout),
-        )
+        provider_kwargs: Dict[str, Any] = {
+            "server_url": _server_origin(connection.url or ""),
+            "client_metadata": client_metadata,
+            "storage": storage,
+            "redirect_handler": redirect_handler,
+            "callback_handler": callback_handler,
+        }
+        # 2.x dropped the kwarg; callback_handler already bounds the wait.
+        if not MCP_IS_V2:
+            provider_kwargs["timeout"] = float(oauth.callback_timeout)
+
+        provider = OAuthClientProvider(**provider_kwargs)
 
         self._oauth_providers[key] = provider
         return provider

--- a/tests/tools/mcp_test_server.py
+++ b/tests/tools/mcp_test_server.py
@@ -16,15 +16,32 @@ Profiles:
 
 import sys
 
-from mcp.server.fastmcp import FastMCP
 from starlette.responses import JSONResponse
+
+try:
+    # mcp 1.x
+    from mcp.server.fastmcp import FastMCP
+
+    def _build_server(port: int):
+        return FastMCP(
+            "swarms-test-server", host="127.0.0.1", port=port
+        )
+
+except ImportError:
+    # 2.x renamed FastMCP to MCPServer and moved the transport settings
+    # off the constructor; uvicorn binds the port here either way.
+    from mcp.server.mcpserver import MCPServer
+
+    def _build_server(port: int):
+        return MCPServer("swarms-test-server")
+
 
 API_KEY = "test-key-123"
 BEARER_TOKEN = "test-token-abc"
 
 
 def build_app(profile: str, port: int):
-    mcp = FastMCP("swarms-test-server", host="127.0.0.1", port=port)
+    mcp = _build_server(port)
 
     @mcp.tool()
     def add(a: int, b: int) -> int:

--- a/tests/tools/test_mcp_manager.py
+++ b/tests/tools/test_mcp_manager.py
@@ -30,6 +30,7 @@ import pytest
 from swarms.schemas.agent_mcp_errors import AgentMCPConnectionError
 from swarms.schemas.mcp_schemas import MCPConnection, MCPOAuthConfig
 from swarms.tools.mcp_manager import (
+    MCP_IS_V2,
     MCPFileTokenStorage,
     MCPInMemoryTokenStorage,
     MCPManager,
@@ -527,7 +528,16 @@ class TestToolDiscovery:
         )
         with pytest.raises(AgentMCPConnectionError) as excinfo:
             manager.get_tools()
-        assert "401" in str(excinfo.value)
+        message = str(excinfo.value)
+        assert apikey_server.url in message
+        if MCP_IS_V2:
+            # 2.x collapses every non-404 non-2xx response into
+            # ErrorData(INTERNAL_ERROR, "Server returned an error
+            # response") (mcp/client/streamable_http.py), so the status
+            # is gone before it reaches us. Only the rejection survives.
+            assert "error response" in message
+        else:
+            assert "401" in message
 
     def test_bearer_server_accepts_authorization_token(
         self, bearer_server


### PR DESCRIPTION
## Description

`requirements.txt` now allows `mcp` 2.x (#2108). The 2.x SDK renamed several attributes, and three sites in `mcp_manager.py` still read the 1.x spellings. Because all three used `getattr` with a default, two of them **failed silently** instead of raising — which is why this was not caught by the pin change itself.

### 1. `isError` → `is_error` (silent, and the reason this matters)

`CallToolResult` renamed the Python attribute to `is_error`, keeping `isError` only as a serialization alias:

```python
>>> list(CallToolResult.model_fields)
['meta', 'content', 'structured_content', 'is_error', 'result_type']
>>> CallToolResult.model_fields["is_error"].alias
'isError'
```

`getattr(result, "isError", False)` therefore returned the default on every call, so **every failed MCP tool call was reported to the agent as a success**. No exception, no log line — the model simply never learned the call had failed.

### 2. `structuredContent` → `structured_content`

Same rename class, same silent-fallthrough shape, in `_extract_result`.

`_mcp_tool_to_openai` already handles `inputSchema` → `input_schema` exactly this way; these two sites were missed.

### 3. `OAuthClientProvider(timeout=...)` removed in 2.x

This one failed loudly:

```
TypeError: OAuthClientProvider.__init__() got an unexpected keyword argument 'timeout'
```

Confirmed against the [SDK migration guide](https://py.sdk.modelcontextprotocol.io/migration/) ("`timeout` parameter removed from `OAuthClientProvider`"). Now gated on the existing `MCP_IS_V2` flag. The wait stays bounded either way, because `callback_handler` already closes over `oauth.callback_timeout`.

## Test fixture

`tests/tools/mcp_test_server.py` imported `mcp.server.fastmcp`, which 2.x removed — the fixture server could not start, so **28 tests errored in setup** and never ran. `FastMCP` is now `MCPServer`, behind a try/except shim that still works on 1.x. Transport settings moved off the constructor in 2.x; uvicorn binds the port either way.

## One assertion changed rather than deleted

`test_api_key_server_rejects_wrong_key` asserted `"401" in message`. Rejection still works correctly, but 2.x collapses every non-404 non-2xx response into `ErrorData(INTERNAL_ERROR, "Server returned an error response")` (`mcp/client/streamable_http.py:370`) before it reaches us, so the status is genuinely unrecoverable from the exception — I traced the full cause chain to confirm.

The assertion is now version-gated rather than dropped: **1.x still requires the status**, 2.x asserts the rejection and the server URL.

Worth flagging separately: this is a real diagnosability regression in the SDK — a 401 and a 500 are now indistinguishable to callers, and `_describe_exception`'s own docstring exists specifically to stop a 401 reaching the user blank. Not something this repo can fix; noting it for whoever hits it next.

## Verification

```
tests/tools/test_mcp_manager.py    85 passed          (was 2 failed, 28 errors)
```

Runtime 94s → 7s, because the fixture server now starts instead of timing out.

- Ran offline with API keys blanked.
- The 6 remaining failures in `tests/tools/` are in `test_base_tool.py` and `test_parse_tools.py`. I confirmed them **identical on unmodified master** (`95cd129d1`) via a detached worktree — pre-existing and unrelated.
- `tests/agents/test_autonomous_loop.py` + `test_context_compressor.py`: 73 passed, no regression from #2110.
- `black --line-length 70` and `ruff check` clean.

## Note on scope

Only the three `mcp_manager.py` sites and the fixture were touched. `create_mcp_http_client` already builds the correct `httpx2.AsyncClient`, and no raw `httpx.AsyncClient` in this file passes `auth=`, so the 2.x `httpx2.Auth` change needs no action here.

## Tag maintainer

@kyegomez
