### PR TITLE
feat(package): expose swarms.__version__

### DIFF
--- a/swarms/__init__.py
+++ b/swarms/__init__.py
@@ -14,3 +14,36 @@ from swarms.structs import *  # noqa: E402, F403
 from swarms.telemetry import *  # noqa: E402, F403
 from swarms.tools import *  # noqa: E402, F403
 from swarms.utils import *  # noqa: E402, F403
+
+
+def __getattr__(name: str) -> str:
+    """Resolve ``swarms.__version__`` on first access.
+
+    The version comes from the installed distribution's metadata rather
+    than a literal here, so it cannot drift from ``pyproject.toml``.
+    Resolving it lazily keeps the dist-info scan off the import path for
+    the majority of programs, which never read it.
+    """
+    if name == "__version__":
+        from importlib.metadata import (
+            PackageNotFoundError,
+            version,
+        )
+
+        try:
+            resolved = version("swarms")
+        except PackageNotFoundError:
+            # A source checkout with no installed distribution.
+            resolved = "unknown"
+
+        globals()["__version__"] = resolved
+        return resolved
+
+    raise AttributeError(
+        f"module {__name__!r} has no attribute {name!r}"
+    )
+
+
+def __dir__() -> list:
+    """Advertise ``__version__`` before anything has accessed it."""
+    return sorted(set(globals()) | {"__version__"})

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -1,0 +1,77 @@
+import re
+import subprocess
+import sys
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+
+import swarms
+
+
+def test_version_attribute_exists():
+    assert isinstance(swarms.__version__, str)
+    assert swarms.__version__
+
+
+def test_version_matches_installed_distribution():
+    from importlib.metadata import version
+
+    assert swarms.__version__ == version("swarms")
+
+
+def test_version_is_pep440_shaped():
+    assert re.match(
+        r"^\d+\.\d+", swarms.__version__
+    ), f"expected a numeric version, got {swarms.__version__!r}"
+
+
+def test_hasattr_reports_true():
+    assert hasattr(swarms, "__version__")
+
+
+def test_version_is_advertised_by_dir_before_access():
+    """dir() lists it even in a process that has never read it."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import swarms; print('__version__' in dir(swarms))",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip().endswith("True"), result.stderr
+
+
+def test_unknown_attribute_still_raises_attribute_error():
+    with pytest.raises(AttributeError) as excinfo:
+        swarms.definitely_not_a_real_attribute
+
+    assert "definitely_not_a_real_attribute" in str(excinfo.value)
+
+
+def test_version_is_cached_after_first_access():
+    """The second read comes from globals(), not a fresh metadata scan."""
+    swarms.__version__
+    assert "__version__" in vars(swarms)
+
+
+def test_falls_back_when_distribution_is_absent(monkeypatch):
+    """A source checkout with no installed dist reports 'unknown'."""
+    import importlib.metadata as metadata
+
+    monkeypatch.delitem(vars(swarms), "__version__", raising=False)
+
+    def _raise(name):
+        raise PackageNotFoundError(name)
+
+    monkeypatch.setattr(metadata, "version", _raise)
+
+    assert swarms.__getattr__("__version__") == "unknown"
+
+    monkeypatch.undo()
+    vars(swarms).pop("__version__", None)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## The bug

```python
>>> import swarms
>>> swarms.__version__
AttributeError: module 'swarms' has no attribute '__version__'
```

`swarms/__init__.py` is sixteen lines of star imports. It defines no `__version__` and no module `__getattr__`, so the attribute nearly every Python package carries is simply absent.

## It is not only a docs problem

`scripts/docker/test_docker.py` reads `swarms.__version__` twice as its smoke test:

```python
print(f" Swarms imported successfully. Version: {swarms.__version__}")
...
return {"status": "success", "version": swarms.__version__, ...}
```

The `AttributeError` is caught by the bare `except Exception` below it, so the script reports a failure on a perfectly good install:

```
 Testing Swarms Docker Image...
 Unexpected error: module 'swarms' has no attribute '__version__'
 Tests failed! Please check the Docker image.
```

The command documented in `scripts/docker/DOCKER.md:27` fails the same way.

## Approach

**The version is read from installed distribution metadata, not duplicated as a literal.** A hand-maintained `__version__ = "15.0.0"` is a second source of truth that drifts from `pyproject.toml` the moment someone bumps one and not the other. `importlib.metadata.version("swarms")` reads what was actually installed, so the two cannot disagree.

**Resolution is deferred to first access.** `importlib.metadata.version()` scans dist-info and costs ~0.44 ms measured locally. That is not worth adding to every `import swarms` for an attribute most programs never read, so a module-level `__getattr__` (PEP 562) resolves it on demand and caches it in `globals()`; the second read is a plain dict lookup.

**`__dir__` is included** so the name is discoverable before anything has touched it. Without it, a lazily-resolved attribute is missing from `dir(swarms)` and tab-completion until someone reads it — which is the literal complaint in #196.

**A source checkout with no installed distribution reports `"unknown"`** rather than raising, so the attribute is safe to reference unconditionally.

The `__getattr__` still raises `AttributeError` for every other name, so `hasattr` keeps working correctly for genuinely missing attributes.

## Verification

```
import swarms; swarms.__version__   ->  14.0.0     (was AttributeError)
black --line-length 70 --check      ->  279 files unchanged
ruff check .                        ->  All checks passed
```

## Tests

`tests/test___init__.py` was an empty file; it now holds 8 tests. Against a clean `master` worktree, **7 of the 8 fail**:

```
FAILED test_version_attribute_exists
FAILED test_version_matches_installed_distribution
FAILED test_version_is_pep440_shaped
FAILED test_hasattr_reports_true
FAILED test_version_is_advertised_by_dir_before_access
FAILED test_version_is_cached_after_first_access
FAILED test_falls_back_when_distribution_is_absent
7 failed, 1 passed
```

The one that passes on master is `test_unknown_attribute_still_raises_attribute_error`, which guards against a `__getattr__` that swallows unknown names — correctly passing either way is the point of it.

All 8 pass here. They are offline and make no network or provider calls.

The `dir()` test runs in a subprocess on purpose: it has to assert on a process that has *never* read `__version__`, and the in-process test suite has already resolved and cached it by then.

## Notes for review

- **`example.py` is modified in my working tree but is deliberately not in this PR** — it was already dirty when I started and is someone else's edit (`from swarms.structs.agent import Agent`, `reasoning_effort=None`). Left alone.
- **#196** ("swarms does not have a `__version__` string set", *"dir(swarms) does not show `__version__`"*) reported this in 2023 and was closed without the attribute ever being added. Not using `Fixes` since it is long closed, but it is the same bug and it is why `__dir__` is part of this change.
- **Version skew is expected on a source checkout.** `pyproject.toml` reads `15.0.0` while my locally installed dist metadata reads `14.0.0`, so `__version__` reports `14.0.0` here. That is the attribute correctly reporting the *installed* distribution rather than the checked-out source, which is the intended behaviour — but it is worth a second opinion if you would rather it track the source tree.
