### PR TITLE
[FIX][Agent][Stop writing tool schemas into the conversation as an assistant turn]

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -897,7 +897,6 @@ class Agent:
         2. Initializes tools_list_dictionary if None
         3. Tracks existing tool names to prevent duplicates
         4. Adds new tools that don't already exist
-        5. Adds tools to conversation memory for LLM context
 
         **Tool Schema Format:**
         Tools are converted to OpenAI function calling format:
@@ -923,16 +922,16 @@ class Agent:
             None: Uses self.tools and self.tools_list_dictionary from instance.
 
         Returns:
-            None: Modifies self.tools_list_dictionary and self.short_memory.
+            None: Modifies self.tools_list_dictionary.
 
         Note:
             - This method is called automatically during agent initialization if tools are provided
-            - Tools are added to conversation memory so the LLM knows what tools are available
+            - Schemas reach the model through the API's `tools` parameter, not the conversation
             - The method preserves existing tools in tools_list_dictionary (e.g., handoff tools)
             - Tool names are case-sensitive for duplicate detection
 
         Raises:
-            Exception: If tool conversion fails or tools cannot be added to memory.
+            Exception: If tool conversion fails.
 
         Examples:
             >>> def my_tool(query: str) -> str:
@@ -966,11 +965,6 @@ class Agent:
             if tool_name not in existing_tool_names:
                 self.tools_list_dictionary.append(tool)
                 existing_tool_names.add(tool_name)
-
-        self.short_memory.add(
-            role=self.agent_name,
-            content=self.tools_list_dictionary,
-        )
 
     def short_memory_init(self):
         # Compactly assemble initial prompt as a string with available fields

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -862,6 +862,32 @@ class TestToolsListIsolation:
         )
 
 
+class TestToolSchemasStayOutOfTheConversation:
+    """Schemas reach the model as the API's `tools` parameter, not as a turn."""
+
+    def test_no_conversation_turn_carries_the_tool_schemas(self):
+        # dynamic_tools=False is the branch that reaches tool_handling().
+        agent = _patched_agent(
+            "SchemaAgent",
+            model_name="gpt-5.4",
+            dynamic_tools=False,
+            tools=[_math_tool],
+        )
+
+        assert any(
+            schema["function"]["name"] == "_math_tool"
+            for schema in agent.tools_list_dictionary
+        )
+        assert [
+            m
+            for m in agent.short_memory.conversation_history
+            if not isinstance(m["content"], str)
+        ] == []
+        assert [
+            m["role"] for m in agent.short_memory.conversation_history
+        ] == ["System"]
+
+
 class TestAutonomousAgentLoop:
     """The ``max_loops="auto"`` loop lives in ``AutonomousAgentLoop``, not on
     ``Agent``. These pin the seam: the loop is wired up, it reads and writes


### PR DESCRIPTION
## What is wrong

`tool_handling()` finishes by putting the whole tool-schema list into the conversation, attributed to the agent:

```python
self.short_memory.add(
    role=self.agent_name,
    content=self.tools_list_dictionary,
)
```

Reproduced on `master` with one tool (`dynamic_tools=False` is the branch that reaches `tool_handling`):

```
'System' str   '\nYou are an autonomous agent designed to serve users by automating...'
'X'      list  [{'type': 'function', 'function': {'name': '_math_tool', 'description': ...
```

## Why it is wrong

The same schemas already reach the provider through the supported channel — `LLMManager.build` passes `tools_list_dictionary` straight to LiteLLM as the `tools` parameter (`swarms/agents/llm_manager.py:245-271`). So:

- Every request sends the full JSON schema of every tool twice, once as `tools` and once as conversation content — a permanent per-call overhead that grows with the tool count.
- `role=self.agent_name` means anything mapping conversation roles onto chat roles reads it as an **assistant** turn, so the conversation opens with the assistant reciting its own tool schemas.
- `content` is a `list` where every other entry is a string, so `return_history_as_string()` renders a Python repr.

Nothing reads that message: `grep` for consumers finds none, and the schemas are re-derived from `self.tools_list_dictionary` wherever they are needed.

## What this changes

Drops the `short_memory.add(...)` call, and corrects the three docstring lines that described the conversation as the channel by which the model learns its tools.

The dynamic-tools path (`setup_dynamic_tools` / `defer_tool_schemas`, the default when `tools` are given) never wrote this turn, so this is the one site.

One regression test in `tests/structs/test_agent.py`, next to the existing tools-list coverage. Verified to fail on the unfixed source.

`pytest tests/structs/test_agent.py tests/agents/test_llm_manager.py tests/tools/test_dynamic_tool_loader.py`: 207 passed, 1 failed. That failure (`test_call_llm_delegates`) is pre-existing on `master` and unrelated.

Closes #1989