### PR TITLE
docs(examples): agent.usage and router.usage walkthroughs

### DIFF
--- a/examples/multi_agent/swarm_router/README.md
+++ b/examples/multi_agent/swarm_router/README.md
@@ -11,6 +11,7 @@ This directory contains examples demonstrating swarm routing patterns for direct
 - [swarm_router_benchmark.py](swarm_router_benchmark.py) - Router performance benchmarking
 - [swarm_router_example.py](swarm_router_example.py) - Basic swarm router example
 - [swarm_router_fallback_example.py](swarm_router_fallback_example.py) - `fallback_swarms`: try the next swarm type when the first one fails
+- [swarm_router_usage.py](swarm_router_usage.py) - `router.usage`: token usage summed over the swarm's agents
 - [swarm_router_test.py](swarm_router_test.py) - Router testing suite
 - [swarm_router.py](swarm_router.py) - Core swarm router implementation
 

--- a/examples/multi_agent/swarm_router/swarm_router_usage.py
+++ b/examples/multi_agent/swarm_router/swarm_router_usage.py
@@ -1,0 +1,124 @@
+"""
+router.usage — token usage for the whole swarm.
+
+``SwarmRouter.usage`` sums ``Agent.usage`` over every agent its swarms have
+run: the agents you passed in, plus any the swarm built for itself — a
+HierarchicalSwarm director, a MixtureOfAgents aggregator, a judge. Same
+four keys as the agent version:
+
+    {"input_tokens": ..., "output_tokens": ..., "cached_tokens": ..., "total_tokens": ...}
+
+Agent totals are lifetime totals, so an agent shared between two routers
+contributes what it spent in both. Streaming calls are not counted.
+
+Run:
+    export OPENAI_API_KEY=...
+    python examples/multi_agent/swarm_router/swarm_router_usage.py
+"""
+
+from swarms import Agent, SwarmRouter
+
+# $ per 1M tokens — substitute your provider's rates.
+INPUT_PRICE, OUTPUT_PRICE = 2.50, 10.00
+
+
+def cost(usage: dict) -> float:
+    return (
+        usage["input_tokens"] * INPUT_PRICE
+        + usage["output_tokens"] * OUTPUT_PRICE
+    ) / 1_000_000
+
+
+def show(label: str, usage: dict) -> None:
+    print(
+        f"  {label:<22} in={usage['input_tokens']:>6}  "
+        f"out={usage['output_tokens']:>6}  "
+        f"total={usage['total_tokens']:>6}  ${cost(usage):.5f}"
+    )
+
+
+def make_agents():
+    return [
+        Agent(
+            agent_name="Researcher",
+            system_prompt="Gather the key facts. Be brief.",
+            model_name="gpt-5.4",
+            max_loops=1,
+        ),
+        Agent(
+            agent_name="Analyst",
+            system_prompt="Weigh the facts you were given. Be brief.",
+            model_name="gpt-5.4",
+            max_loops=1,
+        ),
+        Agent(
+            agent_name="Writer",
+            system_prompt="Write a three-sentence brief from the analysis.",
+            model_name="gpt-5.4",
+            max_loops=1,
+        ),
+    ]
+
+
+TASK = "Should a small team adopt a monorepo? Give a recommendation."
+
+
+# --- 1. Sequential: the total is the sum of the three agents ---------------
+
+agents = make_agents()
+router = SwarmRouter(
+    name="usage-sequential",
+    agents=agents,
+    swarm_type="SequentialWorkflow",
+    max_loops=1,
+)
+
+print("SequentialWorkflow")
+show("before run", router.usage)
+router.run(TASK)
+
+for agent in agents:
+    show(agent.agent_name, agent.usage)
+show("router.usage", router.usage)
+
+
+# --- 2. Hierarchical: the director is counted too --------------------------
+#
+# The director is built by the swarm, not passed in, so it is not in
+# router.agents. router.usage still includes it.
+
+hierarchical = SwarmRouter(
+    name="usage-hierarchical",
+    agents=make_agents(),
+    swarm_type="HierarchicalSwarm",
+    max_loops=1,
+)
+
+print("\nHierarchicalSwarm")
+hierarchical.run(TASK)
+
+for agent in hierarchical.agents:
+    show(agent.agent_name, agent.usage)
+show("router.usage", hierarchical.usage)
+
+workers = sum(a.usage["total_tokens"] for a in hierarchical.agents)
+director = hierarchical.usage["total_tokens"] - workers
+print(
+    f"  director's share: {director} tokens, not in any worker's usage"
+)
+
+
+# --- 3. The cost of one run on a router that has run before ----------------
+
+# Each run starts fresh -- the agents do not remember the first task --
+# so the question has to stand on its own.
+before = router.usage
+router.run(
+    "Should a fifty-person engineering org adopt a monorepo? "
+    "Give a recommendation."
+)
+after = router.usage
+
+print("\nSecond sequential run")
+show("this run only", {k: after[k] - before[k] for k in after})
+show("lifetime", after)

--- a/examples/single_agent/README.md
+++ b/examples/single_agent/README.md
@@ -127,6 +127,7 @@ Configuration, output formats, and misc helpers.
 - [async_agent.py](utils/async_agent.py) — Async agent
 - [custom_agent_base_url.py](utils/custom_agent_base_url.py) — Custom base URL
 - [dynamic_context_window.py](utils/dynamic_context_window.py) — Dynamic context window
+- [agent_usage.py](utils/agent_usage.py) — Token usage and cost
 - [fallback_test.py](utils/fallback_test.py) — Model fallback
 - [grok_4_agent.py](utils/grok_4_agent.py) — Grok 4 agent
 - [list_agent_output_types.py](utils/list_agent_output_types.py) — Output types

