### PR TITLE
[Fix] DebateWithJudge pastes every argument into the next agent's prompt, so no one can tell a peer's turn from their own instruction (#2029)

### DIFF
--- a/swarms/prompts/debate_with_judge_prompts.py
+++ b/swarms/prompts/debate_with_judge_prompts.py
@@ -68,29 +68,25 @@ Provide a strong, well-reasoned argument with evidence and examples."""
 
 PRO_REFINEMENT_ROUND_PROMPT = """Loop {loop_number}: Based on the judge's previous evaluation, present an improved argument in favor of: {topic}
 
+The judge's evaluation is in the conversation above.
+
 Address any weaknesses identified and strengthen your position with additional evidence and reasoning."""
 
 CON_FIRST_ROUND_PROMPT = """Present your counter-argument against: {topic}
 
-Pro's argument:
-{pro_argument}
+The Pro argument you are answering is in the conversation above.
 
 Provide a strong, well-reasoned counter-argument that addresses the Pro's points and presents evidence against the position."""
 
 CON_REFINEMENT_ROUND_PROMPT = """Loop {loop_number}: Based on the judge's previous evaluation, present an improved counter-argument against: {topic}
 
-Pro's current argument:
-{pro_argument}
+Pro's current argument and the judge's evaluation are in the conversation above.
 
 Address any weaknesses identified and strengthen your counter-position with additional evidence and reasoning."""
 
 JUDGE_ROUND_PROMPT = """Loop {loop_number}/{max_loops}: Evaluate the debate on: {topic}
 
-Pro's argument ({pro_agent_name}):
-{pro_argument}
-
-Con's argument ({con_agent_name}):
-{con_argument}
+This loop's arguments are in the conversation above: {pro_agent_name} for the Pro position, {con_agent_name} for the Con position.
 
 """
 
@@ -104,4 +100,4 @@ JUDGE_INTERMEDIATE_ROUND_INSTRUCTIONS = """Evaluate both arguments and provide:
 - Assessment of strengths and weaknesses in each argument
 - A refined synthesis that incorporates the best elements from both sides
 - Specific feedback for improvement in the next loop
-- Your synthesis will be used as the topic for the next loop"""
+- Both debaters read your synthesis before their next argument"""

--- a/swarms/structs/debate_with_judge.py
+++ b/swarms/structs/debate_with_judge.py
@@ -4,7 +4,7 @@ from loguru import logger
 
 from swarms.structs.execution_utils import batched_run
 from swarms.structs.agent import Agent
-from swarms.structs.context_utils import agent_answer
+from swarms.structs.context_utils import agent_answer, messages_for
 from swarms.structs.conversation import Conversation
 from swarms.utils.history_output_formatter import (
     history_output_formatter,
@@ -136,6 +136,11 @@ class DebateWithJudge:
 
         # Initialize conversation history
         self.conversation = Conversation()
+
+        # Each agent's system prompt as the caller supplied it, so the
+        # per-run role framing in _initialize_agents replaces the previous
+        # run's framing instead of accumulating on top of it.
+        self._base_system_prompts: dict[int, str] = {}
 
         if self.verbose:
             logger.info(
@@ -283,9 +288,6 @@ class DebateWithJudge:
         # Initialize agents with their roles
         self._initialize_agents(task)
 
-        # Start with the initial task
-        current_topic = task
-
         if self.verbose:
             logger.info(f"Starting debate on: {task}")
 
@@ -295,10 +297,13 @@ class DebateWithJudge:
                 logger.info(f"Loop {round_num + 1}/{self.max_loops}")
 
             # Step 1: Pro agent presents argument
-            pro_prompt = self._create_pro_prompt(
-                current_topic, round_num
+            pro_prompt = self._create_pro_prompt(task, round_num)
+            pro_argument = self.pro_agent.run(
+                task=pro_prompt,
+                messages=messages_for(
+                    self.pro_agent.agent_name, self.conversation
+                ),
             )
-            pro_argument = self.pro_agent.run(task=pro_prompt)
             pro_argument = agent_answer(
                 self.pro_agent, fallback=pro_argument
             )
@@ -310,10 +315,13 @@ class DebateWithJudge:
                 logger.debug(f"Pro argument: {pro_argument[:100]}...")
 
             # Step 2: Con agent presents counter-argument
-            con_prompt = self._create_con_prompt(
-                current_topic, pro_argument, round_num
+            con_prompt = self._create_con_prompt(task, round_num)
+            con_argument = self.con_agent.run(
+                task=con_prompt,
+                messages=messages_for(
+                    self.con_agent.agent_name, self.conversation
+                ),
             )
-            con_argument = self.con_agent.run(task=con_prompt)
             con_argument = agent_answer(
                 self.con_agent, fallback=con_argument
             )
@@ -325,10 +333,13 @@ class DebateWithJudge:
                 logger.debug(f"Con argument: {con_argument[:100]}...")
 
             # Step 3: Judge evaluates both arguments and provides synthesis
-            judge_prompt = self._create_judge_prompt(
-                current_topic, pro_argument, con_argument, round_num
+            judge_prompt = self._create_judge_prompt(task, round_num)
+            judge_synthesis = self.judge_agent.run(
+                task=judge_prompt,
+                messages=messages_for(
+                    self.judge_agent.agent_name, self.conversation
+                ),
             )
-            judge_synthesis = self.judge_agent.run(task=judge_prompt)
             judge_synthesis = agent_answer(
                 self.judge_agent, fallback=judge_synthesis
             )
@@ -341,8 +352,9 @@ class DebateWithJudge:
                     f"Judge synthesis: {judge_synthesis[:100]}..."
                 )
 
-            # Use judge's synthesis as input for next loop
-            current_topic = judge_synthesis
+            # current_topic stays the debate's motion. The synthesis is what
+            # the next loop refines, and every agent now reads it as its own
+            # turn -- restating it as the "topic" would send it twice.
 
         # Return formatted output
         return history_output_formatter(
@@ -351,10 +363,22 @@ class DebateWithJudge:
 
     def _initialize_agents(self, task: str) -> None:
         """
-        Initialize agents with their respective roles and context.
+        Give each agent its role and the motion, in its system prompt.
+
+        The intros used to be delivered by running each agent once and
+        throwing the answer away: three billed calls whose only effect was to
+        leave the intro in that agent's ``short_memory``. Each debate turn now
+        carries the shared conversation as ``messages=``, which replaces the
+        memory-derived prefix, so an intro parked in memory would never reach
+        the model at all. It goes in the system prompt instead, where role
+        framing belongs and where it costs nothing to send.
+
+        The agent's own system prompt is captured on the first call and
+        re-used on every later one, so repeated ``run()`` calls on the same
+        instance re-frame it rather than stacking intros.
 
         Args:
-            task (str): The initial task/topic for context.
+            task (str): The motion being debated.
         """
         names = {
             "task": task,
@@ -363,22 +387,25 @@ class DebateWithJudge:
             "judge_agent_name": self.judge_agent.agent_name,
         }
 
-        self.pro_agent.run(
-            task=PRO_AGENT_INTRO_PROMPT.format(**names)
-        )
-        self.con_agent.run(
-            task=CON_AGENT_INTRO_PROMPT.format(**names)
-        )
-        self.judge_agent.run(
-            task=JUDGE_AGENT_INTRO_PROMPT.format(**names)
-        )
+        for agent, intro in (
+            (self.pro_agent, PRO_AGENT_INTRO_PROMPT),
+            (self.con_agent, CON_AGENT_INTRO_PROMPT),
+            (self.judge_agent, JUDGE_AGENT_INTRO_PROMPT),
+        ):
+            base = self._base_system_prompts.setdefault(
+                id(agent), agent.system_prompt or ""
+            )
+            framing = intro.format(**names)
+            agent.system_prompt = (
+                f"{base}\n\n{framing}" if base else framing
+            )
 
     def _create_pro_prompt(self, topic: str, round_num: int) -> str:
         """
         Create the prompt for the Pro agent.
 
         Args:
-            topic (str): The current topic or refined question.
+            topic (str): The motion being debated.
             round_num (int): The current loop number (0-indexed).
 
         Returns:
@@ -391,45 +418,37 @@ class DebateWithJudge:
             loop_number=round_num + 1, topic=topic
         )
 
