### PR TITLE
feat(usage): count streaming runs and reasoning tokens, and send OpenAI the key it accepts

### DIFF
--- a/examples/mcp/agents/01_deepwiki_repo_qa.py
+++ b/examples/mcp/agents/01_deepwiki_repo_qa.py
@@ -45,9 +45,8 @@ agent = Agent(
     reasoning_effort=None,
 )
 
-if __name__ == "__main__":
-    result = agent.run(
-        "Use your DeepWiki tools to explain what the kyegomez/swarms "
-        "repository is for and list its main multi-agent structures."
-    )
-    print(result)
+result = agent.run(
+    "Use your DeepWiki tools to explain what the kyegomez/swarms "
+    "repository is for and list its main multi-agent structures."
+)
+print(result)

--- a/examples/models/README.md
+++ b/examples/models/README.md
@@ -31,6 +31,10 @@ Set the matching API key as an environment variable before running any example (
 - [groq_gpt_oss_models.py](gpt_oss/groq_gpt_oss_models.py) — GPT-OSS on Groq
 - [multi_agent_gpt_oss_example.py](gpt_oss/multi_agent_gpt_oss_example.py) — Multi-agent GPT-OSS
 
+### GPT-6 Astra
+- [gpt_astra.py](gpt_astra/gpt_astra.py) — Quantitative trading agent on gpt-6-astra
+- [gpt_astra_usage.py](gpt_astra/gpt_astra_usage.py) — Streamed run with `agent.usage`, including reasoning tokens
+
 ### Llama 4
 - [llama_4.py](llama4/llama_4.py) — Llama 4 agent
 - [litellm_example.py](llama4/litellm_example.py) — Llama 4 via LiteLLM

--- a/examples/models/gpt_astra/gpt_astra.py
+++ b/examples/models/gpt_astra/gpt_astra.py
@@ -1,0 +1,37 @@
+from dotenv import load_dotenv
+
+from swarms.structs.agent import Agent
+
+load_dotenv()
+
+# Define an expanded system prompt
+system_prompt = (
+    "You are Quantitative-Trading-Agent, a highly advanced and helpful assistant specializing "
+    "in quantitative trading, algorithmic analysis, and financial research. "
+    "You assist users with complex trading questions, delivering comprehensive and insightful answers. "
+    "When evaluating investment options, you critically analyze metrics such as performance, expense ratios, "
+    "holdings, strategy, and notable risk factors. Provide data-driven recommendations, explain your reasoning, "
+    "and tailor your explanations to both novice and expert audiences as appropriate. "
+    "Maintain professional tone, cite relevant financial principles or sources where helpful, and "
+    "always clarify any assumptions or limitations in your analysis."
+)
+
+# Initialize the agent
+agent = Agent(
+    agent_name="Quantitative-Trading-Agent",
+    agent_description="Advanced quantitative trading and algorithmic analysis agent",
+    system_prompt=system_prompt,
+    model_name="gpt-6-astra",
+    max_loops=1,
+    top_p=None,
+    temperature=None,
+    reasoning_effort=None,
+    persistent_memory=False,
+)
+
+out = agent.run(
+    task="Analyze the best semiconductor ETFs and provide a detailed comparison. Include metrics such as performance, expense ratio, holdings, and any notable strategies.",
+)
+
+
+print(agent.usage)

--- a/examples/models/gpt_astra/gpt_astra_usage.py
+++ b/examples/models/gpt_astra/gpt_astra_usage.py
@@ -1,0 +1,25 @@
+from dotenv import load_dotenv
+
+from swarms import Agent
+
+load_dotenv()
+
+agent = Agent(
+    agent_name="Astra-Agent",
+    system_prompt="You are a concise research assistant.",
+    model_name="gpt-6-astra",
+    max_loops=1,
+    top_p=None,
+    temperature=None,
+    reasoning_effort="low",
+    persistent_memory=False,
+    streaming_on=True,
+)
+
+out = agent.run(
+    "A bat and a ball cost $1.10 in total. The bat costs $1.00 more than "
+    "the ball. How much does the ball cost? Answer with the number only."
+)
+
+print(out)
+print(agent.usage)

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -4023,7 +4023,10 @@ Summary: {summary}
 
         Keys: ``input_tokens``, ``output_tokens``, ``cached_tokens`` (the
         part of ``input_tokens`` served from the provider's prompt cache),
-        ``total_tokens``. Streaming calls are not counted.
+        ``reasoning_tokens`` (the part of ``output_tokens`` the model spent
+        thinking, 0 when the provider does not report it), ``total_tokens``.
+        Streaming calls count once their stream has been consumed, since the
+        provider reports usage in the final chunk.
         """
         return dict(self._usage)
 

--- a/swarms/structs/swarm_router.py
+++ b/swarms/structs/swarm_router.py
@@ -601,7 +601,7 @@ class SwarmRouter(SerializableMixin):
         agent a built swarm holds on its own — a ``HierarchicalSwarm``
         director, a ``MixtureOfAgents`` aggregator, a judge. Keys:
         ``input_tokens``, ``output_tokens``, ``cached_tokens``,
-        ``total_tokens``. Agent totals are lifetime totals, so an agent
+        ``reasoning_tokens``, ``total_tokens``. Agent totals are lifetime totals, so an agent
         shared with another router contributes what it spent there too.
         Streaming calls are not counted.
         """

--- a/swarms/utils/litellm_wrapper.py
+++ b/swarms/utils/litellm_wrapper.py
@@ -111,6 +111,7 @@ def empty_usage() -> dict:
         "input_tokens": 0,
         "output_tokens": 0,
         "cached_tokens": 0,
+        "reasoning_tokens": 0,
         "total_tokens": 0,
     }
 
@@ -126,19 +127,33 @@ def usage_from_response(response: any) -> Optional[dict]:
 
     LiteLLM reports every provider in the OpenAI shape: ``prompt_tokens``,
     ``completion_tokens``, ``total_tokens``, with cache reads under
-    ``prompt_tokens_details.cached_tokens``.
+    ``prompt_tokens_details.cached_tokens`` and hidden reasoning under
+    ``completion_tokens_details.reasoning_tokens``. Both are breakdowns of
+    the input and output counts, not additions to them; a provider that
+    does not report a breakdown yields 0, which means unknown.
     """
     usage = _field(response, "usage")
     if not usage:
         return None
-    details = _field(usage, "prompt_tokens_details")
-    cached = _field(details, "cached_tokens", 0) if details else 0
+    prompt_details = _field(usage, "prompt_tokens_details")
+    cached = (
+        _field(prompt_details, "cached_tokens", 0)
+        if prompt_details
+        else 0
+    )
+    completion_details = _field(usage, "completion_tokens_details")
+    reasoning = (
+        _field(completion_details, "reasoning_tokens", 0)
+        if completion_details
+        else 0
+    )
     input_tokens = _field(usage, "prompt_tokens", 0) or 0
     output_tokens = _field(usage, "completion_tokens", 0) or 0
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "cached_tokens": cached or 0,
+        "reasoning_tokens": reasoning or 0,
         "total_tokens": _field(usage, "total_tokens", 0)
         or input_tokens + output_tokens,
     }
@@ -758,6 +773,51 @@ class LiteLLM:
             return bool(override)
         return self._is_anthropic_model()
 
+    # OpenAI families that reject max_tokens and require max_completion_tokens
+    _COMPLETION_TOKEN_FAMILIES = ("o1", "o3", "o4", "gpt-5", "gpt-6")
+
+    def _output_token_key(self) -> str:
+        """The request key the provider accepts for the output-token cap.
+
+        OpenAI's reasoning-era models reject ``max_tokens`` outright and
+        require ``max_completion_tokens``; every other provider LiteLLM
+        routes to takes ``max_tokens``. LiteLLM does not translate between
+        them, so the choice has to be made here.
+        """
+        name = (self.model_name or "").lower().split("/")[-1]
+        if name.startswith(self._COMPLETION_TOKEN_FAMILIES):
+            return "max_completion_tokens"
+        return "max_tokens"
+
+    @staticmethod
+    def _swap_token_key_for(
+        error: Exception, params: dict
+    ) -> Optional[dict]:
+        """Params with the output-token key renamed, if that is what ``error`` asks for.
+
+        The family list above cannot know every model in advance, so a
+        rejection that names the other key is retried once with it. Returns
+        None when the error is about something else.
+        """
+        text = str(error)
+        if "max_tokens" in params and "max_completion_tokens" in text:
+            swapped = dict(params)
+            swapped["max_completion_tokens"] = swapped.pop(
+                "max_tokens"
+            )
+            return swapped
+        if (
+            "max_completion_tokens" in params
+            and "max_completion_tokens" in text
+            and "max_tokens" in text
+        ):
+            swapped = dict(params)
+            swapped["max_tokens"] = swapped.pop(
+                "max_completion_tokens"
+            )
+            return swapped
+        return None
+
     def _is_anthropic_model(self) -> bool:
         """
         Whether the configured model is in the Anthropic Claude family, incl.
@@ -1199,7 +1259,7 @@ class LiteLLM:
                 task=task, img=img, imgs=imgs, messages=messages
             ),
             "stream": self.stream,
