### PR TITLE
fix(conversation): store tool calls and tool results as typed rows

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -108,7 +108,7 @@ class AutonomousAgentLoop:
 
     def __init__(self, agent: Any):
         self.agent = agent
-        # The real body sent to the model; short_memory mirrors it.
+        # Placeholder: short_memory does not exist yet, each run rebuilds this
         self._transcript = Transcript()
         # Removed before the next append, so runs do not stack copies.
         self._applied_handoff_block: Optional[str] = None
@@ -171,7 +171,10 @@ class AutonomousAgentLoop:
         # compact() already re-seeded short_memory with the summary,
         # so the transcript copy must not be mirrored back a second
         # time.
-        self._transcript = Transcript()
+        self._transcript = Transcript(
+            conversation=self.agent.short_memory,
+            agent_name=self.agent.agent_name,
+        )
         self._say_user(
             "[Compressed Memory Summary]\n"
             "Earlier turns were compressed to stay within the "
@@ -255,7 +258,10 @@ class AutonomousAgentLoop:
         try:
 
             # Cleared before seeding, or the opening turn is lost.
-            self._transcript = Transcript()
+            self._transcript = Transcript(
+                conversation=self.agent.short_memory,
+                agent_name=self.agent.agent_name,
+            )
             self.agent.autonomous_subtasks = []
             self.agent.current_subtask_index = 0
             self.agent.subtask_status = {}
@@ -471,9 +477,6 @@ class AutonomousAgentLoop:
                     )
 
                     response = self.agent.parse_llm_output(response)
-                    self.agent.short_memory.add(
-                        role=self.agent.agent_name, content=response
-                    )
                     planning_calls = self._record_assistant(response)
                     planning_results: Dict[str, Any] = {}
 
@@ -733,10 +736,6 @@ class AutonomousAgentLoop:
 
                         response = self.agent.parse_llm_output(
                             response
-                        )
-                        self.agent.short_memory.add(
-                            role=self.agent.agent_name,
-                            content=response,
                         )
 
                         # Answer every call before the next request.

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -1482,15 +1482,15 @@ class Agent:
                         # Parse the response from the agent with the output type
                         response = self.parse_llm_output(response)
 
-                        self.short_memory.add(
-                            role=self.agent_name,
-                            content=response,
-                        )
-
                         # Every tool call in this turn needs a matching result before the next request.
                         if use_transcript:
                             turn_calls = transcript.record_assistant(
                                 response
+                            )
+                        else:
+                            self.short_memory.add(
+                                role=self.agent_name,
+                                content=response,
                             )
 
                         # Print