-    def _create_con_prompt(
-        self, topic: str, pro_argument: str, round_num: int
-    ) -> str:
+    def _create_con_prompt(self, topic: str, round_num: int) -> str:
         """
         Create the prompt for the Con agent.
 
+        The Pro argument it is answering is not pasted in: it reaches the Con
+        agent as its own turn in ``messages=``.
+
         Args:
-            topic (str): The current topic or refined question.
-            pro_argument (str): The Pro agent's argument to counter.
+            topic (str): The motion being debated.
             round_num (int): The current loop number (0-indexed).
 
         Returns:
             str: The prompt for the Con agent.
         """
         if round_num == 0:
-            return CON_FIRST_ROUND_PROMPT.format(
-                topic=topic, pro_argument=pro_argument
-            )
+            return CON_FIRST_ROUND_PROMPT.format(topic=topic)
 
         return CON_REFINEMENT_ROUND_PROMPT.format(
             loop_number=round_num + 1,
             topic=topic,
-            pro_argument=pro_argument,
         )
 
-    def _create_judge_prompt(
-        self,
-        topic: str,
-        pro_argument: str,
-        con_argument: str,
-        round_num: int,
-    ) -> str:
+    def _create_judge_prompt(self, topic: str, round_num: int) -> str:
         """
         Create the prompt for the Judge agent.
 
+        Both arguments reach the judge as turns in ``messages=``, so only the
+        loop framing and the speakers' names are in the prompt.
+
         Args:
-            topic (str): The current topic or refined question.
-            pro_argument (str): The Pro agent's argument.
-            con_argument (str): The Con agent's argument.
+            topic (str): The motion being debated.
             round_num (int): The current loop number (0-indexed).
 
         Returns:
@@ -442,9 +461,7 @@ class DebateWithJudge:
             max_loops=self.max_loops,
             topic=topic,
             pro_agent_name=self.pro_agent.agent_name,
-            pro_argument=pro_argument,
             con_agent_name=self.con_agent.agent_name,
-            con_argument=con_argument,
         )
 
         if is_final_round:

--- a/tests/structs/test_debate_with_judge.py
+++ b/tests/structs/test_debate_with_judge.py
@@ -1,0 +1,170 @@
+"""
+Context shape for :class:`~swarms.structs.debate_with_judge.DebateWithJudge`.
+
+Covers #2029: every structure used to render the shared conversation as
+``"role: content"`` prose and hand it to ``agent.run(task=<one big string>)``.
+In this structure the flattening was per-speaker f-strings - the Con agent was
+handed the Pro argument inside its prompt, the judge was handed both - so the
+model could not tell a peer's argument from its own instruction.
+
+The stub agents here record what each ``run()`` was actually given, so the
+assertions are about the request that would go on the wire, not about the
+prompt constants.
+"""
+
+from swarms.structs.agent import Agent
+from swarms.structs.debate_with_judge import DebateWithJudge
+
+
+def _record(agent, calls):
+    """Replace an agent's run() with a stub that records the context it got."""
+    name = agent.agent_name
+    turns = [0]
+
+    def _run(task=None, messages=None, **kwargs):
+        turns[0] += 1
+        answer = f"{name}-answer-{turns[0]}"
+        calls.append(
+            {
+                "agent": name,
+                "task": task,
+                "messages": list(messages or []),
+                "answer": answer,
+                "system_prompt": agent.system_prompt,
+            }
+        )
+        # agent_answer reads the answer back out of short_memory, not out of
+        # the return value, so the stub has to write it there too.
+        agent.short_memory.add(role=name, content=answer)
+        return answer
+
+    agent.run = _run
+    return agent
+
+
+def _debate(max_loops=2):
+    """A DebateWithJudge whose three agents all record what they were sent."""
+    calls = []
+    agents = []
+    for name in ("Pro-Debater", "Con-Debater", "Debate-Judge"):
+        agent = Agent(
+            agent_name=name,
+            agent_description=f"Recording {name}",
+            system_prompt=f"You are {name}.",
+            model_name="gpt-4o",
+            max_loops=1,
+            persistent_memory=False,
+            print_on=False,
+            autosave=False,
+        )
+        agents.append(_record(agent, calls))
+
+    debate = DebateWithJudge(
+        pro_agent=agents[0],
+        con_agent=agents[1],
+        judge_agent=agents[2],
+        max_loops=max_loops,
+        verbose=False,
+    )
+    return debate, calls
+
+
+def _for(calls, name):
+    return [c for c in calls if c["agent"] == name]
+
+
+def test_con_reads_the_pro_argument_as_a_turn_not_inside_its_task():
+    """The Pro argument reaches the Con agent as a turn, not pasted in."""
+    debate, calls = _debate(max_loops=1)
+    debate.run("Motion: open models will win")
+
+    pro = _for(calls, "Pro-Debater")[0]
+    con = _for(calls, "Con-Debater")[0]
+
+    assert pro["answer"] not in str(con["task"])
+    assert f"Pro-Debater: {pro['answer']}" in "\n".join(
+        m["content"] for m in con["messages"]
+    )
+
+
+def test_judge_reads_both_arguments_as_turns_not_inside_its_task():
+    """Both arguments reach the judge as turns, not as prompt sections."""
+    debate, calls = _debate(max_loops=1)
+    debate.run("Motion: open models will win")
+
+    pro = _for(calls, "Pro-Debater")[0]
+    con = _for(calls, "Con-Debater")[0]
+    judge = _for(calls, "Debate-Judge")[0]
+
+    judge_turns = "\n".join(m["content"] for m in judge["messages"])
+    for speaker in (pro, con):
+        assert speaker["answer"] not in str(judge["task"])
+        assert (
+            f"{speaker['agent']}: {speaker['answer']}" in judge_turns
+        )
+
+
+def test_every_turn_is_a_typed_message():
+    """Nothing reaches an agent as a role-prefixed blob in the task."""
+    debate, calls = _debate(max_loops=2)
+    debate.run("Motion: open models will win")
+
+    for call in calls:
+        assert isinstance(call["messages"], list)
+        for message in call["messages"]:
+            assert isinstance(message, dict)
+            assert message["role"] in ("user", "assistant")
+            assert isinstance(message["content"], str)
+
+    # The opening Pro turn has nothing before it, so it carries no history.
+    assert _for(calls, "Pro-Debater")[0]["messages"] == []
+
+
+def test_an_agent_sees_its_own_prior_argument_as_assistant():
+    """An agent's own output must not come back labelled as the user's."""
+    debate, calls = _debate(max_loops=2)
+    debate.run("Motion: open models will win")
+
+    pro_calls = _for(calls, "Pro-Debater")
+    assert len(pro_calls) == 2
+
+    assistant = [
+        m["content"]
+        for m in pro_calls[1]["messages"]
+        if m["role"] == "assistant"
+    ]
+    assert pro_calls[0]["answer"] in assistant
+
+
+def test_the_topic_stays_the_motion_across_loops():
+    """The judge's synthesis is a turn, so it is not also restated as the topic."""
+    motion = "Motion: a very distinctive claim about tungsten"
+    debate, calls = _debate(max_loops=2)
+    debate.run(motion)
+
+    judge_first = _for(calls, "Debate-Judge")[0]
+    for call in calls:
+        if call["agent"] == "Pro-Debater":
+            assert motion in str(call["task"])
+        # The second-loop prompts must not carry the synthesis text as well.
+        assert judge_first["answer"] not in str(call["task"])
+
+
+def test_role_framing_costs_no_llm_call_and_does_not_stack():
+    """Intros go in the system prompt, not into three discarded run() calls."""
+    debate, calls = _debate(max_loops=1)
+
+    debate.run("Motion: open models will win")
+    # one Pro, one Con, one Judge -- no discarded intro calls
+    assert len(calls) == 3
+
+    first_pro_prompt = _for(calls, "Pro-Debater")[0]["system_prompt"]
+    assert "You are Pro-Debater." in first_pro_prompt
+    assert "arguing in favor" in first_pro_prompt
+
+    debate.run("Motion: a second, unrelated debate")
+    second_pro_prompt = _for(calls, "Pro-Debater")[1]["system_prompt"]
+
+    assert second_pro_prompt.count("You are Pro-Debater.") == 1
+    assert "Motion: open models will win" not in second_pro_prompt
+    assert "Motion: a second, unrelated debate" in second_pro_prompt


