### PR TITLE
docs(examples): print the full Swarms API response in the gpt-6-astra examples

### DIFF
--- a/examples/models/gpt_astra/swarms_api_mixture_of_agents.py
+++ b/examples/models/gpt_astra/swarms_api_mixture_of_agents.py
@@ -1,13 +1,3 @@
-"""A MixtureOfAgents swarm of gpt-6-astra agents through the Swarms API.
-
-Three specialists answer the task in parallel and a synthesizer combines
-their answers. Every agent runs gpt-6-astra.
-
-Run:
-    export SWARMS_API_KEY=...   # https://swarms.world/platform/api-keys
-    python examples/models/gpt_astra/swarms_api_mixture_of_agents.py
-"""
-
 import json
 import os
 
@@ -85,6 +75,8 @@ response = requests.post(
 )
 response.raise_for_status()
 result = response.json()
+
+print(json.dumps(result, indent=2))
 
 # output is the whole conversation, the synthesis is the last entry
 for message in result["output"]:

--- a/examples/models/gpt_astra/swarms_api_single_agent.py
+++ b/examples/models/gpt_astra/swarms_api_single_agent.py
@@ -1,10 +1,3 @@
-"""One gpt-6-astra agent through the Swarms API, no framework install needed.
-
-Run:
-    export SWARMS_API_KEY=...   # https://swarms.world/platform/api-keys
-    python examples/models/gpt_astra/swarms_api_single_agent.py
-"""
-
 import json
 import os
 
@@ -29,7 +22,6 @@ payload = {
         ),
         "model_name": "gpt-6-astra",
         "max_loops": 1,
-        "max_tokens": 8000,
     },
     "task": (
         "Compare the SMH and SOXX semiconductor ETFs in one short paragraph: "
@@ -43,6 +35,4 @@ response = requests.post(
 response.raise_for_status()
 result = response.json()
 
-# outputs is the conversation, the agent's answer is the last entry
-print(result["outputs"][-1]["content"])
-print(json.dumps(result["usage"], indent=2))
+print(json.dumps(result, indent=2))


### PR DESCRIPTION
## What

Follow-up to #2199. Both Swarms API examples under `examples/models/gpt_astra/` now print the full JSON response.

- `swarms_api_single_agent.py` — prints the whole response instead of the last output entry plus usage. Drops the `max_tokens` override so the request is the minimum the endpoint needs.
- `swarms_api_mixture_of_agents.py` — prints the whole response before the per-turn loop.
- Module docstrings removed from both.

## Why

A reader copying these should see the exact shape the API returns rather than two fields picked out of it.

## Checks

- `black --line-length 70 --check` and `ruff check` pass on the directory.
- Examples make live API calls and were not run in CI.