@@ -2121,16 +2121,50 @@ class Agent:
         added *during* a run are appended structurally on top of this prefix,
         which is what preserves tool-call fidelity where it matters most.
         """
-        transcript = Transcript()
+        transcript = Transcript(
+            conversation=self.short_memory, agent_name=self.agent_name
+        )
+        open_calls: set = set()
+        # A tool result goes directly after its call, ahead of any log rows
+        result_slot = 0
         for message in self.short_memory.conversation_history:
             if not isinstance(message, dict):
                 continue
             role = message.get("role")
             content = message.get("content")
+
+            # Rows an earlier run's Transcript wrote come back typed
+            tool_calls = message.get("tool_calls")
+            if tool_calls and role == self.agent_name:
+                transcript.append_message(
+                    {
+                        "role": "assistant",
+                        "content": content,
+                        "tool_calls": tool_calls,
+                    }
+                )
+                open_calls = {call.get("id") for call in tool_calls}
+                result_slot = len(transcript)
+                continue
+            tool_call_id = message.get("tool_call_id")
+            if tool_call_id and tool_call_id in open_calls:
+                transcript.insert_message(
+                    result_slot,
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call_id,
+                        "content": str(content),
+                    },
+                )
+                result_slot += 1
+                open_calls.discard(tool_call_id)
+                continue
+
             if content is None or str(role).lower() == "system":
                 continue
             if role == self.agent_name:
                 transcript.append_assistant_text(content)
+                open_calls = set()
             else:
                 transcript.append_user(content)
         return transcript
@@ -4443,7 +4477,11 @@ Summary: {summary}
         if messages is None:
             return self._transcript_from_memory()
 
-        transcript = Transcript(list(messages))
+        transcript = Transcript(
+            list(messages),
+            conversation=self.short_memory,
+            agent_name=self.agent_name,
+        )
         if task is not None:
             transcript.append_user(task)
         return transcript

--- a/swarms/structs/context_utils.py
+++ b/swarms/structs/context_utils.py
@@ -23,6 +23,8 @@ a structure can reset it per task without this module tracking anything.
 
 from typing import Any, Dict, List, Optional
 
+from swarms.structs.conversation import render_message
+
 NO_NEW_MESSAGES = (
     "No new messages since your last turn. Continue from your own "
     "previous response."
@@ -75,18 +77,57 @@ def messages_for(
     )
 
     messages: List[Dict[str, str]] = []
+    # Open call ids, and the slot directly after the call their results go in
+    open_calls: set = set()
+    result_slot = 0
     for message in history:
         if not isinstance(message, dict):
             continue
 
         role = message.get("role")
         content = message.get("content")
+
+        # Only the caller may answer its own calls, so a peer's tool use is prose
+        tool_calls = message.get("tool_calls")
+        if tool_calls and role == agent_name:
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": content,
+                    "tool_calls": tool_calls,
+                }
+            )
+            open_calls = {call.get("id") for call in tool_calls}
+            result_slot = len(messages)
+            continue
+
+        tool_call_id = message.get("tool_call_id")
+        if tool_call_id and tool_call_id in open_calls:
+            messages.insert(
+                result_slot,
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": str(content),
+                },
+            )
+            result_slot += 1
+            open_calls.discard(tool_call_id)
+            continue
+
+        if tool_calls or tool_call_id:
+            messages.append(
+                {"role": "user", "content": render_message(message)}
+            )
+            continue
+
         if content is None:
             continue
         content = str(content)
 
         if role == agent_name:
             messages.append({"role": "assistant", "content": content})
+            open_calls = set()
             continue
 
         role_key = str(role).lower()

--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -55,6 +55,34 @@ def get_conversation_dir():
 DEFAULT_CONVERSATION_NAME = "conversation-test"
 
 
+def render_message(message: dict) -> str:
+    """One conversation row as ``role: content`` prose.
+
+    A tool-calling turn renders as ``role → name(arguments)`` and a tool
+    result as ``name → content``, so logs, exports and summaries read
+    sensibly. This is the only place tool turns become text; requests get
+    them typed via :func:`~swarms.structs.context_utils.messages_for`.
+    """
+    role = message.get("role")
+    content = message.get("content")
+
+    tool_calls = message.get("tool_calls")
+    if tool_calls:
+        calls = "; ".join(
+            f"{call.get('function', {}).get('name')}"
+            f"({call.get('function', {}).get('arguments', '')})"
+            for call in tool_calls
+        )
+        text = f"{role} → {calls}"
+        return f"{text}: {content}" if content else text
+
+    if message.get("tool_call_id"):
+        name = (message.get("metadata") or {}).get("name", "tool")
+        return f"{name} → {content}"
+
+    return f"{role}: {content}"
+
+
 class Conversation:
     """
     A class to manage a conversation history, allowing for the addition, deletion,
@@ -467,6 +495,8 @@ class Conversation:
         content: Union[str, dict, list, Any],
         metadata: Optional[dict] = None,
         category: Optional[str] = None,
+        tool_calls: Optional[List[dict]] = None,
+        tool_call_id: Optional[str] = None,
     ):
         """Add a message to the conversation history.
 
@@ -475,12 +505,19 @@ class Conversation:
             content (Union[str, dict, list]): The content of the message to be added.
             metadata (Optional[dict]): Optional metadata for the message.
             category (Optional[str]): Optional category for the message.
+            tool_calls (Optional[List[dict]]): See :meth:`add`.
+            tool_call_id (Optional[str]): See :meth:`add`.
         """
         # Base message with role and timestamp
         message = {
             "role": role,
             "content": content,
         }
+
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        if tool_call_id:
+            message["tool_call_id"] = tool_call_id
 
         if self.time_enabled:
             message["timestamp"] = datetime.datetime.now().isoformat()
