### PR TITLE
[Bug] Nine structures never reset their conversation, so a batch answers task 2 with task 1 still in the prompt (#2054)

### DIFF
--- a/swarms/structs/advisor_swarm.py
+++ b/swarms/structs/advisor_swarm.py
@@ -199,6 +199,7 @@ class AdvisorSwarm:
         if not task:
             raise ValueError("A task is required")
 
+        self.conversation.clear()
         self.conversation.add(role="User", content=task)
         advisor_uses = 0
 

--- a/swarms/structs/auction_swarm.py
+++ b/swarms/structs/auction_swarm.py
@@ -381,6 +381,7 @@ class AuctionSwarm(SerializableMixin):
         """
         self._log("info", f"[{self.name}] auctioning task: {task}")
 
+        self.conversation.clear()
         self.conversation.add(role="User", content=task)
 
         if self.auto_equip:

--- a/swarms/structs/council_as_judge.py
+++ b/swarms/structs/council_as_judge.py
@@ -442,6 +442,7 @@ class CouncilAsAJudge:
 
         try:
 
+            self.conversation.clear()
             self.conversation.add(
                 role="User",
                 content=task,

--- a/swarms/structs/debate_with_judge.py
+++ b/swarms/structs/debate_with_judge.py
@@ -278,6 +278,8 @@ class DebateWithJudge:
         if not task or not isinstance(task, str):
             raise ValueError("Task must be a non-empty string")
 
+        self.conversation.clear()
+
         # Initialize agents with their roles
         self._initialize_agents(task)
 

--- a/swarms/structs/heavy_swarm.py
+++ b/swarms/structs/heavy_swarm.py
@@ -315,6 +315,8 @@ class HeavySwarm(SerializableMixin):
         if self.show_dashboard:
             self.dashboard.show_task_init(task)
 
+        self.conversation.clear()
+
         # Add initial task to conversation
         self.conversation.add(
             role="User",

--- a/swarms/structs/llm_council.py
+++ b/swarms/structs/llm_council.py
@@ -415,6 +415,8 @@ class LLMCouncil:
             print("=" * 80)
             print(f"\n📝 Query: {query}\n")
 
+        self.conversation.clear()
+
         # Add user query to conversation
         self.conversation.add(role="User", content=query)
 

--- a/swarms/structs/planner_generator_evaluator.py
+++ b/swarms/structs/planner_generator_evaluator.py
@@ -810,6 +810,8 @@ class PlannerGeneratorEvaluator:
         total_retries = 0
 
         try:
+            self.conversation.clear()
+
             # Add task to conversation
             self.conversation.add(role="User", content=task)
 

--- a/swarms/structs/planner_worker_swarm.py
+++ b/swarms/structs/planner_worker_swarm.py
@@ -877,6 +877,7 @@ class PlannerWorkerSwarm:
             raise ValueError("A task is required")
 
         self._original_task = task
+        self.conversation.clear()
         self.conversation.add(role="User", content=task)
 
         verdict = None

--- a/swarms/structs/round_robin.py
+++ b/swarms/structs/round_robin.py
@@ -216,6 +216,7 @@ class RoundRobinSwarm(SerializableMixin):
             Exception: If an exception occurs during task execution.
         """
         try:
+            self.conversation.clear()
             self.conversation.add(role="User", content=task)
             n = len(self.agents)
             agent_names = return_all_agent_names(self.agents)

--- a/tests/structs/test_round_robin_swarm.py
+++ b/tests/structs/test_round_robin_swarm.py
@@ -72,3 +72,42 @@ def test_prior_turns_are_typed_not_flattened_into_the_task():
     assert any(
         "original task" in text for text in contents
     ), f"original task missing from the turns: {contents}"
+
+
+def test_second_run_does_not_replay_the_first_task():
+    """A reused swarm starts each task from an empty shared conversation."""
+
+    class _Memory:
+        def __init__(self):
+            self.last = ""
+
+        def get_final_message_content(self):
+            return self.last
+
+    class _RecordingAgent:
+        def __init__(self, name):
+            self.agent_name = name
+            self.short_memory = _Memory()
+            self.calls = []
+
+        def run(self, task=None, messages=None, **kwargs):
+            self.calls.append(
+                {"task": str(task), "messages": messages or []}
+            )
+            self.short_memory.last = f"{self.agent_name}-out"
+            return f"{self.agent_name}-out"
+
+    agent = _RecordingAgent("A")
+    swarm = RoundRobinSwarm(agents=[agent], max_loops=1)
+
+    swarm.run("first task")
+    swarm.run("second task")
+
+    second_call = agent.calls[-1]
+    seen = [second_call["task"]] + [
+        m["content"] for m in second_call["messages"]
+    ]
+
+    assert not any(
+        "first task" in text for text in seen
+    ), f"previous task replayed into the next run: {seen}"


### PR DESCRIPTION
## What this fixes

Part of #2054, which reports that eleven multi-agent structures build their `Conversation` in `__init__` and never reset it, so a second `run()` on the same instance serves the previous task's history as context. This PR covers the nine sequential-reuse leaks in that issue's table. The two data races it also lists (`hybrid_hiearchical_peer_swarm`, `multi_agent_router`) are already handled in #2068, which needs a different fix because resetting a shared object does not make it safe to fan across threads.

## Why it matters

The leak is not hypothetical for callers who never asked to share state. Every one of these classes ships a batch entry point that reuses one instance:

| Structure | Batch entry point |
|---|---|
| `advisor_swarm` | `batched_run` |
| `llm_council` | `batched_run` |
| `round_robin` | `run_batch` |
| `debate_with_judge` | `batched_run` |
| `auction_swarm` | `batch_run` |
| `planner_generator_evaluator` | `batched_run` |
| `council_as_judge` | repeated `run()` |
| `heavy_swarm` | repeated `run()` |
| `planner_worker_swarm` | repeated `run()` |

So task 2 of a batch is answered with task 1 still in the prompt, and `history_output_formatter` at the end of `run()` returns both tasks' messages to the caller who asked about one. Cost grows with batch position, and the output the caller receives is not the output of the task they passed.

## The change

One line at the top of each `run()`, before the first message is added:

```python
self.conversation.clear()
```

This is the shape `MajorityVoting.run` already uses, so the fix matches the pattern already in the tree rather than introducing a second one.

`clear()` rather than rebuilding the `Conversation`: several of these pass constructor arguments (`name`, `time_enabled`, `message_id_on`), and rebuilding would mean restating them at a second site where they can drift. `Conversation.__init__` only seeds history when `system_prompt`, `rules` or `custom_rules_prompt` are given, and none of the nine pass any of those, so clearing and rebuilding produce the same state here.

## What is deliberately not in scope

- The two races, per #2068 above.
- `spreadsheet_swarm` and `hierarchical_structured_communication_framework`, which #2054 lists separately as non-`Conversation` per-task state. They need per-attribute decisions rather than this one-line shape, so #2054 stays open after this merges.
- The flattening of the conversation into a single user blob in several of these files, which is #2053.

## Test

One test, in the file the diff already touches, on the structure with the cheapest offline harness. It runs the same swarm twice and asserts the second run never sees the first task, in either the task string or the typed turns.

Verified it fails on the unfixed source: reverting only `round_robin.py` turns `test_second_run_does_not_replay_the_first_task` red at the final assertion, and restoring it turns it green.

```
tests/structs/test_round_robin_swarm.py
  test_second_run_does_not_replay_the_first_task ... passed (fails without the fix)

tests/structs/test_round_robin_swarm.py tests/structs/test_llm_council.py
tests/structs/test_heavy_swarm.py tests/structs/test_multi_agent_debate.py
  1 failed, 73 passed, 10 skipped
```

The one failure is `test_round_robin_swarm.py::test_run`, which calls a live model and fails identically on unpatched master.

`black . --check` clean across the repo.
