### PR TITLE
[Feat] Autonomous loop: a plan step can say how it will be checked, and subtask_done refuses a success claim that skips the check (#1985)

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -703,6 +703,9 @@ class AutonomousAgentLoop:
                     subtask_id,
                     subtask_desc,
                     self.agent.autonomous_subtasks,
+                    verification=current_subtask.get(
+                        "verification", ""
+                    ),
                 )
                 self._say_user(execution_prompt)
 
@@ -891,10 +894,23 @@ class AutonomousAgentLoop:
                                                 )
                                                 == subtask_id
                                             ):
-                                                subtask_done = True
+                                                # Read what the handler did,
+                                                # not what the model asked
+                                                # for: subtask_done refuses a
+                                                # success claim on a step
+                                                # with an unmet verification,
+                                                # and a refusal has to leave
+                                                # the loop running.
+                                                subtask_done = self.agent.subtask_status.get(
+                                                    subtask_id
+                                                ) in (
+                                                    "completed",
+                                                    "failed",
+                                                )
                                                 # Show subtask completion
                                                 if (
-                                                    self.agent.print_on
+                                                    subtask_done
+                                                    and self.agent.print_on
                                                 ):
                                                     status = (
                                                         "completed"
@@ -1355,6 +1371,12 @@ class AutonomousAgentLoop:
                 "priority": step.get("priority", "medium"),
                 "dependencies": dependencies,
                 "status": "pending",
+                # Declared at planning time, before there is any incentive to
+                # call the step done. A revision may add or sharpen it; a
+                # finished step keeps whatever it was checked against.
+                "verification": str(
+                    step.get("verification", "") or ""
+                ),
             }
             incoming_order.append(step_id)
 
@@ -1646,7 +1668,12 @@ class AutonomousAgentLoop:
         return result
 
     def _subtask_done_tool(
-        self, task_id: str, summary: str, success: bool, **kwargs
+        self,
+        task_id: str,
+        summary: str,
+        success: bool,
+        verification_result: str = "",
+        **kwargs,
     ) -> str:
         """
         Mark a subtask as completed and move to the next task in the plan.
@@ -1677,6 +1704,9 @@ class AutonomousAgentLoop:
             success (bool): Whether the subtask was completed successfully.
                 - True: Subtask completed as intended
                 - False: Subtask failed but execution continues
+            verification_result (str): What the model ran or looked at to check
+                the step's ``verification`` criterion, and what it observed.
+                Required to mark a step that declared a criterion successful.
             **kwargs: Additional arguments (currently unused, reserved for future use).
 
         Returns:
@@ -1689,6 +1719,11 @@ class AutonomousAgentLoop:
             - Failed subtasks don't block execution but are tracked for final summary
             - Think call count is reset to prevent carryover thinking loops
             - If verbose=True, subtask completion is logged
+            - A step that declared a ``verification`` cannot be marked
+              successful without a ``verification_result``. The refusal is
+              returned as an ordinary tool result and no state is touched, so
+              the model can run the check and call again. ``success=False``
+              never needs one: failing is not a claim that has to be proved.
 
         Examples:
             >>> result = agent._subtask_done_tool(
@@ -1699,6 +1734,34 @@ class AutonomousAgentLoop:
             >>> # Returns: "Subtask step1 marked as completed"
             >>> # Updates status and allows loop to proceed to next subtask
         """
+        subtask = next(
+            (
+                s
+                for s in self.agent.autonomous_subtasks
+                if s["step_id"] == task_id
+            ),
+            None,
+        )
+        declared = (subtask or {}).get("verification", "")
+        verification_result = str(verification_result or "").strip()
+
+        # A success claim on a step with a criterion has to carry the check.
+        # Refused as a tool result, not raised: the loop continues and the
+        # model gets another turn to actually run it.
+        if success and declared and not verification_result:
+            logger.info(
+                f"Refused subtask_done for {task_id}: no verification_result "
+                f"for the declared check {declared!r}"
+            )
+            return (
+                f"Not accepted. Subtask {task_id} declared a verification: "
+                f"{declared}\n"
+                "Run it, then call subtask_done again with "
+                "verification_result set to what you actually observed. "
+                "If it does not pass, call subtask_done with success=false "
+                "and say why."
+            )
+
         if self.agent.verbose:
             logger.info(f"Completing subtask {task_id}: {summary}")
 
@@ -1709,13 +1772,11 @@ class AutonomousAgentLoop:
             )
 
         # Update subtask in list
