### PR TITLE
[Bug] HeavySwarm pastes the whole conversation into all three synthesis prompts (#2053)

### DIFF
--- a/swarms/structs/heavy_swarm.py
+++ b/swarms/structs/heavy_swarm.py
@@ -12,6 +12,7 @@ from swarms.prompts.heavy_swarm_prompts import (
     grok_heavy_schema,
     schema,
 )
+from swarms.structs.context_utils import messages_for
 from swarms.structs.conversation import Conversation
 from swarms.structs.serialization import SerializableMixin
 from swarms.tools.tool_type import tool_type
@@ -1142,13 +1143,6 @@ class HeavySwarm(SerializableMixin):
         - Deliver prioritized, actionable recommendations with confidence levels
         - Flag risks, ethical concerns (Elizabeth), long-term systemic issues (Noah), and mitigation strategies
 
-        Conversation history for full context:
-
-        \n\n
-
-        {self.conversation.return_history_as_string()}
-
-        \n\n
 
         Present your synthesis as:
         1. Executive Summary (3-5 sentences)
@@ -1183,13 +1177,6 @@ class HeavySwarm(SerializableMixin):
         - Provide prioritized, actionable recommendations with confidence levels.
         - Identify risks, blind spots flagged by Lucas, and mitigation strategies.
 
-        Conversation history for context:
-
-        \n\n
-
-        {self.conversation.return_history_as_string()}
-
-        \n\n
 
         Present your synthesis as:
         1. Executive Summary
@@ -1227,13 +1214,6 @@ class HeavySwarm(SerializableMixin):
         - Ensure the report is well-structured, concise, and suitable for decision-makers (executive summary style).
         - Use bullet points, numbered lists, and section headings where appropriate for clarity and readability.
 
-        You may reference the conversation history for additional context:
-
-        \n\n
-
-        {self.conversation.return_history_as_string()}
-
-        \n\n
 
         Please present your synthesis in the following structure:
         1. Executive Summary
@@ -1246,7 +1226,12 @@ class HeavySwarm(SerializableMixin):
         Be thorough, objective, and ensure your synthesis is easy to follow for a non-technical audience.
         """
 
-        return synthesis_agent.run(synthesis_prompt)
+        return synthesis_agent.run(
+            synthesis_prompt,
+            messages=messages_for(
+                synthesis_agent.agent_name or "", self.conversation
+            ),
+        )
 
     def _parse_tool_calls(self, tool_calls: List) -> Dict[str, any]:
         """


### PR DESCRIPTION
Closes #2053. `heavy_swarm.py` is the last row left in its table, after #2181 took the planner-worker judge, #2182 took `aggregate()` and #2188 took the advisor pair.

## What is wrong

`_synthesize_results` builds one of three prompts depending on `self.variant`, and every one of them interpolates the entire shared conversation:

```
Conversation history for full context:

\n\n

{self.conversation.return_history_as_string()}

\n\n
```

at `:1149`, `:1190` and `:1234`. That is the densest case in the whole issue: the heavy variant runs 15 specialists into one conversation, and the synthesis agent is handed all fifteen collapsed into a single `user` message, with the speaker names surviving only as prose inside it.

## The fix

Drop the interpolation from all three prompts and pass the history the way the rest of the codebase now does:

```py
return synthesis_agent.run(
    synthesis_prompt,
    messages=messages_for(
        synthesis_agent.agent_name or "", self.conversation
    ),
)
```

Each prompt keeps its instructions and its output structure untouched; only the pasted history and the surrounding `\n\n` scaffolding go.

## Verified on `be097ded`

```
messages:
  {'role': 'user', 'content': 'analyse the market'}
  {'role': 'user', 'content': 'Research Agent: found three trends'}
history pasted into prompt? False
```

Each specialist arrives as its own labelled turn. `tests/structs/test_heavy_swarm.py` is 59 passed, 10 skipped, and `black -l 70` is clean.

## Scope

One file, three prompt bodies and one call site. This is the last structure in #2053, so the issue closes with it. #2149 is also open against this file but touches `_generate_questions`, which is a different function.