### PR TITLE
[FIX][IterativeReflectiveExpansion.run][Bound path expansion so a low score cannot multiply the run]

### DIFF
--- a/swarms/agents/i_agent.py
+++ b/swarms/agents/i_agent.py
@@ -295,8 +295,6 @@ class IterativeReflectiveExpansion:
                 f"Candidate paths for next iteration: {candidate_paths}"
             )
 
-            # Every path already cleared the threshold, so another iteration
-            # would re-simulate the same paths and revise nothing.
             if not revised_any:
                 logger.info(
                     "All paths met the score threshold; stopping early."

--- a/swarms/agents/i_agent.py
+++ b/swarms/agents/i_agent.py
@@ -54,17 +54,27 @@ class IterativeReflectiveExpansion:
         system_prompt: str = GENERAL_REASONING_AGENT_SYS_PROMPT,
         model_name: str = "gpt-5.4",
         output_type: OutputType = "dict",
+        max_paths: int = 4,
+        score_threshold: float = 0.7,
     ) -> None:
         """
         Initialize the Iterative Reflective Expansion engine.
 
         :param agent: The Swarms agent instance used to perform reasoning tasks.
         :param max_loops: Maximum number of loops for the reasoning process.
+        :param max_paths: Maximum reasoning paths carried at once. Without a
+            bound the model returns several paths per revision and each of
+            those can be revised again, so the work per iteration grows with
+            every low-scoring path instead of converging (#1261).
+        :param score_threshold: Score at or above which a path is kept as is
+            rather than revised.
         """
         self.agent_name = agent_name
         self.description = description
         self.agent = agent
         self.max_loops = max_loops
+        self.max_paths = max_paths
+        self.score_threshold = score_threshold
         self.output_type = output_type
         self.system_prompt = system_prompt
         self.conversation = Conversation()
@@ -252,30 +262,46 @@ class IterativeReflectiveExpansion:
         logger.info(
             f"Starting iterative reflective expansion for problem: {task}"
         )
-        candidate_paths = self.generate_initial_hypotheses(task)
+        candidate_paths = self.generate_initial_hypotheses(task)[
+            : self.max_paths
+        ]
         memory_pool: List[str] = []
 
         for iteration in range(self.max_loops):
             logger.info(f"Iteration {iteration + 1}/{self.max_loops}")
             expanded_paths: List[str] = []
+            revised_any = False
 
             for path in candidate_paths:
                 outcome, score, error_info = self.simulate_path(path)
-                # Use a threshold score of 0.7 (this can be adjusted)
-                if score < 0.7:
+                if score < self.score_threshold:
+                    revised_any = True
                     feedback = self.meta_reflect(error_info)
                     revised_paths = self.revise_path(path, feedback)
-                    expanded_paths.extend(revised_paths)
+                    expanded_paths.extend(
+                        revised_paths[: self.max_paths]
+                    )
                 else:
                     expanded_paths.append(path)
+
+                if len(expanded_paths) >= self.max_paths:
+                    break
 
             memory_pool.extend(candidate_paths)
             candidate_paths = self.select_promising_paths(
                 expanded_paths
-            )
+            )[: self.max_paths]
             logger.info(
                 f"Candidate paths for next iteration: {candidate_paths}"
             )
+
+            # Every path already cleared the threshold, so another iteration
+            # would re-simulate the same paths and revise nothing.
+            if not revised_any:
+                logger.info(
+                    "All paths met the score threshold; stopping early."
+                )
+                break
 
         self.synthesize_solution(candidate_paths, memory_pool)
         logger.info("Final solution generated.")

--- a/tests/structs/test_i_agent.py
+++ b/tests/structs/test_i_agent.py
@@ -82,3 +82,68 @@ def test_ire_agent_workflow():
 
     # Check that conversation was populated during execution
     assert agent.conversation is not None
