### PR TITLE
[Bug] HierarchicalSwarm reuses one conversation and one delivery cursor for every task in a batch (#2033)

### DIFF
--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -587,6 +587,10 @@ class HierarchicalSwarm:
             if task is None and self.interactive:
                 task = self._get_interactive_task()
 
+            self.conversation.clear()
+            self._delivered = {}
+            self.add_context_to_director()
+
             if task is not None:
                 self.conversation.add(role="User", content=task)
 

--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -59,9 +59,6 @@ _JUDGE_REPORT_SCHEMA = BaseTool().base_model_to_dict(JudgeReport)
 class HierarchicalSwarm:
     """Coordinate a director and workers across iterative task loops."""
 
-    conversation: Conversation
-    _delivered: Dict[str, int]
-
     def __init__(
         self,
         name: str = "HierarchicalAgentSwarm",
@@ -191,6 +188,11 @@ class HierarchicalSwarm:
         )
         self.swarm_workspace_dir = self.workspace.dir
 
+        # How much of the shared conversation each agent has already seen.
+        self._delivered: Dict[str, int] = {}
+
+        self.conversation = Conversation(time_enabled=False)
+
         self.initialize_swarm()
 
         capture_init(self)
@@ -229,11 +231,6 @@ class HierarchicalSwarm:
 
     def init_swarm(self):
         """Initialize conversation state and validate the swarm."""
-        # How much of the shared conversation each agent has already seen.
-        self._delivered = {}
-
-        self.conversation = Conversation(time_enabled=False)
-
         # Reliability checks
         self.reliability_checks()
 

--- a/swarms/structs/hiearchical_swarm.py
+++ b/swarms/structs/hiearchical_swarm.py
@@ -59,6 +59,9 @@ _JUDGE_REPORT_SCHEMA = BaseTool().base_model_to_dict(JudgeReport)
 class HierarchicalSwarm:
     """Coordinate a director and workers across iterative task loops."""
 
+    conversation: Conversation
+    _delivered: Dict[str, int]
+
     def __init__(
         self,
         name: str = "HierarchicalAgentSwarm",

--- a/tests/structs/test_hierarchical_swarm.py
+++ b/tests/structs/test_hierarchical_swarm.py
@@ -1081,3 +1081,40 @@ def test_the_director_panel_carries_the_plan(capsys):
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_second_run_does_not_carry_the_first_task():
+    """A reused swarm starts each task from an empty conversation and cursor."""
+    director = StubAgent(
+        "Director",
+        [
+            OrderBatch(
+                orders=[
+                    HierarchicalOrder(
+                        agent_name="Worker", task="first subtask"
+                    )
+                ]
+            ),
+            OrderBatch(
+                orders=[
+                    HierarchicalOrder(
+                        agent_name="Worker", task="second subtask"
+                    )
+                ]
+            ),
+        ],
+    )
+    worker = StubAgent("Worker", ["first answer", "second answer"])
+    swarm = make_recovery_swarm(director, [worker], max_loops=1)
+
+    swarm.run("first task")
+    swarm.run("second task")
+
+    history = swarm.conversation.get_str()
+
+    assert "first task" not in history, history
+    assert "first answer" not in history, history
+    assert "second task" in history, history
+    assert swarm._delivered.get("Worker", 0) <= len(
+        swarm.conversation.conversation_history
+    )


### PR DESCRIPTION
## What this fixes

Part of #2033, which reports (in its closing note) that `HierarchicalSwarm._delivered` is initialised only in `init_swarm` and never reset per task, so `batched_run` reuses the cursor across tasks. The same is true of the conversation `init_swarm` builds beside it.

The larger half of #2033, the streaming path re-sending the full transcript while the sync path sent a delta, no longer applies: that second loop implementation was removed in #2093 and #2118, and there is no `conversation.get_str()` left in the module. This PR closes the part that survived the refactor.

## Why it matters

`init_swarm()` runs once, from `__init__`:

```python
def init_swarm(self):
    self._delivered = {}
    self.conversation = Conversation(time_enabled=False)
    ...
```

`run()` then adds the task straight onto whatever is already there, and `batched_run` is a loop over `self.run`. So on task 2 of a batch:

- the conversation still holds task 1, every worker answer, and the loop markers, and `history_output_formatter` at the end of `run()` hands all of it back to the caller who asked about task 2;
- `_delivered` still points past those messages, so `new_context_for` computes the delta against a cursor that belongs to a different task.

The cursor is the part that does not merely leak. `context_utils` documents that the caller owns the cursor precisely so it can be reset per task; here nothing resets it, so an agent's "what is new since my last turn" is measured from a position in the previous task's transcript.

## The change

Four lines at the top of `run()`:

```python
self.conversation.clear()
self._delivered = {}
self.add_context_to_director()
```

The third line is the part worth reviewing. Clearing the conversation also removes the worker roster that `init_swarm` seeds through `add_context_to_director`, which the director needs in order to address workers by name, so it is re-added. `list_all_agents` only writes a System row and does not mutate the agents, so re-calling it per task is safe.

The rest of `init_swarm` is deliberately not re-run. `prepare_worker_agents` does `agent.system_prompt += prompt`, so re-running it would grow every worker's system prompt by one collaboration preamble per task, and `reliability_checks` has nothing to re-check.

## Test

One test, in the module's own test file, built on the `StubAgent` and `make_recovery_swarm` helpers already there, so it runs offline. It runs the same swarm twice and asserts the second run's conversation contains neither the first task nor the first worker answer, and that the delivery cursor is not left pointing past the end of the new conversation.

Verified it fails on the unfixed source: reverting only `hiearchical_swarm.py` turns `test_second_run_does_not_carry_the_first_task` red.

```
tests/structs/test_hierarchical_swarm.py ... 31 passed
```

That includes `TestHierarchicalContextManagement::test_the_director_prompt_does_not_balloon`, which is what caught the dropped roster: without the `add_context_to_director` line the director's first prompt shrinks to 57 characters and the test fails on the growth ratio.

`black . --check` clean across the repo.


## Follow-up commit

`8f07a685` declares `conversation` and `_delivered` at class scope. Both are assigned only inside `init_swarm()`, which `__init__` reaches through `initialize_swarm()`; Pyre does not follow that indirection, so every read of them was already an undefined attribute. This diff was just the first change to touch them on a diffed line, which promoted two standing alerts into new code-scanning findings. Bare annotations, no runtime change.

`kyegomez/swarms#2041` catalogues the same defect across several structures and lists `HierarchicalSwarm` (`_delivered` set only in `init_swarm`, reused by `batched_run`) in its table. This PR covers the `HierarchicalSwarm` row of it.
