### PR TITLE
[Bug] AGENT_SYSTEM_PROMPT_3 freezes its Time line at import, so every agent is told the boot time

### DIFF
--- a/swarms/prompts/agent_system_prompts.py
+++ b/swarms/prompts/agent_system_prompts.py
@@ -127,12 +127,14 @@ def agent_system_prompt_2(name: str):
     return AGENT_SYSTEM_PROMPT_2
 
 
-AGENT_SYSTEM_PROMPT_3 = f"""
+_AGENT_SYSTEM_PROMPT_3_HEADER = """
 You are an autonomous agent designed to serve users by automating complex tasks, workflows, and activities with precision and intelligence. 
 Agents leverage custom instructions, specialized capabilities, and curated data to optimize large language models for specific domains and use cases.
 
-Time: {get_time()}
+"""
 
+
+_AGENT_SYSTEM_PROMPT_3_BODY = """
 You possess the ability to engage in both internal reasoning and external interactions to achieve optimal results. 
 Through self-reflection and user collaboration, you can break down complex problems, identify optimal solutions, and execute tasks with high efficiency.
 
@@ -145,3 +147,21 @@ Your responses must demonstrate:
 
 Always aim to exceed expectations by delivering comprehensive, well-structured, and contextually appropriate solutions that address both the explicit and implicit needs of the task.
 """
+
+
+AGENT_SYSTEM_PROMPT_3 = (
+    _AGENT_SYSTEM_PROMPT_3_HEADER + _AGENT_SYSTEM_PROMPT_3_BODY
+)
+
+
+def build_agent_system_prompt() -> str:
+    """Render the default agent system prompt with the current time.
+
+    Returns:
+        str: The prompt with a freshly interpolated ``Time:`` line.
+    """
+    return (
+        _AGENT_SYSTEM_PROMPT_3_HEADER
+        + f"Time: {get_time()}\n"
+        + _AGENT_SYSTEM_PROMPT_3_BODY
+    )

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -40,7 +40,9 @@ from swarms.agents.context_compressor import ContextCompressor
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
 from swarms.agents.llm_manager import LLMManager
 from swarms.agents.skills_manager import SkillsManager
-from swarms.prompts.agent_system_prompts import AGENT_SYSTEM_PROMPT_3
+from swarms.prompts.agent_system_prompts import (
+    build_agent_system_prompt,
+)
 from swarms.prompts.autonomous_agent_prompt import (
     get_autonomous_agent_prompt,
 )
@@ -313,7 +315,7 @@ class Agent:
         agent_description: Optional[
             str
         ] = "An autonomous agent that can perform tasks and learn from experience powered by Swarms",
-        system_prompt: Optional[str] = AGENT_SYSTEM_PROMPT_3,
+        system_prompt: Optional[str] = None,
         llm: Optional[Any] = None,
         max_loops: Optional[Union[int, str]] = 1,
         stopping_condition: Optional[Callable[[str], bool]] = None,
@@ -429,6 +431,8 @@ class Agent:
         self.sop = sop
         self.sop_list = sop_list
         self.tools = tools
+        if system_prompt is None:
+            system_prompt = build_agent_system_prompt()
         self.system_prompt = system_prompt or ""
         self.agent_name = agent_name
         self.agent_description = agent_description

--- a/tests/prompts/test_agent_system_prompts.py
+++ b/tests/prompts/test_agent_system_prompts.py
@@ -1,0 +1,38 @@
+import re
+
+import swarms.prompts.agent_system_prompts as prompt_module
+
+TIMESTAMP = re.compile(r"Current date and time: [^\n]*")
+
+
+def _freeze(monkeypatch, value):
+    monkeypatch.setattr(
+        prompt_module,
+        "get_time",
+        lambda: f"Current date and time: {value}\n",
+    )
+
+
+def test_constant_carries_no_timestamp():
+    assert not TIMESTAMP.search(prompt_module.AGENT_SYSTEM_PROMPT_3)
+
+
+def test_builder_reflects_the_clock_at_call_time(monkeypatch):
+    _freeze(monkeypatch, "FIRST")
+    first = prompt_module.build_agent_system_prompt()
+    _freeze(monkeypatch, "SECOND")
+    second = prompt_module.build_agent_system_prompt()
+
+    assert "FIRST" in first
+    assert "SECOND" in second
+    assert first != second
+
+
+def test_builder_is_the_constant_plus_a_time_line(monkeypatch):
+    _freeze(monkeypatch, "ONLY")
+    built = prompt_module.build_agent_system_prompt()
+
+    assert (
+        built.replace("Time: Current date and time: ONLY\n\n", "")
+        == prompt_module.AGENT_SYSTEM_PROMPT_3
+    )


### PR DESCRIPTION
Fixes #2131

`AGENT_SYSTEM_PROMPT_3` was a module-level f-string interpolating `get_time()`, so the timestamp was computed once when `swarms.prompts.agent_system_prompts` was first imported and stayed bound for the life of the process. It is the default of `Agent(system_prompt=...)`, so this is the grounding every agent gets unless the caller supplies their own prompt.

## Why it needed two changes, not one

The freeze happens twice, and fixing either half alone leaves the bug in place:

1. The constant itself is built at import.
2. `swarms/structs/agent.py:316` used that constant as a **default parameter**, and Python evaluates defaults once at function-definition time. Even a constant that refreshed itself would have been captured once here.

That is why this also changes the default to `None` and resolves it inside `__init__`.

## Shape

Follows #2130, the reviewed precedent for this module family:

- `_AGENT_SYSTEM_PROMPT_3_HEADER` / `_AGENT_SYSTEM_PROMPT_3_BODY` as plain, non-f strings
- `AGENT_SYSTEM_PROMPT_3 = header + body`, carrying no timestamp, so it cannot regress into a stale one
- `build_agent_system_prompt()` joins header, a freshly interpolated `Time:` line, and body
- `Agent.__init__` resolves the default when the caller passed nothing

## Before, on master @ 7a6eeebe

```
AGENT_SYSTEM_PROMPT_3 at import : Wednesday, September 02, 2026 16:09 PDT
--- 70 seconds later, a brand-new Agent ---
agent.system_prompt says         : Wednesday, September 02, 2026 16:09 PDT
real wall-clock time             : Wednesday, September 02, 2026 16:10 PDT
```

## After

```
builder at t0      : Wednesday, September 02, 2026 18:41 PDT
agent 65s later    : Wednesday, September 02, 2026 18:42 PDT
real wall clock    : Wednesday, September 02, 2026 18:42 PDT
AGENT TRACKS CLOCK : True
```

A caller passing their own prompt is unaffected, verified in the same run (`Agent(system_prompt="mine").system_prompt == "mine"`).

## Prompt text is unchanged

Masking the timestamp, the rendered prompt is byte-identical to master's:

```
byte-identical after masking timestamp: True
constant carries no timestamp         : True
```

## One behaviour change worth flagging

Passing `system_prompt=None` **explicitly** previously produced an empty system prompt, because the old line was `self.system_prompt = system_prompt or ""`. It now resolves to the default prompt, which is what `Optional[str] = None` conventionally means and what the issue asks for. Passing `""` still yields `""`.

## Tests

`tests/prompts/test_agent_system_prompts.py`, three cases: the constant carries no timestamp, the builder tracks the clock across calls, and the builder is exactly the constant plus one time line. Verified they fail on unfixed source:

```
unfixed  3 failed
fixed    3 passed
```

`black . --check` clean repo-wide, 953 files unchanged.