-            "max_tokens": self.max_tokens,
+            self._output_token_key(): self.max_tokens,
             "caching": self.caching,
             "temperature": self.temperature,
         }
@@ -1207,6 +1267,12 @@ class LiteLLM:
         # Only include top_p if explicitly set (not None)
         if self.top_p is not None:
             completion_params["top_p"] = self.top_p
+
+        # A stream carries no usage unless asked, it then arrives as a final chunk
+        if self.stream:
+            completion_params["stream_options"] = {
+                "include_usage": True
+            }
 
         # Runtime kwargs override init kwargs
         if self.init_kwargs:
@@ -1293,21 +1359,40 @@ class LiteLLM:
         if completion_params.get("max_tokens", 0) < threshold:
             completion_params["max_tokens"] = target
 
-    def _record_usage(self, response: any) -> None:
-        """Add the provider-reported token counts of one response to ``self.usage``.
-
-        Streaming responses are generators with no usage attached, so they
-        are skipped; a response without a ``usage`` block is skipped too.
-        """
-        if self.stream or response is None:
-            return
-        call_usage = usage_from_response(response)
+    def _accumulate_usage(self, call_usage: Optional[dict]) -> None:
+        """Fold one call's token counts into ``self.usage`` and tell the hook."""
         if call_usage is None:
             return
         for key in self.usage:
             self.usage[key] += call_usage[key]
         if self.usage_hook is not None:
             self.usage_hook(call_usage)