@@ -595,6 +632,8 @@ class Conversation:
         content: Union[str, dict, list, Any],
         metadata: Optional[dict] = None,
         category: Optional[str] = None,
+        tool_calls: Optional[List[dict]] = None,
+        tool_call_id: Optional[str] = None,
     ):
         """Add a message to the conversation history.
 
@@ -603,12 +642,19 @@ class Conversation:
             content (Union[str, dict, list]): The content of the message to be added.
             metadata (Optional[dict]): Optional metadata for the message.
             category (Optional[str]): Optional category for the message.
+            tool_calls (Optional[List[dict]]): Tool calls the speaker made, in
+                the chat-completions shape. Makes this an assistant turn that
+                a tool result must answer.
+            tool_call_id (Optional[str]): Marks this message as the result of
+                that tool call. Put the tool's name in ``metadata["name"]``.
         """
         result = self.add_in_memory(
             role=role,
             content=content,
             metadata=metadata,
             category=category,
+            tool_calls=tool_calls,
+            tool_call_id=tool_call_id,
         )
 
         # Ensure autosave happens after the message is added
@@ -711,9 +757,7 @@ class Conversation:
             # Simple text export for non-JSON files
             with open(filename, "w", encoding="utf-8") as f:
                 for message in self.conversation_history:
-                    f.write(
-                        f"{message['role']}: {message['content']}\n"
-                    )
+                    f.write(f"{render_message(message)}\n")
 
     def import_conversation(self, filename: str):
         """Import a conversation history from a file.
@@ -783,14 +827,11 @@ class Conversation:
 
         for message in self.conversation_history:
             timestamp = message.get("timestamp")
+            rendered = render_message(message)
             if timestamp:
-                formatted_messages.append(
-                    f"[{timestamp}] {message['role']}: {message['content']}"
-                )
+                formatted_messages.append(f"[{timestamp}] {rendered}")
             else:
-                formatted_messages.append(
-                    f"{message['role']}: {message['content']}"
-                )
+                formatted_messages.append(rendered)
 
         return "\n\n".join(formatted_messages)
 
@@ -1264,7 +1305,7 @@ class Conversation:
             str: The last message formatted as 'role: content'.
         """
         if self.conversation_history:
-            return f"{self.conversation_history[-1]['role']}: {self.conversation_history[-1]['content']}"
+            return render_message(self.conversation_history[-1])
         return ""
 
     def return_messages_as_strings(self):
@@ -1277,7 +1318,7 @@ class Conversation:
             list: List of messages formatted as 'role: content'.
         """
         return [
-            f"{message['role']}: {message['content']}"
+            render_message(message)
             for message in self.conversation_history
         ]
 
@@ -1333,7 +1374,7 @@ class Conversation:
             str: The final message formatted as 'role: content'.
         """
         if self.conversation_history:
-            return f"{self.conversation_history[-1]['role']}: {self.conversation_history[-1]['content']}"
+            return render_message(self.conversation_history[-1])
         return ""
 
     def get_final_message_content(self):
@@ -1343,7 +1384,11 @@ class Conversation:
             str: The content of the final message.
         """
         if self.conversation_history:
-            output = self.conversation_history[-1]["content"]
+            last = self.conversation_history[-1]
+            output = last["content"]
+            # A tool-calling turn has no text, its content is the calls it made
+            if output is None and last.get("tool_calls"):
+                return last["tool_calls"]
             return output
         return ""
 

--- a/swarms/structs/transcript.py
+++ b/swarms/structs/transcript.py
@@ -14,9 +14,11 @@ results arrive as prose, and the stable prefix needed for prompt caching is
 rebuilt on every turn.
 
 This module owns that structure so the agent loops do not each reimplement it.
-``short_memory`` is still maintained alongside a ``Transcript`` by its callers,
-because persistence, output formatting and the final summary all read from
-there; see :class:`~swarms.structs.conversation.Conversation`.
+Given a ``conversation``, a ``Transcript`` also records the assistant's turns
+and the tool results into it as typed rows, so ``short_memory`` carries the
+same tool calls the model saw and persistence, rendering and other agents
+reading it (:func:`~swarms.structs.context_utils.messages_for`) see them.
+User turns are still recorded by the callers, which own their role names.
 """
 
 from typing import Any, Dict, List, Optional
