### PR TITLE
[Bug] Sub-agents are created with no tools, so delegation returns less than doing the work inline (#1973)

### DIFF
--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -1244,14 +1244,6 @@ def create_sub_agent_tool(
             # strictly less capable than the parent asking the question itself.
             parent_tools = list(getattr(agent, "tools", None) or [])
 
-            # Omitted rather than passed as [], which is not the same thing:
-            # exists([]) is true, so an empty list sends every response
-            # through tool execution. Agent.tools is annotated List[Callable],
-            # so None is not passable either.
-            tool_kwargs = (
-                {"tools": parent_tools} if parent_tools else {}
-            )
-
             # Create sub-agent with the same LLM and tools as parent
             sub_agent = Agent(
                 id=agent_id,
@@ -1259,12 +1251,12 @@ def create_sub_agent_tool(
                 agent_description=agent_description,
                 system_prompt=system_prompt,  # Use custom system prompt if provided
                 model_name=agent.model_name,
+                tools=parent_tools,
                 # Tools need a call-then-read turn. Finite whatever the parent
                 # is, so a max_loops="auto" parent cannot recurse into sub-agents.
                 max_loops=5 if parent_tools else 1,
                 print_on=getattr(agent, "print_on", False),
                 verbose=agent.verbose,
-                **tool_kwargs,
             )
 
             # Cache the sub-agent

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -1244,6 +1244,14 @@ def create_sub_agent_tool(
             # strictly less capable than the parent asking the question itself.
             parent_tools = list(getattr(agent, "tools", None) or [])
 
+            # Omitted rather than passed as [], which is not the same thing:
+            # exists([]) is true, so an empty list sends every response
+            # through tool execution. Agent.tools is annotated List[Callable],
+            # so None is not passable either.
+            tool_kwargs = (
+                {"tools": parent_tools} if parent_tools else {}
+            )
+
             # Create sub-agent with the same LLM and tools as parent
             sub_agent = Agent(
                 id=agent_id,
@@ -1251,12 +1259,12 @@ def create_sub_agent_tool(
                 agent_description=agent_description,
                 system_prompt=system_prompt,  # Use custom system prompt if provided
                 model_name=agent.model_name,
-                tools=parent_tools or None,
                 # Tools need a call-then-read turn. Finite whatever the parent
                 # is, so a max_loops="auto" parent cannot recurse into sub-agents.
                 max_loops=5 if parent_tools else 1,
                 print_on=getattr(agent, "print_on", False),
                 verbose=agent.verbose,
+                **tool_kwargs,
             )
 
             # Cache the sub-agent

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -1240,15 +1240,23 @@ def create_sub_agent_tool(
             # Import Agent class to create sub-agent
             from swarms.structs.agent import Agent
 
-            # Create sub-agent with the same LLM as parent
+            # Without the parent's tools a sub-agent is one stateless LLM call,
+            # strictly less capable than the parent asking the question itself.
+            parent_tools = list(getattr(agent, "tools", None) or [])
+
+            # Create sub-agent with the same LLM and tools as parent
             sub_agent = Agent(
                 id=agent_id,
                 agent_name=agent_name,
                 agent_description=agent_description,
                 system_prompt=system_prompt,  # Use custom system prompt if provided
                 model_name=agent.model_name,
-                max_loops=1,
-                print_on=True,  # Reduce noise from sub-agents
+                tools=parent_tools or None,
+                # Tools need a call-then-read turn. Finite whatever the parent
+                # is, so a max_loops="auto" parent cannot recurse into sub-agents.
+                max_loops=5 if parent_tools else 1,
+                print_on=getattr(agent, "print_on", False),
+                verbose=agent.verbose,
             )
 
             # Cache the sub-agent

--- a/tests/structs/test_async_subagent.py
+++ b/tests/structs/test_async_subagent.py
@@ -563,6 +563,44 @@ class TestAutonomousLoopCreateAndAssignTools:
         assert sub_entry["name"] == "worker-1"
         assert sub_entry["description"] == "Does work"
 
+    def test_sub_agent_inherits_the_parent_tools(self):
+        """A sub-agent with no tools is strictly weaker than asking the parent."""
+
+        def parent_tool(query: str) -> str:
+            """Look something up.
+
+            Args:
+                query: what to look up.
+            """
+            return query
+
+        class ParentAgentStub:
+            def __init__(self):
+                self.model_name = MODEL
+                self.verbose = False
+                self.print_on = False
+                self.tools = [parent_tool]
+                self.short_memory = (
+                    TestAutonomousLoopCreateAndAssignTools._ShortMemoryStub()
+                )
+
+        parent = ParentAgentStub()
+
+        create_sub_agent_tool(
+            parent,
+            agents=[
+                {
+                    "agent_name": "worker-1",
+                    "agent_description": "Does work",
+                }
+            ],
+        )
+
+        sub_agent = next(iter(parent.sub_agents.values()))["agent"]
+        assert sub_agent.tools == [parent_tool]
+        # Tools are unusable without a turn to read the result in.
+        assert sub_agent.max_loops > 1
+
     def test_create_sub_agent_missing_required_fields(self):
         """create_sub_agent_tool returns error if required fields are missing."""
 


### PR DESCRIPTION
## What is wrong

`create_sub_agent_tool` builds the sub-agent like this:

```python
sub_agent = Agent(
    id=agent_id,
    agent_name=agent_name,
    agent_description=agent_description,
    system_prompt=system_prompt,
    model_name=agent.model_name,
    max_loops=1,
    print_on=True,  # Reduce noise from sub-agents
)
```

No `tools`, and one loop.

## Why it is wrong

The result is a single stateless LLM call. It cannot read a file, run a command, or take any action, so `assign_task` can only ever return text — a sub-agent is strictly less capable than the parent asking the same question directly, while costing an extra round-trip. The autonomous prompt advertises "create specialized sub-agents for delegation", which the implementation does not back.

`max_loops=1` compounds it: even with tools, there is no turn in which to read a tool result.

The `print_on=True` line and the comment next to it say opposite things.

## What this changes

- Pass the parent's `tools` to the sub-agent.
- Give a sub-agent that has tools enough loops to call one and read the result. The budget is a fixed finite number rather than the parent's `max_loops`, so a `max_loops="auto"` parent cannot recurse into sub-agents that spawn their own autonomous loops.
- `print_on` follows the parent instead of being hardcoded against its own comment.

Not done here, deliberately: the issue also offers passing the autonomous loop's own file/bash/grep tools to sub-agents. That widens the workspace-confinement question rather than the capability one, so it is left out of this diff.

`workspace_dir` needs no plumbing — `Agent.__init__` resolves it from `get_workspace_dir()`, so the sub-agent already lands in the parent's workspace.

One test in the file that already owns `create_sub_agent_tool`. Verified to fail on the unfixed source (`None = <Agent>.tools`).

`pytest tests/structs/test_async_subagent.py tests/agents/test_autonomous_loop.py`: 77 passed, 12 failed. Those 12 fail identically on `master`.

Closes #1973