### PR TITLE
style: compact multi-line comments to one line across swarms/

### DIFF
--- a/swarms/agents/auto_generate_swarm_config.py
+++ b/swarms/agents/auto_generate_swarm_config.py
@@ -49,8 +49,7 @@ def parse_yaml_from_swarm_markdown(markdown_text: str) -> dict:
     Returns:
         dict: A parsed Python dictionary of the YAML content.
     """
-    # Match YAML blocks inside triple backticks — use the last match
-    # because the LLM's generated YAML comes after any examples in the prompt
+    # Last match: the generated YAML comes after any examples in the prompt
     pattern = r"```yaml\s*\n(.*?)```"
     matches = re.findall(pattern, markdown_text, re.DOTALL)
 

--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -169,9 +169,7 @@ class AutonomousAgentLoop:
         if summary is None:
             return False
 
-        # compact() already re-seeded short_memory with the summary,
-        # so the transcript copy must not be mirrored back a second
-        # time.
+        # compact() already re-seeded short_memory, do not mirror the summary twice
         self._transcript = Transcript()
         self._say_user(
             "[Compressed Memory Summary]\n"
@@ -714,14 +712,9 @@ class AutonomousAgentLoop:
                 ):
                     subtask_iterations += 1
 
-                    # Between iterations every recorded tool call has
-                    # been answered, so this is the one point the
-                    # transcript can be replaced without orphaning a
-                    # tool_call id.
+                    # Every tool call is answered here, so replacing the transcript orphans nothing
                     if self._maybe_compress_context():
-                        # The rebuilt transcript holds only the
-                        # summary; restore the instruction for the
-                        # subtask in flight.
+                        # The rebuilt transcript holds only the summary, restore the subtask
                         self._say_user(execution_prompt)
 
                     try:

--- a/swarms/agents/flexion_agent.py
+++ b/swarms/agents/flexion_agent.py
@@ -91,8 +91,7 @@ class ReflexionMemory:
         Returns:
             List[Dict[str, Any]]: Relevant memories
         """
-        # In a production implementation, this would use embeddings and vector similarity
-        # For now, implement a simple keyword-based relevance scoring
+        # Keyword scoring stands in for embedding similarity
         scored_memories = []
 
         # Score and combine memories from both short and long-term
@@ -306,8 +305,7 @@ class ReflexionAgent:
 
         evaluation = self.evaluator.run(task=prompt)
 
-        # Extract numerical score from evaluation (in a production system, you'd want a more
-        # robust parsing method here, potentially using structured output)
+        # Regex over prose stands in for structured output
         try:
             # Look for a final score in the format "Final Score: X/10" or similar
             import re
@@ -484,8 +482,6 @@ class ReflexionAgent:
                     f"Starting iteration {iteration+1}/{self.max_loops}"
                 )
 
-                # In first iteration, generate new response
-                # In subsequent iterations, refine previous response
                 if iteration == 0:
                     step_result = self.step(task, iteration)
                     step_result["response"]

--- a/swarms/agents/llm_manager.py
+++ b/swarms/agents/llm_manager.py
@@ -289,8 +289,6 @@ class LLMManager:
                     if len(args) == 1 and isinstance(args[0], dict):
                         additional_args.update(args[0])
                     else:
-                        # For other types of args, log them for debugging
-                        # and potentially handle them based on their type
                         logger.debug(
                             f"Received positional args in llm_handling: {args}"
                         )
@@ -756,8 +754,7 @@ class LLMManager:
         # Restore original stream setting
         self.agent.llm.stream = original_stream
 
-        # If the model made tool calls during the stream, return them
-        # so the auto loop executes them — same format as non-streaming.
+        # Tool calls made mid-stream come back in the non-streaming shape
         return tool_calls_out if tool_calls_out else complete_response
 
     def _collect_stream(
@@ -819,8 +816,7 @@ class LLMManager:
                 "".join(thinking_parts), title=self._thinking_title()
             )
 
