### PR TITLE
feat(swarm-router): fallback_swarms tries the next swarm type when one fails

### DIFF
--- a/examples/multi_agent/swarm_router/README.md
+++ b/examples/multi_agent/swarm_router/README.md
@@ -10,6 +10,7 @@ This directory contains examples demonstrating swarm routing patterns for direct
 - [sr_moa_example.py](sr_moa_example.py) - Swarm router with MOA
 - [swarm_router_benchmark.py](swarm_router_benchmark.py) - Router performance benchmarking
 - [swarm_router_example.py](swarm_router_example.py) - Basic swarm router example
+- [swarm_router_fallback_example.py](swarm_router_fallback_example.py) - `fallback_swarms`: try the next swarm type when the first one fails
 - [swarm_router_test.py](swarm_router_test.py) - Router testing suite
 - [swarm_router.py](swarm_router.py) - Core swarm router implementation
 

--- a/examples/multi_agent/swarm_router/swarm_router_fallback_example.py
+++ b/examples/multi_agent/swarm_router/swarm_router_fallback_example.py
@@ -1,0 +1,58 @@
+"""
+SwarmRouter with fallback swarms.
+
+``fallback_swarms`` is an ordered list of swarm types to try when the primary
+``swarm_type`` raises during a run. Each fallback is built from the same agents
+and configuration; the first one to complete wins. If every swarm in the chain
+fails, ``SwarmRouterRunError`` is raised naming each attempt.
+
+After a run, ``router.active_swarm_type`` says which swarm actually served it
+and ``router.fallback_attempts`` lists the ones that failed first.
+
+Run:
+    export OPENAI_API_KEY=...
+    python examples/multi_agent/swarm_router/swarm_router_fallback_example.py
+"""
+
+from swarms import Agent, SwarmRouter
+
+agents = [
+    Agent(
+        agent_name="Researcher",
+        system_prompt="You gather the facts relevant to the task.",
+        model_name="gpt-5.4",
+        max_loops=1,
+    ),
+    Agent(
+        agent_name="Analyst",
+        system_prompt="You weigh the evidence and draw conclusions.",
+        model_name="gpt-5.4",
+        max_loops=1,
+    ),
+    Agent(
+        agent_name="Writer",
+        system_prompt="You turn conclusions into a clear brief.",
+        model_name="gpt-5.4",
+        max_loops=1,
+    ),
+]
+
+router = SwarmRouter(
+    name="resilient-router",
+    agents=agents,
+    swarm_type="HierarchicalSwarm",
+    # Tried in order, only if the swarm before it raises.
+    fallback_swarms=["SequentialWorkflow", "ConcurrentWorkflow"],
+    max_loops=1,
+)
+
+result = router.run(
+    "Assess whether a mid-size SaaS company should adopt usage-based pricing."
+)
+
+print(result)
+print(f"\nserved by: {router.active_swarm_type}")
+for attempt in router.fallback_attempts:
+    print(
+        f"failed first: {attempt['swarm_type']} -> {attempt['error']}"
+    )

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -132,6 +132,47 @@ def _msg_batch_run_error(err: Exception, tb: str) -> str:
     return f"SwarmRouter: Error executing batch task on swarm: {err} Traceback: {tb}"
 
 