@@ -42,9 +44,21 @@ class Transcript:
     """
 
     def __init__(
-        self, messages: Optional[List[Dict[str, Any]]] = None
+        self,
+        messages: Optional[List[Dict[str, Any]]] = None,
+        conversation: Any = None,
+        agent_name: Optional[str] = None,
     ):
+        """
+        Args:
+            messages: Turns to start from.
+            conversation: A :class:`~swarms.structs.conversation.Conversation`
+                that assistant turns and tool results are also written to.
+            agent_name: The role those assistant turns carry there.
+        """
         self._messages: List[Dict[str, Any]] = list(messages or [])
+        self._conversation = conversation
+        self._agent_name = agent_name
 
     # Reading.
 
@@ -69,6 +83,16 @@ class Transcript:
         self._messages.clear()
 
     # Writing.
+
+    def append_message(self, message: Dict[str, Any]) -> None:
+        """Add an already-typed turn, e.g. one read back from a Conversation."""
+        self._messages.append(dict(message))
+
+    def insert_message(
+        self, index: int, message: Dict[str, Any]
+    ) -> None:
+        """Insert a typed turn at ``index``; tool results must directly follow their call."""
+        self._messages.insert(index, dict(message))
 
     def append_user(self, content: Any) -> None:
         """Add a user turn."""
@@ -139,9 +163,19 @@ class Transcript:
                         "tool_calls": tool_calls,
                     }
                 )
+                if self._conversation is not None:
+                    self._conversation.add(
+                        role=self._agent_name,
+                        content=None,
+                        tool_calls=tool_calls,
+                    )
                 return calls
 
         self.append_assistant_text(parsed)
+        if self._conversation is not None:
+            self._conversation.add(
+                role=self._agent_name, content=parsed
+            )
         return calls
 
     def flush_tool_results(
@@ -159,6 +193,7 @@ class Transcript:
                 next request invalid.
         """
         for call in calls:
+            recorded = call["id"] in results
             result = results.get(
                 call["id"],
                 f"(no result recorded for {call['name']})",
@@ -170,6 +205,14 @@ class Transcript:
                     "content": str(result),
                 }
             )
