### PR TITLE
fix(debate-with-judge): propagate image inputs

### DIFF
--- a/swarms/structs/debate_with_judge.py
+++ b/swarms/structs/debate_with_judge.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Union
 
 from loguru import logger
 
@@ -259,14 +259,23 @@ class DebateWithJudge:
 
     @trace_run(
         "DebateWithJudge.run",
-        input_params=("task", "tasks", "img", "imgs"),
+        input_params=("task", "img", "imgs"),
     )
-    def run(self, task: str) -> Union[str, List, dict]:
+    def run(
+        self,
+        task: str,
+        img: Optional[str] = None,
+        imgs: Optional[List[str]] = None,
+    ) -> Union[str, List, dict]:
         """
         Execute the debate with judge refinement process.
 
         Args:
             task (str): The initial topic or question to debate.
+            img (Optional[str]): Optional image input forwarded to each
+                debate agent.
+            imgs (Optional[List[str]]): Optional image inputs forwarded to each
+                debate agent.
 
         Returns:
             Union[str, List, dict]: The formatted conversation history or final refined answer,
@@ -298,7 +307,9 @@ class DebateWithJudge:
             pro_prompt = self._create_pro_prompt(
                 current_topic, round_num
             )
-            pro_argument = self.pro_agent.run(task=pro_prompt)
+            pro_argument = self.pro_agent.run(
+                task=pro_prompt, img=img, imgs=imgs
+            )
             pro_argument = agent_answer(
                 self.pro_agent, fallback=pro_argument
             )
@@ -313,7 +324,9 @@ class DebateWithJudge:
             con_prompt = self._create_con_prompt(
                 current_topic, pro_argument, round_num
             )
-            con_argument = self.con_agent.run(task=con_prompt)
+            con_argument = self.con_agent.run(
+                task=con_prompt, img=img, imgs=imgs
+            )
             con_argument = agent_answer(
                 self.con_agent, fallback=con_argument
             )
@@ -328,7 +341,9 @@ class DebateWithJudge:
             judge_prompt = self._create_judge_prompt(
                 current_topic, pro_argument, con_argument, round_num
             )
-            judge_synthesis = self.judge_agent.run(task=judge_prompt)
+            judge_synthesis = self.judge_agent.run(
+                task=judge_prompt, img=img, imgs=imgs
+            )
             judge_synthesis = agent_answer(
                 self.judge_agent, fallback=judge_synthesis
             )
@@ -452,14 +467,22 @@ class DebateWithJudge:
 
         return prompt + JUDGE_INTERMEDIATE_ROUND_INSTRUCTIONS
 
-    def batched_run(self, tasks: List[str]) -> List[str]:
+    def batched_run(
+        self,
+        tasks: List[str],
+        img: Optional[Union[str, Sequence[Optional[str]]]] = None,
+        imgs: Optional[Sequence[Optional[str]]] = None,
+    ) -> List[str]:
         """
         Run the debate with judge refinement process for a batch of tasks.
 
         Args:
             tasks (List[str]): The list of tasks to run the debate with judge refinement process for.