+def _msg_fallback_swarms_not_list(actual_type: str) -> str:
+    return (
+        f"SwarmRouter fallback_swarms must be a list of swarm type "
+        f"strings, got {actual_type}."
+    )
+
+
+def _msg_invalid_fallback_swarm_type(swarm_type, valid_types) -> str:
+    return (
+        f"SwarmRouter fallback_swarms entry {swarm_type!r} is not a "
+        f"valid swarm type. Valid types: {', '.join(valid_types)}"
+    )
+
+
+def _msg_fallback_rearrange_flow_required() -> str:
+    return (
+        "SwarmRouter fallback_swarms includes 'AgentRearrange', which "
+        "requires rearrange_flow to be set."
+    )
+
+
+def _msg_swarm_failed_trying_next(
+    swarm_type: str, next_type: str, err: Exception
+) -> str:
+    return (
+        f"SwarmRouter swarm '{swarm_type}' failed: {err}. "
+        f"Falling back to '{next_type}'."
+    )
+
+
+def _msg_all_swarms_failed(attempts) -> str:
+    tried = "; ".join(
+        f"{a['swarm_type']}: {type(a['error']).__name__}: {a['error']}"
+        for a in attempts
+    )
+    return (
+        f"SwarmRouter exhausted every swarm type without a successful "
+        f"run. Attempts: {tried}"
+    )
+
+
 def _msg_collab_prompt_ignored(swarm_type: str) -> str:
     return (
         f"multi_agent_collab_prompt is ignored for swarm_type={swarm_type!r}; "
@@ -181,6 +222,10 @@ class SwarmRouterConfig(BaseModel):
     )
     multi_agent_collab_prompt: bool = Field(
         description="Whether to enable multi-agent collaboration prompts",
+    )
+    fallback_swarms: Optional[List[SwarmType]] = Field(
+        default=None,
+        description="Swarm types to try, in order, if the primary swarm fails",
     )
     task: str = Field(
         description="The task to be executed by the swarm",
@@ -243,6 +288,13 @@ class SwarmRouter(SerializableMixin):
         rearrange_flow (str, optional): Required when
             ``swarm_type="AgentRearrange"``. Flow-DSL string like
             ``"A -> B, C -> D"``.
+        fallback_swarms (List[SwarmType], optional): Swarm types to try, in
+            order, when the primary ``swarm_type`` raises during a run. Each
+            fallback is built from the same agents and configuration. The
+            first swarm to complete wins; if every one fails,
+            :class:`SwarmRouterRunError` is raised carrying every attempt.
+            Defaults to ``None`` (no fallback: the primary swarm's error
+            propagates unchanged).
         output_type (OutputType, optional): How the final swarm output is
             formatted. Defaults to ``"dict-all-except-first"``.
         multi_agent_collab_prompt (bool, optional): Append the multi-agent
@@ -287,6 +339,10 @@ class SwarmRouter(SerializableMixin):
         agents (List[Union[Agent, Callable]]): The configured agent roster.
         swarm: The lazily-constructed underlying swarm instance (populated on
             first ``run()``).
+        active_swarm_type (str): The swarm type that served the most recent
+            run — the primary ``swarm_type`` unless a fallback was used.
+        fallback_attempts (List[dict]): One ``{"swarm_type", "error"}`` entry
+            per swarm that failed during the most recent run.
         swarm_workspace_dir (str | None): Autosave workspace, set when
             ``autosave=True``.
         logs (list): Per-instance log buffer.
@@ -321,6 +377,7 @@ class SwarmRouter(SerializableMixin):
         swarm_type: SwarmType = "SequentialWorkflow",
         autosave: bool = False,
         rearrange_flow: str = None,
+        fallback_swarms: Optional[List[SwarmType]] = None,
         output_type: OutputType = "dict",
         multi_agent_collab_prompt: bool = False,
         list_all_agents: bool = False,
@@ -366,6 +423,7 @@ class SwarmRouter(SerializableMixin):
         self.swarm_type = swarm_type
         self.autosave = autosave
         self.rearrange_flow = rearrange_flow
+        self.fallback_swarms = fallback_swarms
         self.output_type = output_type
         self.logs = []
         self.multi_agent_collab_prompt = multi_agent_collab_prompt
@@ -398,6 +456,8 @@ class SwarmRouter(SerializableMixin):
         self._swarm_cache = {}  # Cache for created swarms
         # Built lazily on the first run.
         self.swarm = None
+        self.active_swarm_type = swarm_type
+        self.fallback_attempts = []
 
         # Always built: a disabled manager no-ops, an absent one raises.
         self._setup_autosave()
@@ -434,6 +494,8 @@ class SwarmRouter(SerializableMixin):
               members.
             * ``rearrange_flow`` is provided when ``swarm_type="AgentRearrange"``.
             * ``max_loops != 0``.
+            * ``fallback_swarms``, if given, is a list of valid swarm types,
+              and ``rearrange_flow`` is set if it includes ``AgentRearrange``.
 
         On success, calls :meth:`setup` to apply collaboration prompts and
         agent listing.
@@ -479,6 +541,28 @@ class SwarmRouter(SerializableMixin):
             # Validate max_loops
             if self.max_loops == 0:
                 raise SwarmRouterConfigError(_msg_max_loops_zero())
+
+            if self.fallback_swarms is not None:
+                if not isinstance(self.fallback_swarms, list):
+                    raise SwarmRouterConfigError(
+                        _msg_fallback_swarms_not_list(
+                            type(self.fallback_swarms).__name__
+                        )
+                    )
+                for fallback in self.fallback_swarms:
+                    if fallback not in valid_swarm_types:
+                        raise SwarmRouterConfigError(
+                            _msg_invalid_fallback_swarm_type(
+                                fallback, valid_swarm_types
+                            )
+                        )
+                if (
+                    "AgentRearrange" in self.fallback_swarms
+                    and self.rearrange_flow is None
+                ):
+                    raise SwarmRouterConfigError(
+                        _msg_fallback_rearrange_flow_required()
+                    )
 
             self.setup()
 
@@ -738,13 +822,20 @@ class SwarmRouter(SerializableMixin):
             **kwargs,
         )
 
