### PR TITLE
chore: bump version to 15.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "swarms"
-version = "15.0.0"
+version = "15.0.1"
 description = "Swarms - TGSC"
 license = "Apache-2.0"
 authors = ["Kye Gomez <kye@swarms.world>"]


### PR DESCRIPTION
## What

`pyproject.toml` version `15.0.0` → `15.0.1`. One line, nothing else in the diff.

## Why a patch bump

Everything merged since 15.0.0 is additive or a fix, with no API removed:

- `agent.usage` — provider token counts per agent (#2158)
- `SwarmRouter.usage` — the same, summed over a swarm (#2160)
- `SwarmRouter(fallback_swarms=[...])` — try the next swarm type when one fails (#2157)
- Tool output capped by a token budget from the agent's own context window and tokenizer, not a fixed character count (#2150)
- `Conversation` stores tool calls and tool results as typed rows, so requests rebuilt from memory carry real `tool_calls` / `tool` turns (#2166 — open at the time of writing; if it lands after this, the release notes should still list it)

One behaviour change worth a line in the notes: a tool-calling turn's memory row is now `content: None` + `tool_calls` rather than the raw call list in `content` (#2166). `get_final_message_content()` returns the calls, so `output_type="final"` readers are unaffected.

## Checks

The version string lives only in `pyproject.toml`. `swarms.__version__` is resolved lazily from the installed distribution's metadata (`swarms/__init__.py:18`), so it follows this file and cannot drift.