--- a/examples/single_agent/utils/README.md
+++ b/examples/single_agent/utils/README.md
@@ -4,6 +4,7 @@ This directory contains utility functions and helpers for single agent operation
 
 ## Examples
 
+- [agent_usage.py](agent_usage.py) - `agent.usage`: provider token counts and cost per run
 - [async_agent.py](async_agent.py) - Async agent implementation
 - [custom_agent_base_url.py](custom_agent_base_url.py) - Custom base URL configuration
 - [dynamic_context_window.py](dynamic_context_window.py) - Dynamic context window management

--- a/examples/single_agent/utils/agent_usage.py
+++ b/examples/single_agent/utils/agent_usage.py
@@ -1,0 +1,102 @@
+"""
+agent.usage — what a run cost, from the provider's own numbers.
+
+Every non-streaming completion carries the provider's exact token counts.
+The agent sums them over every call it makes, including the per-loop tool
+summary calls, and exposes the total as ``agent.usage``:
+
+    {"input_tokens": ..., "output_tokens": ..., "cached_tokens": ..., "total_tokens": ...}
+
+``cached_tokens`` is the part of ``input_tokens`` the provider served from
+its prompt cache — already included in ``input_tokens``, not extra.
+
+Totals are lifetime totals for the agent: they keep growing across runs.
+Snapshot before and after if you want the cost of one run.
+
+Run:
+    export OPENAI_API_KEY=...
+    python examples/single_agent/utils/agent_usage.py
+"""
+
+from swarms import Agent
+
+# Published rates in $ per 1M tokens. Check your provider's price list.
+INPUT_PRICE = 2.50
+CACHED_INPUT_PRICE = 1.25
+OUTPUT_PRICE = 10.00
+
+
+def cost(usage: dict) -> float:
+    """Dollar cost of a usage dict at the rates above."""
+    uncached = usage["input_tokens"] - usage["cached_tokens"]
+    return (
+        uncached * INPUT_PRICE
+        + usage["cached_tokens"] * CACHED_INPUT_PRICE
+        + usage["output_tokens"] * OUTPUT_PRICE
+    ) / 1_000_000
+
+
+def show(label: str, usage: dict) -> None:
+    print(
+        f"{label:<28} in={usage['input_tokens']:>6}  "
+        f"cached={usage['cached_tokens']:>6}  "
+        f"out={usage['output_tokens']:>6}  "
+        f"total={usage['total_tokens']:>6}  ${cost(usage):.5f}"
+    )
+
+
+# --- 1. One call ------------------------------------------------------------
+
+agent = Agent(
+    agent_name="Usage-Demo",
+    system_prompt="You answer in one short paragraph.",
+    model_name="gpt-5.4",
+    max_loops=1,
+)
+
+show("before any run", agent.usage)
+
+agent.run(
+    "Explain what a token is, for someone new to language models."
+)
+show("after one run", agent.usage)
+
+
+# --- 2. Several loops with a tool: every call counts ------------------------
+
+
+def word_count(text: str) -> int:
+    """Count the words in a piece of text.
+
+    Args:
+        text: The text to count.
+    """
+    return len(text.split())
+
+
+tool_agent = Agent(
+    agent_name="Usage-Tool-Demo",
+    system_prompt="Use the word_count tool when asked about length.",
+    model_name="gpt-5.4",
+    tools=[word_count],
+    max_loops=3,
+)
+
+tool_agent.run(
+    "How many words are in this sentence: 'The quick brown fox jumps "
+    "over the lazy dog'? Then tell me whether that is a long sentence."
+)
+# Each loop that calls a tool makes two provider calls: the tool call
+# and the summary of its result. Both land here.
+show("tool agent, 3 loops", tool_agent.usage)
+
+
+# --- 3. The cost of one run, on an agent that has run before ----------------
+
+before = agent.usage
+agent.run("Now explain a context window, the same way.")
+after = agent.usage
+
+per_run = {key: after[key] - before[key] for key in after}
+show("second run only", per_run)
+show("lifetime", after)


### PR DESCRIPTION
## What

Runnable walkthroughs for the two usage counters that landed in #2158 and #2160.

**`examples/single_agent/utils/agent_usage.py`** — `agent.usage`

1. One call: zeros before, the provider's numbers after.
2. A three-loop run with a tool, showing that every provider call lands in the total — including the tool-summary call each loop makes.
3. A before/after snapshot to isolate one run's cost from the agent's lifetime total, with a dollar estimate from published per-token rates (`cached_tokens` priced separately).

**`examples/multi_agent/swarm_router/swarm_router_usage.py`** — `router.usage`

1. A `SequentialWorkflow` whose `router.usage` is exactly the sum of its three agents. The per-agent lines make the pipeline cost visible: input grows down the chain because each stage receives the prior outputs.
2. A `HierarchicalSwarm` where the director's spend is visible as the gap between `router.usage` and the workers' totals — the director is built by the swarm, so it is not in `router.agents`, and this is the case `router.usage` exists for.
3. The same per-run snapshot.

Each README in the two folders (and the single-agent index) gets a one-line entry.

## Verified

Both scripts were run offline with `completion` stubbed to return distinct usage per call, and the printed totals matched the stub's sums. The router example was also run live against `gpt-5.4`:

```
  Researcher             in=    43  out=   328  total=   371
  Analyst                in=   384  out=   222  total=   606
  Writer                 in=   603  out=   111  total=   714
  router.usage           in=  1030  out=   661  total=  1691
  ...
  director's share: 3376 tokens, not in any worker's usage
```

That live run caught one defect in the draft: the third task read *"Same question, but for a team of fifty"* and the agents asked for the original question, because a run does not remember the previous one. The task is now self-contained, and the example says why.

`black --line-length 70` and `ruff check` clean.