+            # The placeholder only keeps the request valid, nothing happened
+            if self._conversation is not None and recorded:
+                self._conversation.add(
+                    role="tool",
+                    content=str(result),
+                    tool_call_id=call["id"],
+                    metadata={"name": call["name"]},
+                )
 
     def map_batch_results(
         self,

--- a/tests/structs/test_context_utils.py
+++ b/tests/structs/test_context_utils.py
@@ -1,0 +1,148 @@
+"""Tests for :mod:`swarms.structs.context_utils` — typed delivery of a shared
+conversation, including tool turns."""
+
+import json
+
+from swarms.structs.context_utils import messages_for
+from swarms.structs.conversation import Conversation
+
+
+def _call(name="read_file", call_id="call_1", **arguments):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(arguments),
+        },
+    }
+
+
+def _conversation():
+    return Conversation(time_enabled=False)
+
+
+class TestMessagesForToolTurns:
+    def test_the_recipients_own_tool_use_is_delivered_typed(self):
+        conv = _conversation()
+        conv.add("User", "read a.txt")
+        conv.add("Reader", None, tool_calls=[_call(path="a.txt")])
+        conv.add(
+            "tool",
+            "contents",
+            tool_call_id="call_1",
+            metadata={"name": "read_file"},
+        )
+        conv.add("Reader", "It says contents.")
+
+        messages = messages_for("Reader", conv)
+
+        assert messages[0] == {
+            "role": "user",
+            "content": "read a.txt",
+        }
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["tool_calls"][0]["id"] == "call_1"
+        assert messages[2] == {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "contents",
+        }
+        assert messages[3] == {
+            "role": "assistant",
+            "content": "It says contents.",
+        }
+
+    def test_a_peers_tool_use_is_described_in_prose(self):
+        """Only the caller may answer its own tool calls, so another
+        agent sees what happened as text."""
+        conv = _conversation()
+        conv.add("Reader", None, tool_calls=[_call(path="a.txt")])
+        conv.add(
+            "tool",
+            "contents",
+            tool_call_id="call_1",
+            metadata={"name": "read_file"},
+        )
+
+        messages = messages_for("Writer", conv)
+
+        assert [m["role"] for m in messages] == ["user", "user"]
+        assert messages[0]["content"].startswith(
+            "Reader → read_file("
+        )
+        assert messages[1]["content"] == "read_file → contents"
+        assert not any("tool_calls" in m for m in messages)
+
+    def test_an_orphan_result_is_prose_not_a_tool_message(self):
+        """A tool message the request cannot pair would be rejected."""
+        conv = _conversation()
+        conv.add(
+            "tool",
+            "contents",
+            tool_call_id="call_9",
+            metadata={"name": "read_file"},
+        )
+
+        messages = messages_for("Reader", conv)
+
+        assert messages == [
+            {"role": "user", "content": "read_file → contents"}
+        ]
+
+    def test_a_result_lands_right_after_its_call_despite_log_rows(
+        self,
+    ):
+        """The loop logs a 'Tool Executor' row before the typed result
+        is written; the request must still pair call and result."""
+        conv = _conversation()
+        conv.add("Reader", None, tool_calls=[_call(path="a.txt")])
+        conv.add("Tool Executor", "read_file ran")
+        conv.add(
+            "tool",
+            "contents",
+            tool_call_id="call_1",
+            metadata={"name": "read_file"},
+        )
+
+        messages = messages_for("Reader", conv)
+
+        assert [m["role"] for m in messages] == [
+            "assistant",
+            "tool",
+            "user",
+        ]
+        assert messages[1]["tool_call_id"] == "call_1"
+
+    def test_a_text_turn_closes_the_open_calls(self):
+        conv = _conversation()
+        conv.add("Reader", None, tool_calls=[_call(path="a.txt")])
+        conv.add("Reader", "never mind")
+        conv.add(
+            "tool",
+            "late",
+            tool_call_id="call_1",
+            metadata={"name": "read_file"},
+        )
+
+        messages = messages_for("Reader", conv)
+
+        assert messages[-1] == {
+            "role": "user",
+            "content": "read_file → late",
+        }
+
+    def test_plain_conversations_are_unchanged(self):
+        conv = _conversation()
+        conv.add("User", "draft it")
+        conv.add("Writer", "here is a draft")
+        conv.add("Editor", "needs a stronger opening")
+
+        assert messages_for("Writer", conv) == [
+            {"role": "user", "content": "draft it"},
+            {"role": "assistant", "content": "here is a draft"},
+            {
+                "role": "user",
+                "content": "Editor: needs a stronger opening",
+            },
+        ]

--- a/tests/structs/test_conversation.py
+++ b/tests/structs/test_conversation.py
@@ -1246,6 +1246,113 @@ def test_return_messages_as_dictionary_preserves_roles():
     assert messages[1]["content"] == "Hello, user!"
 
 
