### PR TITLE
fix(autonomous-loop): cap tool output by token budget, not characters

### DIFF
--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -35,9 +35,7 @@ from typing import Any, Dict, List
 from loguru import logger
 
 from swarms.structs.async_subagent import SubagentRegistry, TaskStatus
-
-# Constants.
-
+from swarms.utils.litellm_tokenizer import DEFAULT_MODEL, count_tokens
 
 # Maximum iterations to prevent infinite loops
 MAX_PLANNING_ATTEMPTS = 5
@@ -45,23 +43,44 @@ MAX_SUBTASK_ITERATIONS = 100
 MAX_SUBTASK_LOOPS = 20
 MAX_CONSECUTIVE_THINKS = 2
 
-# The loop re-serializes its history into every later prompt, so one oversized
-# tool result is paid for on every remaining call of the run.
-MAX_TOOL_OUTPUT_CHARS = 65536
+# The loop re-serializes its history into every later prompt, so one oversized tool result is paid for on every remaining call of the run.
+TOOL_OUTPUT_CONTEXT_SHARE = 0.25
+
+# Used when the caller has no context window to share, e.g. a tool called outside an agent.
+DEFAULT_TOOL_OUTPUT_TOKENS = 4096
 
 
-def truncate_tool_output(text: str) -> str:
-    """Cap a tool result, telling the model how much it is not seeing."""
-    if len(text) <= MAX_TOOL_OUTPUT_CHARS:
+def truncate_tool_output(
+    text: str,
+    context_window: int = None,
+    model_name: str = DEFAULT_MODEL,
+) -> str:
+    """Cap a tool result at a share of the context window, telling the model how much it is not seeing."""
+    if not text:
         return text
