### PR TITLE
feat(swarm-router): router.usage sums token usage over the swarm's agents

### DIFF
--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -40,6 +40,7 @@ from swarms.telemetry.otel import (
     trace_run,
 )
 from swarms.utils.generate_id import generate_id
+from swarms.utils.litellm_wrapper import empty_usage
 from swarms.utils.output_types import OutputType
 from swarms.utils.workspace_manager import WorkspaceManager
 
@@ -341,6 +342,8 @@ class SwarmRouter(SerializableMixin):
             first ``run()``).
         active_swarm_type (str): The swarm type that served the most recent
             run — the primary ``swarm_type`` unless a fallback was used.
+        usage (dict): Provider token usage summed over every agent the
+            router's swarms have run. See :attr:`usage`.
         fallback_attempts (List[dict]): One ``{"swarm_type", "error"}`` entry
             per swarm that failed during the most recent run.
         swarm_workspace_dir (str | None): Autosave workspace, set when
@@ -591,6 +594,40 @@ class SwarmRouter(SerializableMixin):
             logger.warning(
                 _msg_collab_prompt_ignored(self.swarm_type)
             )
+
+    @property
+    def usage(self) -> dict:
+        """Provider token usage summed over every agent this router has run.
+
+        Adds up :attr:`Agent.usage` for the configured ``agents`` plus any
+        agent a built swarm holds on its own — a ``HierarchicalSwarm``
+        director, a ``MixtureOfAgents`` aggregator, a judge. Keys:
+        ``input_tokens``, ``output_tokens``, ``cached_tokens``,
+        ``total_tokens``. Agent totals are lifetime totals, so an agent
+        shared with another router contributes what it spent there too.
+        Streaming calls are not counted.
+        """
+        total = empty_usage()
+        for agent in self._usage_agents():
+            for key, value in agent.usage.items():
+                total[key] += value
+        return total
+
+    def _usage_agents(self) -> List[Agent]:
+        """Every distinct Agent the router or its built swarms hold."""
+        candidates = list(self.agents or [])
+        for swarm in self._swarm_cache.values():
+            for value in vars(swarm).values():
+                if isinstance(value, (list, tuple)):
+                    candidates.extend(value)
+                else:
+                    candidates.append(value)
+
+        seen = {}
+        for candidate in candidates:
+            if isinstance(candidate, Agent):
+                seen.setdefault(id(candidate), candidate)
+        return list(seen.values())
 
     def fetch_message_history_as_string(self):
         """Return the underlying swarm's conversation history as a string.

--- a/tests/structs/test_swarm_router.py
+++ b/tests/structs/test_swarm_router.py
@@ -1065,3 +1065,86 @@ def test_config_model_accepts_fallback_swarms():
         task="t",
     )
     assert config.fallback_swarms == ["ConcurrentWorkflow"]
+
+
+# ============================================================================
+# usage
+# ============================================================================
+
+
+def _agent_with_usage(name, input_tokens, output_tokens):
+    """An offline agent whose lifetime usage is set directly."""
+    with patch("swarms.structs.agent.LiteLLM"):
+        agent = Agent(
+            agent_name=name,
+            model_name="gpt-5.4",
+            max_loops=1,
+            autosave=False,
+            print_on=False,
+        )
+    agent._usage = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cached_tokens": 0,
+        "total_tokens": input_tokens + output_tokens,
+    }
+    return agent
+
+
+def _usage_router(agents):
+    with patch("swarms.structs.agent.LiteLLM"):
+        return SwarmRouter(
+            name="usage-router",
+            agents=agents,
+            swarm_type="SequentialWorkflow",
+            autosave=False,
+        )
+
+
+def test_usage_starts_at_zero():
+    router = _usage_router([_agent_with_usage("A", 0, 0)])
+    assert router.usage == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cached_tokens": 0,
+        "total_tokens": 0,
+    }
+
+
+def test_usage_sums_the_configured_agents():
+    router = _usage_router(
+        [
+            _agent_with_usage("A", 100, 10),
+            _agent_with_usage("B", 50, 5),
+        ]
+    )
+    assert router.usage == {
+        "input_tokens": 150,
+        "output_tokens": 15,
+        "cached_tokens": 0,
+        "total_tokens": 165,
+    }
+
+
+def test_usage_includes_agents_a_swarm_holds_on_its_own():
+    """A HierarchicalSwarm director or an MoA aggregator is not in
+    ``router.agents`` but its spend is part of the run."""
+    from types import SimpleNamespace
+
+    worker = _agent_with_usage("Worker", 100, 10)
+    director = _agent_with_usage("Director", 30, 3)
+    router = _usage_router([worker])
+    router._swarm_cache["fake"] = SimpleNamespace(
+        director=director, agents=[worker], conversation=None
+    )
+
+    assert router.usage["input_tokens"] == 130
+    assert router.usage["output_tokens"] == 13
+
+
+def test_usage_counts_a_shared_agent_once():
+    agent = _agent_with_usage("A", 100, 10)
+    router = _usage_router([agent])
+    router._swarm_cache["fake"] = type("S", (), {"agents": [agent]})()
+
+    assert router.usage["input_tokens"] == 100


### PR DESCRIPTION
## What

#2158 gave `Agent` a `usage` dict of provider-reported token counts. This gives `SwarmRouter` the same thing, summed over every agent its swarms have run:

```python
router = SwarmRouter(agents=agents, swarm_type="HierarchicalSwarm")
router.run(task)

router.usage
# {"input_tokens": 3120, "output_tokens": 410, "cached_tokens": 2048, "total_tokens": 3530}
```

## How

One property and one helper, ~30 lines. `usage` adds `Agent.usage` over:

- the configured `agents`, and
- any agent a **built swarm holds on its own** — a `HierarchicalSwarm` director, a `MixtureOfAgents` aggregator, a judge. These are not in `router.agents` but their spend is part of the run. They are found by walking each cached swarm's attributes one level deep (direct `Agent` attributes and lists of them) and deduplicating by identity, so an agent that appears both in `router.agents` and inside the swarm is counted once.

Every swarm in `_swarm_cache` is walked, so with `fallback_swarms` a run that fell through to a second swarm type still reports the whole chain.

Agent totals are **lifetime** totals: an agent shared with another router, or run directly, contributes what it spent there too. That is documented on the property rather than worked around — the alternative (snapshotting per run) is exactly the non-minimal version.

Streaming calls are not counted, same as `Agent.usage` — tracked in #2159.

## Tests

Four in `tests/structs/test_swarm_router.py`: zero start, sum over configured agents, a swarm-held director is included, a shared agent is counted once. All fail on unpatched `master` (no `usage` attribute) and pass here.

Verified end to end offline as well: a three-agent `SequentialWorkflow` with `completion` stubbed to return distinct usage per call (100·n input, n output) reports exactly `600 / 6 / 606` over three calls.

`tests/structs/test_swarm_router.py tests/structs/test_agent.py`: 1 failure, `test_run_with_multi_agent_router`, which fails identically on `master`. `black --line-length 70` and `ruff check` clean.