-        for subtask in self.agent.autonomous_subtasks:
-            if subtask["step_id"] == task_id:
-                subtask["status"] = (
-                    "completed" if success else "failed"
-                )
-                subtask["summary"] = summary
-                break
+        if subtask is not None:
+            subtask["status"] = "completed" if success else "failed"
+            subtask["summary"] = summary
+            if verification_result:
+                subtask["verification_result"] = verification_result
 
         # Reset think call count when subtask is done
         self.agent.think_call_count = 0
@@ -1728,10 +1789,19 @@ class AutonomousAgentLoop:
                 f"Subtask {task_id} marked as {'completed' if success else 'failed'}. Moving to next subtask."
             )
 
-        # Add to memory
+        # Add to memory. The observation goes in too, so the final summary is
+        # written against what was checked rather than what was claimed.
+        verified_line = (
+            f"\n[VERIFIED] {task_id}: {verification_result}"
+            if verification_result
+            else ""
+        )
         self.agent.short_memory.add(
             role=self.agent.agent_name,
-            content=f"[SUBTASK DONE] {task_id}: {summary} (Success: {success})",
+            content=(
+                f"[SUBTASK DONE] {task_id}: {summary} "
+                f"(Success: {success}){verified_line}"
+            ),
         )
 
         return f"Subtask {task_id} marked as {'completed' if success else 'failed'}"

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -99,6 +99,11 @@ def get_planning_prompt(task: str) -> str:
 {task}
 
 Use the create_plan tool to break down this task into manageable subtasks. Each subtask should be specific and actionable.
+
+For each subtask, also give a `verification`: the observable check that
+proves it worked - a command and the result it must produce, or a file and
+what must be true of it. Commit to it now, while you have no stake in the
+answer. Omit it only for a step with genuinely nothing to check.
 """
 
 
@@ -106,6 +111,7 @@ def get_execution_prompt(
     subtask_id: str,
     subtask_desc: str,
     all_subtasks: List[Dict[str, Any]],
+    verification: str = "",
 ) -> str:
     """
     Get the execution phase prompt for a specific subtask.
@@ -114,6 +120,9 @@ def get_execution_prompt(
         subtask_id: The ID of the current subtask
         subtask_desc: The description of the current subtask
         all_subtasks: List of all subtasks with their status
+        verification: The check this subtask declared at planning time, if
+            any. Restated here because the model has to run it before
+            ``subtask_done`` will accept ``success=True``.
 
     Returns:
         str: Execution prompt
@@ -125,9 +134,22 @@ def get_execution_prompt(
         ]
     )
 
