### PR TITLE
docs(examples): gpt-6-astra through the Swarms API, bump to 15.0.2

### DIFF
--- a/examples/models/README.md
+++ b/examples/models/README.md
@@ -34,6 +34,8 @@ Set the matching API key as an environment variable before running any example (
 ### GPT-6 Astra
 - [gpt_astra.py](gpt_astra/gpt_astra.py) — Quantitative trading agent on gpt-6-astra
 - [gpt_astra_usage.py](gpt_astra/gpt_astra_usage.py) — Streamed run with `agent.usage`, including reasoning tokens
+- [swarms_api_single_agent.py](gpt_astra/swarms_api_single_agent.py) — One gpt-6-astra agent through the Swarms API (`/v1/agent/completions`)
+- [swarms_api_mixture_of_agents.py](gpt_astra/swarms_api_mixture_of_agents.py) — MixtureOfAgents of gpt-6-astra agents through the Swarms API (`/v1/swarm/completions`)
 
 ### Llama 4
 - [llama_4.py](llama4/llama_4.py) — Llama 4 agent

--- a/examples/models/gpt_astra/swarms_api_mixture_of_agents.py
+++ b/examples/models/gpt_astra/swarms_api_mixture_of_agents.py
@@ -1,0 +1,92 @@
+"""A MixtureOfAgents swarm of gpt-6-astra agents through the Swarms API.
+
+Three specialists answer the task in parallel and a synthesizer combines
+their answers. Every agent runs gpt-6-astra.
+
+Run:
+    export SWARMS_API_KEY=...   # https://swarms.world/platform/api-keys
+    python examples/models/gpt_astra/swarms_api_mixture_of_agents.py
+"""
+
+import json
+import os
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_KEY = os.getenv("SWARMS_API_KEY")
+BASE_URL = "https://api.swarms.world"
+
+headers = {"x-api-key": API_KEY, "Content-Type": "application/json"}
+
+MODEL = "gpt-6-astra"
+
+payload = {
+    "name": "Semiconductor-ETF-Council",
+    "description": "Three views on a semiconductor ETF question, then a synthesis.",
+    "swarm_type": "MixtureOfAgents",
+    "max_loops": 1,
+    "agents": [
+        {
+            "agent_name": "Fundamentals-Analyst",
+            "description": "Weighs holdings, concentration and expense ratios.",
+            "system_prompt": (
+                "You are a fund analyst. Compare ETFs on holdings, "
+                "concentration and expense ratio. Be concrete and brief."
+            ),
+            "model_name": MODEL,
+            "max_loops": 1,
+            "max_tokens": 4000,
+        },
+        {
+            "agent_name": "Risk-Officer",
+            "description": "Names the risks an investor is taking on.",
+            "system_prompt": (
+                "You are a risk officer. State the main risks of each option "
+                "and who should avoid it. Be concrete and brief."
+            ),
+            "model_name": MODEL,
+            "max_loops": 1,
+            "max_tokens": 4000,
+        },
+        {
+            "agent_name": "Portfolio-Manager",
+            "description": "Recommends an allocation for a long-term investor.",
+            "system_prompt": (
+                "You are a portfolio manager for long-term retail investors. "
+                "Give a clear recommendation and the reason. Be brief."
+            ),
+            "model_name": MODEL,
+            "max_loops": 1,
+            "max_tokens": 4000,
+        },
+        {
+            "agent_name": "Synthesizer",
+            "description": "Combines the specialists' answers into one brief.",
+            "system_prompt": (
+                "You combine the expert answers you are given into one short, "
+                "decision-oriented brief. Keep every concrete number."
+            ),
+            "model_name": MODEL,
+            "max_loops": 1,
+            "max_tokens": 4000,
+        },
+    ],
+    "task": (
+        "Should a long-term investor choose SMH or SOXX for semiconductor "
+        "exposure? Compare concentration, expense ratio and risk."
+    ),
+}
+
+response = requests.post(
+    f"{BASE_URL}/v1/swarm/completions", headers=headers, json=payload
+)
+response.raise_for_status()
+result = response.json()
+
+# output is the whole conversation, the synthesis is the last entry
+for message in result["output"]:
+    print(f"[{message['role']}]\n{message['content']}\n")
+print(json.dumps(result["usage"], indent=2))

--- a/examples/models/gpt_astra/swarms_api_single_agent.py
+++ b/examples/models/gpt_astra/swarms_api_single_agent.py
@@ -1,0 +1,48 @@
+"""One gpt-6-astra agent through the Swarms API, no framework install needed.
+
+Run:
+    export SWARMS_API_KEY=...   # https://swarms.world/platform/api-keys
+    python examples/models/gpt_astra/swarms_api_single_agent.py
+"""
+
+import json
+import os
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_KEY = os.getenv("SWARMS_API_KEY")
+BASE_URL = "https://api.swarms.world"
+
+headers = {"x-api-key": API_KEY, "Content-Type": "application/json"}
+
+payload = {
+    "agent_config": {
+        "agent_name": "Quantitative-Trading-Agent",
+        "description": "Quantitative trading and financial research agent.",
+        "system_prompt": (
+            "You are a quantitative trading assistant. When comparing "
+            "investment options, weigh performance, expense ratio, holdings, "
+            "strategy and risk, and state your assumptions."
+        ),
+        "model_name": "gpt-6-astra",
+        "max_loops": 1,
+        "max_tokens": 8000,
+    },
+    "task": (
+        "Compare the SMH and SOXX semiconductor ETFs in one short paragraph: "
+        "concentration, expense ratio, and which suits a long-term investor."
+    ),
+}
+
+response = requests.post(
+    f"{BASE_URL}/v1/agent/completions", headers=headers, json=payload
+)
+response.raise_for_status()
+result = response.json()
+
+# outputs is the conversation, the agent's answer is the last entry
+print(result["outputs"][-1]["content"])
+print(json.dumps(result["usage"], indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "swarms"
-version = "15.0.1"
+version = "15.0.2"
 description = "Swarms - TGSC"
 license = "Apache-2.0"
 authors = ["Kye Gomez <kye@swarms.world>"]


### PR DESCRIPTION
## What

Two new examples under `examples/models/gpt_astra/` that run gpt-6-astra over the hosted Swarms API instead of the local framework, plus a version bump.

- `swarms_api_single_agent.py` — one agent on `/v1/agent/completions`. Prints the final answer and the usage block.
- `swarms_api_mixture_of_agents.py` — a `MixtureOfAgents` swarm of three specialists and a synthesizer on `/v1/swarm/completions`. Prints every turn of the conversation and the usage block.
- `examples/models/README.md` — links to both examples in the GPT-6 Astra section.
- `pyproject.toml` — version `15.0.1` → `15.0.2`.

## Why

The existing gpt_astra examples require a local install and an OpenAI key. These show the same model through the API with only `requests` and a `SWARMS_API_KEY`.

## Checks

- `black --line-length 70 --check` and `ruff check` pass on the new files.
- Examples make live API calls and were not run in CI.
