### PR TITLE
[Fix] The autonomous agent prompt freezes its 'Time' line at import, so agents are told the boot time (#1975)

### DIFF
--- a/swarms/prompts/__init__.py
+++ b/swarms/prompts/__init__.py
@@ -1,5 +1,6 @@
 from swarms.prompts.autonomous_agent_prompt import (
     AUTONOMOUS_AGENT_SYSTEM_PROMPT,
+    build_autonomous_agent_system_prompt,
     get_autonomous_agent_prompt,
     get_autonomous_agent_prompt_with_context,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "DOCUMENTATION_WRITER_SOP",
     "Prompt",
     "AUTONOMOUS_AGENT_SYSTEM_PROMPT",
+    "build_autonomous_agent_system_prompt",
     "get_autonomous_agent_prompt",
     "get_autonomous_agent_prompt_with_context",
 ]

--- a/swarms/prompts/autonomous_agent_prompt.py
+++ b/swarms/prompts/autonomous_agent_prompt.py
@@ -3,21 +3,22 @@ from datetime import datetime
 
 def get_time() -> str:
     """
-    Build the autonomous agent system prompt with current date/time injected.
+    Render the current local date and time as one prompt line.
 
     Returns:
-        str: Full system prompt with date/time line prepended.
+        str: A ``"Current date and time: ..."`` line ending in a newline.
     """
     now = datetime.now().astimezone()
     return f"Current date and time: {now.strftime('%A, %B %d, %Y %H:%M %Z')}\n"
 
 
-AUTONOMOUS_AGENT_SYSTEM_PROMPT = f"""
+_SYSTEM_PROMPT_HEADER = """
 You are an elite autonomous agent operating in a structured autonomous loop by The Swarms Corporation.
 Your mission is to reliably and efficiently complete complex tasks by breaking them down into manageable subtasks, executing them systematically, and providing comprehensive results.
+"""
 
-Time: {get_time()}
 
+_SYSTEM_PROMPT_BODY = """
 ## CORE PRINCIPLES
 
 1. **Excellence First**: The quality of your outputs directly impacts success. Strive for thoroughness and accuracy.
@@ -250,6 +251,32 @@ Now, begin your mission with excellence.
 """
 
 
+AUTONOMOUS_AGENT_SYSTEM_PROMPT = (
+    _SYSTEM_PROMPT_HEADER + _SYSTEM_PROMPT_BODY
+)
+
+
+def build_autonomous_agent_system_prompt() -> str:
+    """
+    Build the autonomous agent system prompt with the current time injected.
+
+    Returns:
+        str: The system prompt, whose ``Time:`` line is evaluated on this
+        call rather than at import.
+
+    Notes:
+        ``AUTONOMOUS_AGENT_SYSTEM_PROMPT`` deliberately carries no ``Time:``
+        line: a module-level constant is evaluated once per process, so any
+        timestamp baked into it is the process start time forever after. Every
+        caller that needs the agent to know the wall-clock time must go through
+        this function, or through one of the accessors built on it.
+    """
+    return (
+        f"{_SYSTEM_PROMPT_HEADER}\nTime: {get_time()}"
+        f"\n{_SYSTEM_PROMPT_BODY}"
+    )
+
+
 NO_THINK_TOOL_OVERRIDE = """
 
 ## THE THINK TOOL IS NOT AVAILABLE
@@ -280,10 +307,13 @@ def get_autonomous_agent_prompt(
         str: The autonomous agent system prompt.
     """
     if include_think_tool:
-        return AUTONOMOUS_AGENT_SYSTEM_PROMPT
+        return build_autonomous_agent_system_prompt()
 
     # Overridden at the end rather than excised; the think guidance is woven through in a dozen places.
-    return AUTONOMOUS_AGENT_SYSTEM_PROMPT + NO_THINK_TOOL_OVERRIDE
+    return (
+        build_autonomous_agent_system_prompt()
+        + NO_THINK_TOOL_OVERRIDE
+    )
 
 
 def get_autonomous_agent_prompt_with_context(
@@ -302,7 +332,7 @@ def get_autonomous_agent_prompt_with_context(
     Returns:
         str: Contextualized autonomous agent prompt
     """
-    prompt = AUTONOMOUS_AGENT_SYSTEM_PROMPT
+    prompt = build_autonomous_agent_system_prompt()
 
     if agent_name:
         prompt = prompt.replace(

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -10,7 +10,7 @@ to a provider — ``Agent.call_llm`` — is monkeypatched per-test with a script
 sequence of canned responses, so the loop's real control flow, real tool
 dispatch, and real state transitions are exercised end to end.
 
-Covers four fixed defects:
+Covers five fixed defects:
 
 * #1963 — tool errors were logged and discarded, so the model never learned a
   call had failed and re-emitted it until the iteration budget was gone.
@@ -21,6 +21,9 @@ Covers four fixed defects:
 * #1962 — ``ContextCompressor.maybe_compress`` was never called on the
   ``max_loops="auto"`` path, so history grew unbounded in exactly the mode
   that needs compression most.
+* #1975 — the prompt's ``Time:`` line was interpolated into a module-level
+  f-string, so every agent in a long-lived process was told the process start
+  time instead of the current one.
 
 Run:
     cd /Users/swarms_wd/Desktop/research/swarms
@@ -29,11 +32,17 @@ Run:
 
 import json
 import os
+import re
 
 import pytest
 
 from swarms import Agent
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
+from swarms.prompts import autonomous_agent_prompt as prompt_module
+from swarms.prompts.autonomous_agent_prompt import (
+    get_autonomous_agent_prompt,
+    get_autonomous_agent_prompt_with_context,
+)
 from swarms.structs.autonomous_loop_utils import (
     MAX_SUBTASK_LOOPS,
     get_autonomous_planning_tools,
@@ -42,7 +51,6 @@ from swarms.structs.autonomous_loop_utils import (
     read_file_tool,
 )
 from swarms.utils.litellm_tokenizer import count_tokens
-
 
 # --------------------------------------------------------------------------
 # helpers
@@ -1145,6 +1153,112 @@ class TestContextCompression:
 
         assert loop._maybe_compress_context() is False
         assert len(loop._transcript) == 1
+
+
+class TestPromptTimestampIsNotFrozen:
+    """#1975 - the ``Time:`` line must be evaluated per call, not per import."""
+
+    STAMP = re.compile(r"Current date and time: ([^\n]*)")
+
+    def _freeze(self, monkeypatch, value):
+        monkeypatch.setattr(
+            prompt_module,
+            "get_time",
+            lambda: f"Current date and time: {value}\n",
+        )
+
+    def test_builder_reflects_the_clock_at_call_time(
+        self, monkeypatch
+    ):
+        self._freeze(monkeypatch, "FIRST")
+        first = prompt_module.build_autonomous_agent_system_prompt()
+        self._freeze(monkeypatch, "SECOND")
+        second = prompt_module.build_autonomous_agent_system_prompt()
+
+        assert self.STAMP.search(first).group(1) == "FIRST"
+        assert self.STAMP.search(second).group(1) == "SECOND"
+
+    @pytest.mark.parametrize("include_think_tool", [True, False])
+    def test_accessor_reflects_the_clock_at_call_time(
+        self, monkeypatch, include_think_tool
+    ):
+        self._freeze(monkeypatch, "FIRST")
+        first = get_autonomous_agent_prompt(
+            include_think_tool=include_think_tool
+        )
+        self._freeze(monkeypatch, "SECOND")
+        second = get_autonomous_agent_prompt(
+            include_think_tool=include_think_tool
+        )
+
+        assert self.STAMP.search(first).group(1) == "FIRST"
+        assert self.STAMP.search(second).group(1) == "SECOND"
+
+    def test_context_accessor_reflects_the_clock_at_call_time(
+        self, monkeypatch
+    ):
+        self._freeze(monkeypatch, "FIRST")
+        first = get_autonomous_agent_prompt_with_context(
+            agent_name="Scout"
+        )
+        self._freeze(monkeypatch, "SECOND")
+        second = get_autonomous_agent_prompt_with_context(
+            agent_name="Scout"
+        )
+
+        assert self.STAMP.search(first).group(1) == "FIRST"
+        assert self.STAMP.search(second).group(1) == "SECOND"
+        assert "You are Scout, an elite autonomous agent" in second
+
+    def test_agent_system_prompt_carries_the_current_time(
+        self, monkeypatch
+    ):
+        """
+        The defect as a user meets it: an agent built now, told now.
+
+        ``agent.system_prompt`` carries two ``Time:`` lines, because
+        ``AGENT_SYSTEM_PROMPT_3`` interpolates ``get_time()`` into its own
+        module-level f-string at ``agent_system_prompts.py:134`` and is
+        prepended to every agent's prompt. That second site is the same
+        defect in a different module and is deliberately out of scope here —
+        the assertion below is on the autonomous half this issue covers.
+        """
+        self._freeze(monkeypatch, "AT_AGENT_BUILD")
+        agent = build_agent()
+
+        stamps = self.STAMP.findall(agent.system_prompt)
+        assert "AT_AGENT_BUILD" in stamps
+
+    def test_exported_constant_carries_no_timestamp(self):
+        """
+        Structural guard. A module-level constant is evaluated once per
+        process, so any timestamp baked into it is the process start time
+        forever after — the exact shape this issue is about. The constant is
+        therefore timeless by construction and cannot regress into a stale
+        one.
+        """
+        assert (
+            "Current date and time"
+            not in prompt_module.AUTONOMOUS_AGENT_SYSTEM_PROMPT
+        )
+        assert (
+            "Time:"
+            not in prompt_module.AUTONOMOUS_AGENT_SYSTEM_PROMPT
+        )
+
+    def test_only_the_time_line_differs_from_the_constant(
+        self, monkeypatch
+    ):
+        """The split into header/body changed no other prompt text."""
+        self._freeze(monkeypatch, "NOW")
+        built = prompt_module.build_autonomous_agent_system_prompt()
+
+        assert (
+            built.replace(
+                "Time: Current date and time: NOW\n\n\n", ""
+            )
+            == prompt_module.AUTONOMOUS_AGENT_SYSTEM_PROMPT
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1975.

`Time: {get_time()}` sat inside `AUTONOMOUS_AGENT_SYSTEM_PROMPT`, a module-level f-string, so `get_time()` ran once — at import — and every agent in a long-lived process was told the process start time. **The accessor path is affected too, not just the constant**: `get_autonomous_agent_prompt()` returned that same constant, so `Agent(max_loops="auto")` carried the stale stamp as well.

## Problem

The comment on #1975 says the agent path is already correct and only the exported constant is still frozen. On `master` @ `7a6eeebe` both are frozen, because `get_autonomous_agent_prompt()` is a plain return of the constant:

```python
# swarms/prompts/autonomous_agent_prompt.py:283 (before this PR)
    if include_think_tool:
        return AUTONOMOUS_AGENT_SYSTEM_PROMPT
```

Reproduced on `master` @ `7a6eeebe` (v14.0.0), Python 3.12, macOS 26.2:

```python
import re, time, datetime
from swarms.prompts.autonomous_agent_prompt import (
    AUTONOMOUS_AGENT_SYSTEM_PROMPT, get_autonomous_agent_prompt)

P = re.compile(r"Current date and time: (.+)")
print("import-time constant :", P.search(AUTONOMOUS_AGENT_SYSTEM_PROMPT).group(1))
print("accessor             :", P.search(get_autonomous_agent_prompt()).group(1))
time.sleep(75)
print("--- after sleeping 75s ---")
print("import-time constant :", P.search(AUTONOMOUS_AGENT_SYSTEM_PROMPT).group(1))
print("accessor             :", P.search(get_autonomous_agent_prompt()).group(1))
print("wall clock now       :", datetime.datetime.now().astimezone().strftime("%A, %B %d, %Y %H:%M %Z"))
```

```
import-time constant : Wednesday, September 02, 2026 16:01 PDT
accessor             : Wednesday, September 02, 2026 16:01 PDT
--- after sleeping 75s ---
import-time constant : Wednesday, September 02, 2026 16:01 PDT
accessor             : Wednesday, September 02, 2026 16:01 PDT
wall clock now       : Wednesday, September 02, 2026 16:02 PDT
```

Both surfaces are a minute behind after a minute. In a server or notebook that stays up for a day, they are a day behind, and an agent reasoning about "latest", "this quarter" or "yesterday's logs" is grounded on the wrong date.

## Fix

| Site | Change |
|---|---|
| `_SYSTEM_PROMPT_HEADER` / `_SYSTEM_PROMPT_BODY` | **new** — the prompt text either side of the `Time:` line, as plain (non-f) strings |
| `build_autonomous_agent_system_prompt()` | **new** — joins header + a freshly interpolated `Time:` line + body |
| `AUTONOMOUS_AGENT_SYSTEM_PROMPT` | same name, same text, now `_SYSTEM_PROMPT_HEADER + _SYSTEM_PROMPT_BODY` — no `Time:` line |
| `get_autonomous_agent_prompt()` | builds through the new function |
| `get_autonomous_agent_prompt_with_context()` | builds through the new function |
| `get_time()` | docstring said it returned the whole prompt; it returns one line |
| `swarms/prompts/__init__.py` | exports `build_autonomous_agent_system_prompt` |

## Design decisions

- **The constant carries no timestamp rather than a fresh one.** A module-level name is bound once per process, so it can hold "no timestamp" or "a permanently wrong timestamp" — never a current one. Callers that need the time go through `build_autonomous_agent_system_prompt()`, which is what `Agent` now does.
- **Rejected: a module-level `__getattr__` (PEP 562) that recomputes the constant on attribute access.** It only appears to fix the problem. `swarms/prompts/__init__.py` does `from swarms.prompts.autonomous_agent_prompt import AUTONOMOUS_AGENT_SYSTEM_PROMPT`, and a from-import binds the value once — so the package-level export, and every user who imports the name the same way, would be frozen again exactly as today. It would also make the name return a different object on each access, which is surprising for something spelled as a constant.
- **The prompt text is unchanged.** The split is a pure re-partition; see Verification.

## Behavior-change note

`AUTONOMOUS_AGENT_SYSTEM_PROMPT` no longer contains a `Time:` line. Nothing in `swarms/`, `tests/`, `examples/` or `docs/` reads that line off the constant (`grep -rn "AUTONOMOUS_AGENT_SYSTEM_PROMPT"` returns only `swarms/structs/agent.py`'s import of the *accessor*, `swarms/prompts/__init__.py`, and this module). A downstream user who wants the timestamped prompt changes `AUTONOMOUS_AGENT_SYSTEM_PROMPT` to `build_autonomous_agent_system_prompt()` — one call, same string.

## Verification

- **Text identity**: the built prompt was diffed against the pre-fix constant (loaded from `HEAD` via `git show`) with the timestamp masked — byte-identical. The plain constant equals that same text with the `Time:` block removed. Both are asserted in `test_only_the_time_line_differs_from_the_constant`.
- **Unit**: 7 new tests in the existing `tests/agents/test_autonomous_loop.py` (`TestPromptTimestampIsNotFrozen`) — no new file. They freeze `get_time` to two different values and assert the builder, both accessors, `get_autonomous_agent_prompt_with_context`, and a real `Agent(max_loops="auto")` all reflect the second one; plus a structural guard that the exported constant contains no `Current date and time` / `Time:` at all, so it cannot regress into a stale stamp.
- **Suite**: `pytest tests/agents -q -p no:randomly` → **318 passed, 3 failed**. The three are pre-existing and fail identically on clean `master` (`test_agent_marketplace_handler.py::TestAgentErrorHierarchy::test_importable_from_schemas_and_structs_agent_same_object[AgentError]`, `[AgentLLMInitializationError]`, and `test_llm_manager.py::TestAgentWrapperDelegation::test_call_llm_delegates`); master's own run is **311 passed, 3 failed**, i.e. +7 and no new failures.
- **Lint**: `black --check` clean on all three changed files. `ruff` goes from **10 pre-existing errors to 9** across the same files — the change introduces none and clears one (`I001` in the test file).
- **CI baseline, checked not assumed**: `pyre`, `test`, `build (3.10/3.11/3.12)` and `test-main-features` are red on this PR *and on every other open PR*, including the maintainer's own #2090, and on `master` itself. `pyre` reports **1933 type errors on `master` @ `7a6eeebe`** — my PR's base — and **the same 1933** here, so this diff adds none. `test-main-features` fails with `OpenAIException - Missing credentials ... set the OPENAI_API_KEY` because the workflow runs with empty provider keys, and `build`/`test` end in `##[error]The operation was canceled` after hitting the job timeout on the same live-LLM path. Green checks on this PR: `lint`, `Pyre`, `dependency-review`, `label`.
- **Not verified here**: no LLM was called. Nothing in this diff reaches a provider — the prompt is a string built before any request — so the stubless path is the whole path.

## Note for #2131

`AGENT_SYSTEM_PROMPT_3` has the identical defect at `swarms/prompts/agent_system_prompts.py:134`, and it is the **default** `Agent(system_prompt=...)`, so it affects every agent rather than only autonomous ones. Filed as #2131 rather than folded in here — it is a different module with a much wider blast radius and deserves its own review. The new test documents why `agent.system_prompt` still shows two `Time:` lines until that one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Q2sdh8pCNqYUBig5sFRTa
