### PR TITLE
[Fix] LLMCouncil's anonymous responses carry each councillor's own persona, so peers can identify them (#2053)

### DIFF
--- a/swarms/structs/llm_council.py
+++ b/swarms/structs/llm_council.py
@@ -11,10 +11,11 @@ often selecting responses from other models as superior to their own.
 """
 
 import random
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from swarms.structs.execution_utils import batched_run
 from swarms.structs.agent import Agent
+from swarms.structs.context_utils import agent_answer
 from swarms.structs.conversation import Conversation
 from swarms.structs.multi_agent_exec import (
     batched_grid_agent_execution,
@@ -259,6 +260,42 @@ Your task:
 Provide your final synthesized response below. You may reference which perspectives or approaches influenced different parts of your answer."""
 
 
+def councillor_answers(
+    members: List[Any], raw: Dict[str, Any]
+) -> Dict[str, str]:
+    """
+    Reduce each councillor's return to its final answer.
+
+    Args:
+        members: The council members, in roster order.
+        raw: Whatever ``run`` returned, keyed by ``agent_name``.
+
+    Returns:
+        Dict[str, str]: One answer per member name.
+
+    Notes:
+        The council anonymises these as Response A/B/C and shows them to the
+        other members to rank. ``Agent.run`` honours ``output_type``, whose
+        default is the agent's whole conversation -- and a transcript repeats
+        the councillor's own system-prompt persona, so an "anonymous"
+        response is identifiable by anyone reading it.
+
+        The default members are built with ``output_type="final"``, which
+        fixes this at the source. This is the second line: a caller supplying
+        their own members cannot be made to set it, and a nested structure or
+        test double may have no ``short_memory`` at all, so the raw return is
+        the fallback rather than an error.
+    """
+    answers: Dict[str, str] = {}
+
+    for member in members:
+        name = getattr(member, "agent_name", "")
+        fallback = raw.get(name, "")
+        answers[name] = agent_answer(member, fallback=fallback)
+
+    return answers
+
+
 class LLMCouncil:
     """
     An LLM Council that orchestrates multiple specialized agents to collaboratively
@@ -347,6 +384,7 @@ class LLMCouncil:
             model_name="gpt-5.1",
             max_loops=1,
             verbose=False,
+            output_type="final",
             temperature=0.7,
         )
 
@@ -358,6 +396,7 @@ class LLMCouncil:
             model_name="gemini-2.5-flash",  # Using available Gemini model
             max_loops=1,
             verbose=False,
+            output_type="final",
             temperature=0.7,
         )
 
@@ -369,6 +408,7 @@ class LLMCouncil:
             model_name="anthropic/claude-sonnet-4-5",  # Using available Claude model
             max_loops=1,
             verbose=False,
+            output_type="final",
             temperature=0.0,
             top_p=None,
         )
@@ -381,6 +421,7 @@ class LLMCouncil:
             model_name="xai/grok-4-1-fast-reasoning",  # Using available model as proxy for Grok-4
             max_loops=1,
             verbose=False,
+            output_type="final",
             temperature=0.8,
         )
 
@@ -430,17 +471,10 @@ class LLMCouncil:
             return_agent_output_dict=True,
         )
 
-        # Map results to member names
-        original_responses = {
-            member.agent_name: response
-            for member, response in zip(
-                self.council_members,
-                [
-                    results_dict.get(member.agent_name, "")
-                    for member in self.council_members
-                ],
-            )
-        }
+        # Answers, not transcripts: these get anonymised and ranked (#2053).
+        original_responses = councillor_answers(
+            self.council_members, results_dict
+        )
 
         # Add each council member's response to conversation
         for member_name, response in original_responses.items():

--- a/tests/structs/test_llm_council.py
+++ b/tests/structs/test_llm_council.py
@@ -316,3 +316,88 @@ def test_llm_council_output_types():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# --------------------------------------------------------------------------
+# #2053 — councillors must contribute answers, not transcripts
+# --------------------------------------------------------------------------
+
+
+class _EchoCouncillor:
+    """A councillor whose transcript names itself, the way a real one does."""
+
+    def __init__(self, name, persona):
+        self.agent_name = name
+        self.persona = persona
+        self.short_memory = self
+
+    def run(self, task, *args, **kwargs):
+        return (
+            f"System: You are {self.persona}.\n"
+            f"Human: {task}\n"
+            f"{self.agent_name}: the answer is 42"
+        )
+
+    def get_final_message_content(self):
+        return "the answer is 42"
+
+
+def test_default_councillors_return_answers_not_transcripts():
+    """
+    Every councillor is built with output_type='final'.
+
+    Agent.run honours output_type, which defaults to
+    'str-all-except-first' -- the agent's whole conversation. The council
+    then anonymises those returns as Response A/B/C and shows them to the
+    other members to rank. A transcript carries the councillor's own
+    system-prompt persona, so 'anonymous' Response B is identifiable by
+    anyone reading it.
+    """
+    council = LLMCouncil(verbose=False)
+
+    for member in council.council_members:
+        assert member.output_type == "final", (
+            f"{member.agent_name} would contribute its transcript, "
+            "which defeats the anonymisation"
+        )
+
+
+def test_a_transcript_return_is_reduced_to_the_answer():
+    """
+    Defence in depth: a caller passing their own council members cannot be
+    forced to set output_type, so the collection step takes the agent's
+    final message rather than whatever run() returned.
+    """
+    from swarms.structs.llm_council import councillor_answers
+
+    members = [
+        _EchoCouncillor("Alpha", "a terse analyst"),
+        _EchoCouncillor("Beta", "a creative writer"),
+    ]
+    raw = {
+        "Alpha": members[0].run("q"),
+        "Beta": members[1].run("q"),
+    }
+
+    answers = councillor_answers(members, raw)
+
+    assert answers == {
+        "Alpha": "the answer is 42",
+        "Beta": "the answer is 42",
+    }
+    for text in answers.values():
+        assert "System:" not in text
+        assert "terse analyst" not in text
+        assert "creative writer" not in text
+
+
+def test_a_missing_final_message_falls_back_to_the_raw_return():
+    """A test double or nested structure with no short_memory must not vanish."""
+    from swarms.structs.llm_council import councillor_answers
+
+    class Bare:
+        agent_name = "Gamma"
+
+    answers = councillor_answers([Bare()], {"Gamma": "plain answer"})
+
+    assert answers == {"Gamma": "plain answer"}


### PR DESCRIPTION
Refs #2200 (split out of #2053 after #2053 was closed by #2189 with this file still outstanding). This PR covers the recording half of the `llm_council.py` row, and specifically the consequence that issue calls out: *"In `llm_council.py` this also defeats the deliberate anonymisation at `:459-470`: a councillor's transcript echoes its own system-prompt persona, so peers can identify Response B."*

## Problem

`LLMCouncil` shuffles the members' responses into `Response A`, `B`, `C` and shows them to each other to rank. The shuffle is deliberate and the comment says so — `# Shuffle to ensure anonymity`.

The councillors were built with **no `output_type`**:

```python
gpt_agent = Agent(
    agent_name="GPT-5.1-Councilor",
    system_prompt=get_gpt_councilor_prompt(),
    max_loops=1,
    verbose=False,
    temperature=0.7,
)
```

So `Agent.run` returned its default, `"str-all-except-first"` — **the agent's whole conversation**. Each "anonymous" response therefore opened with that councillor's own system prompt, and `get_gpt_councilor_prompt()`, `get_gemini_councilor_prompt()`, `get_claude_councilor_prompt()` and `get_grok_councilor_prompt()` describe four distinct personas. A peer reading Response B could name its author from the first line.

**The code looks like it anonymises and does not.** That is worse than not trying: the ranking step is built on an assumption the data does not satisfy, and nothing fails loudly to say so.

It is also the ordinary #2053 complaint for this file — four transcripts recorded into the shared conversation, each re-injecting everything its author was given.

## Fix

| Site | Change |
|---|---|
| the four default councillors | built with `output_type="final"` — fixed at the source |
| `councillor_answers()` | **new** — reduces whatever `run()` returned to the agent's final message via `context_utils.agent_answer` |
| the collection step | uses it, so what gets anonymised and recorded is an answer |

## Design decisions

- **Both halves, not one.** `output_type="final"` fixes the *default* council. But `LLMCouncil(council_members=[...])` is a supported constructor and a caller cannot be made to set `output_type` on agents they built. Anonymity should not depend on every future caller getting that right, so the collection step reduces as well.
- **The raw return is the fallback.** `agent_answer` returns `None` when there is no usable final message; the helper falls back to what `run()` actually returned, so a nested structure or a test double with no `short_memory` still appears in the roster instead of vanishing from the ranking.
- **The shuffle is untouched.** It was never the broken part — it was the part being quietly undermined.
- **`agent_answer` rather than a local implementation.** `context_utils` exists precisely for this and its docstring names this failure: *"Recording a transcript instead of an answer… `Agent.run` honours the agent's `output_type`, which defaults to `str-all-except-first`."* #2124 and #2125 used it for `MixtureOfAgents` and `RoundRobinSwarm`; this is the same fix in the same shape.

## Verification

- **Unit**: 3 new tests in the existing `tests/structs/test_llm_council.py` (no new file), offline — the councillor double is a plain object, no model is called. All 3 fail on clean `master`:
  - every default councillor is built with `output_type="final"` — the source fix
  - a councillor that *does* return a transcript is reduced to its answer, asserted by checking the persona text (`"terse analyst"`, `"creative writer"`) and the `System:` prefix are **absent** from what the council would anonymise
  - a member with no `short_memory` falls back to its raw return rather than disappearing
- The persona assertion is the one that matters: it tests the property the issue is about — that an anonymised response cannot be attributed — rather than testing that a flag was set.
- **Regression sweep**: `tests/structs/test_llm_council.py tests/structs/test_moa.py tests/structs/test_majority_voting.py tests/agents` — **347 passed, 3 failed**. The same 3 fail identically on a clean `upstream/master` worktree (**344 passed, 3 failed** — the 3-test difference is this PR's). They are the `AgentError` import-identity tests and `test_call_llm_delegates`, none of which this touches.
- **Lint**: `black==24.2.0 --check` and `ruff==0.2.1 check` — the versions the Lint workflow pins — clean.
- **Not verified here**: a live council run, which needs four provider keys. The behaviour under test is what the council does with what `run()` returns, and that is exercised directly with a double that returns a realistic transcript.

## Deliberately not in this PR

The flattening half of this file: `get_synthesis_prompt` (`:221-233`) still joins the responses and evaluations into one string and `self.chairman.run(task=synthesis_prompt)` (`:514`) passes no `messages=`. That is #2200, which this PR references but does not close.

The other files #2053 named: `advisor_swarm.py` (#2188) and `heavy_swarm.py` (#2189) have landed, `ma_blocks.py` is #2182 / #2201, and `planner_generator_evaluator.py` is #2202.