### PR TITLE
[Bug] AdvisorSwarm hands both agents the conversation as one user blob (#2053)

### DIFF
--- a/swarms/structs/advisor_swarm.py
+++ b/swarms/structs/advisor_swarm.py
@@ -32,6 +32,7 @@ from swarms.prompts.advisor_swarm_prompts import (
     EXECUTOR_SYSTEM_PROMPT,
 )
 from swarms.structs.agent import Agent
+from swarms.structs.context_utils import agent_answer, messages_for
 from swarms.structs.conversation import Conversation
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
@@ -211,17 +212,23 @@ class AdvisorSwarm:
 
             # --- Advisor guidance (if budget allows) ---
             if advisor_uses < self.max_advisor_uses:
-                context = self.conversation.get_str()
                 advisor_prompt = (
-                    f"Read the shared conversation context below and "
-                    f"provide strategic guidance for the Executor.\n\n"
-                    f"--- SHARED CONTEXT ---\n{context}\n"
-                    f"--- END SHARED CONTEXT ---"
+                    "Read the shared conversation above and provide "
+                    "strategic guidance for the Executor."
                 )
 
-                advice = self.advisor_agent.run(task=advisor_prompt)
+                advice = self.advisor_agent.run(
+                    task=advisor_prompt,
+                    messages=messages_for(
+                        self.advisor_agent.agent_name or "Advisor",
+                        self.conversation,
+                    ),
+                )
                 advisor_uses += 1
-                self.conversation.add(role="Advisor", content=advice)
+                self.conversation.add(
+                    role="Advisor",
+                    content=agent_answer(self.advisor_agent, advice),
+                )
 
                 if self.verbose:
                     logger.info(
@@ -230,19 +237,24 @@ class AdvisorSwarm:
                     )
 
             # --- Executor turn ---
-            context = self.conversation.get_str()
             executor_prompt = (
-                f"Read the shared conversation context below — it "
-                f"includes the task and any Advisor guidance — then "
-                f"produce your output.\n\n"
-                f"--- SHARED CONTEXT ---\n{context}\n"
-                f"--- END SHARED CONTEXT ---"
+                "Read the shared conversation above, which includes the "
+                "task and any Advisor guidance, then produce your output."
             )
 
             output = self.executor_agent.run(
-                task=executor_prompt, img=img, imgs=imgs
+                task=executor_prompt,
+                img=img,
+                imgs=imgs,
+                messages=messages_for(
+                    self.executor_agent.agent_name or "Executor",
+                    self.conversation,
+                ),
             )
-            self.conversation.add(role="Executor", content=output)
+            self.conversation.add(
+                role="Executor",
+                content=agent_answer(self.executor_agent, output),
+            )
 
             if self.verbose:
                 logger.info(


### PR DESCRIPTION
Refs #2053, the `advisor_swarm.py` row in its table, plus the transcript-recording problem the issue lists under "Compounded by transcript recording". Both are in the same loop, so they are fixed together rather than at the same lines twice.

## What is wrong

`advisor_swarm.py:214` and `:233` both build their prompt by interpolating the whole shared conversation:

```py
context = self.conversation.get_str()
advisor_prompt = (
    f"Read the shared conversation context below and "
    f"provide strategic guidance for the Executor.\n\n"
    f"--- SHARED CONTEXT ---\n{context}\n"
    f"--- END SHARED CONTEXT ---"
)
```

`get_str()` collapses every speaker into one `user` message. The Advisor runs up to `max_advisor_uses` times and the Executor once per turn, and both record into that same conversation, so from turn two each of them is reading its own prior output as anonymous prose in the middle of the other's.

The recorded content makes it worse: `self.conversation.add(role="Advisor", content=advice)` stores whatever `run()` returned, and that is the agent's whole conversation under the default `output_type`. So the blob above is built out of full transcripts.

## The fix

The shape the issue prescribes, already used by `round_robin.py:257` and by #2181 which you merged this morning:

```py
advice = self.advisor_agent.run(
    task=advisor_prompt,
    messages=messages_for(
        self.advisor_agent.agent_name or "Advisor", self.conversation
    ),
)
self.conversation.add(
    role="Advisor", content=agent_answer(self.advisor_agent, advice)
)
```

Both prompts keep their instruction and lose only the interpolated history, which now arrives above them as turns.

## Verified on `be097ded`

One turn, both agents stubbed to return transcript-shaped strings:

```
advisor messages:  [{'role': 'user', 'content': 'do the thing'}]
executor messages: [{'role': 'user', 'content': 'do the thing'},
                    {'role': 'user', 'content': 'Advisor: advice only'}]
history pasted into task?  False
raw run() return recorded? False
```

The Executor sees the Advisor's guidance as its own labelled turn, and what got recorded is `advice only`, not the transcript the stub returned.

## Scope

One file. `heavy_swarm.py` is the last structure in #2053's table and is untouched here, so the issue stays open for it. No test: there is no `tests/structs/test_advisor_swarm.py`, and the repo's convention is not to add a new test file for a call-site change.