### PR TITLE
[Fix] ConcurrentWorkflow.batch_run returns earlier tasks' messages inside every later result (#2041)

### DIFF
--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -166,9 +166,7 @@ class ConcurrentWorkflow:
             self.agent_statuses = {}
 
         self.reliability_check()
-        self.conversation = Conversation(
-            name=f"concurrent_workflow_name_{name}_id_{self.id}_conversation"
-        )
+        self.conversation = self._new_conversation()
 
         if self.show_dashboard is True:
             self.agents = self.fix_agents()
@@ -183,6 +181,19 @@ class ConcurrentWorkflow:
 
         # Capture the full __init__ configuration if telemetry is enabled.
         capture_init(self)
+
+    def _new_conversation(self) -> Conversation:
+        """
+        Build an empty conversation for one task.
+
+        Returns:
+            Conversation: A fresh conversation named after this workflow, used
+                both for the instance's own conversation and for the per-task
+                scopes :meth:`batch_run` runs each task in.
+        """
+        return Conversation(
+            name=f"concurrent_workflow_name_{self.name}_id_{self.id}_conversation"
+        )
 
     def fix_agents(self):
         """
@@ -651,6 +662,10 @@ class ConcurrentWorkflow:
         Each task is executed with all agents running concurrently, but the tasks
         themselves are processed sequentially.
 
+        Every task runs against its own conversation, so a result holds that
+        task's messages and nothing from the tasks before it. The workflow's own
+        conversation is restored afterwards and is left untouched by the batch.
+
         Args:
             tasks (List[str]): List of tasks to be executed.
             imgs (Optional[List[str]]): List of image paths corresponding to each task.
@@ -664,15 +679,20 @@ class ConcurrentWorkflow:
             >>> results = workflow.batch_run(["Task 1", "Task 2", "Task 3"])
         """
         results = []