-    def _compute_swarm_cache_key(self):
+    def _compute_swarm_cache_key(
+        self, swarm_type: Optional[str] = None
+    ):
         """Build a stable cache key for the underlying swarm instance.
 
         Keyed on swarm_type, agent identities, and construction-time config.
         Per-call task/img/tasks args are intentionally excluded — those are
         passed to ``swarm.run()`` and must not invalidate the cached swarm.
+
+        Args:
+            swarm_type (str, optional): The swarm type being keyed. Defaults
+                to ``self.swarm_type``; fallbacks pass their own.
         """
+        swarm_type = swarm_type or self.swarm_type
         agent_ids = tuple(
             getattr(a, "agent_name", None)
             or getattr(a, "__name__", None)
@@ -771,10 +862,16 @@ class SwarmRouter(SerializableMixin):
             config_hash = hash(config)
         except TypeError:
             config_hash = hash(repr(config))
-        return (self.swarm_type, agent_ids, config_hash)
+        return (swarm_type, agent_ids, config_hash)
 
-    def _create_swarm(self, task: str = None, *args, **kwargs):
-        """Create or return the cached swarm selected by ``self.swarm_type``.
+    def _create_swarm(
+        self,
+        task: str = None,
+        swarm_type: Optional[str] = None,
+        *args,
+        **kwargs,
+    ):
+        """Create or return the cached swarm for ``swarm_type``.
 
         The task is accepted for call-site compatibility but is not part of the
         cache key and is not passed to the factory. Runtime inputs such as
@@ -783,6 +880,8 @@ class SwarmRouter(SerializableMixin):
         Args:
             task (str, optional): Runtime task associated with the creation
                 request. Defaults to ``None``.
+            swarm_type (str, optional): Which swarm to build. Defaults to
+                ``self.swarm_type``; :meth:`_run` passes each fallback here.
             *args: Positional arguments forwarded to the selected factory.
             **kwargs: Keyword arguments forwarded to the selected factory.
 
@@ -794,18 +893,20 @@ class SwarmRouter(SerializableMixin):
             RuntimeError: If the selected factory fails.
         """
 
-        cache_key = self._compute_swarm_cache_key()
+        swarm_type = swarm_type or self.swarm_type
+
+        cache_key = self._compute_swarm_cache_key(swarm_type)
         cached = self._swarm_cache.get(cache_key)
         if cached is not None:
-            self._log("debug", _msg_swarm_cached(self.swarm_type))
+            self._log("debug", _msg_swarm_cached(swarm_type))
             return cached
 
         # Use factory pattern for O(1) lookup
-        factory_func = self._swarm_factory.get(self.swarm_type)
+        factory_func = self._swarm_factory.get(swarm_type)
         if factory_func is None:
             raise ValueError(
                 _msg_invalid_factory_type(
-                    self.swarm_type, list(self._swarm_factory.keys())
+                    swarm_type, list(self._swarm_factory.keys())
                 )
             )
 
@@ -816,15 +917,13 @@ class SwarmRouter(SerializableMixin):
             # Cache the created swarm for future use
             self._swarm_cache[cache_key] = swarm
 
-            self._log("info", _msg_swarm_created(self.swarm_type))
+            self._log("info", _msg_swarm_created(swarm_type))
             return swarm
 
         except Exception as e:
-            self._log(
-                "error", _msg_factory_failed(self.swarm_type, e)
-            )
+            self._log("error", _msg_factory_failed(swarm_type, e))
             raise RuntimeError(
-                _msg_factory_failed(self.swarm_type, e)
+                _msg_factory_failed(swarm_type, e)
             ) from e
 
     def list_agents_to_eachother(self):
@@ -836,7 +935,7 @@ class SwarmRouter(SerializableMixin):
         if self.swarm is None:
             return
 
-        if self.swarm_type == "SequentialWorkflow":
+        if self.active_swarm_type == "SequentialWorkflow":
             self.conversation = getattr(
                 self.swarm.agent_rearrange, "conversation", None
             )
@@ -867,20 +966,50 @@ class SwarmRouter(SerializableMixin):
 
         Returns:
             Any: Result returned by the underlying swarm.
-        """
-        self.swarm = self._create_swarm(task, *args, **kwargs)
 
-        args = {}
+        Raises:
+            SwarmRouterRunError: If ``fallback_swarms`` is set and every swarm
+                type, primary and fallbacks alike, fails.
+            Exception: Without fallbacks, whatever the swarm raised.
+        """
+        run_kwargs = {}
 
         if tasks is not None:
-            args["tasks"] = tasks
+            run_kwargs["tasks"] = tasks
         else:
-            args["task"] = task
+            run_kwargs["task"] = task
 
         if img is not None:
-            args["img"] = img
+            run_kwargs["img"] = img
 
-        result = self.swarm.run(**args, **kwargs)
+        chain = [self.swarm_type] + list(self.fallback_swarms or [])
+        self.fallback_attempts = []
+
+        for position, swarm_type in enumerate(chain):
+            try:
+                self.swarm = self._create_swarm(
+                    task, swarm_type, *args, **kwargs
+                )
+                self.active_swarm_type = swarm_type
+                result = self.swarm.run(**run_kwargs, **kwargs)
+                break
+            except Exception as e:
+                # No fallbacks configured: the caller sees the original error.
+                if len(chain) == 1:
+                    raise
+                self.fallback_attempts.append(
+                    {"swarm_type": swarm_type, "error": e}
+                )
+                if position + 1 < len(chain):
+                    logger.warning(
+                        _msg_swarm_failed_trying_next(
+                            swarm_type, chain[position + 1], e
+                        )
+                    )
+        else:
+            raise SwarmRouterRunError(
+                _msg_all_swarms_failed(self.fallback_attempts)
+            ) from self.fallback_attempts[-1]["error"]
 
         self.list_agents_to_eachother()
 
@@ -892,6 +1021,14 @@ class SwarmRouter(SerializableMixin):
                 "task": task if task else None,
                 "tasks": tasks if tasks else None,
                 "status": "completed",
+                "swarm_type": self.active_swarm_type,
+                "fallback_attempts": [
+                    {
+                        "swarm_type": a["swarm_type"],
+                        "error": str(a["error"]),
+                    }
+                    for a in self.fallback_attempts
+                ],
             },
         )
 

--- a/tests/structs/test_swarm_router.py
+++ b/tests/structs/test_swarm_router.py
@@ -831,3 +831,237 @@ def test_conversation_points_at_the_live_swarm_conversation_after_run():
         m["role"] for m in router.conversation.conversation_history
     ]
     assert "A" in roles and "B" in roles
+
+
+# ============================================================================
+# fallback_swarms
+# ============================================================================
+
+
+class _FakeSwarm:
+    """Stands in for any swarm the factory would build."""
+
+    def __init__(self, name, error=None):
+        self.name = name
+        self.error = error
+        self.calls = []
+        self.conversation = None
+        # SequentialWorkflow exposes its conversation via agent_rearrange.
+        self.agent_rearrange = self
+
+    def run(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return f"{self.name}-result"
+
+
+def _fallback_router(primary_error=None, fallbacks=None, **outcomes):
+    """A router whose factory builds ``_FakeSwarm``s instead of real swarms.
+
+    ``outcomes`` maps swarm type -> exception to raise from ``run()`` (or
+    ``None`` to succeed). Types not named succeed.
+    """
+    with patch("swarms.structs.agent.LiteLLM"):
+        agent = Agent(
+            agent_name="A",
+            model_name="gpt-5.4",
+            max_loops=1,
+            autosave=False,
+            print_on=False,
+        )
+        router = SwarmRouter(
+            name="fallback-router",
+            agents=[agent],
+            swarm_type="SequentialWorkflow",
+            fallback_swarms=fallbacks,
+            autosave=False,
+        )
+    outcomes.setdefault("SequentialWorkflow", primary_error)
+    built = {}
+
+    def _factory_for(swarm_type):
+        def _build(*args, **kwargs):
+            built[swarm_type] = _FakeSwarm(
+                swarm_type, outcomes.get(swarm_type)
+            )
+            return built[swarm_type]
+
+        return _build
+
+    router._swarm_factory = {
+        swarm_type: _factory_for(swarm_type)
+        for swarm_type in router._swarm_factory
+    }
+    return router, built
+
+
+def test_fallback_is_not_touched_when_the_primary_succeeds():
+    router, built = _fallback_router(
+        fallbacks=["ConcurrentWorkflow", "GroupChat"]
+    )
+
+    assert router.run("go") == "SequentialWorkflow-result"
+    assert list(built) == ["SequentialWorkflow"]
+    assert router.active_swarm_type == "SequentialWorkflow"
+    assert router.fallback_attempts == []
+
+
+def test_primary_failure_runs_the_first_fallback():
+    boom = RuntimeError("primary down")
+    router, built = _fallback_router(
+        primary_error=boom,
+        fallbacks=["ConcurrentWorkflow", "GroupChat"],
+    )
+
+    assert router.run("go") == "ConcurrentWorkflow-result"
+    assert list(built) == ["SequentialWorkflow", "ConcurrentWorkflow"]
+    assert router.active_swarm_type == "ConcurrentWorkflow"
+    assert router.swarm is built["ConcurrentWorkflow"]
+    assert router.fallback_attempts == [
+        {"swarm_type": "SequentialWorkflow", "error": boom}
+    ]
+
+
+def test_fallbacks_are_tried_in_list_order():
+    router, built = _fallback_router(
+        primary_error=RuntimeError("1"),
+        fallbacks=[
+            "ConcurrentWorkflow",
+            "GroupChat",
+            "MajorityVoting",
+        ],
+        ConcurrentWorkflow=RuntimeError("2"),
+        GroupChat=RuntimeError("3"),
+    )
+
+    assert router.run("go") == "MajorityVoting-result"
+    assert [a["swarm_type"] for a in router.fallback_attempts] == [
+        "SequentialWorkflow",
+        "ConcurrentWorkflow",
+        "GroupChat",
+    ]
+    assert "MajorityVoting" in built
+
+
+def test_every_swarm_failing_raises_with_the_whole_chain():
+    last = ValueError("last one")
+    router, _ = _fallback_router(
+        primary_error=RuntimeError("first"),
+        fallbacks=["ConcurrentWorkflow"],
+        ConcurrentWorkflow=last,
+    )
+
+    with pytest.raises(SwarmRouterRunError) as excinfo:
+        router.run("go")
+
+    message = str(excinfo.value)
+    assert "SequentialWorkflow: RuntimeError: first" in message
+    assert "ConcurrentWorkflow: ValueError: last one" in message
+    assert excinfo.value.__cause__ is last
+    assert len(router.fallback_attempts) == 2
+
+
+def test_without_fallbacks_the_original_error_propagates_unchanged():
+    boom = KeyError("unchanged")
+    router, _ = _fallback_router(primary_error=boom)
+
+    with pytest.raises(KeyError) as excinfo:
+        router.run("go")
+
+    assert excinfo.value is boom
+    assert router.fallback_attempts == []
+
+
+def test_a_swarm_that_fails_to_construct_also_falls_back():
+    router, built = _fallback_router(fallbacks=["ConcurrentWorkflow"])
+
+    def _broken_factory(*args, **kwargs):
+        raise TypeError("cannot build")
+
+    router._swarm_factory["SequentialWorkflow"] = _broken_factory
+
+    assert router.run("go") == "ConcurrentWorkflow-result"
+    assert router.fallback_attempts[0]["swarm_type"] == (
+        "SequentialWorkflow"
+    )
+    assert isinstance(
+        router.fallback_attempts[0]["error"], RuntimeError
+    )
+
+
+def test_the_run_payload_reaches_the_fallback_swarm():
+    router, built = _fallback_router(
+        primary_error=RuntimeError("x"),
+        fallbacks=["ConcurrentWorkflow"],
+    )
+
+    router.run("go", img="chart.png")
+
+    assert built["ConcurrentWorkflow"].calls == [
+        {"task": "go", "img": "chart.png"}
+    ]
+
+
+def test_each_swarm_type_is_cached_under_its_own_key():
+    router, built = _fallback_router(
+        primary_error=RuntimeError("x"),
+        fallbacks=["ConcurrentWorkflow"],
+    )
+
+    router.run("one")
+    router.run("two")
+
+    # Built once each; the second run reused both cached swarms.
+    assert list(built) == ["SequentialWorkflow", "ConcurrentWorkflow"]
+    assert len(built["ConcurrentWorkflow"].calls) == 2
+    assert {key[0] for key in router._swarm_cache} == {
+        "SequentialWorkflow",
+        "ConcurrentWorkflow",
+    }
+
+
+def test_fallback_swarms_must_be_a_list():
+    with pytest.raises(
+        SwarmRouterConfigError, match="must be a list"
+    ):
+        SwarmRouter(
+            agents=create_sample_agents(),
+            swarm_type="SequentialWorkflow",
+            fallback_swarms="ConcurrentWorkflow",
+        )
+
+
+def test_fallback_swarms_entries_must_be_valid_swarm_types():
+    with pytest.raises(
+        SwarmRouterConfigError, match="not a valid swarm type"
+    ):
+        SwarmRouter(
+            agents=create_sample_agents(),
+            swarm_type="SequentialWorkflow",
+            fallback_swarms=["ConcurrentWorkflow", "NoSuchSwarm"],
+        )
+
+
+def test_agent_rearrange_fallback_requires_a_flow():
+    with pytest.raises(
+        SwarmRouterConfigError, match="requires rearrange_flow"
+    ):
+        SwarmRouter(
+            agents=create_sample_agents(),
+            swarm_type="SequentialWorkflow",
+            fallback_swarms=["AgentRearrange"],
+        )
+
+
+def test_config_model_accepts_fallback_swarms():
+    config = SwarmRouterConfig(
+        name="r",
+        description="d",
+        swarm_type="SequentialWorkflow",
+        rearrange_flow=None,
+        multi_agent_collab_prompt=False,
+        fallback_swarms=["ConcurrentWorkflow"],
+        task="t",
+    )
+    assert config.fallback_swarms == ["ConcurrentWorkflow"]


### PR DESCRIPTION
## What

`SwarmRouter` ran exactly one swarm type. If it raised, the run was over — a caller wanting `HierarchicalSwarm` with `SequentialWorkflow` behind it had to build two routers and hand-write the retry.

`fallback_swarms` is an ordered list of swarm types to try when the primary `swarm_type` fails:

```python
router = SwarmRouter(
    agents=agents,
    swarm_type="HierarchicalSwarm",
    fallback_swarms=["SequentialWorkflow", "ConcurrentWorkflow"],  # tried in order
)
result = router.run(task)

router.active_swarm_type   # which swarm actually served the run
router.fallback_attempts   # [{"swarm_type": ..., "error": ...}] for each that failed first
```

## Behaviour

- The primary raises — during construction **or** during `run()` — and the next type in the list is built from the same agents and configuration and given the same payload (`task`/`tasks`/`img`/kwargs). The first to complete wins.
- Every type exhausted: `SwarmRouterRunError` naming each attempt (`"SequentialWorkflow: RuntimeError: …; ConcurrentWorkflow: ValueError: …"`), with the last error as `__cause__`.
- **No `fallback_swarms`: nothing changes.** The original exception propagates exactly as before, so existing callers and tests are unaffected.
- Each swarm type is cached under its own key (`_compute_swarm_cache_key` now takes the type), so later runs reuse whichever swarms were already built.
- `active_swarm_type` and `fallback_attempts` are recorded on the router and written to the autosave metadata.

Validated at construction the same way `swarm_type` is: must be a list, every entry a valid `SwarmType`, and `rearrange_flow` is required when `AgentRearrange` is among them. `SwarmRouterConfig` gains the matching field.

## Tests

12 tests appended to `tests/structs/test_swarm_router.py`, using a fake swarm factory so nothing reaches a provider. They cover: primary success leaves fallbacks untouched; first fallback runs on primary failure; list order is honoured across three failures; the exhausted-chain error names every attempt and chains the last; no-fallback behaviour is byte-for-byte the old behaviour; construction failures fall back too; the run payload reaches the fallback; per-type caching; and the three config validations.

All 12 fail against unpatched `master` and pass here.

`tests/structs/test_swarm_router.py`: 56 passed, 1 failed. The failure (`test_run_with_multi_agent_router`) fails identically on `master`.

`black --line-length 70` and `ruff check` are clean.

## Also

- `examples/multi_agent/swarm_router/swarm_router_fallback_example.py`, listed in that folder's README.
- Not in this diff: the docs site's SwarmRouter page has no mention of the new parameter yet.
