### PR TITLE
[FIX][HeavySwarm][Pass img to the question decomposer so workers are not written blind]

### DIFF
--- a/swarms/structs/heavy_swarm.py
+++ b/swarms/structs/heavy_swarm.py
@@ -361,14 +361,14 @@ class HeavySwarm(SerializableMixin):
                                 start()
                                 questions = (
                                     self.execute_question_generation(
-                                        loop_task
+                                        loop_task, img=img
                                     )
                                 )
                                 finish()
                         else:
                             questions = (
                                 self.execute_question_generation(
-                                    loop_task
+                                    loop_task, img=img
                                 )
                             )
 
@@ -1308,13 +1308,16 @@ class HeavySwarm(SerializableMixin):
             }
 
     def execute_question_generation(
-        self, task: str
+        self, task: str, img: Optional[str] = None
     ) -> Dict[str, str]:
         """
         Execute the question generation using the schema with a language model.
 
         Args:
             task (str): The main task to analyze
+            img (Optional[str]): Image accompanying the task. The decomposer
+                writes the questions every worker then answers, so without it
+                a visual task is decomposed from the sentence alone.
 
         Returns:
             Dict[str, str]: Generated questions for each agent role with parsed data
@@ -1375,6 +1378,14 @@ class HeavySwarm(SerializableMixin):
         """
             active_schema = schema
 
+        # Named so the decomposer treats the image as part of the task
+        # rather than guessing at what the sentence refers to.
+        if img:
+            prompt += (
+                "\n        An image accompanies this task. Read it and write "
+                "the questions from what it actually shows.\n"
+            )
+
         max_tokens = 5000 if self.variant == "heavy" else 3000
 
         question_agent = LiteLLM(
@@ -1390,7 +1401,7 @@ class HeavySwarm(SerializableMixin):
         )
 
         # Get raw tool calls from LiteLLM
-        raw_output = question_agent.run(task)
+        raw_output = question_agent.run(task, img=img)
 
         # Parse the tool calls and return clean data
         out = self._parse_tool_calls(raw_output)
@@ -1402,7 +1413,9 @@ class HeavySwarm(SerializableMixin):
 
         return out
 
-    def get_questions_only(self, task: str) -> Dict[str, str]:
+    def get_questions_only(
+        self, task: str, img: Optional[str] = None
+    ) -> Dict[str, str]:
         """
         Generate and extract only the specialized questions without metadata or execution.
 
@@ -1434,7 +1447,7 @@ class HeavySwarm(SerializableMixin):
             >>> questions = swarm.get_questions_only("Analyze market trends for EVs")
             >>> print(questions['research_question'])
         """
-        result = self.execute_question_generation(task)
+        result = self.execute_question_generation(task, img=img)
 
         if "error" in result:
             return {"error": result["error"]}
@@ -1482,7 +1495,9 @@ class HeavySwarm(SerializableMixin):
             ),
         }
 
-    def get_questions_as_list(self, task: str) -> List[str]:
+    def get_questions_as_list(
+        self, task: str, img: Optional[str] = None
+    ) -> List[str]:
         """
         Generate specialized questions and return them as an ordered list.
 
@@ -1520,7 +1535,7 @@ class HeavySwarm(SerializableMixin):
             This method internally calls get_questions_only() and converts the dictionary
             to a list format, maintaining the standard agent order.
         """
-        questions = self.get_questions_only(task)
+        questions = self.get_questions_only(task, img=img)
 
         if "error" in questions:
             return [f"Error: {questions['error']}"]

--- a/tests/structs/test_heavy_swarm.py
+++ b/tests/structs/test_heavy_swarm.py
@@ -470,6 +470,58 @@ class TestGrokHeavyPrompts:
 # ============================================================================
 
 
+class TestQuestionDecomposerSeesTheImage:
+    """#1903: the decomposer writes the questions every worker answers, but it
+    took only `task`, so a visual run decomposed the sentence and guessed at
+    the image.
+    """
+
+    def _capture(self, monkeypatch):
+        seen = {}
+
+        class FakeLiteLLM:
+            def __init__(self, **kwargs):
+                seen["prompt"] = kwargs.get("system_prompt", "")
+
+            def run(self, task, *args, **kwargs):
+                seen["task"] = task
+                seen["img"] = kwargs.get("img")
+                return ""
+
+        monkeypatch.setattr(
+            "swarms.structs.heavy_swarm.LiteLLM", FakeLiteLLM
+        )
+        return seen
+
+    def test_img_reaches_the_question_agent(self, monkeypatch):
+        seen = self._capture(monkeypatch)
+        swarm = HeavySwarm(
+            worker_model_name=MODEL,
+            question_agent_model_name=MODEL,
+            variant="medium",
+        )
+
+        swarm.execute_question_generation(
+            "What does this chart imply?", img="revenue.png"
+        )
+
+        assert seen["img"] == "revenue.png"
+        assert "An image accompanies this task" in seen["prompt"]
+
+    def test_text_only_runs_are_unchanged(self, monkeypatch):
+        seen = self._capture(monkeypatch)
+        swarm = HeavySwarm(
+            worker_model_name=MODEL,
+            question_agent_model_name=MODEL,
+            variant="medium",
+        )
+
+        swarm.execute_question_generation("A text-only task")
+
+        assert seen["img"] is None
+        assert "An image accompanies this task" not in seen["prompt"]
+
+
 class TestSwarmRouterGrokIntegration:
     """Verify SwarmRouter passes through grok flag."""
 


### PR DESCRIPTION
Closes #1903.

## What is wrong

`execute_question_generation` took only the task:

```python
def execute_question_generation(self, task: str) -> Dict[str, str]:   # heavy_swarm.py:1310
```

So given:

```python
swarm.run("What does this chart imply for Q3 guidance?", img="revenue.png")
```

the decomposer gets the sentence and nothing else. It guesses what the image contains, writes four questions (`medium`) or fifteen (`heavy`) from that guess, and **those are the questions every worker answers**. #1902 got the image to the workers; they were still answering questions written by something that could not see it.

The same gap applied to `get_questions_only()` and `get_questions_as_list()`, both public.

## What this changes

The fix I proposed on the issue, unchanged:

- `img: Optional[str] = None` on `execute_question_generation` and both public helpers
- threaded from `run()`, where `img` was already in scope
- passed to the question agent, whose `run()` already accepts `img`
- one prompt line, appended only when an image is present, so the model treats it as part of the task rather than guessing what the sentence refers to

## On sending this without a direction from you

The issue ended with me offering to wait for a decision on where the image should go. That was 17 days ago with no reply, so I have sent the version I proposed there rather than let it sit. It is the conservative option: `img=None` keeps every text-only path byte-identical, and the shape is easy to change if you want it elsewhere.

## Tests

Two, in the file that already owns `HeavySwarm`. One asserts the image and the prompt line reach the question agent; the other pins that a text-only run still passes `img=None` and gets no extra prompt line, which is the backwards-compatibility claim above.

Verified the first fails on the unfixed source. `pytest tests/structs/test_heavy_swarm.py`: **61 passed, 10 skipped**, against 59 passed and 10 skipped on `master`, the difference being these two. `black --check`: 950 files unchanged.