### PR TITLE
docs(skill): correct reasoning_effort default in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -71,7 +71,7 @@ result = agent.run("Summarize the state of the semiconductor market.")
 | `print_on` | `bool` | `True` | Print the final output |
 | `autosave` | `bool` | `False` | Persist agent state after each run |
 | `retry_attempts` | `int` | `3` | LLM call retries |
-| `reasoning_effort` | `str` | `"medium"` | `minimal`/`low`/`medium`/`high`/`xhigh`/`ultra`/`max`/`none` |
+| `reasoning_effort` | `str` | `None` | `minimal`/`low`/`medium`/`high`/`xhigh`/`ultra`/`max`/`none` |
 | `thinking_tokens` | `int` | `1024` | Extended thinking budget (Claude) |
 | `mcp_url` / `mcp_urls` | `str` / `list[str]` | `None` | MCP servers to load tools from |
 | `handoffs` | `list[Agent]` | `None` | Agents this one may delegate to |


### PR DESCRIPTION
### Problem

`SKILL.md` (the agent-facing parameter reference, stated to be "verified against swarms v14.0.0") documents the default value of `reasoning_effort` as `"medium"`:

| Parameter | Type | Default | Purpose |
|---|---|---|---|
| `reasoning_effort` | `str` | `"medium"` | `minimal`/`low`/... |

But `Agent.__init__` actually defaults it to `None`, not `"medium"`:

```python
# swarms/structs/agent.py
reasoning_effort: Optional[ReasoningEffort] = None,
...
self.reasoning_effort = reasoning_effort   # assigned unchanged, no coercion
```

So an agent constructed without an explicit `reasoning_effort` gets `None` (no reasoning-effort applied), not `"medium"`. The doc leads readers to believe medium reasoning is on by default, which is incorrect.

### Fix

Change the documented default in the SKILL.md parameter table from `"medium"` to `None`. This matches the source and is consistent with how the same table already documents the other nullable parameters (`top_p`, `context_length`, `mcp_url`, `fallback_models` all show a `None` default while keeping their non-null type in the Type column).

### How to verify

```bash
grep -n "reasoning_effort" swarms/structs/agent.py
# -> reasoning_effort: Optional[ReasoningEffort] = None,
# -> self.reasoning_effort = reasoning_effort

python -c "from swarms import Agent; print(Agent(agent_name='t', model_name='gpt-4o-mini').reasoning_effort)"
# -> None
```

`grep -rn "reasoning_effort" swarms/` confirms the value is never coerced to `"medium"` anywhere. Docs-only change; no code touched.