+# ---------------------------------------------------------------------------
+# Tool calls and tool results as conversation rows
+# ---------------------------------------------------------------------------
+
+
+def _tool_call(name="read_file", call_id="call_1", **arguments):
+    import json as _json
+
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": _json.dumps(arguments),
+        },
+    }
+
+
+class TestConversationToolTurns:
+    """``Conversation`` can hold the typed tool-call shape, not just prose."""
+
+    def test_add_stores_tool_calls_on_the_row(self):
+        conv = Conversation(time_enabled=False)
+        conv.add("Agent", None, tool_calls=[_tool_call(path="a.txt")])
+
+        row = conv.conversation_history[-1]
+        assert row["role"] == "Agent"
+        assert row["content"] is None
+        assert row["tool_calls"][0]["function"]["name"] == "read_file"
+
+    def test_add_stores_tool_call_id_on_a_result_row(self):
+        conv = Conversation(time_enabled=False)
+        conv.add(
+            "tool",
+            "contents",
+            tool_call_id="call_1",
+            metadata={"name": "read_file"},
+        )
+
+        row = conv.conversation_history[-1]
+        assert row["tool_call_id"] == "call_1"
+        assert row["metadata"]["name"] == "read_file"
+
+    def test_plain_rows_are_unchanged(self):
+        conv = Conversation(time_enabled=False)
+        conv.add("User", "hi")
+
+        row = conv.conversation_history[-1]
+        assert "tool_calls" not in row and "tool_call_id" not in row
+
+    def test_string_rendering_describes_the_call_and_the_result(self):
+        conv = Conversation(time_enabled=False)
+        conv.add("Agent", None, tool_calls=[_tool_call(path="a.txt")])
+        conv.add(
+            "tool",
+            "contents",
+            tool_call_id="call_1",
+            metadata={"name": "read_file"},
+        )
+
+        text = conv.return_history_as_string()
+        assert "Agent → read_file(" in text
+        assert "read_file → contents" in text
+        assert "None" not in text
+        assert conv.return_messages_as_strings()[0].startswith(
+            "Agent → read_file("
+        )
+
+    def test_final_message_content_of_a_tool_turn_is_its_calls(self):
+        """``output_type="final"`` used to see the raw call list as content;
+        it still gets the calls, not ``None``."""
+        conv = Conversation(time_enabled=False)
+        calls = [_tool_call(path="a.txt")]
+        conv.add("Agent", None, tool_calls=calls)
+
+        assert conv.get_final_message_content() == calls
+        assert conv.get_final_message().startswith(
+            "Agent → read_file("
+        )
+
+    def test_tool_rows_round_trip_through_json(self, tmp_path):
+        path = str(tmp_path / "conv.json")
+        conv = Conversation(
+            time_enabled=False, save_filepath=path, autosave=False
+        )
+        conv.add("Agent", None, tool_calls=[_tool_call(path="a.txt")])
+        conv.add(
+            "tool",
+            "contents",
+            tool_call_id="call_1",
+            metadata={"name": "read_file"},
+        )
+        conv.save_as_json(force=True)
+
+        loaded = Conversation(
+            time_enabled=False, save_filepath=path, autosave=False
+        )
+        loaded.load_from_json(path)
+
+        assert loaded.conversation_history[0]["tool_calls"][0][
+            "id"
+        ] == ("call_1")
+        assert (
+            loaded.conversation_history[1]["tool_call_id"] == "call_1"
+        )
+
+
 if __name__ == "__main__":
     logger.info("Starting test execution")
     results = run_all_tests()

--- a/tests/structs/test_transcript.py
+++ b/tests/structs/test_transcript.py
@@ -268,5 +268,143 @@ class TestIntegerMaxLoopsUsesMessages:
         assert seen["messages"] is None
 
 
