### PR TITLE
[Bug] A failed tool is recorded as an LLM error and recovered by re-running the model (#1924)

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -1650,6 +1650,36 @@ class Agent:
                                 loop_count=loop_count
                             )
 
+                    except AgentToolExecutionError as e:
+                        # A tool that already exhausted its own retries is not
+                        # a provider failure. Re-running the model cannot fix
+                        # it and costs another completion, so record it and
+                        # leave the retry loop instead of falling into the
+                        # generation handler below.
+                        if use_transcript and turn_calls:
+                            transcript.flush_tool_results(
+                                turn_calls, turn_results
+                            )
+
+                        capture_error(
+                            e,
+                            self,
+                            name="Agent.tool_error",
+                            loop=loop_count,
+                        )
+
+                        self.short_memory.add(
+                            role="Tool Executor",
+                            content=(
+                                f"Tool execution failed after "
+                                f"{self.tool_retry_attempts} attempts: {e}"
+                            ),
+                        )
+
+                        # Exit the retry loop, not the run: the next loop lets
+                        # the model read the failure and choose differently.
+                        success = True
+
                     except (
                         BadRequestError,
                         InternalServerError,

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1194,6 +1194,53 @@ class TestToolExecutionRetry:
             ), f"attempts={attempts!r} should still run once"
 
 
+class TestToolFailureIsNotAnLLMError:
+    """#1924: a tool that exhausted its own retries raised into the generation
+    handler, which logged it as Agent.llm_error and re-ran the model, so one
+    broken tool cost up to retry_attempts extra completions.
+    """
+
+    @staticmethod
+    def _broken_tool(query: str) -> str:
+        """Always fails.
+
+        Args:
+            query: anything at all.
+        """
+        raise RuntimeError("tool is broken")
+
+    def test_a_failing_tool_does_not_re_run_the_model(self):
+        agent = _patched_agent(
+            "ToolFailAgent",
+            model_name="gpt-5.4",
+            dynamic_tools=False,
+            tools=[self._broken_tool],
+            retry_attempts=3,
+        )
+
+        llm_calls = []
+
+        def fake_call_llm(task=None, *args, **kwargs):
+            llm_calls.append(task)
+            return [
+                {
+                    "type": "function",
+                    "id": "call-1",
+                    "function": {
+                        "name": "_broken_tool",
+                        "arguments": '{"query": "x"}',
+                    },
+                }
+            ]
+
+        agent.call_llm = fake_call_llm
+        agent.run("use the tool")
+
+        assert (
+            len(llm_calls) == 1
+        ), f"a tool failure re-ran the model {len(llm_calls)} times"
+
+
 class TestConcurrentExecutionPool:
     """#1793: both concurrent entry points referenced self.executor, which
     __init__ never assigned — run_concurrent_tasks swallowed the AttributeError


### PR DESCRIPTION
Closes #1924.

## What is wrong

`tool_execution_retry` raises `AgentToolExecutionError` once a tool has exhausted `tool_retry_attempts` (`agent.py:4398`). That call sits at `agent.py:1612`, inside the `try` whose handler is:

```python
except (
    BadRequestError,
    InternalServerError,
    AuthenticationError,
    Exception,
) as e:
```

`AgentToolExecutionError` is an `Exception`, so the tool failure lands in the generation handler, is reported as `Agent.llm_error`, and the retry loop re-runs the model.

## Measured

A tool that always raises, on the unfixed source:

```
AssertionError: a tool failure re-ran the model 3 times
```

and the run ends with:

```
ERROR swarms.structs.agent:_run:1697 - Failed to generate a valid response after retry attempts.
```

So a broken tool costs `retry_attempts` completions and is then blamed on the provider. Nothing in that message points at the tool.

## What this changes

Catch `AgentToolExecutionError` ahead of the generation handler and treat it as what it is:

- flush any tool results recorded before the failure, so the transcript stays well formed
- report it as `Agent.tool_error`, not `Agent.llm_error`
- write the failure into `short_memory` under `Tool Executor`
- leave the retry loop rather than the run

Leaving the retry loop rather than raising is deliberate. The next loop lets the model read that the tool failed and choose something else, which is the behaviour the surrounding retry design already assumes. Raising instead would be a larger semantic change to `Agent.run`.

## Interaction with #1943

Worth flagging since they touch adjacent lines. #1943 adds `raise AgentLLMError` when the generation handler exhausts its attempts. With both landed and without this change, a **tool** failure would surface to callers as `AgentLLMError`, which is a worse version of the same mislabelling. These two are complementary rather than competing; whichever lands second will need a small conflict resolution and I am happy to do it.

## Tests

One test in `tests/structs/test_agent.py`, next to the existing `TestToolExecutionRetry`. It counts `call_llm` invocations for a tool that always raises, so it asserts the behaviour rather than the source. Verified to fail on the unfixed source with the message quoted above.

`pytest tests/structs/test_agent.py tests/agents/test_autonomous_loop.py`: **131 passed**, against 130 on `master`. `black --check`: 950 files unchanged.