### PR DESCRIPTION
Part of #2029.

`DebateWithJudge` was one of the structures #2029 lists as flattening the shared conversation. Here the flattening is per-speaker f-strings rather than a `get_str()` blob: the Con agent is handed the Pro argument inside its own prompt, and the judge is handed both. **Every argument now travels as its own chat turn via `messages=`, and the round's `topic` stays the motion instead of silently becoming the judge's last synthesis.**

## Problem

Three separate symptoms, all from the same cause.

**1. A peer's argument arrives as the user's instruction.** `debate_with_judge.py:316` built the Con prompt from `CON_FIRST_ROUND_PROMPT.format(topic=..., pro_argument=...)`, whose body is:

```
Present your counter-argument against: {topic}

Pro's argument:
{pro_argument}

Provide a strong, well-reasoned counter-argument ...
```

So the Con agent receives one `user` message containing the motion, the Pro agent's full argument, and its own instruction. `JUDGE_ROUND_PROMPT` did the same with both arguments. The model cannot tell which paragraph is the human's request and which is a peer's output — an argument that itself contains a blank line followed by `Word:` is indistinguishable from a new speaker.

**2. An agent's own prior argument comes back labelled as the user's.** The same `Agent` instances are reused across loops, so `Pro-Debater`'s round-1 answer is already an `assistant` turn in its own `short_memory`; the round-2 prompt then re-injected the debate around it as user text.

