### PR TITLE
[Feat] Autonomous loop: read_file returns numbered lines and reads a window, not the whole file (#1981)

### DIFF
--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -854,6 +854,11 @@ def read_file_tool(
         Windowing is applied before the token cap from :func:`truncate_tool_output`,
         so asking for a window is what keeps a large file from being cut off
         at the tail; the cap remains the backstop.
+
+        Lines are split on ``\n`` alone rather than with ``str.splitlines``,
+        which also breaks on form feed and other separators ``grep -n`` does
+        not count. An empty file returns ``"(empty file)"`` rather than an
+        empty string, which reads to a model like a failed call.
     """
     try:
         if offset < 0:
@@ -879,7 +884,16 @@ def read_file_tool(
         with open(full_path, "r", encoding="utf-8") as f:
             raw = f.read()
 
-        lines = raw.splitlines()
+        # Only "\n" separates lines, which is what grep -n counts. splitlines()
+        # also breaks on form feed, vertical tab, \x1c-\x1e and \x85, so a file
+        # with a ^L page break would number every later line one higher than
+        # grep does -- the exact citation mismatch this function exists to fix.
+        lines = raw.split("\n")
+        if lines and lines[-1] == "":
+            lines.pop()
+
+        if not lines:
+            return "(empty file)"
 
         if offset and offset >= len(lines):
             return (

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -31,7 +31,7 @@ import re as _re
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
@@ -400,13 +400,23 @@ def get_autonomous_planning_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "read_file",
-                "description": "Read the contents of a file. Returns the file content as a string.",
+                "description": "Read a file as numbered lines. Reads the whole file by default; pass offset and limit to read a window of a large file instead of all of it.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "file_path": {
                             "type": "string",
                             "description": "Path to the file to read (relative to workspace or absolute)",
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "description": "Zero-based line to start at. Omit to read from the first line.",
+                            "minimum": 0,
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "How many lines to return. Omit to read to the end of the file.",
+                            "minimum": 1,
                         },
                     },
                     "required": ["file_path"],
@@ -814,19 +824,46 @@ def update_file_tool(
         return error_msg
 
 
-def read_file_tool(agent: Any, file_path: str, **kwargs) -> str:
+def read_file_tool(
+    agent: Any,
+    file_path: str,
+    offset: int = 0,
+    limit: Optional[int] = None,
+    **kwargs,
+) -> str:
     """
-    Read the contents of a file.
+    Read a file, or a window of it, as numbered lines.
 
     Args:
         agent: The agent instance
         file_path: Path to the file (relative to workspace or absolute)
+        offset: Zero-based line to start at. ``0`` reads from the top.
+        limit: How many lines to return. ``None`` reads to the end.
         **kwargs: Additional arguments
 
     Returns:
-        str: File contents or error message
+        str: Numbered lines, or an error message
+
+    Notes:
+        Lines are numbered by their position in the file, not in the window,
+        so a model reading with an offset can still cite a real line number.
+        The number is right-aligned in six columns and separated by a tab -
+        the shape ``grep -n`` already produces, so both tools read the same
+        way.
+
+        Windowing is applied before the token cap from :func:`truncate_tool_output`,
+        so asking for a window is what keeps a large file from being cut off
+        at the tail; the cap remains the backstop.
     """
     try:
+        if offset < 0:
+            return (
+                f"Error: offset must be zero or greater, got {offset}"
+            )
+
+        if limit is not None and limit < 1:
+            return f"Error: limit must be one or greater, got {limit}"
+
         # Resolve path - if relative, use agent workspace
         if not os.path.isabs(file_path):
             workspace_dir = agent._get_agent_workspace_dir()
@@ -841,20 +878,39 @@ def read_file_tool(agent: Any, file_path: str, **kwargs) -> str:
         # Read file
         with open(full_path, "r", encoding="utf-8") as f:
             raw = f.read()
+
+        lines = raw.splitlines()
+
+        if offset and offset >= len(lines):
+            return (
+                f"Error: offset {offset} is past the end of {full_path}, "
+                f"which has {len(lines)} lines"
+            )
+
+        end = None if limit is None else offset + limit
+        window = lines[offset:end]
+
+        numbered = "\n".join(
+            f"{offset + i + 1:6}\t{line}"
+            for i, line in enumerate(window)
+        )
+
         content = truncate_tool_output(
-            raw,
+            numbered,
             context_window=agent.context_length,
             model_name=agent.model_name,
         )
 
+        shown = f"lines {offset + 1}-{offset + len(window)} of {len(lines)}"
+
         # Add to memory
         agent.short_memory.add(
             role="File Operations",
-            content=f"Read file: {full_path} ({len(raw)} characters)",
+            content=f"Read file: {full_path} ({shown})",
         )
 
         if agent.verbose:
-            logger.info(f"Read file: {full_path}")
+            logger.info(f"Read file: {full_path} ({shown})")
 
         return content
     except Exception as e:

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -29,6 +29,7 @@ Run:
 
 import json
 import os
+import subprocess
 
 import pytest
 
@@ -1147,10 +1148,6 @@ class TestContextCompression:
         assert len(loop._transcript) == 1
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-q", "-p", "no:randomly"])
-
-
 # --------------------------------------------------------------------------
 # #1983 — glob tool
 # --------------------------------------------------------------------------
@@ -1244,6 +1241,8 @@ class TestGlobTool:
             "pattern",
             "path",
         }
+
+
 # #1981 — read_file line numbers and windowing
 # --------------------------------------------------------------------------
 
@@ -1334,6 +1333,45 @@ class TestReadFileWindowing:
 
         assert "output truncated" in output
 
+    def test_a_form_feed_does_not_shift_the_numbering(self, tmp_path):
+        """str.splitlines() breaks on \\f; grep -n does not (review on #2178)."""
+        target = tmp_path / "pagebreak.py"
+        target.write_text(
+            "def a():\n    pass\n\x0c\ndef b():\n    return 1\n"
+        )
+
+        output = read_file_tool(build_agent(), str(target))
+        numbered = {
+            line.split("\t", 1)[1]: int(line.split("\t", 1)[0])
+            for line in output.splitlines()
+            if "\t" in line
+        }
+
+        grep = subprocess.run(
+            ["grep", "-n", "def b", str(target)],
+            capture_output=True,
+            text=True,
+        )
+        grep_line = int(grep.stdout.split(":", 1)[0])
+
+        assert numbered["def b():"] == grep_line == 4
+
+    def test_an_empty_file_says_so(self, tmp_path):
+        target = tmp_path / "empty.txt"
+        target.write_text("")
+
+        assert (
+            read_file_tool(build_agent(), str(target))
+            == "(empty file)"
+        )
+
+    def test_a_trailing_newline_is_not_an_extra_line(self, tmp_path):
+        path = self._file(tmp_path, ["alpha", "beta"])
+
+        output = read_file_tool(build_agent(), path)
+
+        assert len(output.splitlines()) == 2
+
     def test_the_schema_advertises_the_window(self):
         read_file = next(
             tool["function"]
@@ -1347,3 +1385,7 @@ class TestReadFileWindowing:
             "limit",
         }
         assert read_file["parameters"]["required"] == ["file_path"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q", "-p", "no:randomly"])

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -1244,3 +1244,106 @@ class TestGlobTool:
             "pattern",
             "path",
         }
+# #1981 — read_file line numbers and windowing
+# --------------------------------------------------------------------------
+
+
+class TestReadFileWindowing:
+    """
+    A model that cannot ask for part of a file reads all of it, and a model
+    that gets no line numbers cannot say where it looked.
+    """
+
+    def _file(self, tmp_path, lines):
+        target = tmp_path / "sample.py"
+        target.write_text("\n".join(lines) + "\n")
+        return str(target)
+
+    def test_lines_are_numbered_from_one(self, tmp_path):
+        path = self._file(tmp_path, ["alpha", "beta", "gamma"])
+
+        output = read_file_tool(build_agent(), path)
+
+        assert output.splitlines() == [
+            "     1\talpha",
+            "     2\tbeta",
+            "     3\tgamma",
+        ]
+
+    def test_offset_skips_lines_and_keeps_absolute_numbering(
+        self, tmp_path
+    ):
+        path = self._file(
+            tmp_path, [f"line {i}" for i in range(1, 11)]
+        )
+
+        output = read_file_tool(build_agent(), path, offset=6)
+
+        assert output.splitlines()[0] == "     7\tline 7"
+        assert output.splitlines()[-1] == "    10\tline 10"
+
+    def test_limit_bounds_the_window(self, tmp_path):
+        path = self._file(
+            tmp_path, [f"line {i}" for i in range(1, 11)]
+        )
+
+        output = read_file_tool(
+            build_agent(), path, offset=2, limit=3
+        )
+
+        assert [
+            line.split("\t")[1] for line in output.splitlines()
+        ] == [
+            "line 3",
+            "line 4",
+            "line 5",
+        ]
+
+    def test_an_offset_past_the_end_says_how_long_the_file_is(
+        self, tmp_path
+    ):
+        path = self._file(tmp_path, ["only", "two"])
+
+        output = read_file_tool(build_agent(), path, offset=50)
+
+        assert "2 lines" in output
+        assert "Error" in output
+
+    def test_a_negative_offset_is_rejected(self, tmp_path):
+        path = self._file(tmp_path, ["a"])
+
+        assert "Error" in read_file_tool(
+            build_agent(), path, offset=-1
+        )
+
+    def test_a_non_positive_limit_is_rejected(self, tmp_path):
+        path = self._file(tmp_path, ["a"])
+
+        assert "Error" in read_file_tool(build_agent(), path, limit=0)
+
+    def test_a_window_is_still_capped_by_the_token_budget(
+        self, tmp_path
+    ):
+        agent = build_agent(context_length=16000)
+        budget = int(agent.context_length * TOOL_OUTPUT_CONTEXT_SHARE)
+        path = self._file(
+            tmp_path, ["word " * 50 for _ in range(budget)]
+        )
+
+        output = read_file_tool(agent, path, offset=0, limit=budget)
+
+        assert "output truncated" in output
+
+    def test_the_schema_advertises_the_window(self):
+        read_file = next(
+            tool["function"]
+            for tool in get_autonomous_planning_tools()
+            if tool["function"]["name"] == "read_file"
+        )
+
+        assert set(read_file["parameters"]["properties"]) == {
+            "file_path",
+            "offset",
+            "limit",
+        }
+        assert read_file["parameters"]["required"] == ["file_path"]


### PR DESCRIPTION
Closes #1981. Part of #2162, which tracks the four file-tool gaps as one deliverable.

**The autonomous loop's `read_file` returns the whole file as bare text.** A model that cannot ask for part of a file reads all of it, and a model that gets no line numbers cannot say where it looked.

## Problem

Two failures, neither of which the model can work around:

**It cannot cite a location.** `grep_tool` numbers its matches by default (`include_line_numbers=True`). So the loop hands the model a match at line 412, and the only tool for looking at line 412 returns text with no line numbers in it.

**It cannot ask for part of a file.** `read_file` reads everything, then `truncate_tool_output` cuts it to the token budget (#2150). On a 4,000-line file the model gets the head, no signal that it saw a fraction, and reasons from that. Windowing is the fix the cap cannot be: a cap decides *how much*, only the caller knows *which part*.

## Fix

`read_file(file_path, offset=0, limit=None)`, returning numbered lines:

```
     1	alpha
     2	beta
     3	gamma
```

| Behaviour | Detail |
|---|---|
| Numbering | The line's position **in the file**, not in the window — a windowed read still cites real line numbers |
| Format | Right-aligned in six columns, tab-separated — the shape `grep -n` already produces, so both tools read the same way |
| Order of operations | Window first, cap second. Asking for a window is what keeps a large file from being cut at the tail; the cap stays the backstop rather than the only limit |
| `offset` past EOF | Reports how many lines the file actually has, instead of returning empty |
| Bad input | A negative `offset` or a `limit` below 1 is rejected by name, not silently coerced |
| Schema | Both parameters advertised with `minimum` bounds, and the description tells the model to window a large file rather than read all of it |

## Design decisions

- **Numbers are absolute, not window-relative.** The whole point is citing a line, and a model that reads with `offset=200` and gets back `1, 2, 3` will cite the wrong place with confidence.
- **`grep -n`'s format, not a new one.** #2162 asks for one output convention across the file tools. Matching the tool that already numbers things costs nothing and means the model does not have to learn two.
- **Reading the whole file stays the default.** `offset=0, limit=None` behaves exactly as before apart from the numbering, so no existing prompt or transcript breaks.
- **The read registry #1982 needs is not added here.** Nothing reads it yet; adding an unused dict to the loop so a later PR can use it is the kind of thing that ships half-wired and stays that way. It belongs with `edit_file`, which is what enforces the invariant.

## Verification

- **Unit**: 8 new tests in the existing `tests/agents/test_autonomous_loop.py` (no new file), all offline — real files under `tmp_path`, no model call. **7 of the 8 fail on clean `master`**; the eighth (the token cap still applies) passes both before and after, and is there to prove the cap was not lost when windowing went in front of it. They cover numbering from one, absolute numbering under an offset, `limit` bounding the window, offset-past-EOF, negative offset, non-positive limit, the cap, and the schema's parameter set.
- **The two existing `read_file` cap tests pass unchanged**, which is the check that the numbering did not push output past the budget.
- **Regression sweep**: `tests/agents tests/structs/test_agent.py` — **410 passed, 7 failed**. The same 7 fail identically on a clean `upstream/master` worktree (**402 passed, 7 failed** there — the 8-test difference is this PR's). They are `TestAgentUsage` and provider tests that need keys.
- **Lint**: `black==24.2.0 --check` and `ruff==0.2.1 check` — the versions the Lint workflow pins — clean.
- **Not verified here**: no live model was asked to use the new parameters. The schema change is what a model sees, and it is asserted directly.

## Deliberately not in this PR

`edit_file` (#1979), `glob` (#1983), read-before-write (#1982), and the shared path resolver #2162 folds in from #1791/#1970 — the last of which has an open PR at #2154. This one changes no path resolution, so it does not collide with it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut4g856LnbHeUjA8MawHxo