+
+    def _record_usage(self, response: any) -> None:
+        """Add the provider-reported token counts of one response to ``self.usage``.
+
+        A stream's usage arrives in its final chunk and is recorded by
+        :meth:`_track_streaming_usage` as the stream is consumed; a
+        response without a ``usage`` block is skipped.
+        """
+        if self.stream or response is None:
+            return
+        self._accumulate_usage(usage_from_response(response))
+
+    def _track_streaming_usage(self, stream: any):
+        """Yield the stream's chunks, recording the trailing usage chunk.
+
+        With ``stream_options={"include_usage": True}`` the provider ends
+        the stream with a chunk that carries ``usage`` and no ``choices``.
+        It is consumed for accounting and not forwarded, so consumers never
+        see an empty token.
+        """
+        for chunk in stream:
+            if _field(chunk, "usage"):
+                self._accumulate_usage(usage_from_response(chunk))
+                if not _field(chunk, "choices"):
+                    continue
+            yield chunk
 
     def _process_response(self, response: any):
         """
@@ -1320,9 +1405,9 @@ class LiteLLM:
             )
             return None
 
-        # Streaming: return the generator directly.
+        # Streaming: hand back the generator, with usage recorded as it drains
         if self.stream:
-            return response
+            return self._track_streaming_usage(response)
 
         # Before the reasoning branch: reasoning models still emit tool_calls, which would be dropped.
         if self.tools_list_dictionary is not None and getattr(
@@ -1426,7 +1511,18 @@ class LiteLLM:
                 runtime_kwargs=kwargs,
                 messages=messages,
             )
-            response = completion(**completion_params)
+            try:
+                response = completion(**completion_params)
+            except Exception as error:
+                retry_params = self._swap_token_key_for(
+                    error, completion_params
+                )
+                if retry_params is None:
+                    raise
+                logger.warning(
+                    f"{self.model_name} rejected the output-token key, retrying: {error}"
+                )
+                response = completion(**retry_params)
             self._record_usage(response)
             return self._process_response(response)
         except self._NETWORK_ERRORS as network_error:
@@ -1467,7 +1563,18 @@ class LiteLLM:
                 runtime_kwargs=kwargs,
                 messages=messages,
             )
-            response = await acompletion(**completion_params)
+            try:
+                response = await acompletion(**completion_params)
+            except Exception as error:
+                retry_params = self._swap_token_key_for(
+                    error, completion_params
+                )
+                if retry_params is None:
+                    raise
+                logger.warning(
+                    f"{self.model_name} rejected the output-token key, retrying: {error}"
+                )
+                response = await acompletion(**retry_params)
             self._record_usage(response)
             return self._process_response(response)
         except self._NETWORK_ERRORS as network_error:

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1471,6 +1471,7 @@ class TestAgentUsage:
             "input_tokens": 0,
             "output_tokens": 0,
             "cached_tokens": 0,
+            "reasoning_tokens": 0,
             "total_tokens": 0,
         }
         usage["input_tokens"] = 999
@@ -1488,6 +1489,7 @@ class TestAgentUsage:
             "input_tokens": 120,
             "output_tokens": 30,
             "cached_tokens": 100,
+            "reasoning_tokens": 0,
             "total_tokens": 150,
         }
 
@@ -1564,5 +1566,56 @@ class TestAgentUsage:
             "input_tokens": sum(100 * i for i in range(1, 7)),
             "output_tokens": sum(range(1, 7)),
             "cached_tokens": 0,
+            "reasoning_tokens": 0,
             "total_tokens": sum(100 * i + i for i in range(1, 7)),
+        }
+
+    def test_a_streaming_run_is_counted_from_the_final_chunk(self):
+        """Streaming usage arrives in a trailing usage-only chunk; the
+        agent's streaming consumer must drain it into agent.usage."""
+        from types import SimpleNamespace
+
+        def chunk(text):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=text)
+                    )
+                ],
+                usage=None,
+            )
+
+        usage_chunk = SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(
+                prompt_tokens=40,
+                completion_tokens=7,
+                total_tokens=47,
+                prompt_tokens_details=None,
+            ),
+        )
+
+        agent = self._agent(streaming_on=True)
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            return_value=iter(
+                [
+                    chunk("SMH "),
+                    chunk("vs "),
+                    chunk("SOXX"),
+                    usage_chunk,
+                ]
+            ),
+        ) as fake:
+            agent.run("Compare them.")
+
+        assert fake.call_args.kwargs["stream_options"] == {
+            "include_usage": True
+        }
+        assert agent.usage == {
+            "input_tokens": 40,
+            "output_tokens": 7,
+            "cached_tokens": 0,
+            "reasoning_tokens": 0,
+            "total_tokens": 47,
         }