+    verification_block = (
+        f"\nVerification for this subtask: {verification}\n"
+        if verification
+        else ""
+    )
+    verification_instruction = (
+        "- Before calling subtask_done with success=true, actually run the "
+        "verification above and pass what you observed as "
+        "verification_result. A subtask_done without it will be refused.\n"
+        if verification
+        else ""
+    )
+
     return f"""You are currently working on subtask: {subtask_id}
 Description: {subtask_desc}
-
+{verification_block}
 Current status of all subtasks:
 {subtask_status_list}
 
@@ -135,7 +157,7 @@ Instructions:
 - Call all required tools for this subtask in a SINGLE response — do not split them across multiple turns.
 - When the subtask is complete, include the subtask_done call in that same response.
 - Only call subtask_done once the work is ACTUALLY DONE, not before.
-"""
+{verification_instruction}"""
 
 
 def get_summary_prompt() -> str:
@@ -152,7 +174,8 @@ def get_summary_prompt() -> str:
         "- Restate the original task and confirm completion.\n"
         "- Outline major accomplishments and deliverables.\n"
         "- Present key results and findings (including important data or insights).\n"
-        "- Briefly summarize each subtask's status (including any failures).\n"
+        "- Briefly summarize each subtask's status (including any failures),\n"
+        "  and for each one that declared a verification, what was observed.\n"
         "- Capture notable lessons learned, challenges, and future recommendations.\n"
         "Clearly state the task's overall success or any limitations.\n"
         "Use the `complete_task` tool with: task_id, summary, success (true/false), results (optional), and lessons_learned (optional).\n"
@@ -209,6 +232,24 @@ def get_autonomous_planning_tools() -> List[Dict[str, Any]]:
                                     "dependencies": {
                                         "type": "array",
                                         "items": {"type": "string"},
+                                    },
+                                    "verification": {
+                                        "type": "string",
+                                        "description": (
+                                            "How this step will be checked, "
+                                            "as something observable: a "
+                                            "command and the result it must "
+                                            "produce, or a file and what must "
+                                            "be true of it. For example "
+                                            "'pytest tests/test_auth.py "
+                                            "exits 0' or 'report.md exists "
+                                            "and is over 500 words'. Omit it "
+                                            "only when the step genuinely "
+                                            "has nothing checkable. You will "
+                                            "be asked to report what you "
+                                            "observed before this step can "
+                                            "be marked successful."
+                                        ),
                                     },
                                 },
                                 "required": [
@@ -279,6 +320,18 @@ def get_autonomous_planning_tools() -> List[Dict[str, Any]]:
                         "success": {
                             "type": "boolean",
                             "description": "Whether the subtask was completed successfully",
+                        },
+                        "verification_result": {
+                            "type": "string",
+                            "description": (
+                                "What you actually ran or looked at to check "
+                                "this step's `verification` criterion, and "
+                                "what you observed - the command and its exit "
+                                "code, or the file and what it contained. "
+                                "Required to mark a step with a criterion "
+                                "successful; a step that declared no "
+                                "criterion does not need one."
+                            ),
                         },
                     },
                     "required": ["task_id", "summary", "success"],

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -37,6 +37,7 @@ from swarms.agents.autonomous_loop import AutonomousAgentLoop
 from swarms.structs.autonomous_loop_utils import (
     MAX_SUBTASK_LOOPS,
     get_autonomous_planning_tools,
+    get_execution_prompt,
     glob_tool,
     TOOL_OUTPUT_CONTEXT_SHARE,
     read_file_tool,
@@ -1244,3 +1245,246 @@ class TestGlobTool:
             "pattern",
             "path",
         }
+
+
+# --------------------------------------------------------------------------
+# #1985 — a plan step can declare how it will be checked
+# --------------------------------------------------------------------------
+
+
+class TestPlanVerification:
+    """
+    subtask_done was a self-report. A step can now commit to a falsifiable
+    criterion at planning time, and cannot be called successful without one.
+    """
+
+    def test_a_step_carries_its_verification_through_the_plan(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t",
+            [
+                {
+                    "step_id": "a",
+                    "verification": "pytest tests/test_auth.py exits 0",
+                },
+                {"step_id": "b"},
+            ],
+        )
+
+        assert (
+            agent.autonomous_subtasks[0]["verification"]
+            == "pytest tests/test_auth.py exits 0"
+        )
+        # A step with nothing checkable is allowed, and is not None.
+        assert agent.autonomous_subtasks[1]["verification"] == ""
+
+    def test_a_revision_can_sharpen_a_pending_step_s_criterion(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a", "verification": "it works"}]
+        )
+        loop._create_plan_tool(
+            "t", [{"step_id": "a", "verification": "pytest exits 0"}]
+        )
+
+        assert (
+            agent.autonomous_subtasks[0]["verification"]
+            == "pytest exits 0"
+        )
+
+    def test_a_finished_step_keeps_what_it_was_checked_against(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a", "verification": "pytest exits 0"}]
+        )
+        loop._subtask_done_tool(
+            task_id="a",
+            summary="did it",
+            success=True,
+            verification_result="ran pytest, exit 0, 12 passed",
+        )
+        loop._create_plan_tool(
+            "t",
+            [
+                {"step_id": "a", "verification": "something else"},
+                {"step_id": "b"},
+            ],
+        )
+
+        assert (
+            agent.autonomous_subtasks[0]["verification_result"]
+            == "ran pytest, exit 0, 12 passed"
+        )
+        assert status_of(agent, "a") == "completed"
+
+    def test_success_is_refused_without_the_observation(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a", "verification": "pytest exits 0"}]
+        )
+
+        result = loop._subtask_done_tool(
+            task_id="a", summary="trust me", success=True
+        )
+
+        assert "Not accepted" in result
+        assert "pytest exits 0" in result
+        # Nothing moved: not the status, not the cursor.
+        assert status_of(agent, "a") == "pending"
+        assert agent.current_subtask_index == 0
+
+    def test_the_observation_is_accepted_and_recorded(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a", "verification": "pytest exits 0"}]
+        )
+
+        loop._subtask_done_tool(
+            task_id="a",
+            summary="fixed the auth check",
+            success=True,
+            verification_result="pytest tests/test_auth.py -> exit 0",
+        )
+
+        assert status_of(agent, "a") == "completed"
+        assert (
+            agent.autonomous_subtasks[0]["verification_result"]
+            == "pytest tests/test_auth.py -> exit 0"
+        )
+        # The summary is written against what was observed, so it has to be
+        # in the transcript the summary is generated from.
+        assert "[VERIFIED] a: pytest tests/test_auth.py" in history(
+            agent
+        )
+
+    def test_failing_needs_no_proof(self):
+        """success=False is not a claim that has to be substantiated."""
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a", "verification": "pytest exits 0"}]
+        )
+
+        result = loop._subtask_done_tool(
+            task_id="a", summary="could not do it", success=False
+        )
+
+        assert "Not accepted" not in result
+        assert status_of(agent, "a") == "failed"
+
+    def test_a_step_with_no_criterion_is_unchanged(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool("t", [{"step_id": "a"}])
+
+        result = loop._subtask_done_tool(
+            task_id="a", summary="done", success=True
+        )
+
+        assert "Not accepted" not in result
+        assert status_of(agent, "a") == "completed"
+
+    def test_whitespace_is_not_an_observation(self):
+        agent = build_agent()
+        loop = AutonomousAgentLoop(agent)
+        loop._create_plan_tool(
+            "t", [{"step_id": "a", "verification": "pytest exits 0"}]
+        )
+
+        result = loop._subtask_done_tool(
+            task_id="a",
+            summary="done",
+            success=True,
+            verification_result="   ",
+        )
+
+        assert "Not accepted" in result
+        assert status_of(agent, "a") == "pending"
+
+    def test_the_criterion_reaches_the_model_in_the_execution_prompt(
+        self,
+    ):
+        subtasks = [
+            {
+                "step_id": "a",
+                "description": "fix auth",
+                "status": "pending",
+            }
+        ]
+
+        with_check = get_execution_prompt(
+            "a", "fix auth", subtasks, verification="pytest exits 0"
+        )
+        without = get_execution_prompt("a", "fix auth", subtasks)
+
+        assert "Verification for this subtask: pytest exits 0" in (
+            with_check
+        )
+        assert "will be refused" in with_check
+        # A step with nothing to check is not told about a check.
+        assert "Verification for this subtask" not in without
+        assert "will be refused" not in without
+
+    def test_a_refusal_leaves_the_loop_running_and_the_retry_lands(
+        self, monkeypatch
+    ):
+        """End to end: refused once, then accepted with the observation."""
+        agent = build_agent()
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                [
+                    tool_call(
+                        "create_plan",
+                        task_description="test task",
+                        steps=[
+                            {
+                                "step_id": "step1",
+                                "description": "do step1",
+                                "priority": "high",
+                                "dependencies": [],
+                                "verification": "pytest exits 0",
+                            }
+                        ],
+                    )
+                ],
+                [
+                    tool_call(
+                        "subtask_done",
+                        task_id="step1",
+                        summary="done",
+                        success=True,
+                    )
+                ],
+                [
+                    tool_call(
+                        "subtask_done",
+                        task_id="step1",
+                        summary="done",
+                        success=True,
+                        verification_result="pytest -> exit 0",
+                    )
+                ],
+                [
+                    tool_call(
+                        "complete_task",
+                        task_id="main",
+                        summary="done",
+                        success=True,
+                    )
+                ],
+            ],
+        )
+
+        agent.run("test task")
+
+        text = history(agent)
+        assert "Not accepted" in text
+        assert status_of(agent, "step1") == "completed"
+        assert "[VERIFIED] step1: pytest -> exit 0" in text


### PR DESCRIPTION
Closes part of #1985.

`subtask_done` takes the model's word for it. **A plan step can now declare, at planning time, the observable check that would prove it worked — and `subtask_done` refuses a success claim on such a step until the model reports what it actually observed.** The refusal is a tool result, not an exception, so the loop keeps running and the model gets another turn to go and run the check.

## Problem

The contract is a self-report:

```python
def _subtask_done_tool(self, task_id: str, summary: str, success: bool, **kwargs) -> str:
```

and the only thing standing behind it is the execution prompt asking nicely (`autonomous_loop_utils.py:137`):

```
- Only call subtask_done once the work is ACTUALLY DONE, not before.
```

That is the right instruction and it is not enforceable on its own. Nothing in the plan schema has a place to say what "done" would look like, so there is nothing to check the claim against — and the criterion, if it exists at all, is invented at the moment the model most wants the step to be finished.

There was also a second, quieter problem. The loop set its `subtask_done` flag from the *call*, not the outcome (`autonomous_loop.py:897`):

```python
if arguments.get("task_id") == subtask_id:
    subtask_done = True
```

Twenty lines further down it already derives the same flag from state:

```python
if subtask_id in self.agent.subtask_status and self.agent.subtask_status[subtask_id] in ["completed", "failed"]:
    subtask_done = True
```

So a handler that declines to complete a subtask would have been overruled by the earlier line. Any enforcement here needs that fixed first.

## What's added

| Surface | Change |
|---|---|
| `create_plan` step schema | optional `verification` — "a command and the result it must produce, or a file and what must be true of it" |
| `subtask_done` schema | optional `verification_result` — what was run or read, and what came back |
| `_create_plan_tool` | carries `verification` onto the stored subtask; a revision can sharpen a pending step's criterion, a finished step keeps its recorded result |
| `_subtask_done_tool` | refuses `success=True` on a step with a criterion and no result; stores the result; writes `[VERIFIED] <id>: <observation>` into the transcript |
| `autonomous_loop.py:897` | `subtask_done` derived from `agent.subtask_status`, not from the model having asked |
| `get_execution_prompt` | restates the criterion for the current subtask, and only then adds the instruction to report it |
| planning / summary prompts | ask for a criterion per step, and for the observation per step in the final summary |

The refusal the model sees:

```
Not accepted. Subtask step1 declared a verification: pytest tests/test_auth.py exits 0
Run it, then call subtask_done again with verification_result set to what you actually observed. If it does not pass, call subtask_done with success=false and say why.
```

## Design decisions

- **Refuse, do not raise.** #1990 established that a failed tool reaches the model as a result so it can react; a refusal is the same shape. Raising would abort the response and leave `tool_call_id`s unanswered. And because the refusal touches no state, the retry is a normal next turn rather than a recovery path.

- **`success=False` never needs a result.** Failing is not a claim that has to be substantiated, and requiring proof of failure is the fastest way to teach a model to claim success instead. There is a test for this.

- **The loop flag had to become state-derived first.** Leaving `subtask_done = True` where it was would have made the enforcement decorative: the handler would decline, and the loop would move on anyway. The replacement reads the status the handler actually wrote — which the loop already did later, so this makes two sites agree rather than introducing a new rule. It also stops the console panel announcing "Subtask completed" for a call that was refused.

- **A criterion is optional, and an empty one is `""` not `None`.** Some steps genuinely have nothing checkable ("decide which approach to take"), and forcing a criterion there produces theatre. Storing `""` keeps `.get("verification", "")` from having to guard against both.

- **The observation goes into the transcript, not just onto the subtask.** `_generate_final_summary` is written from the conversation, so a result recorded only in `autonomous_subtasks` would be invisible to the summary the user actually reads. `[VERIFIED]` sits next to `[SUBTASK DONE]` for that reason.

## Deliberately not done

**Executing the criterion directly and attaching the real exit code.** That is the issue's third bullet, marked optional there, and it is a different feature: it means the loop runs a command the model wrote, which has to go through the permission layer (#2163) and the workspace sandbox before it is something to turn on by default. What this PR does is make the criterion exist, be committed to early, and be reported against — which is the part that costs nothing and blocks nothing.

## Behavior-change note

A plan that declares no `verification` behaves exactly as before: `subtask_done` accepts the same arguments and does the same thing, and the execution prompt gains no extra text. The change is only visible once a plan uses the new field — but note that the *planning prompt* now asks for one, so models will start supplying it, and steps that do will be held to it. `verification_result` is a new optional keyword; nothing calls `_subtask_done_tool` positionally outside the loop (`grep -rn "_subtask_done_tool" swarms/` matches only its definition and the handler map).

## Verification

- **New**: 10 tests in `TestPlanVerification`, added to the existing `tests/agents/test_autonomous_loop.py` rather than a new file. Covered: the criterion survives the plan merge; a revision can sharpen a pending step's; a finished step keeps its result; success refused without an observation; whitespace is not an observation; accepted and recorded; `success=False` needs none; a step with no criterion is unchanged; the execution prompt gains the criterion only when there is one; and an end-to-end run through the real loop where the model is refused once, retries with the observation, and completes.
- **Fails on clean base**: with the two source files stashed and the tests kept, **8 of the 10 fail**. The 2 that pass are exactly the two asserting *unchanged* behavior — a step with no criterion, and `success=False` — which is what they are for.
- **Module suite**: `pytest tests/agents/test_autonomous_loop.py -q -p no:randomly` → **59 passed** (49 pre-existing + 10 new), no failures.
- **Lint at the versions CI pins** (`black==24.2.0`, `ruff==0.2.1`, per `.github/workflows/lint.yml`): `black . --check` → 957 files unchanged; `ruff check .` → exit 0, repo-wide.
- **Not verified here**: the full `tests/` suite. Most of `tests/structs` constructs real agents and calls the provider, and this environment has no `OPENAI_API_KEY`, so a full run only measures retry backoff. Every test added here stubs `call_llm` and makes no network call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut4g856LnbHeUjA8MawHxo
