### PR TITLE
[Bug] MultiAgentRouter runs every selected agent and records only the first answer (#2044)

### DIFF
--- a/swarms/structs/multi_agent_router.py
+++ b/swarms/structs/multi_agent_router.py
@@ -292,14 +292,14 @@ class MultiAgentRouter:
         self, boss_response_str: dict, task: str
     ) -> None:
         """
-        Execute every agent selected by the boss and record the first response.
+        Execute every agent selected by the boss and record every response.
 
         Validates that every ``agent_name`` referenced in ``boss_response_str``
         exists before running anything. Each agent is run with its boss-supplied
         task (or the original ``task`` when the boss did not rewrite it). When
         ``skip_null_tasks`` is True, agents whose resolved task is empty or
-        ``None`` are skipped. After execution, the first selected agent's
-        response is appended to ``self.conversation``.
+        ``None`` are skipped. After execution, each selected agent's response
+        is appended to ``self.conversation``.
 
         Args:
             boss_response_str (dict): Parsed boss decision containing a
@@ -366,12 +366,13 @@ class MultiAgentRouter:
                     )
                 )
 
-            self.conversation.add(
-                role=selected_agents[0].agent_name,
-                content=agent_responses[0],
-            )
-
-        # return agent_responses
+            # executor.map preserves input order, so the zip stays aligned.
+            for agent, response in zip(
+                selected_agents, agent_responses
+            ):
+                self.conversation.add(
+                    role=agent.agent_name, content=response
+                )
 
     def route_task(self, task: str) -> dict:
         """

--- a/tests/structs/test_multi_agent_router.py
+++ b/tests/structs/test_multi_agent_router.py
@@ -512,6 +512,27 @@ def test_selected_agents_run_concurrently():
     ), f"three 0.35s agents took {elapsed:.2f}s, so they ran in series"
 
 
+def test_every_selected_agent_answer_reaches_the_conversation():
+    """Only agent_responses[0] was recorded; the rest ran, billed, and were dropped."""
+    router, ran = _local_router(agents=["A1", "A2", "A3"])
+
+    router.handle_multiple_handoffs(
+        {
+            "handoffs": [
+                {"agent_name": n, "task": "t"}
+                for n in ("A1", "A2", "A3")
+            ]
+        },
+        "x",
+    )
+
+    assert len(ran) == 3
+    assert [
+        (m["role"], m["content"])
+        for m in router.conversation.conversation_history
+    ] == [("A1", "A1-out"), ("A2", "A2-out"), ("A3", "A3-out")]
+
+
 def test_an_unknown_agent_raises_before_any_agent_runs():
     router, ran = _local_router()
 


### PR DESCRIPTION
## What is wrong

`handle_multiple_handoffs` runs every agent the boss selects, then records exactly one of the answers:

```python
agent_responses = list(executor.map(...))          # N answers

self.conversation.add(
    role=selected_agents[0].agent_name,
    content=agent_responses[0],                    # 1 recorded
)

# return agent_responses
```

`agent_responses[1:]` is never read. `route_task` returns `history_output_formatter(conversation=self.conversation, ...)`, so what the conversation does not hold, the caller does not get.

## Why it is wrong

Whenever the boss hands off to more than one agent, the caller pays for N completions and receives one. Nothing logs or warns, so the failure is indistinguishable from the router having chosen a single agent — the case where the boss deliberately fans out to specialists is exactly the case that silently loses the work.

Reproducible offline with the existing `_local_router` harness in the test file: three agents run, one line lands in the conversation.

## What this changes

Record every response. `executor.map` yields results in input order, so zipping the agents back onto their responses keeps each answer under its own author.

The dead `# return agent_responses` comment goes with it, and the docstring — which described the drop as intended behaviour — is corrected.

One regression test in the file that already owns this method, using its existing offline `_local_router`. Verified to fail on the unfixed source (`Right contains 2 more items, first extra item: ('A2', 'A2-out')`).

`pytest tests/structs/test_multi_agent_router.py`: 8 passed, up from 7 on `master`. The 21 failures are pre-existing on `master` — they construct a real `MultiAgentRouter` and need an API key.

Closes #2044