-        # Chain the already-consumed first chunk with the remaining stream,
-        # then wrap with tool-call collection.
+        # The first chunk was already consumed, chain it back in
         chained = itertools.chain(
             (
                 [first_content_chunk]

--- a/swarms/cli/main.py
+++ b/swarms/cli/main.py
@@ -2292,8 +2292,7 @@ def main() -> None:
     try:
         show_ascii_art()
 
-        # Typo correction: catch mistyped command name before argparse
-        # rejects it with a generic "invalid choice" error.
+        # Catch a mistyped command before argparse's generic "invalid choice"
         if (
             len(sys.argv) > 1
             and not sys.argv[1].startswith("-")

--- a/swarms/cli/tips.py
+++ b/swarms/cli/tips.py
@@ -146,8 +146,7 @@ TIP_CATEGORIES: Dict[str, List[str]] = {
 
 # Random labels.
 
-# (emoji, label, accent style). Sampling these gives the startup banner the
-# "feels fresh every time" quality.
+# (emoji, label, accent style), sampled so the startup banner varies
 TIP_LABELS: List[tuple[str, str, str]] = [
     ("※", "Tip", "bold red"),
     ("⚡", "Pro tip", "bold yellow"),

--- a/swarms/cli/utils.py
+++ b/swarms/cli/utils.py
@@ -119,8 +119,7 @@ def show_ascii_art():
     header.add_column(vertical="top")
     header.add_row(icon, info)
 
-    # Two rotating tips: a quick command hint inside the panel + a longer
-    # contextual tip below it. Both pull from swarms.cli.tips for variety.
+    # A command hint inside the panel and a longer tip below it
     panel_tip = render_tip(category="commands")
     startup_tip = render_tip()
 

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -458,11 +458,9 @@ class Agent:
         self.rules = rules
         self.max_tokens = max_tokens
         self.temperature = temperature
-        # Always use environment variable for workspace_dir, ignore user input
-        # Fallback to default if environment variable is not set
+        # The environment wins over the argument, with a default when unset
         self.workspace_dir = get_workspace_dir()
-        # Built on first use: file tools need the dir even without
-        # autosave, but constructing every agent must not create one.
+        # Built on first use, constructing an agent must not create a directory
         self._workspace = None
         self.tags = tags
         self.use_cases = use_cases
@@ -545,8 +543,7 @@ class Agent:
             self.max_tokens = self._default_max_tokens() or 16000
 
         if self.max_loops == "auto":
-            # The prompt must agree with the tool list: without this the model
-            # is instructed to call a `think` tool it was never given.
+            # Without this the prompt tells the model to call a think tool it lacks
             self.system_prompt += (
                 "\n\n"
                 + get_autonomous_agent_prompt(
@@ -557,8 +554,7 @@ class Agent:
         # When False the agent does not read or write MEMORY.md across sessions.
         self.persistent_memory = persistent_memory
 
-        # Context compression is available for both max_loops="auto" and
-        # integer max_loops runs. Gated purely on the user-facing boolean.
+        # Applies to auto and integer max_loops alike
         self.context_compression = context_compression
         if self.context_compression:
             self._context_compressor = ContextCompressor(
@@ -609,8 +605,7 @@ class Agent:
         if self.fallback_models and not self.model_name:
             self.model_name = self.fallback_models[0]
 
-        # Owns model rotation, LiteLLM construction, and LLM invocation.
-        # Reads config off this agent, so it must be built after config is set.
+        # Reads config off this agent, so it must come after the config is set
         self.llm_manager = LLMManager(agent=self)
         self.autonomous_loop = AutonomousAgentLoop(agent=self)
 
@@ -1364,8 +1359,7 @@ class Agent:
             # Set the loop count
             loop_count = 0
 
-            # Structured conversation for this run. Built lazily below so the
-            # transforms path can keep its flattened prompt.
+            # Built lazily so the transforms path can keep its flattened prompt
             transcript: Optional[Transcript] = None
 
             # Clear the short memory
@@ -1383,8 +1377,6 @@ class Agent:
             ):
                 loop_count += 1
 
-                # Compress short-term memory if an auto-loop run has
-                # crossed the configured fraction of the context window.
                 if self._context_compressor is not None:
                     self._context_compressor.maybe_compress(self)
 
@@ -1495,8 +1487,7 @@ class Agent:
 
                         # Print
                         if self.print_on is True:
-                            # Skip printing structured output (list of tool calls) here
-                            # Function call visualization is handled in execute_tools
+                            # Tool calls are visualised in execute_tools
                             if isinstance(response, list):
                                 # Tool calls will be visualized in execute_tools, skip here
                                 pass
@@ -1657,11 +1648,7 @@ class Agent:
                             )
 
                     except AgentToolExecutionError as e:
-                        # A tool that already exhausted its own retries is not
-                        # a provider failure. Re-running the model cannot fix
-                        # it and costs another completion, so record it and
-                        # leave the retry loop instead of falling into the
-                        # generation handler below.
+                        # A tool failure is not a provider failure, re-running the model cannot fix it
                         if use_transcript and turn_calls:
                             transcript.flush_tool_results(
                                 turn_calls, turn_results
@@ -1682,8 +1669,7 @@ class Agent:
                             ),
                         )
 
-                        # Exit the retry loop, not the run: the next loop lets
-                        # the model read the failure and choose differently.
+                        # Exit the retry loop, not the run, so the model can read the failure
                         success = True
 
                     except (
@@ -1693,15 +1679,13 @@ class Agent:
                         Exception,
                     ) as e:
 
-                        # Close out any tool calls recorded before the failure,
-                        # so the retried request is still well formed.
+                        # Answer the recorded tool calls so the retried request is well formed
                         if use_transcript and turn_calls:
                             transcript.flush_tool_results(
                                 turn_calls, turn_results
                             )
 
-                        # Track the LLM/generation error via telemetry — the
-                        # retry loop swallows it, so capture_run never sees it.
+                        # The retry loop swallows this, so capture_run never sees it
                         capture_error(
                             e,
                             self,
@@ -1765,8 +1749,7 @@ class Agent:
                             "[bold cyan]You[/bold cyan] [bold green]❯[/bold green] "
                         )
                     except (KeyboardInterrupt, EOFError):
-                        # Graceful exit on Ctrl+C / Ctrl+D during
-                        # interactive input. No traceback, no error.
+                        # Ctrl+C / Ctrl+D during input exits without a traceback
                         formatter.console.print()
                         self.pretty_print(
                             "Session ended by user. Goodbye.",
@@ -2084,8 +2067,7 @@ class Agent:
             try:
                 cached = self.add_mcp_tools_to_memory()
             except Exception as error:
-                # A server being unreachable must not take down agent setup;
-                # the agent simply runs without those tools.
+                # An unreachable server must not take down agent setup
                 logger.error(
                     f"Could not fetch MCP tools to defer: {error}"
                 )
@@ -3029,8 +3011,7 @@ Subtask Breakdown:
             Dict[str, Any]: A dictionary representation of the class attributes.
         """
 
-        # Create a copy of the dict to avoid mutating the original object
-        # Remove the llm object from the copy since it's not serializable
+        # The llm object is not serializable
         dict_copy = self.__dict__.copy()
         dict_copy.pop("llm", None)
 
@@ -3315,8 +3296,7 @@ Subtask Breakdown:
             >>> agent.run("Describe this image", img=img_base64)
         """
 
-        # If no task is provided, prompt for one only in interactive mode.
-        # Outside interactive mode, fail fast instead of blocking on stdin.
+        # Outside interactive mode, fail fast instead of blocking on stdin
         if task is None or (
             isinstance(task, str) and task.strip() == ""
         ):
@@ -3336,8 +3316,7 @@ Subtask Breakdown:
                     "[bold cyan]You[/bold cyan] [bold green]❯[/bold green] "
                 ).strip()
             except (KeyboardInterrupt, EOFError):
-                # Graceful exit on Ctrl+C / Ctrl+D before the first task
-                # has even been entered. No traceback, no error.
+                # Ctrl+C / Ctrl+D before the first task exits without a traceback
                 formatter.console.print()
                 self.pretty_print(
                     "Session ended by user. Goodbye.",
@@ -3719,8 +3698,7 @@ Subtask Breakdown:
             List[Any]: One entry per agent, in the order the agents were given.
                 An agent whose conversation raised contributes None.
         """
-        # Pool is scoped to the call — see run_concurrent_tasks for why this is
-        # not an Agent-level executor.
+        # Scoped to the call, see run_concurrent_tasks for why
         with ContextThreadPoolExecutor(
             max_workers=os.cpu_count()
         ) as executor:

--- a/swarms/structs/agent_rearrange.py
+++ b/swarms/structs/agent_rearrange.py
@@ -54,8 +54,7 @@ def _split_steps(segments: List[str]) -> List[List[str]]:
     ]
 
 
-# Resolved at import time from the canonical Literal type so it stays in
-# sync if HistoryOutputType ever gains/loses members.
+# Derived from the Literal so it cannot drift from HistoryOutputType
 _VALID_OUTPUT_TYPES = set(get_args(OutputType))
 
 
@@ -196,8 +195,7 @@ class AgentRearrange(SerializableMixin):
         self.team_awareness = team_awareness
         self.collab_prompt = collab_prompt
 
-        # Seeds team awareness itself; seeding again here added the same
-        # system message twice, so every agent read it twice on every call.
+        # Seeds team awareness itself, seeding here too doubled the system message
         self._reset_conversation()
 
         self.reliability_check()
@@ -650,8 +648,7 @@ class AgentRearrange(SerializableMixin):
         for i, agent_name in enumerate(agent_names):
             result = results[i]
 
-            # `run` honours the agent's own output_type, which by default is
-            # its whole conversation; record the answer instead.
+            # run() returns the agent's whole conversation by default, record the answer
             if not isinstance(result, Exception):
                 result = agent_answer(
                     agents_to_run[i], fallback=result
@@ -781,14 +778,12 @@ class AgentRearrange(SerializableMixin):
             based on the flow syntax. It also supports custom task injection
             and multiple execution loops as configured.
         """
-        # A reused instance would otherwise serve the previous task's whole
-        # transcript as context for this one.
+        # A reused instance would otherwise carry the previous task's transcript
         self._reset_conversation()
 
         self.conversation.add("User", task)
 
-        # A raw copy, because custom_tasks splices new segments into it below;
-        # self.steps is the unmutated flow.
+        # A raw copy, custom_tasks splices into it and self.steps stays unmutated
         tasks = self.flow.split("->")
         response_dict = {}
 
@@ -1151,8 +1146,7 @@ class AgentRearrange(SerializableMixin):
         """
         agent = find_agent_by_name(self.agents, agent_name)
 
-        # Awareness is injected via a temporary system-prompt extension.
-        # See _run_sequential_workflow for rationale.
+        # Injected via a temporary system-prompt extension, see _run_sequential_workflow
         awareness_info = self._get_sequential_awareness(
             agent_name, steps, task_idx=task_idx
         )
@@ -1308,8 +1302,7 @@ class AgentRearrange(SerializableMixin):
         Not yet supported in streaming mode: ``max_loops > 1``,
         ``custom_tasks``. Use ``run()`` for those.
         """
-        # A reused instance would otherwise serve the previous task's whole
-        # transcript as context for this one.
+        # A reused instance would otherwise carry the previous task's transcript
         self._reset_conversation()
 
         self.conversation.add("User", task)

--- a/swarms/structs/auction_swarm.py
+++ b/swarms/structs/auction_swarm.py
@@ -63,8 +63,7 @@ from swarms.utils.history_output_formatter import (
 from swarms.utils.output_types import OutputType
 
 BID_TOOL = {
-    # The LLM is forced to call this function so every bid is a structured,
-    # machine-readable (confidence, estimated_cost) pair.
+    # Forced tool call, so every bid is a structured (confidence, estimated_cost) pair
     "type": "function",
     "function": {
         "name": "bid",
@@ -92,8 +91,7 @@ BID_TOOL = {
     },
 }
 
-# Lower bound used when clamping/dividing by estimated_cost so a
-# zero-cost bid can never produce a divide-by-zero or an infinite score.
+# Floor for estimated_cost so a zero-cost bid cannot divide by zero
 MIN_ESTIMATED_COST = 1e-6
 
 # Guards _extract_bid against pathological model output causing excessive parse time.
@@ -131,8 +129,7 @@ def _extract_bid(tool_output: Any) -> Tuple[float, float]:
         into the ``0..1`` range and cost is clamped to be strictly positive.
     """
     if isinstance(tool_output, str):
-        # Agents with output_type="str-all-except-first" (the default)
-        # return tool calls as the str() of a list of dicts, not JSON.
+        # The default output_type returns tool calls as str() of a list, not JSON
         if len(tool_output) > MAX_TOOL_OUTPUT_LEN:
             return 0.0, 1.0
         try:
@@ -425,8 +422,7 @@ class AuctionSwarm(SerializableMixin):
             return_agent_output_dict=True,
         )
 
-        # `winners` is sorted by score, highest first, so the first entry
-        # that did not error is the auctioneer's pick for "best result".
+        # winners is sorted by score, the first non-error entry is the pick
         successful = []
         for agent, *_ in winners:
             response = results.get(agent.agent_name)

--- a/swarms/structs/auto_agent_builder.py
+++ b/swarms/structs/auto_agent_builder.py
@@ -13,12 +13,10 @@ logger = initialize_logger(log_folder="auto_agent_builder")
 
 DEFAULT_MODEL_NAME = "gpt-5.4"
 
-# Kept as a module-level alias so existing imports of BUILDER_SYSTEM_PROMPT keep
-# working now that the text lives in swarms/prompts/.
+# Alias kept for existing imports now that the text lives in swarms/prompts/
 BUILDER_SYSTEM_PROMPT = AUTO_AGENT_BUILDER_SYSTEM_PROMPT
 
-# The builder is forced to call this, so the provider enforces the shape and
-# there is no free-form JSON to parse out of a prose response.
+# Forced tool call, so the provider enforces the shape instead of a JSON parse
 BUILD_AGENTS_TOOL = {
     "type": "function",
     "function": {
@@ -80,8 +78,7 @@ REQUIRED_FIELDS = (
     "model_name",
 )
 
-# Agent keyword arguments the builder fills in from the generated roster.
-# Passing any of these in agent_kwargs would collide with the generated value.
+# Filled in from the roster, passing them in agent_kwargs would collide
 GENERATED_AGENT_FIELDS = (
     "agent_name",
     "agent_description",
@@ -153,16 +150,14 @@ def _extract_agents(tool_output: Any) -> List[Dict[str, str]]:
     for entry in raw:
         if not isinstance(entry, dict):
             continue
-        # Drop partial entries rather than constructing an Agent with a missing
-        # system_prompt, which would silently fall back to the default persona.
+        # A missing system_prompt would silently fall back to the default persona
         if any(not entry.get(f) for f in REQUIRED_FIELDS):
             logger.warning(
                 f"Skipping incomplete agent config: {entry!r}"
             )
             continue
         config = {f: str(entry[f]).strip() for f in REQUIRED_FIELDS}
-        # Agent memory is keyed on agent_name, so duplicates would share and
-        # corrupt each other's state.
+        # Memory is keyed on agent_name, duplicates would corrupt each other
         if config["name"] in seen:
             logger.warning(
                 f"Skipping duplicate agent name: {config['name']!r}"
@@ -296,8 +291,7 @@ class AutoAgentBuilder:
             system_prompt=self.system_prompt,
             model_name=self.model_name,
             max_loops=1,
-            # The roster depends only on the task, so carrying state across runs
-            # would let an earlier task's team leak into a later one.
+            # The roster depends only on the task, no state may leak across runs
             output_type="final",
             persistent_memory=False,
             temperature=None,
@@ -330,8 +324,7 @@ class AutoAgentBuilder:
             raise ValueError("task must be a non-empty string.")
 
         if self.num_agents is not None:
-            # Stated twice, and as a hard requirement, because the system
-            # prompt's prefer-fewer guidance otherwise pulls the count down.
+            # Stated as a hard requirement, the prefer-fewer guidance otherwise wins
             instruction = (
                 f"Design exactly {self.num_agents} agents for this task — not "
                 f"fewer, not more. This exact count is a hard requirement and "
@@ -368,8 +361,7 @@ class AutoAgentBuilder:
             )
             agents = agents[:limit]
 
-        # An exact count is a request, not something we can fabricate — surface
-        # the shortfall rather than silently handing back a smaller roster.
+        # Surface a shortfall rather than hand back a smaller roster silently
         if (
             self.num_agents is not None
             and len(agents) < self.num_agents

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -1383,8 +1383,7 @@ def create_sub_agent_tool(
             # Import Agent class to create sub-agent
             from swarms.structs.agent import Agent
 
-            # Without the parent's tools a sub-agent is one stateless LLM call,
-            # strictly less capable than the parent asking the question itself.
+            # Without tools a sub-agent is strictly weaker than asking the parent
             parent_tools = list(getattr(agent, "tools", None) or [])
 
             # Create sub-agent with the same LLM and tools as parent
@@ -1395,8 +1394,7 @@ def create_sub_agent_tool(
                 system_prompt=system_prompt,  # Use custom system prompt if provided
                 model_name=agent.model_name,
                 tools=parent_tools,
-                # Tools need a call-then-read turn. Finite whatever the parent
-                # is, so a max_loops="auto" parent cannot recurse into sub-agents.
+                # Finite even for an auto parent, so sub-agents cannot recurse
                 max_loops=5 if parent_tools else 1,
                 print_on=getattr(agent, "print_on", False),
                 verbose=agent.verbose,

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -160,9 +160,6 @@ def get_summary_prompt() -> str:
     )
 
 
-# Tool schemas.
-
-
 def get_autonomous_planning_tools() -> List[Dict[str, Any]]:
     """
     Get tool definitions for autonomous planning and execution.
@@ -1100,11 +1097,8 @@ def run_bash_tool(
             content=f"Blocked (security): {command[:100]}{'...' if len(command) > 100 else ''}",
         )
         return f"Error: {rejection}"
-    # -------------------------------------------------------------------------
-
     try:
-        # Run in process cwd (where the user started the script) so commands like
-        # ls -la and python script.py see the project directory, not the agent workspace.
+        # Runs in the process cwd, not the agent workspace
         result = subprocess.run(
             command,
             shell=True,
@@ -1510,8 +1504,7 @@ def assign_task_tool(
 
         # Execute tasks
         if wait_for_completion:
-            # Wait for tasks to complete using registry
-            # (order is not guaranteed; we map by spawned_task_id for reporting)
+            # Completion order is not guaranteed, results are mapped by spawned_task_id
             registry.gather(strategy="wait_all", timeout=None)
 
             # Format results based on registry state
@@ -1552,8 +1545,7 @@ def assign_task_tool(
 
             return result_msg
         else:
-            # Fire and forget: tasks are already running in the registry executor.
-            # Return the spawned IDs so callers can poll/cancel later.
+            # Fire and forget, the spawned ids let callers poll or cancel later
             lines = [
                 f"Dispatched {len(task_mappings)} task(s) to sub-agents (registry async mode).",
                 "Spawned task IDs:",

--- a/swarms/structs/concurrent_workflow.py
+++ b/swarms/structs/concurrent_workflow.py
@@ -20,8 +20,7 @@ from swarms.utils.workspace_manager import WorkspaceManager
 
 logger = initialize_logger(log_folder="concurrent_workflow")
 
-# Upper bound on concurrent agent calls when max_workers is not set. Agent
-# calls are network-bound; this guards provider rate limits, not CPU.
+# Default cap on concurrent agent calls, guards provider rate limits not CPU
 MAX_CONCURRENT_AGENTS = 32
 
 

--- a/swarms/structs/context_utils.py
+++ b/swarms/structs/context_utils.py
@@ -28,8 +28,7 @@ NO_NEW_MESSAGES = (
     "previous response."
 )
 
-# Roles a structure writes for its own bookkeeping - rosters, flow diagrams,
-# loop markers. They are not turns any agent took, so they are not rendered.
+# Structure bookkeeping rows, not turns any agent took, so never rendered
 _STRUCTURE_ROLES = frozenset({"system"})
 
 _USER_ROLES = frozenset({"user", "human"})
@@ -122,8 +121,7 @@ def split_last_turn(
     """
     if not messages:
         return [], fallback
-    # A blank newest turn would reach Agent.run as an empty task, which it
-    # rejects; the flattened form used to smuggle one through as "User: ".
+    # A blank newest turn would reach Agent.run as an empty task, which it rejects
     task = messages[-1]["content"]
     if not str(task).strip():
         return messages[:-1], fallback

--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -50,8 +50,7 @@ def get_conversation_dir():
     return conversation_dir
 
 
-# Conversations built without a name share this one, so they must not resume
-# from each other's files. See setup_file_path.
+# Unnamed conversations share this name, so they must not resume from disk
 DEFAULT_CONVERSATION_NAME = "conversation-test"
 
 
@@ -109,8 +108,7 @@ class Conversation:
         self.id = id or generate_id()
         self.name = name
         self.save_filepath = save_filepath
-        # Whether the caller chose the file, as opposed to it being derived
-        # from the default name. Only an explicit choice resumes from disk.
+        # Only an explicitly chosen file resumes from disk
         self._explicit_save_filepath = save_filepath is not None
         self.system_prompt = system_prompt
         self.time_enabled = time_enabled
@@ -148,8 +146,7 @@ class Conversation:
         self.setup_file_path()
         self.setup()
 
-        # Re-enable MEMORY.md writes and preload any prior interaction log
-        # as a single System preamble message.
+        # Prior MEMORY.md content becomes one System preamble message
         self._suppress_memory_md = False
         if self.memory_md_path:
             self._init_memory_md()
@@ -262,9 +259,6 @@ class Conversation:
 
         if self.custom_rules_prompt is not None:
             self.add(self.user or "User", self.custom_rules_prompt)
-
-        # if self.tokenizer is not None:
-        #     self.truncate_memory_with_tokenizer()
 
     def _autosave(self):
         """Automatically save the conversation if autosave is enabled."""
@@ -1118,8 +1112,7 @@ class Conversation:
                 if remaining_tokens <= 0:
                     break
 
-                # If we have space left, we need to truncate this message
-                # Use binary search to find content length that fits remaining token space
+                # Binary-search a prefix of this message that fits the remaining budget
                 truncated_content = self._binary_search_truncate(
                     content,
                     remaining_tokens,
@@ -1538,8 +1531,7 @@ class Conversation:
         if total_tokens <= self.context_length:
             return all_tokens
 
-        # We need to remove characters from the beginning until we're under the limit
-        # Start by removing a percentage of characters and adjust iteratively
+        # Drop characters from the front until the string fits
         target_tokens = self.context_length
         current_string = all_tokens
 

--- a/swarms/structs/cron_job.py
+++ b/swarms/structs/cron_job.py
@@ -183,8 +183,7 @@ class CronJob:
             number = int(match.group(1))
             unit = match.group(2)
 
-            # "0second" parsed fine and then scheduled a job that never fired:
-            # no error, no log line, just a cron job that silently does nothing.
+            # "0second" used to schedule a job that silently never fired
             if number == 0:
                 raise CronJobConfigError(
                     f"Interval must be greater than zero, got {interval!r}. "
@@ -681,8 +680,7 @@ class CronJob:
                     "max_consecutive_errors"
                 ),
             )
-            # _run schedules the task and starts this job's own thread; it
-            # does not block, which is what lets the fleet run together.
+            # _run starts the job's own thread without blocking
             job._run(spec["task"], **(spec.get("kwargs") or {}))
             jobs.append(job)
 

--- a/swarms/structs/execution_utils.py
+++ b/swarms/structs/execution_utils.py
@@ -82,8 +82,7 @@ def batched_run(
 
     if imgs is not None:
         imgs = list(imgs)
-        # Length-checked rather than zipped: zip would silently drop the
-        # tail and run fewer tasks than the caller asked for.
+        # zip would silently drop the tail and run fewer tasks than asked
         if len(imgs) != len(tasks):
             raise ValueError(
                 f"Got {len(tasks)} tasks and {len(imgs)} images; pass "
@@ -106,13 +105,11 @@ def batched_run(
     if max_workers is None:
         results = [call(i, task) for i, task in enumerate(tasks)]
     else:
-        # ContextThreadPoolExecutor, not the plain one: it carries the
-        # tracing context in, so worker spans stay nested under the run.
+        # ContextThreadPoolExecutor carries the tracing context into the workers
         with ContextThreadPoolExecutor(
             max_workers=max_workers
         ) as executor:
-            # Futures are read in submission order, so element i is always
-            # the result for tasks[i] even when they finish out of order.
+            # Read in submission order, so element i is the result for tasks[i]
             futures = [
                 executor.submit(call, i, task)
                 for i, task in enumerate(tasks)

--- a/swarms/structs/graph_workflow.py
+++ b/swarms/structs/graph_workflow.py
@@ -233,8 +233,7 @@ class NetworkXBackend(GraphBackend):
             NetworkXBackend: A new backend instance with reversed edges.
         """
         reversed_backend = NetworkXBackend()
-        # copy=False avoids deepcopy of node attributes, which fails for
-        # Agent objects that hold unpicklable thread locks.
+        # copy=False, deepcopy fails on Agents holding thread locks
         reversed_backend.graph = self.graph.reverse(copy=False)
         return reversed_backend
 
@@ -250,8 +249,7 @@ class NetworkXBackend(GraphBackend):
         try:
             return list(nx.topological_generations(self.graph))
         except nx.NetworkXUnfeasible:
-            # Cyclic graph: layer what we can with Kahn's algorithm and append
-            # the cyclic remainder so callers still get an execution order.
+            # Cyclic graph, layer what Kahn's algorithm can and append the rest
             graph = self.graph
             indegree = dict(graph.in_degree())
             frontier = [n for n, d in indegree.items() if d == 0]
@@ -274,8 +272,7 @@ class NetworkXBackend(GraphBackend):
             return layers
 
     def simple_cycles(self) -> List[List[str]]:
-        # Enumerating simple cycles is exponential in the number of cycles, so
-        # short-circuit on the overwhelmingly common acyclic case first.
+        # Enumerating cycles is exponential, short-circuit the acyclic case
         if nx.is_directed_acyclic_graph(self.graph):
             return []
         return list(nx.simple_cycles(self.graph))
@@ -401,8 +398,7 @@ class RustworkxBackend(GraphBackend):
             return iter([])
         target_index = self._node_id_to_index[node_id]
         index_to_id = self._index_to_node_id
-        # predecessor_indices is O(in-degree); scanning the full edge list
-        # would make this O(E) per node.
+        # O(in-degree) rather than O(E) per node
         return iter(
             [
                 index_to_id[idx]
@@ -515,8 +511,7 @@ class RustworkxBackend(GraphBackend):
 
     def simple_cycles(self) -> List[List[str]]:
         try:
-            # Enumerating cycles is exponential in their count; the acyclic
-            # check is O(V+E) and covers the common case.
+            # Enumerating cycles is exponential, short-circuit the acyclic case
             if rx.is_directed_acyclic_graph(self.graph):
                 return []
             index_to_id = self._index_to_node_id
@@ -535,8 +530,7 @@ class RustworkxBackend(GraphBackend):
             return set()
         node_index = self._node_id_to_index[node_id]
         index_to_id = self._index_to_node_id
-        # Native Rust traversal; the previous hand-rolled BFS also used
-        # list.pop(0), which is O(n) per dequeue.
+        # Native traversal, the hand-rolled BFS used list.pop(0)
         return {
             index_to_id[idx]
             for idx in rx.descendants(self.graph, node_index)
@@ -985,8 +979,7 @@ class GraphWorkflow:
             )
             self._sorted_layers = sorted_layers
 
-            # Build the adjacency maps once and reuse them for validation and
-            # for per-node predecessor lookups during execution.
+            # Built once, reused for validation and per-node predecessor lookups
             succ, pred = self.graph_backend.adjacency()
             self._successors_map = succ
             self._predecessors_cache = {
@@ -1010,8 +1003,7 @@ class GraphWorkflow:
                         + "; ".join(warnings)
                     )
 
-            # Freeze the per-layer execution plan so run() does no dictionary
-            # lookups or attribute resolution in its hot loop.
+            # Frozen so run() does no lookups in its hot loop
             self._execution_plan = [
                 [
                     (
@@ -1797,8 +1789,7 @@ class GraphWorkflow:
                     "Your goal is to collaborate and create a comprehensive response that builds on all previous work."
                 )
             elif loop_idx > 0 and layer_idx == 0 and prev_outputs:
-                # Entry-point nodes in subsequent loops receive end-point
-                # outputs from the previous loop as refinement context.
+                # Later loops seed entry points with the previous loop's end outputs
                 messages += [
                     {
                         "role": "user",
@@ -2028,8 +2019,7 @@ class GraphWorkflow:
                     else None
                 )
 
-                # Seed entry-point nodes with end-point outputs from the
-                # previous loop so agents can refine iteratively.
+                # Later loops seed entry points with the previous loop's end outputs
                 if prior_loop_end_outputs:
                     prev_outputs.update(prior_loop_end_outputs)
 
@@ -2052,8 +2042,7 @@ class GraphWorkflow:
                                 )
                                 prev_outputs.update(saved)
                                 execution_results.update(saved)
-                                # Replay into conversation so workflow state
-                                # is identical to a non-checkpoint run.
+                                # Replayed so state matches a non-checkpoint run
                                 for node_id, output in saved.items():
                                     agent_name = (
                                         getattr(
@@ -2243,8 +2232,7 @@ class GraphWorkflow:
                                 )
 
                     if len(layer_data) == 1:
-                        # Single-node layer: run inline. Dispatching to a
-                        # worker thread would only add handoff latency.
+                        # Single-node layer, a worker thread would only add latency
                         (
                             node_id,
                             agent,
@@ -2886,8 +2874,7 @@ class GraphWorkflow:
 
         return {
             "id": node.id,
-            # ``.value``, not ``str(node.type)``: the latter renders as
-            # "NodeType.AGENT", which NodeType() then refuses to parse back.
+            # .value, str(node.type) renders as "NodeType.AGENT" and will not parse back
             "type": node.type.value,
             "metadata": node.metadata,
             "agent": self._agent_payload(node),
@@ -2915,8 +2902,7 @@ class GraphWorkflow:
             The serialized workflow.
         """
         if shallow:
-            # Sorted for deterministic output — two equivalent workflows
-            # built in different insertion orders produce identical specs.
+            # Sorted so insertion order does not change the spec
             return {
                 "name": self.name,
                 "description": self.description,

--- a/swarms/structs/groupchat.py
+++ b/swarms/structs/groupchat.py
@@ -79,8 +79,7 @@ from swarms.telemetry.otel import capture_init, trace_run
 logger = initialize_logger(log_folder="groupchat")
 
 RESPOND_TOOL = {
-    # The LLM is forced to call this function for every decision. This keeps
-    # speaking decisions machine-readable and avoids parsing natural language.
+    # Forced tool call, so every speaking decision is machine-readable
     "type": "function",
     "function": {
         "name": "respond",
@@ -248,8 +247,7 @@ class GroupChat(SerializableMixin):
 
         self.conversation = Conversation(time_enabled=False)
 
-        # `agents` defaults to None, so guard before len(): the documented
-        # contract is ValueError, not a TypeError from len(None).
+        # agents may be None, the documented error is ValueError not TypeError
         if self.agents is None or len(self.agents) < 2:
             raise ValueError("GroupChat requires at least 2 agents.")
 

--- a/swarms/structs/llm_council.py
+++ b/swarms/structs/llm_council.py
@@ -453,8 +453,7 @@ class LLMCouncil:
             for name, response in original_responses.items():
                 print(f"   {name}: {response[:100]}...")
 
-        # Step 2: Anonymize responses for evaluation
-        # Create anonymous IDs (A, B, C, D, etc.)
+        # Anonymise responses as A, B, C... for evaluation
         anonymous_ids = [
             chr(65 + i) for i in range(len(self.council_members))
         ]
@@ -476,8 +475,7 @@ class LLMCouncil:
                 "\n🔍 Council members evaluating each other's responses..."
             )
 
-        # Step 3: Have each member evaluate and rank all responses concurrently
-        # Create evaluation tasks for each member
+        # Every member ranks all responses, concurrently
         evaluation_tasks = [
             get_evaluation_prompt(
                 query, anonymous_responses, member.agent_name

--- a/swarms/structs/ma_utils.py
+++ b/swarms/structs/ma_utils.py
@@ -100,8 +100,6 @@ models = [
     "openai/gpt-4o",
     "groq/deepseek-r1-distill-qwen-32b",
     "groq/deepseek-r1-distill-qwen-32b",
-    # "gemini/gemini-pro",
-    # "gemini/gemini-1.5-pro",
     "groq/moonshotai/kimi-k2-instruct",
     "openai/03-mini",
     "o4-mini",

--- a/swarms/structs/majority_voting.py
+++ b/swarms/structs/majority_voting.py
@@ -253,8 +253,7 @@ class MajorityVoting:
 
         """
 
-        # A reused instance would otherwise serve the previous task's votes
-        # as context for this one.
+        # A reused instance would otherwise carry the previous task's votes
         self.conversation = Conversation(time_enabled=False)
 
         self.conversation.add(

--- a/swarms/structs/multi_agent_router.py
+++ b/swarms/structs/multi_agent_router.py
@@ -316,8 +316,7 @@ class MultiAgentRouter:
                 with this router.
         """
 
-        # Resolve every agent up front so an unknown name fails before any
-        # agent runs and is paid for.
+        # Resolve up front so an unknown name fails before anything is paid for
         resolved = []
         for handoff in boss_response_str["handoffs"]:
             try:
@@ -354,8 +353,7 @@ class MultiAgentRouter:
 
         # Execute agents only if there are valid tasks
         if selected_agents:
-            # The boss is prompted for non-overlapping tasks, so these are
-            # independent; running them in series cost the sum of their latencies.
+            # The tasks are independent, in series they cost the sum of their latencies
             with ContextThreadPoolExecutor(
                 max_workers=len(selected_agents)
             ) as executor:
@@ -492,8 +490,7 @@ class MultiAgentRouter:
                 executor.submit(self.route_task, task)
                 for task in tasks
             ]
-            # Read in submission order so element i belongs to tasks[i],
-            # matching batch_run.
+            # Read in submission order so element i belongs to tasks[i]
             for task, future in zip(tasks, futures):
                 try:
                     results.append(future.result())

--- a/swarms/structs/planner_generator_evaluator.py
+++ b/swarms/structs/planner_generator_evaluator.py
@@ -711,8 +711,7 @@ class PlannerGeneratorEvaluator:
                 criterion_scores[criterion] = float(score)
                 criterion_thresholds[criterion] = float(threshold)
 
-        # If no table parsed, try alternative patterns:
-        # "Criterion: score/10" or "Criterion: score out of 10"
+        # No table, try "Criterion: score/10" and "Criterion: score out of 10"
         if not criterion_scores:
             alt_scores = re.findall(
                 r"\*?\*?([^*:\n]+?)\*?\*?\s*:\s*(\d+(?:\.\d+)?)\s*(?:/\s*10|out of 10)",

--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -478,11 +478,7 @@ class SequentialWorkflow:
             )
 
         try:
-            # One clone per task. `run` appends to a conversation that is
-            # built once in __init__ and never reset, then formats the whole
-            # history — so reusing the instance made every result carry the
-            # transcripts of the tasks before it. `AgentRearrange.batch_run`
-            # already isolates this way for the same reason.
+            # One clone per task, a reused instance carries every earlier transcript
             return [
                 self.agent_rearrange._clone_for_task().run(task)
                 for task in tasks

--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -273,8 +273,7 @@ class SocialAlgorithms:
         Returns:
             Callable: A drop-in replacement for ``agent.run``.
         """
-        # Whatever is bound now, so an instance override or an enclosing
-        # recorder still runs rather than being skipped for the class method.
+        # Whatever is bound now, so an instance override still runs
         original = agent.run
 
         def run(task, *args, **kwargs):

--- a/swarms/structs/spreadsheet_swarm.py
+++ b/swarms/structs/spreadsheet_swarm.py
@@ -17,10 +17,8 @@ logger = initialize_logger(log_folder="spreadsheet_swarm")
 
 uuid_hex = uuid.uuid4().hex
 
-# --------------- NEW CHANGE START ---------------
-# Format time variable to be compatible across operating systems
+# Colons are not allowed in filenames on every OS
 formatted_time = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
-# --------------- NEW CHANGE END ---------------
 
 
 def _now() -> str:

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -181,8 +181,7 @@ def _msg_collab_prompt_ignored(swarm_type: str) -> str:
     )
 
 
-# Swarm types whose constructor carries the collaboration preamble through to
-# the agents. Everywhere else the flag has nothing to deliver it.
+# The only constructors that carry the collaboration preamble to the agents
 _COLLAB_PROMPT_SWARM_TYPES = frozenset(
     {"SequentialWorkflow", "AgentRearrange"}
 )
@@ -589,8 +588,7 @@ class SwarmRouter(SerializableMixin):
             self.multi_agent_collab_prompt is True
             and self.swarm_type not in _COLLAB_PROMPT_SWARM_TYPES
         ):
-            # Not self._log: that is gated on verbose, and a flag that
-            # silently does nothing is the thing being warned about.
+            # Not self._log, that is gated on verbose and this must always show
             logger.warning(
                 _msg_collab_prompt_ignored(self.swarm_type)
             )

--- a/swarms/structs/transcript.py
+++ b/swarms/structs/transcript.py
@@ -106,8 +106,7 @@ class Transcript:
                 name = function.get("name")
                 if not name:
                     continue
-                # Providers normally supply an id; synthesise a stable one if
-                # not, since result pairing depends on it.
+                # Result pairing needs an id, synthesise one if the provider gave none
                 call_id = (
                     item.get("id")
                     or f"call_{len(self._messages)}_{index}"

--- a/swarms/structs/tree_swarm.py
+++ b/swarms/structs/tree_swarm.py
@@ -200,8 +200,7 @@ class TreeAgent(Agent):
             )
             if self.verbose:
                 logger.info(f"Embedding type: {type(response)}")
-            # print(response)
-            # Handle different response structures from litellm
+            # litellm returns more than one response shape
             if hasattr(response, "data") and response.data:
                 if hasattr(response.data[0], "embedding"):
                     return response.data[0].embedding

--- a/swarms/telemetry/bootup.py
+++ b/swarms/telemetry/bootup.py
@@ -29,8 +29,7 @@ def _prepare_workspace() -> None:
         Path(workspace).mkdir(parents=True, exist_ok=True)
         return
     except OSError as e:
-        # Covers unwritable paths and a WORKSPACE_DIR that already exists as a
-        # file, which exist_ok does not suppress.
+        # Unwritable paths, or WORKSPACE_DIR existing as a file
         logger.warning(
             f"WORKSPACE_DIR={workspace!r} could not be created ({e}); "
             f"falling back to {fallback}"
@@ -61,8 +60,7 @@ def bootup():
         # Silence wandb
         os.environ["WANDB_SILENT"] = "true"
 
-        # Only default it. Assigning unconditionally discarded whatever the
-        # caller had exported, so WORKSPACE_DIR never survived `import swarms`.
+        # Only default it, assigning unconditionally discarded the caller's value
         _prepare_workspace()
 
         # Suppress deprecation warnings

--- a/swarms/telemetry/otel.py
+++ b/swarms/telemetry/otel.py
@@ -136,8 +136,7 @@ def _describe(value: Any) -> str:
             if "0x" not in text:
                 return text
 
-        # Otherwise identify it by class and whatever name it carries, so an
-        # Agent reads as "Agent(Researcher)" rather than an address.
+        # Class plus name, so an Agent reads as "Agent(Researcher)" not an address
         name = getattr(value, "agent_name", None) or getattr(
             value, "name", None
         )
@@ -257,8 +256,7 @@ class _SpanHandle:
                 handle. Defaults to ``None``.
         """
         self._span = span
-        # Guards against double-finalizing a span (e.g. a caller records an
-        # error and capture_run's auto-capture also fires): first write wins.
+        # First write wins, a caller and the auto-capture can both record an error
         self._done = False
 
     def set(self, key: str, value: Any) -> None:
@@ -348,8 +346,7 @@ def _current_span(span: Optional["Span"]) -> Iterator[None]:
         return
 
     try:
-        # The caller's finally-block ends the span, and _SpanHandle owns error
-        # recording, so both are disabled here to avoid doing either twice.
+        # The caller ends the span and _SpanHandle records errors, so neither is done twice
         with trace.use_span(
             span,
             end_on_exit=False,
@@ -494,12 +491,9 @@ class SwarmTelemetry:
             None
         """
         try:
-            # What kind of component this is: "Agent", "SwarmRouter",
-            # "ConcurrentWorkflow", "SequentialWorkflow", ...
             span.set_attribute("swarms.component", type(obj).__name__)
 
-            # Human-readable name — an Agent stores it as ``agent_name``, a
-            # swarm as ``name``. Resolve either so single agents get a real name.
+            # An Agent stores its name as agent_name, a swarm as name
             name = getattr(obj, "agent_name", None) or getattr(
                 obj, "name", None
             )
@@ -510,8 +504,7 @@ class SwarmTelemetry:
             if obj_id is not None:
                 span.set_attribute("swarms.id", str(obj_id))
 
-            # ``swarm_type`` only exists on multi-agent swarms — never set it on
-            # a single Agent, where it would be meaningless.
+            # swarm_type only exists on multi-agent swarms
             swarm_type = getattr(obj, "swarm_type", None)
             if swarm_type is not None:
                 span.set_attribute(
@@ -575,8 +568,7 @@ class SwarmTelemetry:
             span = self._tracer.start_span(name)
             if obj is not None:
                 self._set_identity(span, obj)
-                # GenAI semantic convention: "agent" for a single Agent,
-                # "swarm" for any multi-agent structure.
+                # GenAI semantic convention
                 operation = (
                     "agent"
                     if type(obj).__name__ == "Agent"
@@ -597,8 +589,7 @@ class SwarmTelemetry:
             with _current_span(span):
                 yield handle
         except BaseException as exc:
-            # Auto-capture ANY error propagating through the block, even if the
-            # caller never called record_error. Then re-raise unchanged.
+            # Auto-capture any error, then re-raise unchanged
             handle.record_error(exc)
             raise
         finally:
@@ -858,8 +849,7 @@ def trace_run(
                 except Exception:
                     inputs = {}
 
-            # capture_run auto-records any exception that propagates here, so
-            # the wrapper only needs to record the success output.
+            # capture_run records exceptions itself, only the success output is needed
             with telem.capture_run(name, self, **inputs) as span:
                 result = func(self, *args, **kwargs)
                 span.record_output(result)

--- a/swarms/tools/mcp_manager.py
+++ b/swarms/tools/mcp_manager.py
@@ -245,8 +245,7 @@ class MCPFileTokenStorage:
                     os.write(fd, json.dumps(data, indent=2).encode())
                 finally:
                     os.close(fd)
-                # os.open's mode only applies on creation; tighten a file that
-                # already existed with looser permissions.
+                # os.open's mode only applies on creation
                 os.chmod(self.path, 0o600)
             except Exception as e:
                 logger.warning(
@@ -1084,8 +1083,7 @@ class MCPManager:
             "tool": name,
             "server": self.label(connection),
             "arguments": arguments,
-            # mcp 2.x renamed `isError` to `is_error`; reading only the
-            # old name reports every failed call as a success.
+            # mcp 2.x renamed isError to is_error
             "is_error": bool(
                 getattr(result, "isError", None)
                 or getattr(result, "is_error", None)
@@ -1573,8 +1571,7 @@ class MCPManager:
         except (asyncio.CancelledError, KeyboardInterrupt):
             raise
         except BaseException as e:
-            # anyio surfaces transport failures as (Base)ExceptionGroups whose
-            # str() is empty, so flatten them into something actionable.
+            # anyio's ExceptionGroups have an empty str(), flatten them
             raise AgentMCPConnectionError(
                 f"Failed to connect to MCP server '{label}' ({detail}): "
                 f"{_describe_exception(e)}"

--- a/swarms/tools/pydantic_to_json.py
+++ b/swarms/tools/pydantic_to_json.py
@@ -53,8 +53,7 @@ def base_model_to_openai_function(
         if k not in ("title", "description")
     }
 
-    # `prop_name`, not `name`: this walrus used to rebind `name`, so the
-    # emitted function name became whichever docstring param matched last.
+    # prop_name, not name, the walrus used to rebind the function name
     for param in docstring.params:
         if (prop_name := param.arg_name) in parameters[
             "properties"

--- a/swarms/utils/class_to_pydantic.py
+++ b/swarms/utils/class_to_pydantic.py
@@ -218,8 +218,7 @@ def class_init_to_pydantic_model(
     for name, param in signature.parameters.items():
         if name == "self":
             continue
-        # *args / **kwargs have no fixed name or arity, so they cannot map to
-        # a field. Skipping them silently matches how the signature reads.
+        # *args / **kwargs have no fixed name or arity, so they cannot be fields
         if param.kind in (
             inspect.Parameter.VAR_POSITIONAL,
             inspect.Parameter.VAR_KEYWORD,

--- a/swarms/utils/docstring_parser.py
+++ b/swarms/utils/docstring_parser.py
@@ -97,8 +97,7 @@ def parse(docstring: str) -> DocstringInfo:
                 continue
 
         if in_args_section and line:
-            # Check if this line starts a new parameter (starts with parameter name)
-            # Pattern: param_name (type): description
+            # param_name (type): description
             param_match = re.match(
                 r"^(\w+)\s*(?:\([^)]*\))?\s*:\s*(.+)$", line
             )

--- a/swarms/utils/formatter.py
+++ b/swarms/utils/formatter.py
@@ -955,8 +955,7 @@ class Formatter:
                     )
                     task = getattr(order, "task", "No task provided")
 
-                # Text.assemble, not markup: task text is model-generated
-                # and any "[...]" in it would parse as a style tag.
+                # Text.assemble, model-generated "[...]" would parse as a style tag
                 tree.add(
                     Text.assemble(
                         (str(agent_name), "bold cyan"),

--- a/swarms/utils/image_file_b64.py
+++ b/swarms/utils/image_file_b64.py
@@ -69,8 +69,7 @@ def _is_safe_url(url: str) -> bool:
         if not host or host.lower() == "localhost":
             return False
 
-        # If the host is already a literal IP (in any notation ipaddress
-        # accepts — decimal, hex, dotted), judge it directly.
+        # A literal IP in any notation ipaddress accepts is judged directly
         try:
             return not _ip_is_blocked(ipaddress.ip_address(host))
         except ValueError:

--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -390,9 +390,6 @@ class LiteLLM:
         self.init_args = args
         self.init_kwargs = kwargs
 
-        # if self.reasoning_enabled is True:
-        #     self.reasoning_check()
-
     def reasoning_check(self):
         """
         Check if reasoning is enabled and supported by the model, and adjust parameters accordingly.
@@ -889,8 +886,7 @@ class LiteLLM:
         if not self.prompt_caching:
             return
 
-        # OpenAI-style controls (harmless/ignored on providers that don't use
-        # them; LiteLLM routes them for OpenAI-compatible backends).
+        # OpenAI-style controls, ignored by providers that lack them
         key = self._cache_opt("prompt_cache_key", None)
         if key is not None:
             completion_params["prompt_cache_key"] = key
@@ -928,8 +924,7 @@ class LiteLLM:
                 "image_url": {"url": image},
             }
         else:
-            # get_image_base64 always returns a data URI, so the MIME type
-            # can be extracted from it directly.
+            # get_image_base64 returns a data URI, the MIME type is in it
             image_url = get_image_base64(image)
             mime_type = "image/jpeg"
             if "data:" in image_url and ";base64," in image_url:
@@ -1213,8 +1208,7 @@ class LiteLLM:
         if self.top_p is not None:
             completion_params["top_p"] = self.top_p
 
-        # Merge initialization kwargs first (lower priority), then runtime
-        # kwargs (higher priority).
+        # Runtime kwargs override init kwargs
         if self.init_kwargs:
             completion_params.update(self.init_kwargs)
         if runtime_kwargs:
@@ -1240,8 +1234,7 @@ class LiteLLM:
         if self.base_url is not None:
             completion_params["base_url"] = self.base_url
 
-        # Only when present: litellm falls back to the provider env var
-        # on absence, and an explicit None would override that.
+        # An explicit None would override litellm's env-var fallback
         if self.api_key is not None:
             completion_params["api_key"] = self.api_key
 
@@ -1253,9 +1246,7 @@ class LiteLLM:
         if self.modalities and len(self.modalities) >= 2:
             completion_params["modalities"] = self.modalities
 
-        # Forward an explicitly requested effort level even when LiteLLM's
-        # local capability registry does not yet recognize a newly released
-        # model. `drop_params` handles providers that do not accept it.
+        # Forwarded even for models LiteLLM's registry lacks, drop_params covers the rest
         if self.reasoning_effort is not None:
             completion_params["reasoning_effort"] = (
                 self.reasoning_effort
@@ -1535,8 +1526,7 @@ class LiteLLM:
             responses = llm.batched_run(["Task 1", "Task 2", "Task 3"], batch_size=2)
             ```
         """
-        # Imported here, not at module scope: swarms.structs pulls this
-        # module back in, and a top-level import would be circular.
+        # Local import, a module-level one is circular via swarms.structs
         from swarms.structs.execution_utils import run_concurrently
 
         return run_concurrently(

--- a/swarms/utils/workspace_manager.py
+++ b/swarms/utils/workspace_manager.py
@@ -272,8 +272,7 @@ class WorkspaceManager:
 
         try:
             path = os.path.join(self.dir, filename)
-            # Written via temp+replace: config.json is rewritten every loop,
-            # so a crash mid-write would otherwise truncate it.
+            # temp+replace, a crash mid-write would otherwise truncate it
             temp_path = f"{path}.tmp"
             with open(temp_path, "w", encoding="utf-8") as f:
                 json.dump(


### PR DESCRIPTION
## What

Every multi-line `#` comment block under `swarms/` compacted to one line — 118 blocks of two to eight lines across 40 files. No code changes.

The repo rule ("a comment is one line; if it needs a paragraph it belongs in the docstring") kept being broken by new PRs, and `c2549850` had already compacted 17 of these once. This clears the rest in one pass so review can hold the line going forward.

## How each block was handled

- **Kept the one thing the code cannot say** — the workaround, the invariant the next edit could break, the deliberate choice that reads like a mistake — and dropped the rest. Example, `agent.py`:

  ```python
  # before
  # A tool that already exhausted its own retries is not
  # a provider failure. Re-running the model cannot fix
  # it and costs another completion, so record it and
  # leave the retry loop instead of falling into the
  # generation handler below.

  # after
  # A tool failure is not a provider failure, re-running the model cannot fix it
  ```

- **Deleted outright** where the block only narrated the code (`# In first iteration, generate new response / In subsequent iterations, refine…` above an `if iteration == 0`).
- **Deleted four blocks of commented-out code** — `conversation.py` (`truncate_memory_with_tokenizer`), `litellm_wrapper.py` (`reasoning_check`), `ma_utils.py` (two model names), `tree_swarm.py` (`print(response)`). Git history keeps them.
- **Removed the banners** — `NEW CHANGE START/END` in `spreadsheet_swarm.py` and a `# ----` divider in `autonomous_loop_utils.py`.

Docstrings were not touched; the rule does not apply to them. `swarms/prompts/` was skipped because its `#` lines are inside string literals, and the one remaining "block" (`py_func_to_openai_func_str.py:413`) is a docstring example.

## Verification

- A scan for two-or-more consecutive `#` lines outside `swarms/prompts/` now returns nothing.
- `black --line-length 70 --check swarms/` and `ruff check swarms/` clean.
- 23 test files covering the touched modules (`test_agent`, `test_autonomous_loop`, `test_conversation`, `test_graph_workflow`, `test_swarm_router`, `test_transcript`, `test_context_utils`, `test_agent_rearrange`, the workflow suites, router/auction/builder/cron/social-algorithms, llm_manager, litellm usage, workspace manager, formatter, docstring parser, telemetry): failures diffed against `master` with `comm` — **nothing introduced**; the 31 that fail are the usual live-API ones and fail identically on `master`.

The branch carries a merge of `master` (the docstring parser was rewritten by #2145 while this was in flight; master's version was taken and its two new comments compacted the same way). Squash on merge.
