### PR TITLE
[Bug] read_file and run_bash return unbounded output, so one read can end the run (#1971)

### DIFF
--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -45,6 +45,21 @@ MAX_SUBTASK_ITERATIONS = 100
 MAX_SUBTASK_LOOPS = 20
 MAX_CONSECUTIVE_THINKS = 2
 
+# The loop re-serializes its history into every later prompt, so one oversized
+# tool result is paid for on every remaining call of the run.
+MAX_TOOL_OUTPUT_CHARS = 65536
+
+
+def truncate_tool_output(text: str) -> str:
+    """Cap a tool result, telling the model how much it is not seeing."""
+    if len(text) <= MAX_TOOL_OUTPUT_CHARS:
+        return text
+    return (
+        text[:MAX_TOOL_OUTPUT_CHARS]
+        + "\n... (output truncated: showing the first "
+        + f"{MAX_TOOL_OUTPUT_CHARS} of {len(text)} characters)"
+    )
+
 
 # Prompts.
 
@@ -784,12 +799,13 @@ def read_file_tool(agent: Any, file_path: str, **kwargs) -> str:
 
         # Read file
         with open(full_path, "r", encoding="utf-8") as f:
-            content = f.read()
+            raw = f.read()
+        content = truncate_tool_output(raw)
 
         # Add to memory
         agent.short_memory.add(
             role="File Operations",
-            content=f"Read file: {full_path} ({len(content)} characters)",
+            content=f"Read file: {full_path} ({len(raw)} characters)",
         )
 
         if agent.verbose:
@@ -1080,7 +1096,7 @@ def run_bash_tool(
         if agent.verbose:
             logger.info(f"Executed bash command: {command[:80]}...")
 
-        return result_msg.strip()
+        return truncate_tool_output(result_msg.strip())
     except subprocess.TimeoutExpired:
         error_msg = f"Error: Command timed out after {timeout_seconds} seconds"
         logger.error(error_msg)
@@ -1097,9 +1113,6 @@ def run_bash_tool(
             content=f"Error: {error_msg}",
         )
         return error_msg
-
-
-_GREP_MAX_BYTES = 65536  # cap output at 64 KB
 
 
 def grep_tool(
@@ -1174,10 +1187,7 @@ def grep_tool(
         stderr = result.stderr or ""
 
         # Truncate oversized output
-        if len(stdout) > _GREP_MAX_BYTES:
-            stdout = (
-                stdout[:_GREP_MAX_BYTES] + "\n... (output truncated)"
-            )
+        stdout = truncate_tool_output(stdout)
 
         if result.returncode == 0:
             output = stdout.strip() or "(no matches)"

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -33,7 +33,11 @@ import pytest
 
 from swarms import Agent
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
-from swarms.structs.autonomous_loop_utils import MAX_SUBTASK_LOOPS
+from swarms.structs.autonomous_loop_utils import (
+    MAX_SUBTASK_LOOPS,
+    MAX_TOOL_OUTPUT_CHARS,
+    read_file_tool,
+)
 
 
 # --------------------------------------------------------------------------
@@ -222,6 +226,20 @@ class TestDependencyResolution:
 # --------------------------------------------------------------------------
 # #1964 — tool calls batched after subtask_done
 # --------------------------------------------------------------------------
+
+
+class TestToolOutputIsCapped:
+    """One oversized read is re-sent on every later call of the run."""
+
+    def test_read_file_truncates_a_large_file(self, tmp_path):
+        agent = build_agent()
+        big = tmp_path / "big.txt"
+        big.write_text("x" * (MAX_TOOL_OUTPUT_CHARS + 5000))
+
+        output = read_file_tool(agent, str(big))
+
+        assert len(output) < MAX_TOOL_OUTPUT_CHARS + 200
+        assert "output truncated" in output
 
 
 class TestBatchedToolCalls:


### PR DESCRIPTION
## What is wrong

`grep_tool` capped its output at 64 KB. The other two output-producing tools did not:

- `read_file_tool` returned `f.read()` whole — a 2 MB log is one 2 MB tool result.
- `run_bash_tool` returned the complete stdout and stderr of whatever ran: `cat`, `find /`, `npm install`, a failing test suite.

## Why it is wrong

The autonomous loop re-serializes its history into the prompt on every iteration, so an oversized tool result is not paid for once — it is re-sent on every remaining LLM call of the run. A single unlucky read can exhaust the context window and end the run, and the model gets no signal that anything was cut, so it cannot narrow its query in response.

The cap already existed and was already the right idea; it was applied to exactly one of the three tools.

## What this changes

Lift `_GREP_MAX_BYTES` into a shared `truncate_tool_output` next to the loop's other limits, and route `read_file`, `run_bash` and `grep` through it. Same 64 KB threshold grep already used, so grep's behaviour is unchanged apart from a more informative marker:

```
... (output truncated: showing the first 65536 of 2103418 characters)
```

`read_file`'s memory note still reports the file's real length rather than the truncated one, so the record of what was read stays accurate.

`offset`/`limit` on `read_file` is the other half the issue proposes; that is tracked separately as #1981 and is not in this diff.

One test in the autonomous loop's suite — there was no existing coverage for these tools anywhere in `tests/`. Verified by reverting only the `read_file` truncation, which fails it while the rest of the suite stays green.

`pytest tests/agents/test_autonomous_loop.py`: 42 passed.

Closes #1971