+class TestTranscriptMirrorsIntoConversation:
+    """Given a conversation, the transcript records the typed turns there
+    too, so short_memory carries what the model saw."""
+
+    def _conversation(self):
+        from swarms.structs.conversation import Conversation
+
+        return Conversation(time_enabled=False)
+
+    def test_tool_calling_turn_and_results_are_recorded_typed(self):
+        conv = self._conversation()
+        t = Transcript(conversation=conv, agent_name="Agent")
+        calls = t.record_assistant([tool_call("read_file", path="a")])
+        t.flush_tool_results(calls, {calls[0]["id"]: "contents"})
+
+        rows = conv.conversation_history
+        assert rows[0]["role"] == "Agent"
+        assert rows[0]["content"] is None
+        assert (
+            rows[0]["tool_calls"][0]["function"]["name"]
+            == "read_file"
+        )
+        assert rows[1]["role"] == "tool"
+        assert rows[1]["tool_call_id"] == calls[0]["id"]
+        assert rows[1]["content"] == "contents"
+        assert rows[1]["metadata"]["name"] == "read_file"
+
+    def test_text_turn_is_recorded_once_under_the_agent_name(self):
+        conv = self._conversation()
+        t = Transcript(conversation=conv, agent_name="Agent")
+        t.record_assistant("plain answer")
+
+        assert [r["role"] for r in conv.conversation_history] == [
+            "Agent"
+        ]
+        assert (
+            conv.conversation_history[0]["content"] == "plain answer"
+        )
+
+    def test_placeholder_results_stay_out_of_the_conversation(self):
+        """The placeholder keeps the request valid; nothing happened."""
+        conv = self._conversation()
+        t = Transcript(conversation=conv, agent_name="Agent")
+        calls = t.record_assistant([tool_call("handoff")])
+        t.flush_tool_results(calls, {})
+
+        assert (
+            t.messages[-1]["role"] == "tool"
+        )  # request still well formed
+        assert [r["role"] for r in conv.conversation_history] == [
+            "Agent"
+        ]
+
+    def test_user_turns_are_left_to_the_caller(self):
+        conv = self._conversation()
+        t = Transcript(conversation=conv, agent_name="Agent")
+        t.append_user("hello")
+
+        assert conv.conversation_history == []
+
+    def test_without_a_conversation_nothing_changes(self):
+        t = Transcript()
+        calls = t.record_assistant([tool_call("read_file", path="a")])
+        t.flush_tool_results(calls, {calls[0]["id"]: "x"})
+        assert len(t) == 2
+
+
+def get_weather(city: str) -> str:
+    """Report the weather for a city.
+
+    Args:
+        city: The city to report on.
+    """
+    return f"sunny in {city}"
+
+
+class TestIntegerPathMemoryCarriesToolTurns(
+    TestIntegerMaxLoopsUsesMessages
+):
+    """After a tool-using run, short_memory holds typed rows, and the next
+    run rebuilds a well-formed request from them."""
+
+    def test_memory_holds_the_typed_turns_after_a_run(
+        self, monkeypatch
+    ):
+        agent = self._agent(max_loops=2, tools=[get_weather])
+        scripted = iter(
+            [[tool_call("get_weather", city="Paris")], "It is sunny."]
+        )
+        monkeypatch.setattr(
+            agent, "call_llm", lambda *a, **k: next(scripted)
+        )
+
+        agent.run("Weather in Paris?")
+
+        rows = agent.short_memory.conversation_history
+        call_rows = [r for r in rows if r.get("tool_calls")]
+        result_rows = [r for r in rows if r.get("tool_call_id")]
+        assert len(call_rows) == 1
+        assert call_rows[0]["role"] == agent.agent_name
+        assert call_rows[0]["content"] is None
+        assert len(result_rows) == 1
+        assert (
+            result_rows[0]["tool_call_id"]
+            == call_rows[0]["tool_calls"][0]["id"]
+        )
+
+    def test_next_run_rebuilds_a_well_formed_request_from_memory(
+        self, monkeypatch
+    ):
+        agent = self._agent(max_loops=2, tools=[get_weather])
+        scripted = iter(
+            [
+                [tool_call("get_weather", city="Paris")],
+                "It is sunny.",
+                "Still sunny.",
+            ]
+        )
+        seen = []
+
+        def capture(*args, **kwargs):
+            seen.append(kwargs.get("messages"))
+            return next(scripted, "Still sunny.")
+
+        monkeypatch.setattr(agent, "call_llm", capture)
+
+        agent.run("Weather in Paris?")
+        agent.run("And now?")
+
+        second_run_request = seen[-1]
+        assert_calls_answered(second_run_request)
+        assistant_tool_turns = [
+            m for m in second_run_request if m.get("tool_calls")
+        ]
+        assert len(assistant_tool_turns) == 1
+        assert assistant_tool_turns[0]["content"] is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-q", "-p", "no:randomly"])


### PR DESCRIPTION
## What is wrong

`Conversation` rows are `role` + `content`. There is no field for `tool_calls` and none for `tool_call_id`, so when #2007 fixed the loops to send the model typed turns, the typed history had to live in a second list, `Transcript`, maintained beside `short_memory`. Everything that reads `short_memory` — persistence, rendering, `messages_for`, and the next run's request rebuilt from memory — saw prose where the model had seen `tool_calls`.

Captured from a scripted run on `master` — the request the model receives on the **second** run, rebuilt from memory:

