### PR TITLE
[Test] batch_run concurrency tests patch a name the module no longer binds

### DIFF
--- a/tests/structs/test_agent_rearrange.py
+++ b/tests/structs/test_agent_rearrange.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from swarms import Agent, AgentRearrange
+from swarms.telemetry.otel import ContextThreadPoolExecutor
 
 
 def create_sample_agents():
@@ -1018,29 +1019,25 @@ class TestBatchRunConcurrency:
         ), "Expected at least two batch_run tasks to overlap in execution"
 
     def test_threadpoolexecutor_is_used(self):
-        """Patch ThreadPoolExecutor to confirm it is invoked for each batch."""
+        """Patch the executor to confirm it is invoked for each batch."""
         pipeline = _make_pipeline("AgentA", "AgentB")
         tasks = ["t1", "t2", "t3"]
 
         with patch(
-            "swarms.structs.agent_rearrange.ThreadPoolExecutor",
-            wraps=__import__(
-                "concurrent.futures", fromlist=["ThreadPoolExecutor"]
-            ).ThreadPoolExecutor,
+            "swarms.structs.agent_rearrange.ContextThreadPoolExecutor",
+            wraps=ContextThreadPoolExecutor,
         ) as mock_tpe:
             pipeline.batch_run(tasks=tasks, batch_size=10)
             assert mock_tpe.call_count == 1
 
     def test_multiple_batches_uses_executor_per_batch(self):
-        """One ThreadPoolExecutor context-manager per batch."""
+        """One executor context-manager per batch."""
         pipeline = _make_pipeline("AgentA", "AgentB")
         tasks = [f"t{i}" for i in range(6)]
 
         with patch(
-            "swarms.structs.agent_rearrange.ThreadPoolExecutor",
-            wraps=__import__(
-                "concurrent.futures", fromlist=["ThreadPoolExecutor"]
-            ).ThreadPoolExecutor,
+            "swarms.structs.agent_rearrange.ContextThreadPoolExecutor",
+            wraps=ContextThreadPoolExecutor,
         ) as mock_tpe:
             pipeline.batch_run(tasks=tasks, batch_size=2)
             # 6 tasks / batch_size=2 -> 3 batches -> 3 executor instances
@@ -1204,13 +1201,11 @@ class TestBatchSizeBoundaries:
         assert len(results) == len(tasks)
 
     def test_batch_size_one_still_uses_executor(self):
-        """Even batch_size=1 should go through ThreadPoolExecutor."""
+        """Even batch_size=1 should go through the executor."""
         pipeline = _make_pipeline("AgentA", "AgentB")
         with patch(
-            "swarms.structs.agent_rearrange.ThreadPoolExecutor",
-            wraps=__import__(
-                "concurrent.futures", fromlist=["ThreadPoolExecutor"]
-            ).ThreadPoolExecutor,
+            "swarms.structs.agent_rearrange.ContextThreadPoolExecutor",
+            wraps=ContextThreadPoolExecutor,
         ) as mock_tpe:
             pipeline.batch_run(tasks=["only"], batch_size=1)
             assert mock_tpe.call_count == 1


### PR DESCRIPTION
## What is wrong

Three tests in `TestBatchRunConcurrency` and `TestBatchSizeBoundaries` patch this:

```python
with patch(
    "swarms.structs.agent_rearrange.ThreadPoolExecutor",
    wraps=__import__("concurrent.futures", fromlist=["ThreadPoolExecutor"]).ThreadPoolExecutor,
) as mock_tpe:
```

`agent_rearrange` stopped binding that name when #2078 (`8f6854f7`) switched `batch_run` to `ContextThreadPoolExecutor`. `mock.patch` fails before the test body ever runs:

```
AttributeError: <module 'swarms.structs.agent_rearrange'> does not have the attribute 'ThreadPoolExecutor'
```

## Why it is wrong

Two things, and the second is the one that matters.

They have been failing on `master` ever since, so the `test` job carries three permanent failures that are easy to read as background noise.

More importantly, the guarantee they exist to protect has had **no working coverage** since the rename. `batch_run` is still genuinely concurrent, so nothing is broken in the source today. But these tests would not have noticed if it had stopped being, because they error at patch time regardless of what the source does.

## What this changes

Patch `ContextThreadPoolExecutor`, the name the module actually binds, and replace the `__import__` dance with a plain import.

Nothing in `swarms/` changes. The source was already correct.

## Verification

The point of a restored guard is that it can fail, so I checked it can. Replacing `batch_run`'s executor block with a sequential loop:

```
FAILED TestBatchRunConcurrency::test_threadpoolexecutor_is_used
FAILED TestBatchRunConcurrency::test_multiple_batches_uses_executor_per_batch
FAILED TestBatchSizeBoundaries::test_batch_size_one_still_uses_executor
```

Restored, `pytest tests/structs/test_agent_rearrange.py` gives **77 passed**, against 74 passed and 3 failed on `master`.

## Note on the lint check

`lint` is red on `master` itself right now, on this same file, for an unrelated formatting reason from #2139. #2143 fixes that in three whitespace lines. I deliberately kept it out of this diff so the quick one can merge without waiting on this review; this PR's `lint` will stay red until #2143 lands, then go green with no rebase needed.