### PR TITLE
[Feat] Autonomous loop: a per-tool allow/deny/ask policy, so an agent can read and grep but never delete (#2163)

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -31,6 +31,7 @@ from swarms.structs.autonomous_loop_utils import (
     MAX_PLANNING_ATTEMPTS,
     MAX_SUBTASK_ITERATIONS,
     MAX_SUBTASK_LOOPS,
+    PERMISSIONED_TOOLS,
     assign_task_tool,
     cancel_sub_agent_tasks_tool,
     check_sub_agent_status_tool,
@@ -51,6 +52,10 @@ from swarms.structs.autonomous_loop_utils import (
 from swarms.tools.handoffs_tool_schema import get_handoff_tool_schema
 from swarms.tools.py_func_to_openai_func_str import (
     convert_multiple_functions_to_openai_function_schema,
+)
+from swarms.structs.tool_permissions import (
+    PermissionDecision,
+    ToolPermissionPolicy,
 )
 from swarms.structs.transcript import Transcript
 from swarms.tools.dynamic_tool_loader import SEARCH_TOOL_NAME
@@ -113,6 +118,27 @@ class AutonomousAgentLoop:
         self._transcript = Transcript()
         # Removed before the next append, so runs do not stack copies.
         self._applied_handoff_block: Optional[str] = None
+        self._permission_policy = ToolPermissionPolicy(
+            tool_permissions=getattr(agent, "tool_permissions", None),
+            default_permission=getattr(
+                agent, "default_permission", "allow"
+            ),
+            permission_callback=getattr(
+                agent, "permission_callback", None
+            ),
+        )
+
+    @property
+    def permission_log(self) -> List[PermissionDecision]:
+        """
+        Every allow/deny ruling this loop made, oldest first.
+
+        Empty when no policy is configured: an all-allow policy is skipped
+        rather than run, so the default path is byte-for-byte what it was.
+        Pass ``tool_permissions={}`` with ``default_permission="allow"`` to
+        keep the log without restricting anything.
+        """
+        return self._permission_policy.log
 
     def _say_user(self, content: str, mirror: bool = True) -> None:
         """Add a user turn to the transcript (and to short_memory)."""
@@ -435,6 +461,21 @@ class AutonomousAgentLoop:
                 }
             else:
                 planning_tool_handlers = all_planning_tool_handlers
+
+            # Gate the tools that touch the world. Control flow (create_plan,
+            # think, subtask_done, complete_task, respond_to_user, the
+            # tool_search loader, sub-agent and handoff calls) is the loop's
+            # own bookkeeping: denying it would strand the run rather than
+            # protect anything.
+            if not self._permission_policy.is_permissive:
+                planning_tool_handlers = {
+                    name: (
+                        self._permission_policy.guard(name, handler)
+                        if name in PERMISSIONED_TOOLS
+                        else handler
+                    )
+                    for name, handler in planning_tool_handlers.items()
+                }
 
             # Add handoff tool handler if handoffs are configured
             if exists(self.agent.handoffs):

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -209,6 +209,19 @@ class Agent:
             "create_sub_agent", "assign_task".
             Defaults to "all" (all tools enabled). Pass a list of tool names to restrict tools, or "all"
             for unrestricted access. Use this to control which tools the agent can use during autonomous execution.
+        tool_permissions (Optional[Dict[str, Union[str, Callable]]]): Per-tool allow/deny policy for the
+            autonomous looper's built-in tools, keyed by tool name. A value is "allow", "deny", "ask", or a
+            callable `(tool_name, arguments) -> "allow" | "deny" | "ask"`, which is how you express a rule
+            such as "allow run_bash only when the command starts with pytest" without a keyword blocklist.
+            A refused call is returned to the model as a tool result, not raised, so the loop continues and
+            the model can choose another route. Every ruling is recorded on
+            `agent.autonomous_loop.permission_log`. Defaults to None (no per-tool rules).
+        default_permission (str): Applied to any autonomous-loop tool with no entry in `tool_permissions`.
+            One of "allow", "deny", "ask". Defaults to "allow", which is unchanged behavior -- with no
+            `tool_permissions` either, the loop skips the permission layer entirely.
+        permission_callback (Optional[Callable[[str, Dict[str, Any]], bool]]): Consulted for "ask", as
+            `(tool_name, arguments) -> bool`. With no callback, "ask" degrades to deny and the model is told
+            why, rather than the loop blocking on a prompt nobody is watching. Defaults to None.
         prompt_caching (bool): Enable provider-side prompt caching. When True, ephemeral
             cache_control breakpoints are added to the stable prefix of each request (system
             prompt, tools, and the last message) so it is cached and re-billed at a discount.
@@ -406,6 +419,15 @@ class Agent:
         marketplace_prompt_id: Optional[str] = None,
         skills_dir: Optional[str] = None,
         selected_tools: Optional[Union[str, List[str]]] = "all",
+        tool_permissions: Optional[
+            Dict[
+                str, Union[str, Callable[[str, Dict[str, Any]], str]]
+            ]
+        ] = None,
+        default_permission: str = "allow",
+        permission_callback: Optional[
+            Callable[[str, Dict[str, Any]], bool]
+        ] = None,
         context_compression: bool = True,
         persistent_memory: bool = False,
         *args,
@@ -415,6 +437,9 @@ class Agent:
         self.id = id or generate_id("agent")
         self.skills = SkillsManager(skills_dir=skills_dir)
         self.selected_tools = selected_tools
+        self.tool_permissions = tool_permissions
+        self.default_permission = default_permission
+        self.permission_callback = permission_callback
         self.llm = llm
         self.max_loops = max_loops
         self.stopping_condition = stopping_condition

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -641,6 +641,25 @@ def get_autonomous_planning_tools() -> List[Dict[str, Any]]:
     ]
 
 
+# The built-in tools a permission policy governs: everything that reads,
+# writes or executes outside the loop. Control-flow tools (create_plan, think,
+# subtask_done, complete_task, respond_to_user, tool_search, the sub-agent
+# calls, handoff_task) are the loop's own bookkeeping and are never gated -
+# denying them strands the run instead of protecting anything.
+PERMISSIONED_TOOLS = frozenset(
+    {
+        "create_file",
+        "update_file",
+        "read_file",
+        "list_directory",
+        "delete_file",
+        "run_bash",
+        "grep",
+        "glob",
+    }
+)
+
+
 def get_autonomous_loop_tool_names() -> List[str]:
     """
     Return a list of all autonomous loop tool names.

--- a/swarms/structs/tool_permissions.py
+++ b/swarms/structs/tool_permissions.py
@@ -1,0 +1,310 @@
+"""
+Per-tool permission policy for the autonomous loop.
+
+The ``max_loops="auto"`` loop ships side-effecting tools - ``create_file``,
+``update_file``, ``delete_file``, ``run_bash`` - that execute unconditionally.
+The only guard is a keyword blocklist on ``run_bash``
+(:func:`~swarms.structs.autonomous_loop_utils._check_bash_command`), which both
+over-blocks benign commands and is bypassed by trivial rewrites. There is no
+way for a caller to say "this agent may read and grep, but must ask before it
+writes, and must never delete".
+
+This module is that missing layer. It is a *policy*, not a sandbox: it decides
+whether a call runs, and records the decision. Path confinement is a separate
+concern and lives with the file tools.
+
+Nothing here changes behavior unless a policy is configured. A denial is
+returned to the model as an ordinary tool result rather than raised, so the
+loop carries on and the model can choose another route - the same contract
+tool errors already have.
+
+Example:
+    >>> policy = ToolPermissionPolicy(
+    ...     tool_permissions={
+    ...         "read_file": "allow",
+    ...         "delete_file": "deny",
+    ...         "run_bash": lambda name, args: (
+    ...             "allow" if args.get("command", "").startswith("pytest")
+    ...             else "deny"
+    ...         ),
+    ...     },
+    ...     default_permission="ask",
+    ...     permission_callback=lambda name, args: input(f"{name}? ") == "y",
+    ... )
+    >>> policy.decide("delete_file", {"file_path": "notes.md"}).allowed
+    False
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from loguru import logger
+
+ALLOW = "allow"
+DENY = "deny"
+ASK = "ask"
+
+_DEFAULT_VALUES = (ALLOW, DENY, ASK)
+_POLICY_VALUES = (ALLOW, DENY, ASK)
+
+# Value returned to the model when a call is refused. Prefixed so the model can
+# recognise a policy refusal rather than reading it as a tool failure it should
+# retry with different arguments.
+_DENIAL_TEMPLATE = (
+    "Permission denied for {tool_name}: {reason} "
+    "Do not retry this call; choose a different approach or ask the user."
+)
+
+PermissionValue = Union[str, Callable[[str, Dict[str, Any]], str]]
+
+
+@dataclass(frozen=True)
+class PermissionDecision:
+    """
+    One allow/deny ruling, kept so a run can be audited afterwards.
+
+    Attributes:
+        tool_name: The tool the model asked for.
+        arguments: The arguments it asked for, as the loop received them.
+        decision: ``"allow"`` or ``"deny"`` - the resolved outcome, never
+            ``"ask"``, which is a route rather than a result.
+        reason: Why, in the words the model is shown on a denial.
+        source: Which rule decided - ``"policy"`` (an entry in
+            ``tool_permissions``), ``"callable"``, ``"callback"``,
+            ``"default"``, or ``"no-callback"`` when ``ask`` degraded to deny.
+    """
+
+    tool_name: str
+    arguments: Dict[str, Any] = field(default_factory=dict)
+    decision: str = ALLOW
+    reason: str = ""
+    source: str = "default"
+
+    @property
+    def allowed(self) -> bool:
+        """True when the call may run."""
+        return self.decision == ALLOW
+
+
+class ToolPermissionPolicy:
+    """
+    Resolves whether a tool call may run, and records every ruling.
+
+    Args:
+        tool_permissions: Per-tool rules, keyed by tool name. A value is
+            ``"allow"``, ``"deny"``, ``"ask"``, or a callable
+            ``(tool_name, arguments) -> "allow" | "deny" | "ask"``. The
+            callable form is what lets a caller express "allow ``run_bash``
+            when the command starts with ``pytest``" without the framework
+            guessing at a blocklist. ``None`` means no per-tool rules.
+        default_permission: Applied to any tool with no rule of its own.
+            Defaults to ``"allow"``, which is exactly today's behavior.
+        permission_callback: Called for ``"ask"`` as
+            ``(tool_name, arguments) -> bool``. With no callback, ``"ask"``
+            degrades to deny and the model is told why, because a loop that
+            blocks on a prompt nobody is watching is worse than one that
+            refuses and moves on.
+
+    Raises:
+        ValueError: If ``default_permission`` or any policy value is not one
+            of ``"allow"``, ``"deny"``, ``"ask"`` or a callable.
+
+    Notes:
+        A callable that raises is treated as a denial, not as a crash: the
+        loop must not die because a caller's policy has a bug in it. The
+        exception text becomes the reason the model is shown.
+    """
+
+    def __init__(
+        self,
+        tool_permissions: Optional[Dict[str, PermissionValue]] = None,
+        default_permission: str = ALLOW,
+        permission_callback: Optional[
+            Callable[[str, Dict[str, Any]], bool]
+        ] = None,
+    ) -> None:
+        if default_permission not in _DEFAULT_VALUES:
+            raise ValueError(
+                f"default_permission must be one of "
+                f"{_DEFAULT_VALUES}, got {default_permission!r}"
+            )
+
+        self.tool_permissions: Dict[str, PermissionValue] = dict(
+            tool_permissions or {}
+        )
+        for name, value in self.tool_permissions.items():
+            if callable(value):
+                continue
+            if value not in _POLICY_VALUES:
+                raise ValueError(
+                    f"tool_permissions[{name!r}] must be one of "
+                    f"{_POLICY_VALUES} or a callable, got {value!r}"
+                )
+
+        self.default_permission = default_permission
+        self.permission_callback = permission_callback
+        self.log: List[PermissionDecision] = []
+
+    @property
+    def is_permissive(self) -> bool:
+        """
+        True when this policy can never refuse anything.
+
+        The loop uses it to skip wrapping its handlers entirely, so an agent
+        that configured nothing runs the exact code path it ran before.
+        """
+        return (
+            not self.tool_permissions
+            and self.default_permission == ALLOW
+        )
+
+    def decide(
+        self,
+        tool_name: str,
+        arguments: Optional[Dict[str, Any]] = None,
+    ) -> PermissionDecision:
+        """
+        Rule on one call and record the ruling.
+
+        Args:
+            tool_name: The tool the model asked for.
+            arguments: The arguments it asked for.
+
+        Returns:
+            The :class:`PermissionDecision`, already appended to ``log``.
+        """
+        arguments = dict(arguments or {})
+        decision = self._resolve(tool_name, arguments)
+        self.log.append(decision)
+
+        if not decision.allowed:
+            logger.warning(
+                f"Tool permission denied: {tool_name} "
+                f"({decision.source}) - {decision.reason}"
+            )
+        return decision
+
+    def _resolve(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> PermissionDecision:
+        """Resolve a rule to allow/deny without touching ``log``."""
+        rule = self.tool_permissions.get(tool_name)
+        source = "policy"
+
+        if rule is None:
+            rule = self.default_permission
+            source = "default"
+        elif callable(rule):
+            source = "callable"
+            try:
+                rule = rule(tool_name, arguments)
+            except Exception as e:
+                return PermissionDecision(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    decision=DENY,
+                    reason=f"the permission rule raised {type(e).__name__}: {e}.",
+                    source=source,
+                )
+            if rule not in _POLICY_VALUES:
+                return PermissionDecision(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    decision=DENY,
+                    reason=(
+                        f"the permission rule returned {rule!r}, which is "
+                        f"not one of {_POLICY_VALUES}."
+                    ),
+                    source=source,
+                )
+
+        if rule == ALLOW:
+            return PermissionDecision(
+                tool_name=tool_name,
+                arguments=arguments,
+                decision=ALLOW,
+                reason="",
+                source=source,
+            )
+
+        if rule == DENY:
+            return PermissionDecision(
+                tool_name=tool_name,
+                arguments=arguments,
+                decision=DENY,
+                reason="the configured policy denies this tool.",
+                source=source,
+            )
+
+        # rule == ASK
+        if self.permission_callback is None:
+            return PermissionDecision(
+                tool_name=tool_name,
+                arguments=arguments,
+                decision=DENY,
+                reason=(
+                    "this tool requires approval and no permission_callback "
+                    "was configured, so it cannot be approved."
+                ),
+                source="no-callback",
+            )
+
+        try:
+            approved = bool(
+                self.permission_callback(tool_name, arguments)
+            )
+        except Exception as e:
+            return PermissionDecision(
+                tool_name=tool_name,
+                arguments=arguments,
+                decision=DENY,
+                reason=f"the permission callback raised {type(e).__name__}: {e}.",
+                source="callback",
+            )
+
+        return PermissionDecision(
+            tool_name=tool_name,
+            arguments=arguments,
+            decision=ALLOW if approved else DENY,
+            reason="" if approved else "the user declined this call.",
+            source="callback",
+        )
+
+    def denial_message(self, decision: PermissionDecision) -> str:
+        """
+        The tool result a refused call returns to the model.
+
+        Args:
+            decision: A denied :class:`PermissionDecision`.
+
+        Returns:
+            The refusal text, phrased so the model does not retry the same
+            call with cosmetically different arguments.
+        """
+        return _DENIAL_TEMPLATE.format(
+            tool_name=decision.tool_name, reason=decision.reason
+        )
+
+    def guard(
+        self, tool_name: str, handler: Callable[..., Any]
+    ) -> Callable[..., Any]:
+        """
+        Wrap one tool handler so it is checked before it runs.
+
+        Args:
+            tool_name: The name the model calls this handler by.
+            handler: The handler, taking keyword arguments only - which is how
+                the loop dispatches every built-in tool.
+
+        Returns:
+            A handler with the same signature that returns the denial string
+            instead of executing when the policy refuses.
+        """
+
+        def _guarded(**kwargs: Any) -> Any:
+            decision = self.decide(tool_name, kwargs)
+            if not decision.allowed:
+                return self.denial_message(decision)
+            return handler(**kwargs)
+
+        return _guarded

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -41,8 +41,8 @@ from swarms.structs.autonomous_loop_utils import (
     TOOL_OUTPUT_CONTEXT_SHARE,
     read_file_tool,
 )
+from swarms.structs.tool_permissions import ToolPermissionPolicy
 from swarms.utils.litellm_tokenizer import count_tokens
-
 
 # --------------------------------------------------------------------------
 # helpers
@@ -1244,3 +1244,303 @@ class TestGlobTool:
             "pattern",
             "path",
         }
+
+
+# --------------------------------------------------------------------------
+# #2163 — per-tool permission policy
+# --------------------------------------------------------------------------
+
+
+def _finish(*extra_calls):
+    """A scripted run that does `extra_calls`, then closes out the task."""
+    return [
+        plan(("step1", [])),
+        [
+            *extra_calls,
+            tool_call(
+                "subtask_done",
+                task_id="step1",
+                summary="done",
+                success=True,
+            ),
+        ],
+        [
+            tool_call(
+                "complete_task",
+                task_id="main",
+                summary="done",
+                success=True,
+            )
+        ],
+    ]
+
+
+class TestToolPermissions:
+    """
+    The side-effecting tools used to execute unconditionally; the only guard
+    was a keyword blocklist on run_bash that both over- and under-blocks.
+    """
+
+    def test_a_denied_tool_does_not_run_and_the_model_is_told(
+        self, monkeypatch, tmp_path
+    ):
+        target = tmp_path / "should_not_exist.txt"
+        agent = build_agent(tool_permissions={"create_file": "deny"})
+        script_llm(
+            agent,
+            monkeypatch,
+            _finish(
+                tool_call(
+                    "create_file",
+                    file_path=str(target),
+                    content="payload",
+                )
+            ),
+        )
+
+        agent.run("test task")
+
+        assert not target.exists()
+        text = history(agent)
+        assert "Permission denied for create_file" in text
+        # The loop carried on rather than aborting on the refusal.
+        assert status_of(agent, "step1") == "completed"
+
+    def test_an_allowed_tool_still_runs(self, monkeypatch, tmp_path):
+        target = tmp_path / "written.txt"
+        agent = build_agent(
+            tool_permissions={"create_file": "allow"},
+            default_permission="deny",
+        )
+        script_llm(
+            agent,
+            monkeypatch,
+            _finish(
+                tool_call(
+                    "create_file",
+                    file_path=str(target),
+                    content="payload",
+                )
+            ),
+        )
+
+        agent.run("test task")
+
+        assert target.read_text() == "payload"
+
+    def test_a_callable_rule_decides_from_the_arguments(
+        self, monkeypatch, tmp_path
+    ):
+        allowed = tmp_path / "allowed.txt"
+        blocked = tmp_path / "blocked.txt"
+
+        def only_allowed_names(tool_name, arguments):
+            return (
+                "allow"
+                if arguments.get("file_path", "").endswith(
+                    "allowed.txt"
+                )
+                else "deny"
+            )
+
+        agent = build_agent(
+            tool_permissions={"create_file": only_allowed_names}
+        )
+        script_llm(
+            agent,
+            monkeypatch,
+            _finish(
+                tool_call(
+                    "create_file",
+                    file_path=str(allowed),
+                    content="ok",
+                ),
+                tool_call(
+                    "create_file",
+                    file_path=str(blocked),
+                    content="no",
+                ),
+            ),
+        )
+
+        agent.run("test task")
+
+        assert allowed.exists()
+        assert not blocked.exists()
+
+    def test_ask_without_a_callback_denies_and_says_why(
+        self, monkeypatch, tmp_path
+    ):
+        target = tmp_path / "asked.txt"
+        agent = build_agent(default_permission="ask")
+        script_llm(
+            agent,
+            monkeypatch,
+            _finish(
+                tool_call(
+                    "create_file",
+                    file_path=str(target),
+                    content="payload",
+                )
+            ),
+        )
+
+        agent.run("test task")
+
+        assert not target.exists()
+        assert "no permission_callback" in history(agent)
+
+    def test_ask_routes_to_the_callback(self, monkeypatch, tmp_path):
+        approved = tmp_path / "yes.txt"
+        refused = tmp_path / "no.txt"
+        asked = []
+
+        def callback(tool_name, arguments):
+            asked.append((tool_name, arguments.get("file_path")))
+            return arguments.get("file_path", "").endswith("yes.txt")
+
+        agent = build_agent(
+            default_permission="ask", permission_callback=callback
+        )
+        script_llm(
+            agent,
+            monkeypatch,
+            _finish(
+                tool_call(
+                    "create_file",
+                    file_path=str(approved),
+                    content="ok",
+                ),
+                tool_call(
+                    "create_file",
+                    file_path=str(refused),
+                    content="no",
+                ),
+            ),
+        )
+
+        agent.run("test task")
+
+        assert approved.exists()
+        assert not refused.exists()
+        assert [name for name, _ in asked] == [
+            "create_file",
+            "create_file",
+        ]
+
+    def test_control_flow_tools_are_never_gated(
+        self, monkeypatch, tmp_path
+    ):
+        """deny-everything must still let the loop plan and finish."""
+        target = tmp_path / "denied.txt"
+        agent = build_agent(default_permission="deny")
+        script_llm(
+            agent,
+            monkeypatch,
+            _finish(
+                tool_call(
+                    "create_file",
+                    file_path=str(target),
+                    content="payload",
+                )
+            ),
+        )
+
+        agent.run("test task")
+
+        assert not target.exists()
+        assert status_of(agent, "step1") == "completed"
+        gated = {
+            d.tool_name for d in agent.autonomous_loop.permission_log
+        }
+        assert gated == {"create_file"}
+
+    def test_every_decision_is_recorded(self, monkeypatch, tmp_path):
+        agent = build_agent(
+            tool_permissions={
+                "create_file": "allow",
+                "delete_file": "deny",
+            }
+        )
+        made = tmp_path / "kept.txt"
+        script_llm(
+            agent,
+            monkeypatch,
+            _finish(
+                tool_call(
+                    "create_file", file_path=str(made), content="x"
+                ),
+                tool_call("delete_file", file_path=str(made)),
+            ),
+        )
+
+        agent.run("test task")
+
+        log = agent.autonomous_loop.permission_log
+        assert [(d.tool_name, d.decision) for d in log] == [
+            ("create_file", "allow"),
+            ("delete_file", "deny"),
+        ]
+        assert (
+            made.exists()
+        ), "the denied delete still removed the file"
+
+    def test_the_default_configuration_skips_the_layer(
+        self, monkeypatch, tmp_path
+    ):
+        target = tmp_path / "default.txt"
+        agent = build_agent()
+        script_llm(
+            agent,
+            monkeypatch,
+            _finish(
+                tool_call(
+                    "create_file",
+                    file_path=str(target),
+                    content="payload",
+                )
+            ),
+        )
+
+        agent.run("test task")
+
+        assert target.read_text() == "payload"
+        assert agent.autonomous_loop.permission_log == []
+
+    def test_a_raising_rule_denies_instead_of_crashing_the_loop(
+        self, monkeypatch, tmp_path
+    ):
+        target = tmp_path / "boom.txt"
+
+        def broken(tool_name, arguments):
+            raise RuntimeError("policy bug")
+
+        agent = build_agent(tool_permissions={"create_file": broken})
+        script_llm(
+            agent,
+            monkeypatch,
+            _finish(
+                tool_call(
+                    "create_file",
+                    file_path=str(target),
+                    content="payload",
+                )
+            ),
+        )
+
+        agent.run("test task")
+
+        assert not target.exists()
+        assert "policy bug" in history(agent)
+        assert status_of(agent, "step1") == "completed"
+
+    def test_an_invalid_policy_value_is_rejected_at_construction(
+        self,
+    ):
+        with pytest.raises(ValueError, match="tool_permissions"):
+            ToolPermissionPolicy(
+                tool_permissions={"run_bash": "maybe"}
+            )
+
+        with pytest.raises(ValueError, match="default_permission"):
+            ToolPermissionPolicy(default_permission="maybe")


### PR DESCRIPTION
Part of #2163 — the permission layer, layer 1 of the two the issue describes.

The `max_loops="auto"` loop's side-effecting tools execute unconditionally. **This adds an opt-in per-tool policy — `"allow"` / `"deny"` / `"ask"` / a callable — that decides each call before it runs, returns a refusal to the model as an ordinary tool result, and records every ruling for audit. `default_permission="allow"` with no rules is today's behavior, and in that case the loop skips the layer entirely rather than running handlers that can never refuse.**

## Problem

`create_file`, `update_file`, `delete_file` and `run_bash` run whenever the model asks. The only guard anywhere is `_check_bash_command` (`swarms/structs/autonomous_loop_utils.py:1060`), a length cap plus a keyword blocklist:

```python
for pattern in _BASH_BLOCKLIST:
    if all(token in cmd_lower for token in pattern):
        return f"Command blocked: matches dangerous pattern {pattern!r}."
```

That guard fails in both directions — it rejects benign commands containing a blocked token and is bypassed by trivial rewrites (#1969) — and it covers exactly one tool. Nothing governs `delete_file` at all. A caller who wants "read and grep freely, ask before writing, never delete" has no way to express it: `selected_tools` can only remove a tool for the whole run, not decide per call.

## What's added

| Surface | Behavior |
|---|---|
| `Agent(tool_permissions={...})` | Per-tool rules, keyed by tool name |
| `Agent(default_permission="allow"\|"deny"\|"ask")` | Applied to any gated tool with no rule of its own |
| `Agent(permission_callback=fn)` | Consulted for `"ask"`, as `(tool_name, arguments) -> bool` |
| `agent.autonomous_loop.permission_log` | Every `PermissionDecision`, oldest first |

```python
agent = Agent(
    max_loops="auto",
    tool_permissions={
        "read_file": "allow",
        "grep": "allow",
        "delete_file": "deny",
        "run_bash": lambda name, args: (
            "allow" if args.get("command", "").startswith("pytest") else "deny"
        ),
    },
    default_permission="ask",
    permission_callback=my_prompt,
)
```

A refused call returns to the model as:

```
Permission denied for delete_file: the configured policy denies this tool. Do not retry this call; choose a different approach or ask the user.
```

## Files

| File | Change |
|---|---|
| `swarms/structs/tool_permissions.py` | **new** — `PermissionDecision` + `ToolPermissionPolicy` (resolve, log, `guard()` wrapper). One file per feature; nothing else in the tree needs to import it to keep working. |
| `swarms/structs/autonomous_loop_utils.py` | `PERMISSIONED_TOOLS`, the eight built-ins a policy governs. Sits beside `get_autonomous_loop_tool_names()`, where the tool surface is already defined. |
| `swarms/agents/autonomous_loop.py` | Builds the policy in `__init__`, wraps the gated handlers after the `selected_tools` filter, exposes `permission_log`. |
| `swarms/structs/agent.py` | Three constructor parameters + docstring. No logic. |
| `tests/agents/test_autonomous_loop.py` | `TestToolPermissions`, 10 tests, added to the existing module rather than a new file. |

## Design decisions

- **Only world-touching tools are gated.** `PERMISSIONED_TOOLS` is `create_file`, `update_file`, `read_file`, `list_directory`, `delete_file`, `run_bash`, `grep`, `glob`. `create_plan`, `think`, `subtask_done`, `complete_task`, `respond_to_user`, the `tool_search` loader and the sub-agent/handoff calls are the loop's own bookkeeping — a `default_permission="deny"` that also denied `create_plan` would strand the run on its first turn instead of protecting anything. The test `test_control_flow_tools_are_never_gated` pins this: with deny-everything the loop still plans, refuses the write, and completes.

- **A denial is a result, not an exception.** #1990 established that a failed tool reaches the model as a tool result so it can react; a refusal is the same shape. Raising would abort the response and leave `tool_call_id`s unanswered.

- **`"ask"` with no callback degrades to deny, and says so.** The alternative — blocking on `input()` — hangs an unattended run forever. The model is told *why* it was refused so it does not retry the identical call.

- **A caller's policy that raises denies rather than crashing.** A bug in someone's `lambda` should not take down a long autonomous run. The exception type and message become the reason the model sees, so the bug is visible rather than silent.

- **The default is not "wrap and always allow".** `ToolPermissionPolicy.is_permissive` is true when there are no rules and the default is `allow`; the loop then leaves `planning_tool_handlers` untouched. That makes "unchanged behavior" a property of the code path, not a claim about the policy's logic. `tool_permissions={}` with `default_permission="allow"` keeps the log without restricting anything, for callers who want the audit trail only.

## Deliberately not done

- **The bash blocklist stays.** #2163 argues it should be deleted once a real policy exists, and I agree with the argument — but deleting it here would leave every default-configured agent (`default_permission="allow"`) with *less* protection than it has today, since the policy is opt-in. That removal is #1969's PR, and it should land with whatever default the maintainer wants.
- **The workspace sandbox (layer 2 of #2163).** It shares `_resolve_path` with #2162 and overlaps #1791 and open PR #2154 on #1970. Separate concern, separate PR.
- **MCP and user-defined tools are not gated.** They dispatch through `MCPManager.execute_tool_calls` and `BaseTool`, not through `planning_tool_handlers`, so gating them is a different insertion point.

## Behavior-change note

Nothing existing changes: with no `tool_permissions` and `default_permission="allow"` the handler map is not wrapped at all. Anyone who *sets* `default_permission="deny"` or `"ask"` will see previously-executed file and bash calls refused — that is the point of the flag.

## Verification

- **Unit**: 10 new tests in `tests/agents/test_autonomous_loop.py::TestToolPermissions`, driving the real loop offline through the module's existing `script_llm` harness — so the assertions are about whether the file on disk was actually written or deleted, not about the policy object in isolation. Covered: deny / allow / callable-per-argument / `ask` with a callback / `ask` without one / control-flow never gated / the full log / the default path skipping the layer / a raising rule / invalid values rejected at construction.
- **Module suite**: `pytest tests/agents/test_autonomous_loop.py -q -p no:randomly` → **59 passed** (49 pre-existing + 10 new), no failures.
- **Lint, at the versions CI pins** (`black==24.2.0`, `ruff==0.2.1`, per `.github/workflows/lint.yml`): `black . --check` → **958 files unchanged**; `ruff check .` → clean, repo-wide.
- **Serialization**: `Agent.to_dict()` and `json.dumps` both succeed with a callable in `tool_permissions`, so `autosave=True` and telemetry are unaffected.
- **Not verified here**: the full `tests/` suite. Most of `tests/structs` constructs real agents and calls the provider; with no `OPENAI_API_KEY` in this environment a full run only measures retry backoff. Everything in `TestToolPermissions` stubs `call_llm` and makes no network call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut4g856LnbHeUjA8MawHxo
