### PR TITLE
[FIX][workspace_manager][Stop caching WORKSPACE_DIR for the life of the process]

### DIFF
--- a/swarms/telemetry/bootup.py
+++ b/swarms/telemetry/bootup.py
@@ -10,9 +10,7 @@ def _prepare_workspace() -> None:
     Resolve ``WORKSPACE_DIR`` and make sure that directory exists.
 
     Defers to :func:`ensure_workspace_env` rather than defaulting the variable
-    here as well, so bootup and ``WorkspaceManager`` cannot drift apart — and
-    so ``get_workspace_dir``'s ``lru_cache`` is invalidated when a default has
-    to be invented.
+    here as well, so bootup and ``WorkspaceManager`` cannot drift apart.
 
     A caller-supplied path that cannot be created falls back to the default
     instead of raising: an unusable workspace should not stop ``import
@@ -20,7 +18,6 @@ def _prepare_workspace() -> None:
     """
     # Imported here, not at module scope, which would run initialize_logger before WORKSPACE_DIR settles.
     from swarms.utils.workspace_manager import ensure_workspace_env
-    from swarms.utils.workspace_utils import get_workspace_dir
 
     fallback = Path.cwd() / "agent_workspace"
     workspace = ensure_workspace_env() or str(fallback)
@@ -37,7 +34,6 @@ def _prepare_workspace() -> None:
         )
 
     os.environ["WORKSPACE_DIR"] = str(fallback)
-    get_workspace_dir.cache_clear()
     try:
         fallback.mkdir(parents=True, exist_ok=True)
     except OSError as e:

--- a/swarms/utils/workspace_manager.py
+++ b/swarms/utils/workspace_manager.py
@@ -90,8 +90,6 @@ def ensure_workspace_env(verbose: bool = False) -> Optional[str]:
     if not os.getenv("WORKSPACE_DIR"):
         default = os.path.join(os.getcwd(), DEFAULT_WORKSPACE_DIRNAME)
         os.environ["WORKSPACE_DIR"] = default
-        # get_workspace_dir is lru_cached, so a stale miss would stick.
-        get_workspace_dir.cache_clear()
         if verbose:
             logger.info(
                 f"WORKSPACE_DIR not set, using default: {default}"

--- a/swarms/utils/workspace_utils.py
+++ b/swarms/utils/workspace_utils.py
@@ -1,5 +1,4 @@
 import os
-from functools import lru_cache
 from loguru import logger
 
 
@@ -17,10 +16,14 @@ def check_if_workspace_dir_exists():
     return os.path.exists(workspace_dir)
 
 
-@lru_cache(maxsize=1)
 def get_workspace_dir():
     """
     Retrieve the workspace directory path from the WORKSPACE_DIR environment variable.
+
+    Read on every call. This used to be lru_cached with no arguments, so the
+    first resolved value was frozen for the life of the process and later
+    changes to WORKSPACE_DIR had no effect. os.getenv is a dict lookup, so
+    there was nothing to cache.
 
     Returns:
         str: The absolute path of the workspace directory.

--- a/tests/structs/test_concurrent_workflow.py
+++ b/tests/structs/test_concurrent_workflow.py
@@ -3,7 +3,6 @@ import pytest
 
 from swarms import Agent
 from swarms.structs.concurrent_workflow import ConcurrentWorkflow
-from swarms.utils.workspace_utils import get_workspace_dir
 
 
 def test_concurrent_workflow_basic_execution():
@@ -406,7 +405,6 @@ def test_concurrent_workflow_autosave_creates_workspace_dir(
     monkeypatch, tmp_path
 ):
     """Test that ConcurrentWorkflow with autosave=True creates a workspace directory."""
