### PR TITLE
[CI] Restore the lint job: one generator black wants wrapped

### DIFF
--- a/tests/structs/test_agent_rearrange.py
+++ b/tests/structs/test_agent_rearrange.py
@@ -611,7 +611,9 @@ def test_agent_error_raises():
         raise TypeError("unexpected error in agent")
 
     next(
-        agent for agent in r.agents if agent.agent_name == "WriterAgent"
+        agent
+        for agent in r.agents
+        if agent.agent_name == "WriterAgent"
     ).run = bad_run
 
     with pytest.raises(TypeError, match="unexpected error in agent"):


### PR DESCRIPTION
## What is wrong

`lint` is failing on `master` itself, as of `6d9e61dd`:

```
1 file would be reformatted, 949 files would be left unchanged.
##[error]Process completed with exit code 1.
```

The file is `tests/structs/test_agent_rearrange.py`, and the reformat is one generator expression that runs past the configured `line-length = 70`:

```python
next(
    agent for agent in r.agents if agent.agent_name == "WriterAgent"
).run = bad_run
```

It arrived with #2139 (`e701af29`).

## Why it is worth fixing now

`lint` is the only check on this repo that currently distinguishes a real break from background noise. `pyre` exits 1 on a whole-repo error count, `test-main-features` runs live LLM calls against an empty `OPENAI_API_KEY`, and the `build (3.x)` and `test` jobs get SIGTERMed at the twenty minute mark. While `lint` is red on master it is red on every open PR too, so the one signal anybody could act on is gone.

## What this changes

`black tests/structs/test_agent_rearrange.py`, nothing else. Three lines, whitespace only.

`black --check .` goes from `1 file would be reformatted` to `950 files would be left unchanged`.

No test, since nothing executable changed. `pytest tests/structs/test_agent_rearrange.py` gives the same 3 failed / 74 passed before and after, all three pre-existing on `master`: `test_threadpoolexecutor_is_used`, `test_multiple_batches_uses_executor_per_batch`, `test_batch_size_one_still_uses_executor`. Those look like a real defect rather than a formatting one, so I am looking at them separately rather than folding them in here.