### PR TITLE
feat(agent): agent.input_tokens, the size of the next request

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -4018,6 +4018,25 @@ Summary: {summary}
             raise e
 
     @property
+    def input_tokens(self) -> int:
+        """Tokens the agent's next request would carry, counted with its model's tokenizer.
+
+        Covers everything the agent sends as input: the system prompt, the
+        whole conversation in ``short_memory``, and the tool schemas. Use it
+        to see how full the context window is before a run. It is an
+        estimate — the conversation is counted as rendered text, role labels
+        included — so it runs a little above what the provider bills. For the
+        billed figure, summed over past calls, see :attr:`usage`.
+        """
+        parts = [self.short_memory.return_history_as_string()]
+        if self.tools_list_dictionary:
+            parts.append(json.dumps(self.tools_list_dictionary))
+        return count_tokens(
+            "\n".join(part for part in parts if part),
+            model=self.model_name,
+        )
+
+    @property
     def usage(self) -> dict:
         """Token usage reported by the provider, summed over every LLM call this agent has made.
 

--- a/tests/structs/test_agent.py
+++ b/tests/structs/test_agent.py
@@ -1619,3 +1619,35 @@ class TestAgentUsage:
             "reasoning_tokens": 0,
             "total_tokens": 47,
         }
+
+
+class TestAgentInputTokens:
+    """``agent.input_tokens`` is the size of the next request, not a bill."""
+
+    def test_counts_the_system_prompt_before_any_run(self):
+        agent = _patched_agent(
+            "CtxAgent", system_prompt="You are terse."
+        )
+        assert agent.input_tokens > 0
+
+    def test_grows_as_the_conversation_grows(self):
+        agent = _patched_agent("CtxAgent", system_prompt="Short.")
+        before = agent.input_tokens
+        agent.short_memory.add("User", "word " * 200)
+        assert agent.input_tokens > before + 100
+
+    def test_counts_tool_schemas_too(self):
+        bare = _patched_agent("CtxAgent", system_prompt="Short.")
+        with_tool = _patched_agent(
+            "CtxAgent",
+            system_prompt="Short.",
+            dynamic_tools=False,
+            tools=[_math_tool],
+        )
+        assert with_tool.input_tokens > bare.input_tokens
+
+    def test_is_independent_of_usage(self):
+        """usage is what the provider charged; input_tokens is a size."""
+        agent = _patched_agent("CtxAgent", system_prompt="Short.")
+        assert agent.usage["input_tokens"] == 0
+        assert agent.input_tokens > 0


### PR DESCRIPTION
## What

`agent.usage` reports what the provider billed *after* a call. Nothing reported how much context an agent is *about to* send. This adds a read-only property for that:

```python
agent = Agent(agent_name="Ctx", system_prompt="You are a concise research assistant.", model_name="gpt-4o-mini")

agent.input_tokens        # 26  — system prompt only
agent.run("In one sentence, what is an ETF?")
agent.input_tokens        # 117 — system prompt + task + answer now in memory
```

`input_tokens` counts everything the agent would send on its next call — the system prompt, the whole `short_memory` conversation, and the tool schemas if any — with `count_tokens` under the agent's own `model_name`, so the tokenizer matches the model. Twelve lines in `agent.py`, next to `usage`.

## How it relates to `usage`

| | `agent.input_tokens` | `agent.usage["input_tokens"]` |
|---|---|---|
| What | Size of the context right now | What the provider billed, summed over past calls |
| Changes | Whenever memory changes | Only after an LLM call returns |
| Source | Local tokenizer | Provider's usage block |
| For | "How full is the window before I run?" | "What did this cost?" |

It is an estimate: the conversation is counted as rendered text, role labels included, so it lands slightly above the billed figure for the same content — 26 counted vs. 27 billed in a live check (the billed call also carried the task). The docstring says so.

## Tests

Four in `tests/structs/test_agent.py::TestAgentInputTokens`: counts the system prompt before any run, grows with the conversation, includes tool schemas, and is independent of `usage`. `tests/structs/test_agent.py` + `tests/agents/test_llm_manager.py`: 161 passed, 1 failed — `test_call_llm_delegates`, pre-existing on `master`.

`black --line-length 70` and `ruff check` clean.
