### PR TITLE
[Fix][Conversation] add_multiple crashes on a machine with fewer than four CPUs

### DIFF
--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import datetime
 import json
 import os
@@ -547,9 +546,6 @@ class Conversation:
             all_input_text = " ".join(input_messages)
             all_output_text = " ".join(output_messages)
 
-            print(all_input_text)
-            print(all_output_text)
-
             # Count tokens only if there is text
             input_tokens = (
                 count_tokens(
@@ -626,23 +622,24 @@ class Conversation:
         roles: List[str],
         contents: List[Union[str, dict, list, any]],
     ):
-        """Add multiple messages to the conversation history."""
+        """Add multiple messages to the conversation history, in order.
+
+        Args:
+            roles (List[str]): One role per message.
+            contents (List[Union[str, dict, list, any]]): One content per role.
+
+        Returns:
+            list: The result of each :meth:`add`, in the order given.
+        """
         if len(roles) != len(contents):
             raise ValueError(
                 "Number of roles and contents must match."
             )
 
-        # Now create a formula to get 25% of available cpus
-        max_workers = int(os.cpu_count() * 0.25)
-
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=max_workers
-        ) as executor:
-            futures = [
-                executor.submit(self.add, role, content)
-                for role, content in zip(roles, contents)
-            ]
-            concurrent.futures.wait(futures)
+        return [
+            self.add(role, content)
+            for role, content in zip(roles, contents)
+        ]
 
     def delete(self, index: str):
         """Delete a message from the conversation history."""

--- a/tests/structs/test_conversation.py
+++ b/tests/structs/test_conversation.py
@@ -1,5 +1,6 @@
 import json
 import concurrent.futures
+import os
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -698,6 +699,33 @@ def test_add_appends_to_memory_md(tmp_path):
     assert "### user — " in content
     assert "Test message" in content
     assert "---" in content
+
+
+def test_add_multiple_returns_one_result_per_message():
+    """add_multiple_messages reports what it added, rather than None."""
+    conv = Conversation()
+    added = conv.add_multiple_messages(
+        ["user", "assistant"], ["Hello", "Hi there"]
+    )
+    assert added is not None
+    assert len(added) == 2
+
+
+def test_add_multiple_does_not_depend_on_the_cpu_count(monkeypatch):
+    """A machine reporting fewer than four CPUs can still add messages.
+
+    int(os.cpu_count() * 0.25) is 0 for 1, 2 and 3 CPUs, which is a
+    ValueError from ThreadPoolExecutor rather than a slow path.
+    """
+    monkeypatch.setattr(os, "cpu_count", lambda: 1)
+    conv = Conversation()
+    conv.add_multiple_messages(
+        ["user", "assistant", "system"],
+        ["Hello", "Hi there", "System message"],
+    )
+    assert [
+        msg["role"] for msg in conv.conversation_history
+    ] == ["user", "assistant", "system"]
 
 
 def test_concurrent_add_thread_safety(tmp_path):

--- a/tests/structs/test_conversation.py
+++ b/tests/structs/test_conversation.py
@@ -723,9 +723,11 @@ def test_add_multiple_does_not_depend_on_the_cpu_count(monkeypatch):
         ["user", "assistant", "system"],
         ["Hello", "Hi there", "System message"],
     )
-    assert [
-        msg["role"] for msg in conv.conversation_history
-    ] == ["user", "assistant", "system"]
+    assert [msg["role"] for msg in conv.conversation_history] == [
+        "user",
+        "assistant",
+        "system",
+    ]
 
 
 def test_concurrent_add_thread_safety(tmp_path):


### PR DESCRIPTION
Closes #1840 items 3 and 5. The round-trip half of that issue (item 4) already landed in #1925, and items 1 and 2 are still open — this is only the part that crashes.

## The crash

`add_multiple` sizes a thread pool from the core count:

```py
max_workers = int(os.cpu_count() * 0.25)
```

That is **0 on 1, 2 and 3 CPUs**, and `ThreadPoolExecutor(max_workers=0)` raises before a single message is appended:

```
cpu_count=1 -> max_workers=0 ValueError: max_workers must be greater than 0
cpu_count=2 -> max_workers=0 ValueError: max_workers must be greater than 0
cpu_count=3 -> max_workers=0 ValueError: max_workers must be greater than 0
cpu_count=4 -> max_workers=1 OK
```

So `add_multiple_messages` is unusable on any container or CI runner reporting three cores or fewer. It works on a developer laptop, which is why it shipped.

## Two more defects in the same six lines

**Order was whichever worker finished first.** The pool submitted one `self.add` per message and waited on the set, so the appended order was not the caller's. It only looks stable at four cores because `int(4 * 0.25)` is exactly one worker.

**Every return value was discarded.** `add_multiple` had no `return`, so `add_multiple_messages` always handed back `None`:

```py
def add_multiple_messages(self, roles, contents):
    added = self.add_multiple(roles, contents)   # always None
    ...
    return added
```

## The change

The pool was there to append to a list. A comprehension does that, in order, and returns what it added:

```py
return [
    self.add(role, content)
    for role, content in zip(roles, contents)
]
```

Also in this diff, both from item 5 of the issue:

- `export_and_count_categories` had two bare `print()` calls dumping the entire conversation to stdout on every call.
- `import concurrent.futures` is now unused in the module.

## Tests

Two added to `tests/structs/test_conversation.py`, the file that already owns this class. Verified against the unfixed source — both fail before the change and pass after:

```
FAILED test_add_multiple_returns_one_result_per_message
FAILED test_add_multiple_does_not_depend_on_the_cpu_count
2 failed, 2 passed
```

`pytest tests/structs/test_conversation.py`: 64 passed.

One note on the existing coverage. `test_add_multiple_messages` asserts the order already, and passes on `master` — but that file's convention wraps assertions in `try/except AssertionError: return False`, which pytest reports as a **pass**, so it could not have caught any of this. The two tests here use plain asserts for that reason, and are not added to the manual runner list at the bottom of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