-    get_workspace_dir.cache_clear()
     monkeypatch.setenv("WORKSPACE_DIR", str(tmp_path))
 
     agent1 = Agent(
@@ -442,14 +440,11 @@ def test_concurrent_workflow_autosave_creates_workspace_dir(
         "Autosave-Concurrent-Workflow" in workflow.swarm_workspace_dir
     )
 
-    get_workspace_dir.cache_clear()
-
 
 def test_concurrent_workflow_autosave_saves_conversation_after_run(
     monkeypatch, tmp_path
 ):
     """Test that ConcurrentWorkflow saves conversation_history.json after run when autosave=True."""
-    get_workspace_dir.cache_clear()
     monkeypatch.setenv("WORKSPACE_DIR", str(tmp_path))
 
     agent1 = Agent(
@@ -486,8 +481,6 @@ def test_concurrent_workflow_autosave_saves_conversation_after_run(
     assert os.path.isfile(
         conversation_path
     ), f"Expected conversation_history.json at {conversation_path}"
-
-    get_workspace_dir.cache_clear()
 
 
 if __name__ == "__main__":

--- a/tests/structs/test_hierarchical_swarm.py
+++ b/tests/structs/test_hierarchical_swarm.py
@@ -9,7 +9,6 @@ from swarms.structs.hiearchical_swarm import (
     HierarchicalOrder,
     HierarchicalSwarm,
 )
-from swarms.utils.workspace_utils import get_workspace_dir
 
 
 def test_hierarchical_swarm_basic_initialization():
@@ -365,7 +364,6 @@ def test_hierarchical_swarm_autosave_creates_workspace_dir(
     monkeypatch, tmp_path
 ):
     """Test that HierarchicalSwarm with autosave=True creates a workspace directory."""
-    get_workspace_dir.cache_clear()
     monkeypatch.setenv("WORKSPACE_DIR", str(tmp_path))
 
     agent1 = Agent(
@@ -400,14 +398,11 @@ def test_hierarchical_swarm_autosave_creates_workspace_dir(
     assert "HierarchicalSwarm" in swarm.swarm_workspace_dir
     assert "Autosave-Test-Swarm" in swarm.swarm_workspace_dir
 
-    get_workspace_dir.cache_clear()
-
 
 def test_hierarchical_swarm_autosave_saves_conversation_after_run(
     monkeypatch, tmp_path
 ):
     """Test that HierarchicalSwarm saves conversation_history.json after run when autosave=True."""
-    get_workspace_dir.cache_clear()
     monkeypatch.setenv("WORKSPACE_DIR", str(tmp_path))
 
     agent1 = Agent(
@@ -445,8 +440,6 @@ def test_hierarchical_swarm_autosave_saves_conversation_after_run(
     assert os.path.isfile(
         conversation_path
     ), f"Expected conversation_history.json at {conversation_path}"
-
-    get_workspace_dir.cache_clear()
 
 
 ##############################################################################

--- a/tests/structs/test_sequential_workflow.py
+++ b/tests/structs/test_sequential_workflow.py
@@ -8,7 +8,6 @@ from swarms.prompts.agent_acknowledgement_prompt import (
     AGENT_COLLAB_PROMPT,
 )
 from swarms.structs.sequential_workflow import DRIFT_DETECTION_PROMPT
-from swarms.utils.workspace_utils import get_workspace_dir
 
 
 def test_sequential_workflow_initialization_with_agents():
@@ -311,7 +310,6 @@ def test_sequential_workflow_autosave_creates_workspace_dir(
     monkeypatch, tmp_path
 ):
     """Test that SequentialWorkflow with autosave=True creates a workspace directory."""
-    get_workspace_dir.cache_clear()
     monkeypatch.setenv("WORKSPACE_DIR", str(tmp_path))
 
     agent1 = Agent(
@@ -340,14 +338,11 @@ def test_sequential_workflow_autosave_creates_workspace_dir(
     assert "SequentialWorkflow" in workflow.swarm_workspace_dir
     assert "Autosave-Test-Workflow" in workflow.swarm_workspace_dir
 
-    get_workspace_dir.cache_clear()
-
 
 def test_sequential_workflow_autosave_saves_conversation_after_run(
     monkeypatch, tmp_path
 ):
     """Test that SequentialWorkflow saves conversation_history.json after run when autosave=True."""
-    get_workspace_dir.cache_clear()
     monkeypatch.setenv("WORKSPACE_DIR", str(tmp_path))
 
     agent1 = Agent(
@@ -384,8 +379,6 @@ def test_sequential_workflow_autosave_saves_conversation_after_run(
     assert os.path.isfile(
         conversation_path
     ), f"Expected conversation_history.json at {conversation_path}"
-
-    get_workspace_dir.cache_clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_workspace_manager.py
+++ b/tests/utils/test_workspace_manager.py
@@ -18,16 +18,13 @@ from swarms.utils.workspace_manager import (
     ensure_workspace_env,
     sanitize_name,
 )
-from swarms.utils.workspace_utils import get_workspace_dir
 
 
 @pytest.fixture(autouse=True)
 def workspace(tmp_path, monkeypatch):
     """Point WORKSPACE_DIR at a tmp dir and clear the lru_cache."""
     monkeypatch.setenv("WORKSPACE_DIR", str(tmp_path))
-    get_workspace_dir.cache_clear()
     yield tmp_path
-    get_workspace_dir.cache_clear()
 
 
 class FakeConversation:
@@ -81,7 +78,6 @@ class TestEnsureWorkspaceEnv:
     def test_defaults_when_unset(self, monkeypatch, tmp_path):
         monkeypatch.delenv("WORKSPACE_DIR", raising=False)
         monkeypatch.chdir(tmp_path)
-        get_workspace_dir.cache_clear()
         resolved = ensure_workspace_env()
         assert resolved.endswith("agent_workspace")
         assert os.environ["WORKSPACE_DIR"] == resolved


### PR DESCRIPTION
## What is wrong

`get_workspace_dir` takes no arguments and is decorated `@lru_cache(maxsize=1)`. Every call therefore shares one cache key, and the first resolved value is frozen for the life of the process:

```python
os.environ["WORKSPACE_DIR"] = "/tmp/first_workspace"
get_workspace_dir()                          # /tmp/first_workspace
os.environ["WORKSPACE_DIR"] = "/tmp/second_workspace"
get_workspace_dir()                          # /tmp/first_workspace   <- stale
```

## Why it is wrong

The body is one `os.getenv`, a dict lookup. The cache saved nothing and bought a correctness bug: anything that sets `WORKSPACE_DIR` after the first read writes to the wrong place, and a long-lived process cannot switch workspaces at all.

The repo was already living with it. Two call sites existed only to work around the cache, `ensure_workspace_env` and `_prepare_workspace`, each calling `cache_clear()` with a comment explaining why. Fifteen more `cache_clear()` calls were scattered across four test files for the same reason.

`tests/structs/test_spreadsheet.py` is where it shows: three tests fail on `master` because that file is the one that did not know about the workaround. Its fixture sets `WORKSPACE_DIR` to a `tmp_path`, `SpreadSheetSwarm` resolves the already-cached value instead, and all three tests write into the repo's real `agent_workspace` and read each other's rows:

```
assert len(rows) == 1
E   AssertionError: assert 3 == 1
```

That also means running the suite leaves CSV files inside the working tree.

## What this changes

Drop the decorator. That is the entire fix; the two source workarounds and the fifteen test `cache_clear()` calls then have nothing to clear, so they go too, along with the imports that only served them. Net deletion.

## Tests

No new tests. The three that already existed in `test_spreadsheet.py` go green on the source change alone, which is better evidence than anything I would add.

Whole-suite failure sets compared rather than counts, `tests/structs tests/agents tests/utils tests/telemetry`, excluding the two files that hang the runner:

```
master:  125 failed, 1609 passed
branch:  121 failed, 1613 passed
branch-only failures: none
fixed:   test_swarm_save_file_path_generation, test_save_to_csv_data,
         test_save_to_csv_appends, test_output_timestamp_persisted_to_csv
```

`black --check` reports one file, `tests/structs/test_agent_rearrange.py`, which is the pre-existing master lint break that #2143 fixes and is untouched here.