### PR TITLE
fix(litellm): send max_completion_tokens to OpenAI reasoning-era models

### DIFF
--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -758,6 +758,51 @@ class LiteLLM:
             return bool(override)
         return self._is_anthropic_model()
 
+    # OpenAI families that reject max_tokens and require max_completion_tokens
+    _COMPLETION_TOKEN_FAMILIES = ("o1", "o3", "o4", "gpt-5", "gpt-6")
+
+    def _output_token_key(self) -> str:
+        """The request key the provider accepts for the output-token cap.
+
+        OpenAI's reasoning-era models reject ``max_tokens`` outright and
+        require ``max_completion_tokens``; every other provider LiteLLM
+        routes to takes ``max_tokens``. LiteLLM does not translate between
+        them, so the choice has to be made here.
+        """
+        name = (self.model_name or "").lower().split("/")[-1]
+        if name.startswith(self._COMPLETION_TOKEN_FAMILIES):
+            return "max_completion_tokens"
+        return "max_tokens"
+
+    @staticmethod
+    def _swap_token_key_for(
+        error: Exception, params: dict
+    ) -> Optional[dict]:
+        """Params with the output-token key renamed, if that is what ``error`` asks for.
+
+        The family list above cannot know every model in advance, so a
+        rejection that names the other key is retried once with it. Returns
+        None when the error is about something else.
+        """
+        text = str(error)
+        if "max_tokens" in params and "max_completion_tokens" in text:
+            swapped = dict(params)
+            swapped["max_completion_tokens"] = swapped.pop(
+                "max_tokens"
+            )
+            return swapped
+        if (
+            "max_completion_tokens" in params
+            and "max_completion_tokens" in text
+            and "max_tokens" in text
+        ):
+            swapped = dict(params)
+            swapped["max_tokens"] = swapped.pop(
+                "max_completion_tokens"
+            )
+            return swapped
+        return None
+
     def _is_anthropic_model(self) -> bool:
         """
         Whether the configured model is in the Anthropic Claude family, incl.
@@ -1199,7 +1244,7 @@ class LiteLLM:
                 task=task, img=img, imgs=imgs, messages=messages
             ),
             "stream": self.stream,
-            "max_tokens": self.max_tokens,
+            self._output_token_key(): self.max_tokens,
             "caching": self.caching,
             "temperature": self.temperature,
         }
@@ -1426,7 +1471,18 @@ class LiteLLM:
                 runtime_kwargs=kwargs,
                 messages=messages,
             )
-            response = completion(**completion_params)
+            try:
+                response = completion(**completion_params)
+            except Exception as error:
+                retry_params = self._swap_token_key_for(
+                    error, completion_params
+                )
+                if retry_params is None:
+                    raise
+                logger.warning(
+                    f"{self.model_name} rejected the output-token key, retrying: {error}"
+                )
+                response = completion(**retry_params)
             self._record_usage(response)
             return self._process_response(response)
         except self._NETWORK_ERRORS as network_error:
@@ -1467,7 +1523,18 @@ class LiteLLM:
                 runtime_kwargs=kwargs,
                 messages=messages,
             )
-            response = await acompletion(**completion_params)
+            try:
+                response = await acompletion(**completion_params)
+            except Exception as error:
+                retry_params = self._swap_token_key_for(
+                    error, completion_params
+                )
+                if retry_params is None:
+                    raise
+                logger.warning(
+                    f"{self.model_name} rejected the output-token key, retrying: {error}"
+                )
+                response = await acompletion(**retry_params)
             self._record_usage(response)
             return self._process_response(response)
         except self._NETWORK_ERRORS as network_error:

--- a/tests/utils/test_litellm_output_tokens.py
+++ b/tests/utils/test_litellm_output_tokens.py
@@ -1,0 +1,158 @@
+"""The output-token cap must reach each provider under the key it accepts.
+
+OpenAI's reasoning-era models reject ``max_tokens`` and require
+``max_completion_tokens``; everything else takes ``max_tokens``. LiteLLM does
+not translate, and ``drop_params`` cannot help because LiteLLM believes both
+keys are supported. Offline: ``completion`` is stubbed throughout.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from swarms.utils.litellm_wrapper import LiteLLM
+
+
+def _response():
+    message = SimpleNamespace(content="ok", tool_calls=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message)], usage=None
+    )
+
+
+def _params_sent(model_name):
+    llm = LiteLLM(model_name=model_name, max_tokens=1234)
+    with patch(
+        "swarms.utils.litellm_wrapper.completion",
+        return_value=_response(),
+    ) as fake:
+        llm.run("hi")
+    return fake.call_args.kwargs
+
+
+class TestOutputTokenKeyByModel:
+    @pytest.mark.parametrize(
+        "model", ["gpt-5.4", "gpt-6-astra", "o3", "openai/o4-mini"]
+    )
+    def test_openai_reasoning_families_get_max_completion_tokens(
+        self, model
+    ):
+        sent = _params_sent(model)
+        assert sent["max_completion_tokens"] == 1234
+        assert "max_tokens" not in sent
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4o-mini",
+            "claude-sonnet-5",
+            "gemini/gemini-2.5-pro",
+            "groq/llama-3.3-70b-versatile",
+        ],
+    )
+    def test_everything_else_keeps_max_tokens(self, model):
+        sent = _params_sent(model)
+        assert sent["max_tokens"] == 1234
+        assert "max_completion_tokens" not in sent
+
+
+class TestRetryOnRejectedKey:
+    """A model the family list does not know is still handled: the
+    provider's own rejection says which key it wants, so retry once.
+    """
+
+    REJECT_MAX_TOKENS = (
+        "OpenAIException - Unsupported parameter: 'max_tokens' is not "
+        "supported with this model. Use 'max_completion_tokens' instead."
+    )
+
+    def test_retries_with_max_completion_tokens_when_asked(self):
+        llm = LiteLLM(model_name="gpt-4o-mini", max_tokens=99)
+        calls = []
+
+        def fake(**kwargs):
+            calls.append(kwargs)
+            if "max_tokens" in kwargs:
+                raise RuntimeError(self.REJECT_MAX_TOKENS)
+            return _response()
+
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            side_effect=fake,
+        ):
+            assert llm.run("hi") == "ok"
+
+        assert len(calls) == 2
+        assert "max_tokens" in calls[0]
+        assert calls[1]["max_completion_tokens"] == 99
+        assert "max_tokens" not in calls[1]
+
+    def test_retries_the_other_way_too(self):
+        llm = LiteLLM(model_name="gpt-5.4", max_tokens=99)
+        calls = []
+
+        def fake(**kwargs):
+            calls.append(kwargs)
+            if "max_completion_tokens" in kwargs:
+                raise RuntimeError(
+                    "Unsupported parameter 'max_completion_tokens', "
+                    "use 'max_tokens'"
+                )
+            return _response()
+
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            side_effect=fake,
+        ):
+            assert llm.run("hi") == "ok"
+
+        assert calls[1]["max_tokens"] == 99
+
+    def test_unrelated_errors_are_not_retried(self):
+        llm = LiteLLM(model_name="gpt-4o-mini", max_tokens=99)
+        calls = []
+
+        def fake(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError("invalid api key")
+
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            side_effect=fake,
+        ):
+            with pytest.raises(RuntimeError, match="invalid api key"):
+                llm.run("hi")
+
+        assert len(calls) == 1
+
+    def test_a_second_rejection_propagates(self):
+        llm = LiteLLM(model_name="gpt-4o-mini", max_tokens=99)
+
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            side_effect=RuntimeError(self.REJECT_MAX_TOKENS),
+        ) as fake:
+            with pytest.raises(RuntimeError):
+                llm.run("hi")
+
+        assert fake.call_count == 2
+
+    def test_arun_retries_too(self):
+        llm = LiteLLM(model_name="gpt-4o-mini", max_tokens=99)
+        calls = []
+
+        async def fake(**kwargs):
+            calls.append(kwargs)
+            if "max_tokens" in kwargs:
+                raise RuntimeError(self.REJECT_MAX_TOKENS)
+            return _response()
+
+        with patch(
+            "swarms.utils.litellm_wrapper.acompletion",
+            side_effect=fake,
+        ):
+            assert asyncio.run(llm.arun("hi")) == "ok"
+
+        assert calls[1]["max_completion_tokens"] == 99


