### PR TITLE
[Bug] The planner-worker cycle judge reads the conversation as one user blob (#2053)

### DIFF
--- a/swarms/structs/planner_worker_swarm.py
+++ b/swarms/structs/planner_worker_swarm.py
@@ -21,6 +21,7 @@ from swarms.schemas.planner_worker_schemas import (
     TaskPriority,
 )
 from swarms.structs.agent import Agent
+from swarms.structs.context_utils import messages_for
 from swarms.structs.conversation import Conversation
 from swarms.tools.base_tool import BaseTool
 from swarms.utils.workspace_manager import WorkspaceManager
@@ -802,12 +803,18 @@ class PlannerWorkerSwarm:
         eval_task = (
             f"Original goal: {self._original_task}\n\n"
             f"Task execution report:\n{task_report}\n\n"
-            f"Full conversation history:\n{self.conversation.get_str()}\n\n"
             "Evaluate whether the goal has been achieved. "
             "If not, identify specific gaps and provide instructions for the next planning cycle."
         )
 
-        raw_output = judge.run(task=eval_task, img=img)
+        # The history goes as typed turns rather than inside the task string:
+        # the judge's own earlier verdicts come back as assistant turns, so a
+        # second cycle can tell its own reasoning from the planner's.
+        raw_output = judge.run(
+            task=eval_task,
+            img=img,
+            messages=messages_for("CycleJudge", self.conversation),
+        )
 
         try:
             verdict = self._parse_structured_output(


### PR DESCRIPTION
Refs #2053, the `planner_worker_swarm.py` row in its table.

## What is wrong

`planner_worker_swarm.py:805` builds the judge's task by pasting the whole shared conversation into it as a string:

```py
eval_task = (
    f"Original goal: {self._original_task}\n\n"
    f"Task execution report:\n{task_report}\n\n"
    f"Full conversation history:\n{self.conversation.get_str()}\n\n"
    ...
)
raw_output = judge.run(task=eval_task, img=img)
```

`get_str()` collapses every speaker into one `user` message. The judge runs once per cycle and records its verdict back into that same conversation (`:829`), so on cycle two it is handed its own previous verdict as anonymous prose in the middle of everyone else's, with no way to tell which reasoning was its own.

#2053 notes the rest of this file already gets it right: the worker path resets memory at `:444` and uses scoped dependency context at `:452-460`. The judge is the one site left.

## The fix

The same shape the issue prescribes and `round_robin.py:257` already uses:

```py
raw_output = judge.run(
    task=eval_task,
    img=img,
    messages=messages_for("CycleJudge", self.conversation),
)
```

Verified on `37c49905`:

```
>>> for m in messages_for('CycleJudge', c): print(m)
{'role': 'user', 'content': 'Planner: plan it'}
{'role': 'assistant', 'content': 'not done, gap X'}
{'role': 'user', 'content': 'Worker-1: did step 1'}
```

The judge's own verdict comes back as an `assistant` turn, peers stay `user` turns labelled with the speaker, and the request now has a stable prefix to cache.

#2030, which the issue lists as the blocker for passing typed turns, is closed, and `Agent.run` documents `messages` at `agent.py:4457`.

## Scope

One file, one call site. The other flattened structures in #2053 (`advisor_swarm`, `heavy_swarm`, `ma_blocks`) are untouched here and the issue stays open for them. No test: there is no `tests/structs/test_planner_worker_swarm.py` and this is a single call-site change, not a new entry point.