### PR TITLE
fix(conversation): bound the MEMORY.md preamble injected at startup

### DIFF
--- a/swarms/structs/conversation.py
+++ b/swarms/structs/conversation.py
@@ -54,6 +54,15 @@ def get_conversation_dir():
 DEFAULT_CONVERSATION_NAME = "conversation-test"
 
 
+# Upper bound on the MEMORY.md text injected as the preload preamble.
+# The file itself keeps growing on disk; only what is injected is capped.
+MEMORY_MD_PRELOAD_CHARS = 8000
+
+# Inserted between the kept head and tail of a truncated preamble so the
+# omitted history is visible to the model instead of silently dropped.
+MEMORY_MD_PRELOAD_OMITTED_MARKER = "[… older entries omitted …]"
+
+
 class Conversation:
     """
     A class to manage a conversation history, allowing for the addition, deletion,
@@ -102,6 +111,7 @@ class Conversation:
         cache_enabled: bool = False,
         output_metadata: bool = False,
         memory_md_path: Optional[str] = None,
+        memory_md_preload_chars: int = MEMORY_MD_PRELOAD_CHARS,
     ):
 
         # Initialize all attributes first
@@ -129,6 +139,7 @@ class Conversation:
         self.caching = cache_enabled
         self.output_metadata = output_metadata
         self.memory_md_path = memory_md_path
+        self.memory_md_preload_chars = memory_md_preload_chars
         self._memory_md_lock = threading.Lock()
 
         # Suppressed so the static system_prompt and rules are not re-appended to MEMORY.md every construction.
@@ -307,6 +318,8 @@ class Conversation:
         if "### " not in content:
             return
 
+        content = self._bound_memory_md_for_preload(content)
+
         self.conversation_history.append(
             {
                 "role": "System",
@@ -320,6 +333,45 @@ class Conversation:
             }
         )
         self._str_cache = None
+
+    def _bound_memory_md_for_preload(self, content: str) -> str:
+        """Cap the MEMORY.md text injected as the preload preamble.
+
+        MEMORY.md is an append-only log, so the preamble would otherwise
+        grow with the agent's whole history and be paid on the first
+        request of every run. A file within ``memory_md_preload_chars``
+        is returned unchanged. A larger file keeps its head (the file
+        header and any curated sections written before the first log
+        entry) and the most recent log entries, and marks the omitted
+        middle so the model knows history was dropped rather than
+        silently truncated. MEMORY.md on disk is never modified.
+        """
+        limit = self.memory_md_preload_chars
+        if limit is None or limit <= 0 or len(content) <= limit:
+            return content
+
+        first_entry = content.find("### ")
+        head = content[:first_entry]
+        log = content[first_entry:]
+
+        # The head is bounded too, so a curated section cannot crowd out
+        # every recent entry. Reserve at least half of the budget for
+        # the log.
+        head_budget = min(len(head), limit // 2)
+        head = head[:head_budget]
+
+        tail_budget = limit - len(head)
+        tail = log[-tail_budget:]
+        # Start the tail at an entry boundary so no entry is cut in half.
+        boundary = tail.find("### ")
+        if boundary > 0:
+            tail = tail[boundary:]
+
+        return (
+            f"{head.rstrip()}\n\n"
+            f"{MEMORY_MD_PRELOAD_OMITTED_MARKER}\n\n"
+            f"{tail}"
+        )
 
     def compact(
         self,

--- a/tests/structs/test_conversation.py
+++ b/tests/structs/test_conversation.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 from loguru import logger
 
-from swarms.structs.conversation import Conversation
+from swarms.structs.conversation import (
+    MEMORY_MD_PRELOAD_OMITTED_MARKER,
+    Conversation,
+)
 
 
 def setup_temp_conversations_dir():
@@ -681,6 +684,112 @@ def test_preload_does_not_write_to_disk(tmp_path):
         conversations_dir=str(tmp_path / "convs"),
     )
     assert md_path.read_text() == content
+
+
+def _preamble(conv):
+    return [
+        m
+        for m in conv.conversation_history
+        if "Persistent Memory" in str(m.get("content", ""))
+    ]
+
+
+def _entry(i):
+    return f"### user — 2025-01-01T00:00:{i:02d}\n\nmessage {i}\n\n---\n\n"
+
+
+def test_preload_within_bound_is_injected_unchanged(tmp_path):
+    """A file smaller than the bound is injected in full."""
+    md_path = tmp_path / "MEMORY.md"
+    file_text = "# Agent Memory\n\n## Interaction Log\n\n" + _entry(1)
+    md_path.write_text(file_text)
+    conv = Conversation(
+        memory_md_path=str(md_path),
+        conversations_dir=str(tmp_path / "convs"),
+        memory_md_preload_chars=len(file_text),
+    )
+    content = _preamble(conv)[0]["content"]
+    assert file_text in content
+    assert MEMORY_MD_PRELOAD_OMITTED_MARKER not in content
+
+
+def test_preload_is_bounded_and_keeps_head_and_recent_entries(
+    tmp_path,
+):
+    """An oversized file is cut to the bound: header plus the most
+    recent entries survive, the omitted middle is marked."""
+    md_path = tmp_path / "MEMORY.md"
+    head = (
+        "# Agent Memory\n\n## Lessons Learned\n\n- keep it short\n\n"
+        "## Interaction Log\n\n"
+    )
+    file_text = head + "".join(_entry(i) for i in range(1, 41))
+    md_path.write_text(file_text)
+    limit = 600
+    conv = Conversation(
+        memory_md_path=str(md_path),
+        conversations_dir=str(tmp_path / "convs"),
+        memory_md_preload_chars=limit,
+    )
+    preambles = _preamble(conv)
+    assert len(preambles) == 1
+    content = preambles[0]["content"]
+    injected = content.split("context coherently.\n\n", 1)[1]
+
+    assert (
+        len(injected)
+        <= limit + len(MEMORY_MD_PRELOAD_OMITTED_MARKER) + 4
+    )
+    assert injected.startswith("# Agent Memory")
+    assert "## Lessons Learned" in injected
+    assert MEMORY_MD_PRELOAD_OMITTED_MARKER in injected
+    # The newest entry is kept, the oldest is dropped.
+    assert "message 40" in injected
+    assert "message 1\n" not in injected
+    # The tail starts at an entry boundary, never inside an entry.
+    tail = injected.split(MEMORY_MD_PRELOAD_OMITTED_MARKER, 1)[1]
+    assert tail.lstrip().startswith("### user")
+    # Bounding the preamble never touches the file on disk.
+    assert md_path.read_text() == file_text
+
+
+def test_preload_bound_does_not_grow_across_sessions(tmp_path):
+    """The preamble stays bounded no matter how many sessions have
+    appended to MEMORY.md."""
+    md_path = tmp_path / "MEMORY.md"
+    sizes = []
+    for session in range(4):
+        conv = Conversation(
+            memory_md_path=str(md_path),
+            conversations_dir=str(tmp_path / "convs"),
+            memory_md_preload_chars=2000,
+        )
+        preambles = _preamble(conv)
+        sizes.append(len(preambles[0]["content"]) if preambles else 0)
+        for i in range(10):
+            conv.add(
+                "user", f"session {session} message {i} " + "x" * 80
+            )
+    assert sizes[0] == 0
+    assert sizes[1] > 0
+    assert max(sizes) < 2000 + 200
+    # On disk the log keeps everything.
+    assert md_path.stat().st_size > 4 * 10 * 80
+
+
+def test_preload_bound_disabled_with_zero(tmp_path):
+    """memory_md_preload_chars=0 disables the bound."""
+    md_path = tmp_path / "MEMORY.md"
+    file_text = "# Agent Memory\n\n## Interaction Log\n\n" + "".join(
+        _entry(i) for i in range(1, 30)
+    )
+    md_path.write_text(file_text)
+    conv = Conversation(
+        memory_md_path=str(md_path),
+        conversations_dir=str(tmp_path / "convs"),
+        memory_md_preload_chars=0,
+    )
+    assert file_text in _preamble(conv)[0]["content"]
 
 
 # ── Write-through ──


### PR DESCRIPTION
## Description

With `persistent_memory=True`, `Conversation` preloads the entire `MEMORY.md` as a System preamble on every construction. `MEMORY.md` is an append-only log of every message, so the preamble grows linearly with the agent's whole history (about 5k characters per session in the reproducer in #2198) and is paid on the first request of every run, before the task. `compact()` only fires when the in-run conversation crosses the context threshold, so an agent doing many short runs never compacts and never stops growing.

This PR bounds what is injected, not what is written:

- `Conversation` gets `memory_md_preload_chars` (default `MEMORY_MD_PRELOAD_CHARS = 8000`). A file within the bound is injected unchanged, so nothing changes for ordinary use.
- A larger file keeps its head (the file header and any curated sections written before the first `### ` log entry, capped at half the budget so a curated section cannot crowd out every recent entry) plus the most recent entries, starting at an entry boundary so no entry is cut in half.
- The omitted middle is marked with `[… older entries omitted …]` so the model knows history was dropped rather than silently truncated.
- `MEMORY.md` on disk keeps growing as before; `memory_md_preload_chars=0` disables the bound.

A character cap rather than a token cap, as proposed in the issue: it avoids a tokenizer pass on every agent start for a bound that does not need to be exact.

## Tests

`tests/structs/test_conversation.py`:

- a file within the bound is injected in full, without the marker;
- an oversized file is cut to the bound, keeps the header and a `## Lessons Learned` section, keeps the newest entry and drops the oldest, starts the tail at an entry boundary, and leaves the file on disk untouched;
- across four sessions that each append ten messages, the preamble stays bounded while the file keeps growing;
- `memory_md_preload_chars=0` disables the bound.

Ran `pytest tests/structs/test_conversation.py` (66 passed), `black` and `ruff check` on the changed files (ruff reports the same pre-existing findings on `main` and none in the new code).

Fixes #2198