### PR DESCRIPTION
## What users hit

```
litellm.exceptions.BadRequestError: OpenAIException - Unsupported parameter:
'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
... swarms.structs.agent:_run - Failed to generate a valid response after retry attempts.
```

Any `Agent(model_name="gpt-6-astra")`, `"gpt-5.4"`, `"o3"`, … fails on its first call. OpenAI's reasoning-era models reject `max_tokens` outright and require `max_completion_tokens`.

## Why nothing upstream caught it

- `LiteLLM._build_completion_params` always sent `"max_tokens": self.max_tokens`. It stored a `max_completion_tokens` field and never sent it.
- `drop_params=True` (the wrapper's default) cannot help: litellm's registry lists **both** keys as supported for these models (`get_supported_openai_params("gpt-6-astra")` → both `True`), so it neither drops nor translates the parameter. The rejection comes from OpenAI, after litellm has already approved the request.
- `Agent` always resolves `max_tokens` to a number (`_default_max_tokens()`, fallback 8192), so a caller could not keep it out of the request. `llm_args={"max_completion_tokens": N}` just added the second key alongside the rejected one.

## Fix — two layers

**1. Pick the key by model family.** `_output_token_key()` returns `max_completion_tokens` for the `o1`/`o3`/`o4` and `gpt-5`/`gpt-6` families (provider prefix stripped, so `openai/o4-mini` works) and `max_tokens` for everything else. Anthropic, Gemini, Groq, `gpt-4o` are untouched; `_apply_anthropic_thinking_constraints` still writes `max_tokens` and is gated on Anthropic models.

**2. Retry once when the provider names the other key.** The family list cannot know models that do not exist yet. So `run` and `arun` catch a rejection whose message names the other key, rename it, and retry once — in either direction. Any other error propagates untouched, and a second rejection propagates too. This is what makes the next `gpt-7` work the day it ships rather than the day someone updates a list.

`max_completion_tokens` as an init parameter is left as it was; making it meaningful is a separate question.

## Verified

- Reproduced the report offline: `Agent(model_name="gpt-6-astra").run(...)` with `completion` stubbed now sends `{'max_completion_tokens': 128000}` and no `max_tokens`.
- **Live:** ran the reporting script (`Agent(model_name="gpt-6-astra", max_loops=1)`, the exact configuration from the report) against OpenAI on this branch. It completed with a full response and zero `BadRequestError` / `Unsupported parameter` lines in the log; on `master` the same script fails on the first call.
- `tests/utils/test_litellm_output_tokens.py` (new; the wrapper's existing test file is live-API only): key selection across 8 model names, the retry in both directions, no retry on unrelated errors, a second rejection propagating, and the `arun` path. **8 of 13 fail on unpatched `master`**; the 5 that pass are the `max_tokens` families, pinned so this cannot regress the other providers.
- `tests/structs/test_agent.py tests/agents/test_llm_manager.py tests/agents/test_autonomous_loop.py tests/structs/test_transcript.py tests/utils/test_litellm_usage.py` + the new file: 241 passed, 1 failed — the failure is pre-existing on `master` (`comm` reports nothing introduced).
- `black --line-length 70` and `ruff check` clean.