### PR TITLE
[FIX][run_bash][Run in the agent workspace, not the process cwd]

### DIFF
--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -1081,15 +1081,21 @@ def run_bash_tool(
     # -------------------------------------------------------------------------
 
     try:
-        # Run in process cwd (where the user started the script) so commands like
-        # ls -la and python script.py see the project directory, not the agent workspace.
+        workspace_dir = agent._get_agent_workspace_dir()
+        os.makedirs(workspace_dir, exist_ok=True)
+
         result = subprocess.run(
             command,
             shell=True,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
-            cwd=None,  # use process current working directory
+            # The agent workspace, not the process cwd. Every file tool
+            # resolves relative paths against the workspace, so leaving bash
+            # in the launch directory gave the two halves of the toolset
+            # different views: create_file("notes.md") then run_bash("ls")
+            # would not show the file it had just written.
+            cwd=workspace_dir,
             encoding="utf-8",
             errors="replace",
         )

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -28,6 +28,7 @@ Run:
 """
 
 import json
+import os
 
 import pytest
 
@@ -36,7 +37,9 @@ from swarms.agents.autonomous_loop import AutonomousAgentLoop
 from swarms.structs.autonomous_loop_utils import (
     MAX_SUBTASK_LOOPS,
     TOOL_OUTPUT_CONTEXT_SHARE,
+    create_file_tool,
     read_file_tool,
+    run_bash_tool,
 )
 from swarms.utils.litellm_tokenizer import count_tokens
 
@@ -258,6 +261,34 @@ class TestToolOutputIsCapped:
         )
 
         assert len(large) > len(small)
+
+
+class TestBashSharesTheFileToolsRoot:
+    """#1970: run_bash ran in the process cwd while every file tool resolved
+    against the agent workspace, so the two halves of the toolset disagreed
+    about what the filesystem looked like.
+    """
+
+    def test_bash_sees_a_file_the_file_tools_just_wrote(self):
+        agent = build_agent()
+        create_file_tool(agent, "notes.md", "written by create_file")
+
+        listing = run_bash_tool(agent, "ls")
+
+        assert (
+            "notes.md" in listing
+        ), f"run_bash cannot see what create_file wrote: {listing[:200]}"
+
+    def test_bash_pwd_is_the_agent_workspace(self):
+        agent = build_agent()
+        workspace = os.path.realpath(agent._get_agent_workspace_dir())
+
+        out = run_bash_tool(agent, "pwd")
+
+        assert (
+            os.path.realpath(out.strip().splitlines()[-1])
+            == workspace
+        )
 
 
 class TestBatchedToolCalls:


### PR DESCRIPTION
Closes #1970.

## What is wrong

`run_bash_tool` passed `cwd=None`:

```python
result = subprocess.run(
    command, shell=True, ..., cwd=None,   # use process current working directory
)
```

while every file tool resolves relative paths against the agent workspace:

```python
if not os.path.isabs(file_path):
    workspace_dir = agent._get_agent_workspace_dir()
    full_path = os.path.join(workspace_dir, file_path)
```

So the two halves of the same toolset disagree about what the filesystem looks like. `create_file("notes.md")` writes to the workspace; `run_bash("ls")` lists whatever directory the user happened to launch the script from.

Reproduced, and it is as blunt as it sounds:

```
FAILED test_bash_sees_a_file_the_file_tools_just_wrote
FAILED test_bash_pwd_is_the_agent_workspace
```

The model has no way to reason about this. It writes a file, cannot find it, and writes it again.

## What this changes

`cwd=workspace_dir`, the same root the file tools use, with a `makedirs(..., exist_ok=True)` first because a fresh agent may not have a workspace yet and `subprocess.run` raises if `cwd` does not exist.

## Note on direction

The old comment argued for the process cwd so `ls -la` and `python script.py` would see the project directory. That is a coherent position, but it is not the one the rest of the toolset takes, and an agent cannot use a toolset whose halves disagree. If you would rather move the **file tools** to the process cwd instead, that is the same one-line decision in the other direction and I will send it that way.

Worth knowing: my #1815 confines the file tools to the workspace. It and this change point the same way, so if both land the agent gets one coherent root. They touch different functions in the same file, so expect at most a trivial conflict.

## Tests

Two, in the file that owns the loop, asserting behaviour rather than the argument: bash can see a file `create_file` just wrote, and `pwd` is the workspace. Both verified to fail on the unfixed source.

`pytest tests/agents/test_autonomous_loop.py`: **45 passed**, up from 43. `black --check`: 950 files unchanged.