+            img (Optional[Union[str, Sequence[Optional[str]]]]): One image
+                broadcast to every task, or a sequence paired one per task.
+            imgs (Optional[Sequence[Optional[str]]]): One image per task.
 
         Returns:
             List[str]: The list of final refined answers.
         """
-        return batched_run(self.run, tasks)
+        return batched_run(self.run, tasks, img=img, imgs=imgs)

--- a/tests/structs/test_debate_with_judge.py
+++ b/tests/structs/test_debate_with_judge.py
@@ -1,0 +1,98 @@
+from swarms.structs.debate_with_judge import DebateWithJudge
+from swarms.structs.agent import Agent
+
+
+def _recording_agent(name):
+    agent = Agent(
+        agent_name=name,
+        model_name="gpt-4o-mini",
+        max_loops=1,
+        autosave=False,
+        verbose=False,
+        output_type="final",
+    )
+    agent.calls = []
+
+    def run(task, *args, **kwargs):
+        image_call_count = sum(
+            1
+            for call in agent.calls
+            if call.get("img") is not None
+            or call.get("imgs") is not None
+        )
+        answer = (
+            f"{agent.agent_name} image result {image_call_count + 1}"
+            if kwargs.get("img") is not None
+            or kwargs.get("imgs") is not None
+            else f"{agent.agent_name} answer"
+        )
+        agent.calls.append({"task": task, **kwargs})
+        agent.short_memory.add(agent.agent_name, answer)
+        return answer
+
+    agent.run = run
+    return agent
+
+
+def _debate():
+    pro = _recording_agent("Pro-Debater")
+    con = _recording_agent("Con-Debater")
+    judge = _recording_agent("Debate-Judge")
+    debate = DebateWithJudge(
+        agents=[pro, con, judge],
+        max_loops=1,
+        output_type="final",
+        verbose=False,
+    )
+    return debate, pro, con, judge
+
+
+def test_run_forwards_img_to_each_debate_agent():
+    debate, pro, con, judge = _debate()
+
+    debate.run("Motion: inspect this chart", img="chart.png")
+
+    assert pro.calls[-1]["img"] == "chart.png"
+    assert con.calls[-1]["img"] == "chart.png"
+    assert judge.calls[-1]["img"] == "chart.png"
+
+
+def test_run_forwards_imgs_to_each_debate_agent():
+    debate, pro, con, judge = _debate()
+    images = ["chart-a.png", "chart-b.png"]
+
+    debate.run("Motion: compare these charts", imgs=images)
+
+    assert pro.calls[-1]["imgs"] == images
+    assert con.calls[-1]["imgs"] == images
+    assert judge.calls[-1]["imgs"] == images
+
+
+def test_batched_run_pairs_imgs_by_task():
+    debate, pro, con, judge = _debate()
+    tasks = ["Motion: t1", "Motion: t2", "Motion: t3"]
+    images = ["img1.png", "img2.png", "img3.png"]
+
+    results = debate.batched_run(tasks, imgs=images)
+    pro_debate_calls = [
+        call for call in pro.calls if call.get("img") is not None
+    ]
+
+    assert results == [
+        "Debate-Judge image result 1",
+        "Debate-Judge image result 2",
+        "Debate-Judge image result 3",
+    ]
+    assert [
+        (task in call["task"], call["img"])
+        for task, call in zip(tasks, pro_debate_calls)
+    ] == [(True, img) for img in images]
+    assert [
+        call["img"] for call in pro.calls if call.get("img")
+    ] == images
+    assert [
+        call["img"] for call in con.calls if call.get("img")
+    ] == images
+    assert [
+        call["img"] for call in judge.calls if call.get("img")
+    ] == images


### PR DESCRIPTION
## What

`DebateWithJudge.run()` and `DebateWithJudge.batched_run()` advertised multimodal telemetry inputs but rejected `img`/`imgs`, so a caller could not pass image context into a debate.

## Reproduction

On current `master` at `862d5e44e4e8c030e9f13170bbbb35137d7cfbf2`:

```text
run_has_img False
run_img_error TypeError DebateWithJudge.run() got an unexpected keyword argument 'img'
batch_imgs_error TypeError DebateWithJudge.batched_run() got an unexpected keyword argument 'imgs'
```

## Root cause

`trace_run` listed `img`/`imgs`, but the actual `run()` and `batched_run()` signatures did not accept them. The internal pro, con, and judge `Agent.run(...)` calls also did not forward image kwargs.

## Change

- Added `img` and `imgs` to `DebateWithJudge.run()`.
- Forwarded them to the pro, con, and judge agents for each debate round.
- Added `img`/`imgs` to `batched_run()` and delegated pairing/broadcast behavior to the existing shared `execution_utils.batched_run(...)`.
- Removed the non-existent `tasks` parameter from `trace_run` input capture for `run()`.

## Verification

- `uv run --no-sync python -m pytest tests/structs/test_debate_with_judge.py -q --tb=short -ra` - 3 passed, 1 warning
- `uv run --no-sync python -m pytest tests/telemetry/test_telemetry.py::TestDebateWithJudge -q --tb=short -ra` - 2 passed, 1 warning
- `uv run --no-sync python -m pytest tests/structs/test_execution_utils.py -q --tb=short -ra` - 43 passed, 1 warning
- `uv run --no-sync black --check .` - passed
- `uv run --no-sync ruff check .` - passed
- `git diff --check` - passed
- `git show --check --stat HEAD` - passed

Local `pyre` was not runnable because the project environment does not currently provide the `pyre` executable.

## Scope

This does not change debate prompting, judging behavior, telemetry setup, or generic batch image validation. The shared execution helper still owns task/image pairing and length validation.

Closes #2193.