-        for idx, task in enumerate(tasks):
-            img = None
-            if imgs is not None and idx < len(imgs):
-                img = imgs[idx]
-            results.append(
-                self.run(
-                    task=task,
-                    img=img,
-                    streaming_callback=streaming_callback,
+        workflow_conversation = self.conversation
+        try:
+            for idx, task in enumerate(tasks):
+                img = None
+                if imgs is not None and idx < len(imgs):
+                    img = imgs[idx]
+                self.conversation = self._new_conversation()
+                results.append(
+                    self.run(
+                        task=task,
+                        img=img,
+                        streaming_callback=streaming_callback,
+                    )
                 )
-            )
+        finally:
+            self.conversation = workflow_conversation
         return results

--- a/tests/structs/test_concurrent_workflow.py
+++ b/tests/structs/test_concurrent_workflow.py
@@ -490,5 +490,57 @@ def test_concurrent_workflow_autosave_saves_conversation_after_run(
     get_workspace_dir.cache_clear()
 
 
+class _EchoAgent:
+    """Minimal stand-in for Agent: names itself and echoes the task it was given."""
+
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+
+    def run(self, task: str, img=None, imgs=None, **kwargs) -> str:
+        return f"{self.agent_name} answered: {task}"
+
+
+def test_concurrent_workflow_batch_run_scopes_each_task():
+    """batch_run must not carry an earlier task's messages into a later result (#2041)."""
+    workflow = ConcurrentWorkflow(
+        name="Batch-Scope-Workflow",
+        agents=[_EchoAgent("Alpha"), _EchoAgent("Beta")],
+        output_type="dict",
+    )
+
+    results = workflow.batch_run(
+        ["summarise the first filing", "summarise the second filing"]
+    )
+
+    assert len(results) == 2
+    for result, task in zip(
+        results,
+        ["summarise the first filing", "summarise the second filing"],
+    ):
+        assert len(result) == 3
+        assert result[0] == {"role": "User", "content": task}
+        assert {m["role"] for m in result[1:]} == {"Alpha", "Beta"}
+
+    assert all(
+        "first filing" not in message["content"]
+        for message in results[1]
+    )
+
+
+def test_concurrent_workflow_batch_run_leaves_the_instance_conversation_alone():
+    """The per-task scopes are temporary: batch_run restores the workflow's own conversation (#2041)."""
+    workflow = ConcurrentWorkflow(
+        name="Batch-Restore-Workflow",
+        agents=[_EchoAgent("Alpha"), _EchoAgent("Beta")],
+        output_type="dict",
+    )
+    conversation = workflow.conversation
+
+    workflow.batch_run(["one", "two"])
+
+    assert workflow.conversation is conversation
+    assert conversation.conversation_history == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Part of #2041 — the `ConcurrentWorkflow` row of that issue's table, and only that row.

`ConcurrentWorkflow` builds one `Conversation` in `__init__` and never resets it, so **`batch_run` returns task N's result with tasks 1..N-1 still in it**. Every task is billed and run correctly; the caller is handed the wrong thing back.

## Problem

`_run` (`swarms/structs/concurrent_workflow.py:470`) appends the user turn and every agent answer to `self.conversation`, then returns `history_output_formatter` over that same object (`:514`). `batch_run` (`:639`) loops `self.run(task=...)` on one instance, so nothing ever clears between tasks.

Two shapes of the same defect, depending on `output_type`:

| `output_type` | What `batch_run` returns |
|---|---|
| `dict-all-except-first` (default) | `conversation_history[2:]` — a growing slice, so result N carries every earlier task |
| `dict` | `Conversation.to_dict()` (`conversation.py:834`) returns the **live** `conversation_history` list, not a copy, so every element of the returned list is literally the same object |

Reproducer, two echo agents and two tasks:

```python
workflow = ConcurrentWorkflow(
    name="repro",
    agents=[EchoAgent("Alpha"), EchoAgent("Beta")],
    output_type="dict",
)
results = workflow.batch_run(["task one", "task two"])
```

On `master` @ `6d9e61dd`:

```
messages in results[0] : 6
messages in results[1] : 6
results[0] is results[1]: True
roles in results[1]     : ['User', 'Alpha', 'Beta', 'User', 'Alpha', 'Beta']
results[1] mentions task one: True
```

With this PR:

```
messages in results[0] : 3
messages in results[1] : 3
results[0] is results[1]: False
roles in results[1]     : ['User', 'Alpha', 'Beta']
results[1] mentions task one: False
```

## Fix

| Site | Change |
|---|---|
| `ConcurrentWorkflow._new_conversation` | **new** — the conversation naming that was inline in `__init__`, so the instance conversation and the per-task scopes are built one way |
| `ConcurrentWorkflow.__init__` | calls it instead of constructing `Conversation` inline |
| `ConcurrentWorkflow.batch_run` | a fresh conversation per task, with the workflow's own conversation restored in a `finally` |

`AgentRearrange.batch_run` already solves this with `_clone_for_task` (`agent_rearrange.py:943`), which also deep-copies the agents because it runs tasks in parallel. `ConcurrentWorkflow.batch_run` is documented as sequential — "the tasks themselves are processed sequentially" — so a conversation scope is the whole fix here and cloning agents would be scope creep.

## Behavior-change note

With `autosave=True` the run writes `conversation_history.json` after every task. It now holds the **last task's** conversation rather than the accumulation of all of them. That is the same file a single `run()` produces, so the batch no longer writes a shape nothing else writes.

Callers who relied on `batch_run` returning cumulative history get per-task history instead. That is the documented contract — "List of results for each task" — so this is a fix, not a new option.

## Deliberately not in this PR

- The other structures #2041 names — `AgentRearrange`, `SequentialWorkflow`, `MixtureOfAgents`, `MajorityVoting`, `HierarchicalSwarm`. Each is a different file and a different helper.
- The threading half of #2041 (`run_concurrently` / `concurrent_run` mutating one `Conversation` from N threads, and `AgentRearrange`'s `system_prompt` injection racing). `ConcurrentWorkflow.batch_run` is sequential, so it has the accumulation half without the threading half.
- Repeated `run()` calls on one instance still accumulate. That is instance state a caller can see and reason about; `batch_run` handing back the wrong result is not.

**#2041 should stay open.**

## Verification

- **Unit**: 2 new tests in the existing `tests/structs/test_concurrent_workflow.py` (no new file). Both fail on clean `master` — `assert 6 == 3` and `conversation_history != []` — and pass here.
- **File suite**: `tests/structs/test_concurrent_workflow.py` — **12 passed**.
- **Regression sweep**: every test file that touches `ConcurrentWorkflow` (`tests/test_main_features.py`, `tests/agents/test_autoswarm_writer.py`, `tests/structs/test_swarm_router.py`, `tests/structs/test_concurrent_workflow.py`, `tests/telemetry/test_telemetry.py`) — **273 passed, 9 failed, 5 skipped**. The same 9 fail identically on a clean `upstream/master` worktree (271 passed there, the 2 fewer being these new tests): `test_multi_agent_router`, `test_run_with_multi_agent_router` and 7 telemetry tests, all `litellm` provider errors unrelated to this change.
- **Lint**: `ruff check --select E4,E7,E9,F` (the CI selection for ruff 0.2.1) clean on both files; `black --check` clean.
- The new tests use a local echo agent rather than a live model, so they cost nothing and run offline.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut4g856LnbHeUjA8MawHxo
