### PR TITLE
[Bug] A wrapped Args line makes the docstring parser drop every parameter after it

### DIFF
--- a/swarms/utils/docstring_parser.py
+++ b/swarms/utils/docstring_parser.py
@@ -5,8 +5,28 @@ This module provides a simple docstring parser that extracts parameter informati
 and descriptions from Python docstrings in Google/NumPy style format.
 """
 
+import inspect
 import re
 from typing import List, Optional, NamedTuple
+
+# Headers that end the description and, inside Args, end the parameter list.
+_SECTION_HEADERS = (
+    "args:",
+    "arguments:",
+    "parameters:",
+    "returns:",
+    "yields:",
+    "raises:",
+    "note:",
+    "notes:",
+    "example:",
+    "examples:",
+    "see also:",
+    "see_also:",
+    "attributes:",
+)
+
+_PARAM_RE = re.compile(r"^(\w+)\s*(?:\([^)]*\))?\s*:\s*(.+)$")
 
 
 class DocstringParam(NamedTuple):
@@ -36,102 +56,64 @@ def parse(docstring: str) -> DocstringInfo:
     if not docstring or not docstring.strip():
         return DocstringInfo(short_description=None, params=[])
 
-    # Clean up the docstring
-    lines = [line.strip() for line in docstring.strip().split("\n")]
+    # cleandoc, not strip-every-line: the parser below needs the relative
+    # indentation to tell a wrapped description from the next parameter.
+    lines = inspect.cleandoc(docstring).split("\n")
 
-    # Extract short description (first non-empty line that's not a section header)
+    # Extract short description: the first prose line before any section.
     short_description = None
     for line in lines:
-        if line and not line.startswith(
-            (
-                "Args:",
-                "Parameters:",
-                "Returns:",
-                "Yields:",
-                "Raises:",
-                "Note:",
-                "Example:",
-                "Examples:",
-            )
-        ):
-            short_description = line
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.lower().startswith(_SECTION_HEADERS):
             break
+        short_description = stripped
+        break
 
     # Extract parameters
-    params = []
-
-    # Look for Args: or Parameters: section
+    params: List[DocstringParam] = []
     in_args_section = False
     current_param = None
+    param_indent = 0
 
     for line in lines:
-        # Check if we're entering the Args/Parameters section
-        if line.lower().startswith(("args:", "parameters:")):
-            in_args_section = True
+        stripped = line.strip()
+        if not stripped:
+            continue
+        indent = len(line) - len(line.lstrip())
+        lowered = stripped.lower()
+
+        if not in_args_section:
+            if lowered.startswith(
+                ("args:", "arguments:", "parameters:")
+            ):
+                in_args_section = True
             continue
 
-        # Check if we're leaving the Args/Parameters section
-        if (
-            in_args_section
-            and line
-            and not line.startswith(" ")
-            and not line.startswith("\t")
-        ):
-            # Check if this is a new section header
-            if line.lower().startswith(
-                (
-                    "returns:",
-                    "yields:",
-                    "raises:",
-                    "note:",
-                    "example:",
-                    "examples:",
-                    "see also:",
-                    "see_also:",
-                )
-            ):
-                in_args_section = False
-                if current_param:
-                    params.append(current_param)
-                    current_param = None
-                continue
-
-        if in_args_section and line:
-            # Check if this line starts a new parameter (starts with parameter name)
-            # Pattern: param_name (type): description
-            param_match = re.match(
-                r"^(\w+)\s*(?:\([^)]*\))?\s*:\s*(.+)$", line
+        # A continuation is indented past the parameter it belongs to. Check
+        # this before the parameter pattern, which a wrapped line containing a
+        # colon would otherwise match.
+        if current_param is not None and indent > param_indent:
+            current_param = DocstringParam(
+                arg_name=current_param.arg_name,
+                description=f"{current_param.description} {stripped}",
             )
-            if param_match:
-                # Save previous parameter if exists
-                if current_param:
-                    params.append(current_param)
+            continue
 
-                param_name = param_match.group(1)
-                param_desc = param_match.group(2).strip()
-                current_param = DocstringParam(
-                    arg_name=param_name, description=param_desc
-                )
-            elif current_param and (
-                line.startswith(" ") or line.startswith("\t")
-            ):
-                # This is a continuation of the current parameter description
-                current_param = DocstringParam(
-                    arg_name=current_param.arg_name,
-                    description=current_param.description
-                    + " "
-                    + line.strip(),
-                )
-            elif not line.startswith(" ") and not line.startswith(
-                "\t"
-            ):
-                # This might be a new section, stop processing args
-                in_args_section = False
-                if current_param:
-                    params.append(current_param)
-                    current_param = None
+        if lowered.startswith(_SECTION_HEADERS):
+            break
 
-    # Add the last parameter if it exists
+        param_match = _PARAM_RE.match(stripped)
+        if param_match:
+            if current_param:
+                params.append(current_param)
+            current_param = DocstringParam(
+                arg_name=param_match.group(1),
+                description=param_match.group(2).strip(),
+            )
+            param_indent = indent
+
     if current_param:
         params.append(current_param)
 


### PR DESCRIPTION
## What is wrong

`parse()` strips every line before parsing:

```python
lines = [line.strip() for line in docstring.strip().split("\n")]
```

and the loop below it then decides what a continuation line is by testing `line.startswith(" ")`, which after that strip can never be true. A wrapped parameter description therefore falls through to the final branch:

```python
elif not line.startswith(" ") and not line.startswith("\t"):
    # This might be a new section, stop processing args
    in_args_section = False
```

So the first line that wraps ends the Args section.

## Why it is wrong

Two things happen to any docstring whose `Args` wrap. The wrapped parameter keeps only its first line, cut mid-sentence, and **every parameter after it is discarded**.

`pydantic_to_json.base_model_to_openai_function` feeds these straight into tool-schema descriptions, so this is what the model is handed. On `master`:

```
query  -> The search phrase to send upstream. Keep it short,
limit  -> None
safe   -> None
```

With this change:

```
query  -> The search phrase to send upstream. Keep it short, because long phrases are truncated by the provider.
limit  -> How many results to return.
safe   -> Whether to enable safe search.
```

Wrapping an `Args` line is normal at this repo's `line-length = 70`, so this is not an edge case.

Separately, `short_description` picked the first non-empty line that was not a section header, without noticing it was inside a section. A docstring opening with `Args:` reported its first parameter as the description.

## What this changes

Use `inspect.cleandoc` to normalise the indentation rather than destroy it, track the indent of the parameter currently being read, and treat a more-indented line as its continuation.

Checking indentation **before** the parameter pattern also fixes a case the old order got wrong: a wrapped line containing a colon, like `properly concatenated: see above`, used to match the parameter regex and be read as a new parameter.

`short_description` now stops at the first section header instead of skipping it.

## Tests

No new test file. The repo already had three tests for exactly this, red since they were written:

```
test_docstring_with_multiline_param_description
test_docstring_with_no_description
test_docstring_with_mixed_indentation
```

`pytest tests/utils/test_docstring_parser.py`: **21 passed**, against 18 passed and 3 failed on `master`.

Both consumers checked. `pytest tests/utils` goes 15 failed to 12, the three being these; the rest are pre-existing credential failures in `test_litellm_wrapper.py`. `pytest tests/tools` is unchanged at 6 failed, 145 passed, 7 errors on both sides.

`black --check` reports one file, `tests/structs/test_agent_rearrange.py`, which is the pre-existing master lint break that #2143 fixes and is untouched here.