--- a/tests/structs/test_swarm_router.py
+++ b/tests/structs/test_swarm_router.py
@@ -1086,6 +1086,7 @@ def _agent_with_usage(name, input_tokens, output_tokens):
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "cached_tokens": 0,
+        "reasoning_tokens": 0,
         "total_tokens": input_tokens + output_tokens,
     }
     return agent
@@ -1107,6 +1108,7 @@ def test_usage_starts_at_zero():
         "input_tokens": 0,
         "output_tokens": 0,
         "cached_tokens": 0,
+        "reasoning_tokens": 0,
         "total_tokens": 0,
     }
 
@@ -1122,6 +1124,7 @@ def test_usage_sums_the_configured_agents():
         "input_tokens": 150,
         "output_tokens": 15,
         "cached_tokens": 0,
+        "reasoning_tokens": 0,
         "total_tokens": 165,
     }
 

--- a/tests/utils/test_litellm_output_tokens.py
+++ b/tests/utils/test_litellm_output_tokens.py
@@ -1,0 +1,158 @@
+"""The output-token cap must reach each provider under the key it accepts.
+
+OpenAI's reasoning-era models reject ``max_tokens`` and require
+``max_completion_tokens``; everything else takes ``max_tokens``. LiteLLM does
+not translate, and ``drop_params`` cannot help because LiteLLM believes both
+keys are supported. Offline: ``completion`` is stubbed throughout.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from swarms.utils.litellm_wrapper import LiteLLM
+
+
+def _response():
+    message = SimpleNamespace(content="ok", tool_calls=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message)], usage=None
+    )
+
+
+def _params_sent(model_name):
+    llm = LiteLLM(model_name=model_name, max_tokens=1234)
+    with patch(
+        "swarms.utils.litellm_wrapper.completion",
+        return_value=_response(),
+    ) as fake:
+        llm.run("hi")
+    return fake.call_args.kwargs
+
+
+class TestOutputTokenKeyByModel:
+    @pytest.mark.parametrize(
+        "model", ["gpt-5.4", "gpt-6-astra", "o3", "openai/o4-mini"]
+    )
+    def test_openai_reasoning_families_get_max_completion_tokens(
+        self, model
+    ):
+        sent = _params_sent(model)
+        assert sent["max_completion_tokens"] == 1234
+        assert "max_tokens" not in sent
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4o-mini",
+            "claude-sonnet-5",
+            "gemini/gemini-2.5-pro",
+            "groq/llama-3.3-70b-versatile",
+        ],
+    )
+    def test_everything_else_keeps_max_tokens(self, model):
+        sent = _params_sent(model)
+        assert sent["max_tokens"] == 1234
+        assert "max_completion_tokens" not in sent
+
+
+class TestRetryOnRejectedKey:
+    """A model the family list does not know is still handled: the
+    provider's own rejection says which key it wants, so retry once.
+    """
+
+    REJECT_MAX_TOKENS = (
+        "OpenAIException - Unsupported parameter: 'max_tokens' is not "
+        "supported with this model. Use 'max_completion_tokens' instead."
+    )
+
+    def test_retries_with_max_completion_tokens_when_asked(self):
+        llm = LiteLLM(model_name="gpt-4o-mini", max_tokens=99)
+        calls = []
+
+        def fake(**kwargs):
+            calls.append(kwargs)
+            if "max_tokens" in kwargs:
+                raise RuntimeError(self.REJECT_MAX_TOKENS)
+            return _response()
+
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            side_effect=fake,
+        ):
+            assert llm.run("hi") == "ok"
+
+        assert len(calls) == 2
+        assert "max_tokens" in calls[0]
+        assert calls[1]["max_completion_tokens"] == 99
+        assert "max_tokens" not in calls[1]
+
+    def test_retries_the_other_way_too(self):
+        llm = LiteLLM(model_name="gpt-5.4", max_tokens=99)
+        calls = []
+
+        def fake(**kwargs):
+            calls.append(kwargs)
+            if "max_completion_tokens" in kwargs:
+                raise RuntimeError(
+                    "Unsupported parameter 'max_completion_tokens', "
+                    "use 'max_tokens'"
+                )
+            return _response()
+
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            side_effect=fake,
+        ):
+            assert llm.run("hi") == "ok"
+
+        assert calls[1]["max_tokens"] == 99
+
+    def test_unrelated_errors_are_not_retried(self):
+        llm = LiteLLM(model_name="gpt-4o-mini", max_tokens=99)
+        calls = []
+
+        def fake(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError("invalid api key")
+
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            side_effect=fake,
+        ):
+            with pytest.raises(RuntimeError, match="invalid api key"):
+                llm.run("hi")
+
+        assert len(calls) == 1
+
+    def test_a_second_rejection_propagates(self):
+        llm = LiteLLM(model_name="gpt-4o-mini", max_tokens=99)
+
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            side_effect=RuntimeError(self.REJECT_MAX_TOKENS),
+        ) as fake:
+            with pytest.raises(RuntimeError):
+                llm.run("hi")
+
+        assert fake.call_count == 2
+
+    def test_arun_retries_too(self):
+        llm = LiteLLM(model_name="gpt-4o-mini", max_tokens=99)
+        calls = []
+
+        async def fake(**kwargs):
+            calls.append(kwargs)
+            if "max_tokens" in kwargs:
+                raise RuntimeError(self.REJECT_MAX_TOKENS)
+            return _response()
+
+        with patch(
+            "swarms.utils.litellm_wrapper.acompletion",
+            side_effect=fake,
+        ):
+            assert asyncio.run(llm.arun("hi")) == "ok"
+
+        assert calls[1]["max_completion_tokens"] == 99

--- a/tests/utils/test_litellm_usage.py
+++ b/tests/utils/test_litellm_usage.py
@@ -34,6 +34,7 @@ class TestUsageFromResponse:
             "input_tokens": 10,
             "output_tokens": 5,
             "cached_tokens": 3,
+            "reasoning_tokens": 0,
             "total_tokens": 15,
         }
 
@@ -47,6 +48,21 @@ class TestUsageFromResponse:
             }
         }
         assert usage_from_response(response)["cached_tokens"] == 4
+
+    def test_reads_reasoning_tokens_from_completion_details(self):
+        response = _response(10, 68)
+        response.usage.completion_tokens_details = SimpleNamespace(
+            reasoning_tokens=53
+        )
+        usage = usage_from_response(response)
+        # A breakdown of output_tokens, not an addition to it
+        assert usage["output_tokens"] == 68
+        assert usage["reasoning_tokens"] == 53
+
+    def test_no_reasoning_details_means_zero_reasoning(self):
+        assert (
+            usage_from_response(_response())["reasoning_tokens"] == 0
+        )
 
     def test_no_cache_details_means_zero_cached(self):
         assert usage_from_response(_response())["cached_tokens"] == 0
@@ -86,6 +102,7 @@ class TestLiteLLMUsage:
             "input_tokens": 30,
             "output_tokens": 6,
             "cached_tokens": 2,
+            "reasoning_tokens": 0,
             "total_tokens": 36,
         }
 
@@ -103,6 +120,7 @@ class TestLiteLLMUsage:
                 "input_tokens": 3,
                 "output_tokens": 4,
                 "cached_tokens": 0,
+                "reasoning_tokens": 0,
                 "total_tokens": 7,
             }
         ]
@@ -133,12 +151,89 @@ class TestLiteLLMUsage:
 
         assert llm.usage == empty_usage()
 
-    def test_streaming_is_not_counted(self):
+    @staticmethod
+    def _content_chunk(text):
+        delta = SimpleNamespace(content=text)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(delta=delta)], usage=None
+        )
+
+    @staticmethod
+    def _usage_chunk(prompt, completion, cached=0):
+        """The trailing include_usage chunk: a usage block and no choices."""
+        details = (
+            SimpleNamespace(cached_tokens=cached) if cached else None
+        )
+        return SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(
+                prompt_tokens=prompt,
+                completion_tokens=completion,
+                total_tokens=prompt + completion,
+                prompt_tokens_details=details,
+            ),
+        )
+
+    def test_streaming_is_counted_from_the_final_chunk(self):
+        seen = []
+        llm = LiteLLM(
+            model_name="gpt-5.4", stream=True, usage_hook=seen.append
+        )
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            return_value=iter(
+                [
+                    self._content_chunk("hel"),
+                    self._content_chunk("lo"),
+                    self._usage_chunk(10, 5, cached=2),
+                ]
+            ),
+        ):
+            forwarded = [
+                c.choices[0].delta.content for c in llm.run("x")
+            ]
+
+        # The usage-only chunk is consumed, never handed to the caller
+        assert forwarded == ["hel", "lo"]
+        assert llm.usage == {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cached_tokens": 2,
+            "reasoning_tokens": 0,
+            "total_tokens": 15,
+        }
+        assert seen == [llm.usage]
+
+    def test_streaming_asks_the_provider_for_usage(self):
         llm = LiteLLM(model_name="gpt-5.4", stream=True)
         with patch(
             "swarms.utils.litellm_wrapper.completion",
-            return_value=iter(["chunk"]),
+            return_value=iter([]),
+        ) as fake:
+            list(llm.run("x"))
+
+        assert fake.call_args.kwargs["stream_options"] == {
+            "include_usage": True
+        }
+
+    def test_a_stream_without_a_usage_chunk_leaves_usage_unchanged(
+        self,
+    ):
+        llm = LiteLLM(model_name="gpt-5.4", stream=True)
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            return_value=iter([self._content_chunk("hi")]),
         ):
-            llm.run("x")
+            list(llm.run("x"))
 
         assert llm.usage == empty_usage()
+
+    def test_non_streaming_requests_do_not_set_stream_options(self):
+        llm = LiteLLM(model_name="gpt-5.4")
+        with patch(
+            "swarms.utils.litellm_wrapper.completion",
+            return_value=_response(1, 1),
+        ) as fake:
+            llm.run("x")
+
+        assert "stream_options" not in fake.call_args.kwargs


### PR DESCRIPTION
## What

One script exposed three gaps in token accounting: stream a `gpt-6-astra` agent, then read `agent.usage`.

```python
agent = Agent(model_name="gpt-6-astra", max_loops=1, streaming_on=True, ...)
out = agent.run("A bat and a ball cost $1.10 in total ... How much does the ball cost?")
print(agent.usage)
# {'input_tokens': 55, 'output_tokens': 23, 'cached_tokens': 0, 'reasoning_tokens': 11, 'total_tokens': 78}
```

On `master` that script fails on the first call; with the request fixed it would report all zeros; and with streaming fixed it would still hide that 11 of the 23 output tokens were reasoning.

### 1. Streaming runs reported zero (#2159)

A stream carries no usage unless asked. The wrapper now sends `stream_options={"include_usage": True}` and returns the generator wrapped in `_track_streaming_usage`, which records the provider's trailing usage-only chunk (`usage` set, `choices` empty) and does **not** forward it, so `streaming_callback` never receives an empty token. Usage lands in `agent.usage` once the stream is drained — `agent.run` drains it itself, so from the caller's side it behaves like non-streaming. Non-streaming requests do not get `stream_options`.

### 2. Reasoning tokens were invisible

OpenAI bills hidden reasoning as output and reports the split under `completion_tokens_details.reasoning_tokens`. `agent.usage` (and `router.usage`) now carry `reasoning_tokens`: a breakdown of `output_tokens`, the way `cached_tokens` is a breakdown of `input_tokens`, and 0 when the provider reports none — which means unknown, not "no thinking".

Checked against the API directly: OpenAI's chat-completions stream sends **no** reasoning text at all (0 `reasoning_content` deltas even at `reasoning_effort="high"`), only the count. So the count is all there is to surface; there is nothing to stream.

### 3. OpenAI's reasoning-era models rejected the request (supersedes #2185)

```
BadRequestError: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

`drop_params` could not help: litellm's registry lists both keys as supported for these models, so it neither dropped nor translated, and the rejection came from OpenAI. `_output_token_key` sends `max_completion_tokens` for the `o1`/`o3`/`o4` and `gpt-5`/`gpt-6` families and `max_tokens` for everyone else; `run`/`arun` retry once when a provider's rejection names the other key, in either direction, so a model the family list does not know yet still works. This is the same change as #2185, carried here so the three fixes ship together — #2185 can be closed.

### Also in the diff

- `examples/models/gpt_astra/` — `gpt_astra.py` (a quantitative-trading agent) and `gpt_astra_usage.py` (the script above), listed in `examples/models/README.md`.
- `examples/mcp/agents/01_deepwiki_repo_qa.py` — runs on import rather than behind an `if __name__` guard, matching the other numbered examples in that folder. Small and unrelated; called out so it can be dropped if unwanted.

## Verified

Live, on this branch, against OpenAI:

| Run | `agent.usage` |
|---|---|
| `gpt-4o-mini`, streaming | `{input 30, output 68, cached 0, reasoning 0, total 98}` |
| `gpt-6-astra`, streaming, trivial prompt | `{input 28, output 88, cached 0, reasoning 0, total 116}` |
| `gpt-6-astra`, streaming, bat-and-ball | `{input 55, output 23, cached 0, reasoning 11, total 78}` |

Offline: `tests/utils/test_litellm_usage.py` (streaming counted from the final chunk, usage-only chunk not forwarded, `stream_options` set only when streaming, reasoning parsed from `completion_tokens_details`), `tests/utils/test_litellm_output_tokens.py` (key by model family, the retry both ways, unrelated errors untouched, `arun`), and an agent-level test in `tests/structs/test_agent.py` that drives `Agent(streaming_on=True)` through the real streaming consumer with stubbed chunks. The exact-dict assertions across three test files were updated for the new key.

Seven suites (`test_litellm_usage`, `test_litellm_output_tokens`, `test_agent`, `test_swarm_router`, `test_llm_manager`, `test_transcript`, `test_autonomous_loop`): 307 passed, 2 failed — `test_run_with_multi_agent_router` and `test_call_llm_delegates`, both failing identically on `master`.

`black --line-length 70` and `ruff check` clean. The branch carries a merge of `master`, no conflicts; squash on merge.