```json
{"role": "assistant", "content": "[{'id': 'call_1', 'type': 'function', 'function': {'name': 'get_weather', 'arguments': ..."}
{"role": "user",      "content": "Function 'get_weather' result:\nsunny in Paris"}
```

The call is a Python repr as assistant prose; the result comes back as a user message. A peer agent via `messages_for` got `"Reader: [{'id': 'call_1', ...}"` — indistinguishable from Reader *saying* that string.

## What this changes

Three pieces, in dependency order:

- **`Conversation` holds the typed shape.** `add()` takes `tool_calls=` and `tool_call_id=`; rows store them and round-trip through `save_as_json`/`load_from_json`. `render_message()` shows a call as `Agent → read_file({"path": "a.txt"})` and a result as `read_file → contents` in `return_history_as_string`, `return_messages_as_strings`, exports, and the last-message helpers — the only place tool turns become prose. `get_final_message_content()` returns a tool turn's calls rather than `None`, which keeps `output_type="final"` readers (the `HierarchicalSwarm` director) working.
- **`Transcript` writes through instead of beside.** `Transcript(conversation=short_memory, agent_name=...)` records assistant turns and real tool results into the conversation as typed rows. The three duplicate `short_memory.add(role=agent_name, content=response)` calls next to `record_assistant` in `Agent._run` and the autonomous loop are gone: one write per turn. Placeholder results for calls never dispatched stay transcript-only — they keep the request valid; nothing happened.
- **Readers deliver tool turns typed.** `messages_for()` sends the recipient's own tool use as `assistant` + `tool` messages and a peer's as prose (only the caller may answer its own calls; anything else the API rejects). `_transcript_from_memory` does the same when the integer path rebuilds a request from an earlier run. Both slot each result directly after its call, ahead of the loop's own "Tool Executor" log rows — the ordering bug the tests caught.

Same run, on this branch:

```json
{"role": "assistant", "content": null, "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}}]}
{"role": "tool",      "tool_call_id": "call_1", "content": "Function 'get_weather' result:\nsunny in Paris"}
```

Byte-identical to what the model saw during the first run, which is what a cacheable prefix needs. The peer now gets `"Reader → get_weather({\"city\": \"Paris\"})"` followed by `"get_weather → …"`.

## Behaviour changes worth a second look

- A tool-calling turn's memory row is now `{"role": <agent>, "content": None, "tool_calls": [...]}` rather than the raw list in `content`. Anything that read the list out of `content` should use `get_final_message_content()` (which returns the calls) or the `tool_calls` field.
- `Transcript()` with no conversation is unchanged; only callers that pass one get the mirroring.

## Not done here

The loop's `"Tool Executor: …"` log rows remain alongside the typed rows, so an autonomous agent's memory says each result twice and the request carries one stray `user` turn. Removing them is ~15 sites and is the next step in #2164, along with deleting `Transcript` once nothing constructs one without a conversation.

## Tests

23 new tests: `TestConversationToolTurns` in `tests/structs/test_conversation.py` (rows, rendering, final content, JSON round trip); `TestTranscriptMirrorsIntoConversation` and `TestIntegerPathMemoryCarriesToolTurns` in `tests/structs/test_transcript.py` (mirroring, placeholders stay out, and an end-to-end integer-path run whose second run rebuilds a well-formed request from memory); and a new `tests/structs/test_context_utils.py` (own tool use typed, peer's as prose, orphan result as prose, result slotted after its call despite interleaved log rows). 15 fail against unpatched `master`; the rest pin unchanged behaviour.

13 affected suites (`test_transcript`, `test_conversation`, `test_context_utils`, `test_agent`, `test_autonomous_loop`, `test_agent_rearrange`, `test_hierarchical_swarm`, `test_moa`, `test_self_moa_seq`, `test_groupchat`, `test_majority_voting`, `test_swarm_router`, `test_sequential_workflow`, `test_graph_workflow`) diffed against `master` with `comm`: nothing introduced. The one failure, `test_run_with_multi_agent_router`, is pre-existing.

`black --line-length 70` and `ruff check` clean.

Refs #1988 (the report) and #2164 (the full design; this is steps 1–2). Not closing either: the log-row cleanup and `Transcript` removal are still open.
