### PR TITLE
[Bug] return_all_except_first_string drops two messages where its dict sibling drops one

### DIFF
--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -1364,7 +1364,7 @@ class Conversation:
         return "\n".join(
             [
                 f"{msg['content']}"
-                for msg in self.conversation_history[2:]
+                for msg in self.conversation_history[1:]
             ]
         )
 


### PR DESCRIPTION
Fixes #2112

`Conversation.return_all_except_first_string()` slices `conversation_history[2:]`, while `return_all_except_first()` slices `[1:]`. Both docstrings promise the same thing, "all messages except the first one", so the string variant silently loses the first real message on every call.

## Why this matters beyond the method itself

The two are exposed as sibling output types by the same formatter, so a caller picking between them expects only a format difference:

```
swarms/utils/history_output_formatter.py:52   "dict-all-except-first" -> return_all_except_first()
swarms/utils/history_output_formatter.py:56   "str-all-except-first"  -> return_all_except_first_string()
```

`SwarmRouter` reaches for the string variant at `swarms/structs/swarm_router.py:524`, so a router run using that output type returns a transcript with the first agent's contribution missing. Nothing errors, the output is just short one message, which is why this survived.

## Reproduction on master

```
c = Conversation()
c.add("system", "System"); c.add("user", "Hello"); c.add("assistant", "Hi")

c.return_all_except_first()         -> ['user', 'assistant']
c.return_all_except_first_string()  -> 'Hi'
```

The `user` turn is gone from the string form.

## After

```
c.return_all_except_first()         -> ['user', 'assistant']
c.return_all_except_first_string()  -> 'Hello\nHi'
```

## On tests

No new test here on purpose. `tests/structs/test_conversation.py:458` already covers exactly this case and asserts `"Hello" in result`. That assertion is false on master, but the test catches its own `AssertionError` and returns `False` rather than failing, so the suite stayed green and the bug stayed hidden. Verified both directions:

```
unfixed  test_return_all_except_first_string() -> False
fixed    test_return_all_except_first_string() -> True
```

`black --check` clean on the touched file.