### PR TITLE
[FIX][aggregate][Record each worker turn instead of flattening the conversation]

### DIFF
--- a/swarms/structs/ma_blocks.py
+++ b/swarms/structs/ma_blocks.py
@@ -72,8 +72,11 @@ def aggregate(
     # return: the default is the agent's whole conversation, which would put
     # every worker's full transcript into the shared one.
     for result, agent in zip(results, workers):
+        # agent_name is Optional on Agent; a null role would be carried
+        # straight into the turns the aggregator reads.
         conversation.add(
-            content=agent_answer(agent, result), role=agent.agent_name
+            content=agent_answer(agent, result),
+            role=agent.agent_name or "Worker",
         )
 
     final_result = aggregator_agent.run(

--- a/swarms/structs/ma_blocks.py
+++ b/swarms/structs/ma_blocks.py
@@ -31,7 +31,7 @@ def aggregator_agent_task_prompt(
 
 
 def aggregate(
-    workers: List[Callable],
+    workers: List[Agent],
     task: str = None,
     type: HistoryOutputType = "all",
     aggregator_model_name: str = "anthropic/claude-3-sonnet-20240229",
@@ -77,7 +77,9 @@ def aggregate(
         )
 
     final_result = aggregator_agent.run(
-        task=aggregator_agent_task_prompt(task, workers, conversation),
+        task=aggregator_agent_task_prompt(
+            task, workers, conversation
+        ),
         messages=messages_for("Aggregator", conversation),
     )
 

--- a/swarms/structs/ma_blocks.py
+++ b/swarms/structs/ma_blocks.py
@@ -1,6 +1,7 @@
 from typing import Union
 from swarms.structs.agent import Agent
 from typing import List, Callable
+from swarms.structs.context_utils import agent_answer, messages_for
 from swarms.structs.conversation import Conversation
 from swarms.structs.multi_agent_exec import run_agents_concurrently
 from swarms.utils.history_output_formatter import (
@@ -16,15 +17,14 @@ from swarms.prompts.agent_conversation_aggregator import (
 def aggregator_agent_task_prompt(
     task: str, workers: List[Agent], conversation: Conversation
 ):
+    """The aggregator's instruction. The conversation itself is sent
+    alongside it as chat turns, not pasted in here as one string."""
     return f"""
-    Please analyze and summarize the following multi-agent conversation, following your guidelines for comprehensive synthesis:
+    Please analyze and summarize the multi-agent conversation in the messages above, following your guidelines for comprehensive synthesis:
 
     Conversation Context:
     Original Task: {task}
     Number of Participating Agents: {len(workers)}
-
-    Conversation Content:
-    {conversation.get_str()}
 
     Please provide a 3,000 word comprehensive summary report of the conversation.
     """
@@ -68,12 +68,17 @@ def aggregate(
 
     results = run_agents_concurrently(agents=workers, task=task)
 
-    # Zip the results with the agents
+    # Record each worker's answer, not whatever its output_type made run()
+    # return: the default is the agent's whole conversation, which would put
+    # every worker's full transcript into the shared one.
     for result, agent in zip(results, workers):
-        conversation.add(content=result, role=agent.agent_name)
+        conversation.add(
+            content=agent_answer(agent, result), role=agent.agent_name
+        )
 
     final_result = aggregator_agent.run(
-        task=aggregator_agent_task_prompt(task, workers, conversation)
+        task=aggregator_agent_task_prompt(task, workers, conversation),
+        messages=messages_for("Aggregator", conversation),
     )
 
     conversation.add(


### PR DESCRIPTION
Closes #2201. That issue is the `ma_blocks.py` row of #2053 plus its `ma_blocks.py:73` entry under "Compounded by transcript recording", split out after #2053 was closed by #2189 with this file still outstanding. Both defects are in the same eight lines, so they are fixed together rather than at the same lines twice.

## What is wrong

**The conversation is pasted into the task as one string.** `aggregator_agent_task_prompt` (`ma_blocks.py:27`) interpolates `conversation.get_str()`, so every worker collapses into a single `user` message and the aggregator cannot tell which participant said what except by reading the prose labels.

**The recorded content is each worker's whole transcript, not its answer.** `ma_blocks.py:73` records what `run()` returned:

```py
for result, agent in zip(results, workers):
    conversation.add(content=result, role=agent.agent_name)
```

`Agent.run` returns according to `output_type`, which defaults to the agent's whole conversation. So the flattened blob above is built out of full transcripts, and the aggregator is asked to summarise a conversation that contains several copies of itself.

## The fix

The shape #2053 prescribes, already used by `round_robin.py:257`:

```py
for result, agent in zip(results, workers):
    conversation.add(
        content=agent_answer(agent, result), role=agent.agent_name
    )

final_result = aggregator_agent.run(
    task=aggregator_agent_task_prompt(task, workers, conversation),
    messages=messages_for("Aggregator", conversation),
)
```

`agent_answer` falls back to the raw result when an agent exposes no final message, so nested structures and test doubles behave as before.

## Verified on `37c49905`

Two workers, patched so `run_agents_concurrently` returns transcript-shaped strings:

```
{'role': 'user', 'content': 'W1: answer one'}
{'role': 'user', 'content': 'W2: answer two'}
raw run() return recorded?  False
history pasted into task?   False
```

Before this change both of those read True.

## Scope

One file. The task prompt keeps its instruction and its context header and loses only the interpolated history, which now arrives as turns above it. No test: there is no `tests/structs/test_ma_blocks.py` and the repo's convention is not to add a new test file for a single call-site change. `advisor_swarm` (#2188) and `heavy_swarm` (#2189) have since landed. The two structures from #2053 still outstanding after this PR are tracked in #2200 (`llm_council`) and #2202 (`planner_generator_evaluator`).