### PR TITLE
[FIX][autonomous_loop][Order subtask execution by the priority it already collects]

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -75,6 +75,14 @@ def _format_tool_error(function_name: str, error: Exception) -> str:
 
 
 # Enough for a typical plan without pulling in the whole catalog.
+# Ranking for the plan schema's priority enum; lower sorts first.
+SUBTASK_PRIORITY_ORDER = {
+    "critical": 0,
+    "high": 1,
+    "medium": 2,
+    "low": 3,
+}
+
 PREWARM_TOOL_LIMIT = 8
 
 # Pre-warm matches must score at least this fraction of the best match.
@@ -1743,7 +1751,7 @@ class AutonomousAgentLoop:
         self,
     ) -> Optional[Dict[str, Any]]:
         """
-        Get the next executable subtask based on dependencies and status.
+        Get the next executable subtask by dependencies, then priority.
 
         Returns:
             Dictionary of the next subtask or None if all are done
@@ -1752,13 +1760,15 @@ class AutonomousAgentLoop:
             return None
 
         # Find subtasks that are pending and have all dependencies completed
+        eligible = []
         for subtask in self.agent.autonomous_subtasks:
             if subtask["status"] != "pending":
                 continue
 
             dependencies = subtask.get("dependencies", [])
             if not dependencies:
-                return subtask
+                eligible.append(subtask)
+                continue
 
             statuses = [
                 self.agent.subtask_status.get(dep)
@@ -1767,7 +1777,8 @@ class AutonomousAgentLoop:
 
             # Only completed unblocks; failed and unknown do not.
             if all(status == "completed" for status in statuses):
-                return subtask
+                eligible.append(subtask)
+                continue
 
             # Unreachable: skip so the run can terminate.
             blockers = [
@@ -1778,7 +1789,19 @@ class AutonomousAgentLoop:
             if blockers:
                 self._skip_subtask(subtask, blockers)
 
-        return None
+        if not eligible:
+            return None
+
+        # min() is stable, so creation order remains the tiebreaker.
+        return min(eligible, key=self._priority_rank)
+
+    @staticmethod
+    def _priority_rank(subtask: Dict[str, Any]) -> int:
+        """Rank a subtask's priority, defaulting unknown values to medium."""
+        priority = str(subtask.get("priority") or "medium").lower()
+        return SUBTASK_PRIORITY_ORDER.get(
+            priority, SUBTASK_PRIORITY_ORDER["medium"]
+        )
 
     def _skip_subtask(
         self, subtask: Dict[str, Any], blockers: List[str]

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -224,6 +224,44 @@ class TestDependencyResolution:
 # --------------------------------------------------------------------------
 
 
+class TestPriorityOrdering:
+    """The plan schema, the prompt and the docstring all promise this."""
+
+    def test_a_critical_subtask_runs_before_an_earlier_low_one(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t",
+            [
+                {"step_id": "a", "priority": "low"},
+                {"step_id": "b", "priority": "critical"},
+                {"step_id": "c", "priority": "high"},
+            ],
+        )
+
+        assert loop._get_next_executable_subtask()["step_id"] == "b"
+
+        agent.autonomous_subtasks[1]["status"] = "completed"
+        assert loop._get_next_executable_subtask()["step_id"] == "c"
+
+    def test_a_blocked_critical_subtask_does_not_jump_the_queue(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t",
+            [
+                {"step_id": "a", "priority": "low"},
+                {
+                    "step_id": "b",
+                    "priority": "critical",
+                    "dependencies": ["a"],
+                },
+            ],
+        )
+
+        assert loop._get_next_executable_subtask()["step_id"] == "a"
+
+
 class TestBatchedToolCalls:
     """Every tool call in a response runs, whatever its position."""
 


### PR DESCRIPTION
## What is wrong

`_get_next_executable_subtask` returns the first `pending` subtask whose dependencies are satisfied. There is no priority comparison anywhere in the loop:

```python
for subtask in self.agent.autonomous_subtasks:
    if subtask["status"] != "pending":
        continue
    dependencies = subtask.get("dependencies", [])
    if not dependencies:
        return subtask
    ...
```

## Why it is wrong

Three places tell the model that priority matters, and it is the only one paying attention:

- The plan tool's schema makes `priority` a **required** field with the enum `low | medium | high | critical` (`swarms/structs/autonomous_loop_utils.py:168-186`).
- `_create_plan_tool`'s docstring documents the ordering as "1. Dependencies … 2. Priority: Higher priority tasks are preferred when multiple are available 3. Creation order: Used as tiebreaker".
- The system prompt says "Critical priority tasks are foundational and must be completed first" (`swarms/prompts/autonomous_agent_prompt.py:45`).

A model that assigns priorities carefully gets nothing for it, and the plan panel prints a priority the scheduler is not using.

## What this changes

Collect the eligible subtasks rather than returning the first, then take the highest-priority one. `min()` is stable, so creation order stays the tiebreaker as documented, and dependencies still win over priority — a blocked `critical` subtask does not jump ahead of a runnable `low` one.

One behavioural note: because the scan no longer returns early, a subtask whose dependencies have already failed is skipped in this pass rather than a later one. Same outcome, one pass sooner.

The alternative the issue offers — deleting the field from the schema, the prompt and the docstring — is the larger change and contradicts what the prompt asks the model to reason about.

Two tests in the file that already owns this method. The first fails on the unfixed source (returns `a`, the `low`-priority step, instead of `b`); the second guards the dependency-precedence risk this change introduces.

`pytest tests/agents/test_autonomous_loop.py`: 43 passed.

Closes #1967