**3. The motion mutates into the judge's synthesis.** `debate_with_judge.py:345` ended each loop with `current_topic = judge_synthesis`, and `current_topic` is what every prompt renders as `{topic}`. From loop 2 onward the judge is told `Evaluate the debate on: <the judge's own previous synthesis>`, and the debaters are told to argue for or against a paragraph of judicial commentary rather than the motion.

## Fix

| Site | Before | After |
|---|---|---|
| `run()` steps 1-3 | `agent.run(task=<prompt with peer text pasted in>)` | `agent.run(task=<instruction only>, messages=messages_for(agent_name, self.conversation))` |
| `_create_con_prompt` | took `pro_argument` | takes `(topic, round_num)` |
| `_create_judge_prompt` | took `pro_argument`, `con_argument` | takes `(topic, round_num)` |
| `current_topic` | reassigned to `judge_synthesis` each loop | removed; `task` is the topic for the whole debate |
| `_initialize_agents` | three `agent.run()` calls, answers discarded | writes the role framing into `agent.system_prompt` |
| `CON_*`, `JUDGE_ROUND_PROMPT` | `{pro_argument}` / `{con_argument}` blocks | point at the conversation above |

`messages_for` is already the shared helper for this in `swarms/structs/context_utils.py:38`, and `Agent._transcript_from_messages` (`agent.py:4436`) replaces the memory-derived prefix with the caller's turns and appends `task` as the new user turn.

## Design decisions

- **`topic` had to stop drifting.** Once the judge's synthesis reaches both debaters as a turn, keeping `current_topic = judge_synthesis` would send the same text twice per round — strictly worse than today. Removing the reassignment is not a separable change; it is what makes the turn delivery correct rather than redundant. `JUDGE_INTERMEDIATE_ROUND_INSTRUCTIONS` said "Your synthesis will be used as the topic for the next loop", so the prompt line moved to "Both debaters read your synthesis before their next argument".

- **Role framing moved to the system prompt because `messages=` makes the old mechanism dead.** `_initialize_agents` used to run each agent once purely so the intro landed in `short_memory`. With `messages=` supplying the prefix, that memory is no longer read, so the intro would silently stop reaching the model. Putting it in the system prompt is where role framing belongs, and it removes three LLM calls per `run()`. The agent's own system prompt is captured once in `self._base_system_prompts` and the framing is rebuilt from that base each run, so calling `run()` twice on one instance re-frames instead of stacking two motions.

- **The blocklist-style "just keep both" option was rejected for the prompts.** Leaving `{pro_argument}` in place *and* sending turns would double every argument in the request, which is the token cost this issue is about.

## Behavior-change notes

- Agents constructed with a bare `system_prompt` now carry the debate framing in the system prompt rather than as an opening exchange in their memory. `agent.system_prompt` is mutated on `run()`; the pre-run value is preserved and restored-from on every later run.
- `DebateWithJudge.run()` makes `3 * max_loops` LLM calls instead of `3 + 3 * max_loops`.
- `_create_con_prompt` and `_create_judge_prompt` are private and changed signature; nothing outside this module calls them (`grep -rn "_create_con_prompt\|_create_judge_prompt" swarms/` matches only `debate_with_judge.py`).
- The shape of the returned conversation is unchanged: the same three rows per loop, in the same order.

## Verification

- **New**: 6 tests in `tests/structs/test_debate_with_judge.py`. There was no existing test module for this structure — `test_multi_agent_debate.py` covers `swarms.structs.multi_agent_debates.ExpertPanelDiscussion` and `test_one_on_one_debate.py` a different class — so this is a new file rather than an addition to an unrelated one.
- **Fails on clean base**: with the two source files stashed and the test file kept, **5 of the 6 fail** (`test_every_turn_is_a_typed_message` is the one that passes, since `messages` is empty either way). All 6 pass with the change.
- **Suite**: `pytest tests/structs/test_debate_with_judge.py tests/structs/test_transcript.py tests/structs/test_conversation.py tests/structs/test_execution_utils.py tests/structs/test_component_ids.py -q` → **184 passed**.
- `ruff check` reports the same **17** pre-existing findings on `debate_with_judge.py` as on clean `master` (all `UP006`/`UP045`/`I001`/`TRY004` on code this PR does not touch); `black --check` is clean on both changed files.
- **Not verified here**: the full `tests/structs` suite. Most modules in it construct real `Agent`s and call the provider, and this environment has no `OPENAI_API_KEY`, so a full run only measures retry backoff. The tests added here stub `agent.run` and make no network call.

## Note for #2029

`llm_council.py:167,221,228` is the remaining site from the issue's table that still fuses N answers into one blob. It is left alone here because #2184 is already open against that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut4g856LnbHeUjA8MawHxo