+
+
+def test_low_scoring_paths_do_not_multiply_without_bound():
+    """Every low score used to add a full set of revisions, each revisable
+    again, so one run of the reported repro made tens of thousands of model
+    calls and never finished iteration 1 (#1261)."""
+    from unittest.mock import MagicMock, patch
+
+    calls = {"simulate": 0}
+
+    with patch("swarms.agents.i_agent.Agent"):
+        ire = IterativeReflectiveExpansion(max_loops=5, max_paths=4)
+
+    def simulate(path):
+        calls["simulate"] += 1
+        assert calls["simulate"] < 500, "path expansion is unbounded"
+        return ("out", 0.5, "err")
+
+    ire.generate_initial_hypotheses = lambda task: [
+        f"h{i}" for i in range(9)
+    ]
+    ire.simulate_path = simulate
+    ire.meta_reflect = lambda err: "feedback"
+    ire.revise_path = lambda path, fb: [
+        f"{path}-r{i}" for i in range(9)
+    ]
+    ire.select_promising_paths = lambda paths: paths
+    ire.synthesize_solution = lambda paths, pool: "done"
+    ire.conversation = MagicMock()
+
+    with patch(
+        "swarms.agents.i_agent.history_output_formatter",
+        return_value="ok",
+    ):
+        ire.run("What is the 2nd prime number?")
+
+    assert calls["simulate"] <= ire.max_loops * ire.max_paths
+
+
+def test_a_run_where_every_path_scores_well_stops_early():
+    """Nothing to revise means another iteration re-simulates the same paths."""
+    from unittest.mock import MagicMock, patch
+
+    calls = {"simulate": 0}
+
+    with patch("swarms.agents.i_agent.Agent"):
+        ire = IterativeReflectiveExpansion(max_loops=5, max_paths=4)
+
+    def simulate(path):
+        calls["simulate"] += 1
+        return ("out", 0.95, "")
+
+    ire.generate_initial_hypotheses = lambda task: ["only-path"]
+    ire.simulate_path = simulate
+    ire.select_promising_paths = lambda paths: paths
+    ire.synthesize_solution = lambda paths, pool: "done"
+    ire.conversation = MagicMock()
+
+    with patch(
+        "swarms.agents.i_agent.history_output_formatter",
+        return_value="ok",
+    ):
+        ire.run("trivial")
+
+    assert calls["simulate"] == 1


### PR DESCRIPTION
Closes #1261.

## Reproduced

The repro in the issue, with the model calls counted instead of made:

```
before: 20,001 simulate_path calls (aborted, still climbing)
after:  5
```

Each of those is a real model call, which is why the reported run sat in iteration 1 for minutes.

## Why

`run()` fanned out with nothing bounding it:

```py
for path in candidate_paths:          # 9 initial hypotheses
    if score < 0.7:
        expanded_paths.extend(self.revise_path(path, feedback))   # 9 more each
```

`revise_path` asks for revised paths, plural, so a low score turned 1 path into 9, and every one of those could score low and become 9 again. Nothing capped the initial hypotheses, the revisions per path, or the paths carried into the next iteration, and the loop always ran all `max_loops` even when nothing needed revising. That is the three problems the issue lists.

## The change

A `max_paths` bound (default 4) applied at the three places the count grows, plus an early exit:

- initial hypotheses truncated
- revisions per path truncated
- `candidate_paths` truncated after selection, and the inner loop stops once the cap is reached
- if no path scored below threshold, stop: another iteration would re-simulate the same paths and revise nothing

`0.7` becomes `score_threshold`, since the comment beside it already said it should be adjustable. Both are constructor parameters, so the old behaviour is reachable by raising them.

## Tests

Two added to `tests/structs/test_i_agent.py`, both offline. The first drives the exact reported shape, 9 hypotheses and 9 revisions each all scoring 0.5, and asserts the call count stays within `max_loops * max_paths`; it trips an assertion well before 500 calls on master. The second checks a run where everything scores well stops after one simulation instead of five.

Worth knowing: every existing test in that file makes a live model call, `grep -c "patch\|mock"` returns 0 on master, so the file cannot pass offline as it stands and `test_ire_agent_execution` is the one that hangs CI (#1940). The two I added are self-contained and do not add to that.