### PR TITLE
fix(litellm): count token usage for streaming runs (#2159)

### DIFF
--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -1209,6 +1209,11 @@ class LiteLLM:
             "temperature": self.temperature,
         }
 
+        if self.stream:
+            completion_params["stream_options"] = {
+                "include_usage": True
+            }
+
         # Only include top_p if explicitly set (not None)
         if self.top_p is not None:
             completion_params["top_p"] = self.top_p
@@ -1302,21 +1307,39 @@ class LiteLLM:
         if completion_params.get("max_tokens", 0) < threshold:
             completion_params["max_tokens"] = target
 
-    def _record_usage(self, response: any) -> None:
-        """Add the provider-reported token counts of one response to ``self.usage``.
-
-        Streaming responses are generators with no usage attached, so they
-        are skipped; a response without a ``usage`` block is skipped too.
-        """
-        if self.stream or response is None:
-            return
-        call_usage = usage_from_response(response)
+    def _accumulate_usage(self, call_usage: Optional[dict]) -> None:
+        """Fold one call's normalised token counts into ``self.usage``."""
         if call_usage is None:
             return
         for key in self.usage:
             self.usage[key] += call_usage[key]
         if self.usage_hook is not None:
             self.usage_hook(call_usage)
+
+    def _record_usage(self, response: any) -> None:
+        """Add the provider-reported token counts of one response to ``self.usage``.
+
+        Streaming responses are generators whose usage arrives in a trailing
+        chunk; they are handled by ``_track_streaming_usage`` instead. A
+        response without a ``usage`` block is skipped too.
+        """
+        if self.stream or response is None:
+            return
+        self._accumulate_usage(usage_from_response(response))
+
+    def _track_streaming_usage(self, stream: any):
+        """Yield content chunks while folding a trailing usage chunk into ``self.usage``.
+
+        With ``stream_options={"include_usage": True}`` the provider emits a
+        final chunk carrying ``usage`` and no ``choices``; it is consumed for
+        accounting and not forwarded, so callbacks never see an empty token.
+        """
+        for chunk in stream:
+            if _field(chunk, "usage"):
+                self._accumulate_usage(usage_from_response(chunk))
+                if not _field(chunk, "choices"):
+                    continue
+            yield chunk
 
     def _process_response(self, response: any):
         """
@@ -1331,7 +1354,7 @@ class LiteLLM:
 
         # Streaming: return the generator directly.
         if self.stream:
-            return response
+            return self._track_streaming_usage(response)
 
         # Before the reasoning branch: reasoning models still emit tool_calls, which would be dropped.
         if self.tools_list_dictionary is not None and getattr(

--- a/tests/utils/test_litellm_usage.py
+++ b/tests/utils/test_litellm_usage.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from swarms.utils.litellm_wrapper import (
     LiteLLM,
+    _field,
     empty_usage,
     usage_from_response,
 )
@@ -26,6 +27,28 @@ def _response(prompt=10, completion=5, cached=0, total=None):
     return SimpleNamespace(
         choices=[SimpleNamespace(message=message)], usage=usage
     )
+
+
+def _content_chunk(text):
+    """A streaming chunk carrying a content delta and no usage."""
+    delta = SimpleNamespace(content=text)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta)], usage=None
+    )
+
+
+def _usage_chunk(prompt=10, completion=5, cached=0, total=None):
+    """The trailing include_usage chunk: a usage block and no choices."""
+    details = (
+        SimpleNamespace(cached_tokens=cached) if cached else None
+    )
+    usage = SimpleNamespace(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=prompt + completion if total is None else total,
+        prompt_tokens_details=details,
+    )
+    return SimpleNamespace(choices=[], usage=usage)
 
 
 class TestUsageFromResponse:
@@ -133,12 +156,54 @@ class TestLiteLLMUsage:
 
         assert llm.usage == empty_usage()
 
-    def test_streaming_is_not_counted(self):
+    def test_streaming_usage_is_counted(self):
         llm = LiteLLM(model_name="gpt-5.4", stream=True)
         with patch(
             "swarms.utils.litellm_wrapper.completion",
-            return_value=iter(["chunk"]),
+            return_value=iter(
+                [
+                    _content_chunk("hel"),
+                    _content_chunk("lo"),
+                    _usage_chunk(10, 5, cached=2),
+                ]
+            ),
         ):
-            llm.run("x")
+            stream = llm.run("x")
+            forwarded = [
+                _field(chunk.choices[0].delta, "content")
+                for chunk in stream
+            ]
+
+        assert forwarded == ["hel", "lo"]
+        assert llm.usage == {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cached_tokens": 2,
+            "total_tokens": 15,
+        }
+
+    def test_streaming_without_a_usage_chunk_leaves_usage_unchanged(
+        self,
+    ):
+        llm = LiteLLM(model_name="gpt-5.4", stream=True)
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            return_value=iter(
+                [_content_chunk("hi"), _content_chunk("!")]
+            ),
+        ):
+            list(llm.run("x"))
 
         assert llm.usage == empty_usage()
+
+    def test_streaming_sets_include_usage(self):
+        llm = LiteLLM(model_name="gpt-5.4", stream=True)
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            return_value=iter([_usage_chunk(3, 4)]),
+        ) as mock_completion:
+            list(llm.run("x"))
+
+        assert mock_completion.call_args.kwargs["stream_options"] == {
+            "include_usage": True
+        }


### PR DESCRIPTION
**Description:** `agent.usage` (added in #2158) reports all-zeros for streaming runs. `LiteLLM._record_usage` skips when `self.stream` is set, because `completion(stream=True)` returns a generator with no `usage` block — so an agent built with `streaming_on=True` reports `{"input_tokens": 0, ...}` no matter how many loops it runs, silently under-reporting any cost accounting built on it.

Fix, following the approach in the issue:
- Request usage on streams via `stream_options={"include_usage": True}` so the provider emits a trailing usage chunk.
- Wrap the returned generator (`_track_streaming_usage`) to fold that chunk's counts into `self.usage` as the stream is consumed, and skip forwarding the usage-only chunk (no `choices`) so callbacks never see an empty token.
- Factor the accumulation out of `_record_usage` into `_accumulate_usage`, shared by the streaming and non-streaming paths (the `usage_hook` still fires per call).

**Issue:** Fixes #2159

**Dependencies:** none.

**Tests** (`tests/utils/test_litellm_usage.py`, offline — `completion` stubbed):
- `test_streaming_usage_is_counted` — a stream of content chunks + a trailing usage chunk: content is forwarded, `agent.usage` equals the usage chunk's numbers.
- `test_streaming_without_a_usage_chunk_leaves_usage_unchanged` — a stream with no usage chunk leaves `usage` at zero rather than raising.
- `test_streaming_sets_include_usage` — asserts `stream_options={"include_usage": True}` is sent.
- The prior `test_streaming_is_not_counted` (which pinned the gap) is inverted, as the issue asked.

**Validation:**
```
python -m pytest tests/utils/test_litellm_usage.py -q   # 13 passed
python -m pytest tests/structs/test_agent.py -k usage -q # 28 passed
```
Verified genuine RED→GREEN: reverting only the source change (keeping the tests) makes `test_streaming_usage_is_counted` and `test_streaming_sets_include_usage` fail (`KeyError: 'stream_options'` / usage stays zero); restoring it → all green. Ran `black --line-length 70` on the touched files. The remaining ruff `List`→`list` warnings in the file are pre-existing and outside this diff.

Happy to adjust.