-    return (
-        text[:MAX_TOOL_OUTPUT_CHARS]
-        + "\n... (output truncated: showing the first "
-        + f"{MAX_TOOL_OUTPUT_CHARS} of {len(text)} characters)"
+
+    budget = (
+        int(context_window * TOOL_OUTPUT_CONTEXT_SHARE)
+        if context_window
+        else DEFAULT_TOOL_OUTPUT_TOKENS
     )
 
+    total_tokens = count_tokens(text, model=model_name)
+    if total_tokens <= budget:
+        return text
 
-# Prompts.
+    # count_tokens has no decode counterpart, so cut by the text's own token density, then shrink until it fits.
+    kept = text[: max(1, int(len(text) * budget / total_tokens))]
+    kept_tokens = count_tokens(kept, model=model_name)
+    while kept_tokens > budget and len(kept) > 1:
+        kept = kept[: int(len(kept) * 0.9)]
+        kept_tokens = count_tokens(kept, model=model_name)
+
+    return (
+        kept
+        + "\n... (output truncated: showing the first "
+        + f"{kept_tokens} of {total_tokens} tokens)"
+    )
 
 
 def get_planning_prompt(task: str) -> str:
@@ -800,7 +819,11 @@ def read_file_tool(agent: Any, file_path: str, **kwargs) -> str:
         # Read file
         with open(full_path, "r", encoding="utf-8") as f:
             raw = f.read()
-        content = truncate_tool_output(raw)
+        content = truncate_tool_output(
+            raw,
+            context_window=agent.context_length,
+            model_name=agent.model_name,
+        )
 
         # Add to memory
         agent.short_memory.add(
@@ -1096,7 +1119,11 @@ def run_bash_tool(
         if agent.verbose:
             logger.info(f"Executed bash command: {command[:80]}...")
 
-        return truncate_tool_output(result_msg.strip())
+        return truncate_tool_output(
+            result_msg.strip(),
+            context_window=agent.context_length,
+            model_name=agent.model_name,
+        )
     except subprocess.TimeoutExpired:
         error_msg = f"Error: Command timed out after {timeout_seconds} seconds"
         logger.error(error_msg)
@@ -1187,7 +1214,11 @@ def grep_tool(
         stderr = result.stderr or ""
 
         # Truncate oversized output
-        stdout = truncate_tool_output(stdout)
+        stdout = truncate_tool_output(
+            stdout,
+            context_window=agent.context_length,
+            model_name=agent.model_name,
+        )
 
         if result.returncode == 0:
             output = stdout.strip() or "(no matches)"

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -35,9 +35,10 @@ from swarms import Agent
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
 from swarms.structs.autonomous_loop_utils import (
     MAX_SUBTASK_LOOPS,
-    MAX_TOOL_OUTPUT_CHARS,
+    TOOL_OUTPUT_CONTEXT_SHARE,
     read_file_tool,
 )
+from swarms.utils.litellm_tokenizer import count_tokens
 
 
 # --------------------------------------------------------------------------
@@ -232,14 +233,31 @@ class TestToolOutputIsCapped:
     """One oversized read is re-sent on every later call of the run."""
 
     def test_read_file_truncates_a_large_file(self, tmp_path):
-        agent = build_agent()
+        agent = build_agent(context_length=16000)
+        budget = int(agent.context_length * TOOL_OUTPUT_CONTEXT_SHARE)
         big = tmp_path / "big.txt"
-        big.write_text("x" * (MAX_TOOL_OUTPUT_CHARS + 5000))
+        big.write_text("word " * (budget * 2))
 
         output = read_file_tool(agent, str(big))
 
-        assert len(output) < MAX_TOOL_OUTPUT_CHARS + 200
         assert "output truncated" in output
+        assert (
+            count_tokens(output, model=agent.model_name)
+            <= budget + 50
+        )
+
+    def test_budget_follows_the_agent_context_window(self, tmp_path):
+        big = tmp_path / "big.txt"
+        big.write_text("word " * 20000)
+
+        small = read_file_tool(
+            build_agent(context_length=16000), str(big)
+        )
+        large = read_file_tool(
+            build_agent(context_length=128000), str(big)
+        )
+
+        assert len(large) > len(small)
 
 
 class TestBatchedToolCalls:


### PR DESCRIPTION
## What is wrong

`truncate_tool_output` capped a tool result at a fixed **character** count:

```python
MAX_TOOL_OUTPUT_CHARS = 65536

def truncate_tool_output(text: str) -> str:
    if len(text) <= MAX_TOOL_OUTPUT_CHARS:
        return text
```

Two problems follow from that:

- The cap is unrelated to what the model can hold. The same 65536 characters were kept for an agent with a 16k context window and for one with 128k — too much for the first, needlessly little for the second.
- Characters are a poor proxy for tokens. The ratio swings widely between prose, minified JSON, base64 and non-Latin text, so the real cost of a capped result was never known.

## What this changes

`truncate_tool_output` now measures with `count_tokens(text, model=model_name)`, so the count comes from the agent's own model's tokenizer, and the budget is a share of the agent's context window:

```python
TOOL_OUTPUT_CONTEXT_SHARE = 0.25
DEFAULT_TOOL_OUTPUT_TOKENS = 4096   # when no window is passed
```

The three call sites — `read_file_tool`, `run_bash_tool` and `grep_tool` — all have the agent in hand and now pass `context_window=agent.context_length` and `model_name=agent.model_name`. Those are the only callers of the function.

`count_tokens` has no decode counterpart, so the cut is made by the text's own token density and then shrunk until it fits. The truncation notice reports tokens kept versus total rather than characters.

`MAX_TOOL_OUTPUT_CHARS` is gone; nothing outside this module referenced it.

## Behaviour change worth a second opinion

The share is 0.25 of the context window. On the 16000-token default that is a 4000-token cap, tighter than the old 65536 characters; on a large-context model it is far more generous. The intent is that one tool result cannot claim the whole window, since the loop re-serializes its history into every later prompt.

## Tests

`tests/agents/test_autonomous_loop.py`: the existing truncation test now asserts a token budget, plus a new test pinning that a 128k-context agent keeps more output than a 16k one. Both were verified to fail against the unpatched function.

`tests/agents/test_autonomous_loop.py tests/structs/test_agent.py tests/tools`: 283 passed, 6 failed. All six (`test_base_tool.py`, `test_parse_tools.py`) fail identically on `master` and are unrelated.
