### PR TITLE
[Fix][LLMCouncil][Send the council to the Chairman as typed turns instead of one flattened user blob]

### DIFF
--- a/swarms/structs/llm_council.py
+++ b/swarms/structs/llm_council.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional
 
 from swarms.structs.execution_utils import batched_run
 from swarms.structs.agent import Agent
+from swarms.structs.context_utils import messages_for
 from swarms.structs.conversation import Conversation
 from swarms.structs.multi_agent_exec import (
     batched_grid_agent_execution,
@@ -202,8 +203,6 @@ Remember: The goal is honest, objective evaluation. If another model's response 
 
 def get_synthesis_prompt(
     query: str,
-    original_responses: Dict[str, str],
-    evaluations: Dict[str, str],
     id_to_member: Dict[str, str],
 ) -> str:
     """
@@ -211,37 +210,15 @@ def get_synthesis_prompt(
 
     Args:
         query: Original user query
-        original_responses: Dict mapping member names to their responses
-        evaluations: Dict mapping evaluator names to their evaluation texts
         id_to_member: Mapping from anonymous IDs to member names
 
     Returns:
         Formatted synthesis prompt
     """
-    responses_section = "\n\n".join(
-        [
-            f"=== {name} ===\n{response}"
-            for name, response in original_responses.items()
-        ]
-    )
-
-    evaluations_section = "\n\n".join(
-        [
-            f"=== Evaluation by {name} ===\n{evaluation}"
-            for name, evaluation in evaluations.items()
-        ]
-    )
-
-    return f"""As the Chairman of the LLM Council, synthesize the following information into a final, comprehensive answer.
+    return f"""As the Chairman of the LLM Council, synthesize the council's responses and evaluations above into a final, comprehensive answer.
 
 ORIGINAL QUERY:
 {query}
-
-COUNCIL MEMBER RESPONSES:
-{responses_section}
-
-COUNCIL MEMBER EVALUATIONS AND RANKINGS:
-{evaluations_section}
 
 ANONYMOUS ID MAPPING (for reference):
 {chr(10).join([f"  {aid} = {name}" for aid, name in id_to_member.items()])}
@@ -507,11 +484,14 @@ class LLMCouncil:
         if self.verbose:
             print("👔 Chairman synthesizing final response...\n")
 
-        synthesis_prompt = get_synthesis_prompt(
-            query, original_responses, evaluations, id_to_member
-        )
+        synthesis_prompt = get_synthesis_prompt(query, id_to_member)
 
-        final_response = self.chairman.run(task=synthesis_prompt)
+        final_response = self.chairman.run(
+            task=synthesis_prompt,
+            messages=messages_for(
+                self.chairman.agent_name, self.conversation
+            ),
+        )
 
         # Add chairman's final response to conversation
         self.conversation.add(role="Chairman", content=final_response)

--- a/tests/structs/test_llm_council.py
+++ b/tests/structs/test_llm_council.py
@@ -316,3 +316,113 @@ def test_llm_council_output_types():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def _record(agent, calls):
+    """Replace an agent's run() with a stub that records the context it got."""
+    name = agent.agent_name
+    turns = [0]
+
+    def _run(task=None, messages=None, **kwargs):
+        turns[0] += 1
+        answer = f"{name}-answer-{turns[0]}"
+        calls.append(
+            {
+                "agent": name,
+                "task": task,
+                "messages": list(messages or []),
+                "answer": answer,
+            }
+        )
+        agent.short_memory.add(role=name, content=answer)
+        return answer
+
+    agent.run = _run
+    return agent
+
+
+def _recorded_council():
+    """An LLMCouncil whose members and chairman all record what they were sent."""
+    calls = []
+    members = [
+        _record(
+            Agent(
+                agent_name=name,
+                agent_description=f"Recording councillor {name}",
+                model_name="gpt-4o",
+                max_loops=1,
+                persistent_memory=False,
+                print_on=False,
+                autosave=False,
+            ),
+            calls,
+        )
+        for name in ("Member-A", "Member-B")
+    ]
+    council = LLMCouncil(council_members=members, verbose=False)
+    _record(council.chairman, calls)
+    return council, calls
+
+
+def _chairman_call(calls):
+    """The single recorded call the Chairman made."""
+    return next(c for c in calls if c["agent"] == "Chairman")
+
+
+def test_chairman_receives_each_councillor_response_as_its_own_turn():
+    """Each member's answer reaches the Chairman as a labelled turn."""
+    council, calls = _recorded_council()
+    council.run("what is the best vector database")
+
+    chairman = _chairman_call(calls)
+    turns = "\n".join(m["content"] for m in chairman["messages"])
+
+    for name in ("Member-A", "Member-B"):
+        assert f"{name}: {name}-answer-1" in turns
+
+
+def test_chairman_task_carries_no_councillor_text():
+    """The synthesis prompt holds the instruction, not the council's output."""
+    council, calls = _recorded_council()
+    council.run("what is the best vector database")
+
+    chairman = _chairman_call(calls)
+
+    assert "=== Member-A ===" not in str(chairman["task"])
+    assert "Member-A-answer-1" not in str(chairman["task"])
+    assert "COUNCIL MEMBER RESPONSES" not in str(chairman["task"])
+    assert "COUNCIL MEMBER EVALUATIONS" not in str(chairman["task"])
+
+
+def test_chairman_receives_the_evaluations_as_turns():
+    """Peer evaluations arrive as turns rather than an interpolated section."""
+    council, calls = _recorded_council()
+    council.run("what is the best vector database")
+
+    chairman = _chairman_call(calls)
+    turns = "\n".join(m["content"] for m in chairman["messages"])
+
+    assert "Member-A-Evaluation:" in turns
+    assert "Member-B-Evaluation:" in turns
+
+
+def test_chairman_task_keeps_the_query_and_the_id_mapping():
+    """The query and the anonymous id key stay in the instruction."""
+    council, calls = _recorded_council()
+    council.run("a very distinctive question about tungsten")
+
+    task = str(_chairman_call(calls)["task"])
+
+    assert "a very distinctive question about tungsten" in task
+    assert "ANONYMOUS ID MAPPING" in task
+
+
+def test_everything_the_chairman_reads_is_a_typed_turn():
+    """No message reaches the Chairman as anything but a typed chat turn."""
+    council, calls = _recorded_council()
+    council.run("what is the best vector database")
+
+    for message in _chairman_call(calls)["messages"]:
+        assert isinstance(message, dict)
+        assert message["role"] in ("user", "assistant")
+        assert isinstance(message["content"], str)


### PR DESCRIPTION
Closes #2200.

The Chairman received the entire council — every response and every evaluation — as one `user` string. **`self.conversation` already holds each of those as a typed turn, so this throws nothing away: it stops rebuilding role attribution as `=== name ===` prose and hands the Chairman the turns that already exist.**

## Problem

`get_synthesis_prompt` (`llm_council.py:221-233`) fused two sections into an f-string:

```python
responses_section = "\n\n".join(
    [f"=== {name} ===\n{response}" for name, response in original_responses.items()]
)
evaluations_section = "\n\n".join(
    [f"=== Evaluation by {name} ===\n{evaluation}" for name, evaluation in evaluations.items()]
)
```

and `llm_council.py:514` handed the result over with no `messages=`:

```python
final_response = self.chairman.run(task=synthesis_prompt)
```

Meanwhile the same content is already recorded as typed turns — responses at `:447`, evaluations at `:499-501`. So the Chairman got N responses plus N evaluations, each up to a full model answer, collapsed into one message whose prefix differs on every run. LLMCouncil is one of the largest contexts in the repo and it was the one guaranteed never to hit prompt caching.

## Fix

| Site | Before | After |
|---|---|---|
| `get_synthesis_prompt` | `(query, original_responses, evaluations, id_to_member)` | `(query, id_to_member)` |
| its body | two interpolated sections | instruction + query + anonymous id mapping only |
| `run()` | `chairman.run(task=synthesis_prompt)` | `chairman.run(task=synthesis_prompt, messages=messages_for(self.chairman.agent_name, self.conversation))` |

## Design decisions

- **I did not use `split_last_turn`, which the issue's snippet suggests.** `split_last_turn` takes the newest turn as the task, and the newest turn here is the last councillor's *evaluation* — so the Chairman's instruction would have become a peer's evaluation text and the synthesis instruction would have been dropped entirely. Passing the instruction as `task` and the history as `messages=` is the shape `advisor_swarm.py` (#2188) and `heavy_swarm.py` (#2189) use, and it keeps the instruction as the newest user turn because `Agent._transcript_from_messages` appends `task` after `messages`.

- **`self.chairman.agent_name`, not the literal `"Chairman"`.** The name is what `messages_for` matches on to decide which turns come back as `assistant`. Hard-coding it would silently mislabel the Chairman's own prior turns if the agent were ever renamed.

- **The id mapping stays in the instruction.** It is a key for reading the evaluations, not a turn anyone took, so it belongs with the instruction rather than in the transcript.

- **The two stale `Args:` entries are removed from the existing docstring.** Leaving a docstring describing parameters the signature no longer has is the exact defect open PR #2170 is cleaning up repo-wide.

## Behavior-change note

`get_synthesis_prompt` is module-level and its signature changed. `grep -rn "get_synthesis_prompt" swarms/ tests/ examples/` finds exactly two references: the definition and the one call site in this file. Nothing outside `llm_council.py` imports it.

The conversation recorded and returned by `run()` is unchanged — same rows, same order, so `output_type` behaviour is untouched.

## Relationship to #2184

#2184 (open, mine) fixes the *recording* half of this file — councillors built with `output_type="final"` so transcripts stop being anonymised as answers. As #2200 states, it deliberately leaves the flattening at `:221-233` / `:514` alone. The two touch the same file in different places; whichever merges first, I will rebase the other.

## Verification

- **New**: 5 tests appended to the existing `tests/structs/test_llm_council.py` — no new file. They stub every agent's `run()` and record what it was handed, so the assertions are about the request that would go on the wire. Covered: each councillor response arrives as its own labelled turn; the Chairman's task carries no councillor text and neither `COUNCIL MEMBER RESPONSES` nor `COUNCIL MEMBER EVALUATIONS` heading; evaluations arrive as turns; the query and the anonymous id mapping survive in the task; every message is a typed turn.
- **Fails on clean base**: with `llm_council.py` stashed and the tests kept, **3 of the 5 fail**. The 2 that pass are the ones asserting what is *preserved* (query + id mapping) and the shape check, which an empty message list satisfies trivially — that is what they are for.
- **Offline**: the 5 new tests make no network call. The 5 pre-existing tests in this file construct real agents and call the provider, so they are not runnable here and were not run — `pytest -k "chairman or typed_turn"` selects only the new ones: **5 passed**.
- **Lint at the versions CI pins** (`black==24.2.0`, `ruff==0.2.1`, per `.github/workflows/lint.yml`): `black . --check` → 959 files unchanged; `ruff check .` → exit 0, repo-wide.
- **Comments**: Zero comments in the diff. `git diff upstream/master -- '*.py' | grep -E '^\+' | grep -E '(^\+\s*#|\s#\s)'` returns nothing outside pragmas. Docstrings are written normally, matching the surrounding files.
- **Not verified here**: a real council run end to end, which needs provider credentials this environment does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut4g856LnbHeUjA8MawHxo


