### PR TITLE
docs: remove docstring parameters that do not exist in signatures

### DIFF
--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -523,7 +523,6 @@ class Conversation:
         3. Counts tokens for each category using the specified tokenizer model
 
         Args:
-            tokenizer_model_name (str): Name of the model to use for tokenization
 
         Returns:
             Dict[str, int]: A dictionary containing:

--- a/swarms/structs/council_as_judge.py
+++ b/swarms/structs/council_as_judge.py
@@ -265,7 +265,7 @@ class CouncilAsAJudge:
             model_name (str): Name of the model to use for evaluations
             output_type (str): Type of output to return
             cache_size (int): Size of the LRU cache for prompts
-            max_workers (int): Maximum number of worker threads for parallel execution
+            max_workers: Derived internally from CPU count (read-only attribute, not a constructor parameter).
             random_model_name (bool): Whether to use random model names
             max_loops (int): Maximum number of loops for agents
             aggregation_model_name (str): Model name for the aggregator agent

--- a/swarms/structs/transforms.py
+++ b/swarms/structs/transforms.py
@@ -485,7 +485,9 @@ def handle_transforms(
     original message history as a string if no transforms are enabled.
 
     Args:
-        messages: List of message dictionaries to process.
+        transforms: The message transforms to apply.
+            short_memory: The conversation memory to pull messages from.
+            model_name: The model name used for the transforms.
         transforms: MessageTransforms instance to apply.
         short_memory: Object with methods to return messages as dictionary or string.
         model_name: Name of the model for context.


### PR DESCRIPTION
Three docstrings documented parameters that don't exist, each verified against the signature:

1. `CouncilAsAJudge.__init__` documented a `max_workers` constructor argument — it is derived internally from CPU count (`max(1, int(os.cpu_count() * 0.75))`); passing it raises `TypeError`. The class-level Attributes entry (which legitimately documents the attribute) is kept; only the Args entry is corrected to say it's derived internally.
2. `transforms.handle_transforms(transforms, short_memory, model_name)` documented `messages`, copied from a sibling function.
3. `conversation.export_and_count_categories()` documented a `tokenizer_model_name` argument; the method reads `self.tokenizer_model_name`.