### PR TITLE
feat(structs): add check_models, and example folders for one_to_one, broadcast and one_to_three

### DIFF
--- a/examples/multi_agent/README.md
+++ b/examples/multi_agent/README.md
@@ -21,6 +21,11 @@ This directory contains comprehensive examples demonstrating various multi-agent
 - [batched_grid_workflow_example.py](batched_grid_workflow/batched_grid_workflow_example.py) - Complete workflow example
 - [README.md](batched_grid_workflow/README.md) - Detailed documentation
 
+## Broadcast
+- [broadcast_class_example.py](broadcast_examples/broadcast_class_example.py) - `Broadcast`: one sender, many receivers, synchronous `run()`
+- [broadcast_function_example.py](broadcast_examples/broadcast_function_example.py) - `broadcast()`: the async functional form
+- [README.md](broadcast_examples/README.md) - Detailed documentation
+
 ## Caching Examples
 - [example_multi_agent_caching.py](caching_examples/example_multi_agent_caching.py) - Multi-agent caching implementation
 - [quick_start_agent_caching.py](caching_examples/quick_start_agent_caching.py) - Quick start guide for caching
@@ -116,6 +121,16 @@ This directory contains comprehensive examples demonstrating various multi-agent
 
 ## Spreadsheet Examples
 - [spreadsheet_examples/](spreadsheet_examples/) - Spreadsheet-based agent examples and swarm usage
+
+## One-to-One
+- [one_to_one_class_example.py](one_to_one_examples/one_to_one_class_example.py) - `OneToOne`: a sender and receiver exchange messages for `max_loops` turns
+- [one_to_one_function_example.py](one_to_one_examples/one_to_one_function_example.py) - `one_to_one()`: the functional form
+- [README.md](one_to_one_examples/README.md) - Detailed documentation
+
+## One-to-Three
+- [one_to_three_class_example.py](one_to_three_examples/one_to_three_class_example.py) - `OneToThree`: one sender, exactly three receivers
+- [one_to_three_function_example.py](one_to_three_examples/one_to_three_function_example.py) - `one_to_three()`: the functional form
+- [README.md](one_to_three_examples/README.md) - Detailed documentation
 
 ## Orchestration
 - [orchestration_examples/](orchestration_examples/) - Workflow orchestration patterns

--- a/examples/multi_agent/broadcast_examples/README.md
+++ b/examples/multi_agent/broadcast_examples/README.md
@@ -1,0 +1,21 @@
+# Broadcast Examples
+
+One agent speaks, many agents respond. The sender answers the task first, then every receiver reads the shared conversation and replies in turn. Receivers can be a flat list of agents or a list of lists.
+
+- [broadcast_class_example.py](broadcast_class_example.py) - `Broadcast`, a reusable group with a synchronous `run()` (Kimi K3 via OpenRouter)
+- [broadcast_function_example.py](broadcast_function_example.py) - `broadcast()`, the async functional form (GLM 5.3 via OpenRouter)
+
+```python
+import asyncio
+from swarms import Agent, Broadcast, broadcast
+
+group = Broadcast(sender=announcer, receivers=departments, output_type="dict")
+history = group.run("Announce the change.")
+
+# or, inside an event loop
+history = asyncio.run(broadcast(announcer, departments, "Announce the change."))
+```
+
+Both return the conversation history in the format named by `output_type`. See `swarms/structs/broadcast.py`.
+
+Each example names its model with a plain LiteLLM string; swap it for any provider you have a key for. OpenRouter models need `OPENROUTER_API_KEY`.

--- a/examples/multi_agent/broadcast_examples/broadcast_class_example.py
+++ b/examples/multi_agent/broadcast_examples/broadcast_class_example.py
@@ -1,0 +1,37 @@
+from swarms import Agent, Broadcast
+
+MODEL = "openrouter/moonshotai/kimi-k3"
+
+announcer = Agent(
+    agent_name="Announcer",
+    system_prompt="You announce a company policy change in three sentences.",
+    model_name=MODEL,
+    max_loops=1,
+    print_on=False,
+)
+
+departments = [
+    Agent(
+        agent_name=name,
+        system_prompt=f"You lead the {name} department. In two sentences, say how this change affects your team.",
+        model_name=MODEL,
+        max_loops=1,
+        print_on=False,
+    )
+    for name in ["Engineering", "Sales", "Support", "Finance"]
+]
+
+group = Broadcast(
+    sender=announcer,
+    receivers=departments,
+    name="Policy-Broadcast",
+    description="One announcement, four departmental responses.",
+    output_type="dict",
+)
+
+history = group.run(
+    "Announce that the company is moving to a four-day work week."
+)
+
+for message in history:
+    print(f"[{message['role']}] {message['content']}\n")

--- a/examples/multi_agent/broadcast_examples/broadcast_function_example.py
+++ b/examples/multi_agent/broadcast_examples/broadcast_function_example.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from swarms import Agent, broadcast
+
+MODEL = "openrouter/z-ai/glm-5.3"
+
+lead = Agent(
+    agent_name="Tech-Lead",
+    system_prompt="You describe a proposed architecture change in three sentences.",
+    model_name=MODEL,
+    max_loops=1,
+    print_on=False,
+)
+
+reviewers = [
+    Agent(
+        agent_name=name,
+        system_prompt=f"You are the {name} reviewer. In one sentence, give your verdict on the proposal.",
+        model_name=MODEL,
+        max_loops=1,
+        print_on=False,
+    )
+    for name in ["Security", "Performance", "Cost"]
+]
+
+
+async def main():
+    history = await broadcast(
+        sender=lead,
+        agents=reviewers,
+        task="Propose moving the session store from Redis to Postgres.",
+        output_type="dict",
+    )
+    for message in history:
+        print(f"[{message['role']}] {message['content']}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/multi_agent/one_to_one_examples/README.md
+++ b/examples/multi_agent/one_to_one_examples/README.md
@@ -1,0 +1,20 @@
+# One-to-One Examples
+
+Two agents exchange messages on a shared conversation. The sender answers the task, the receiver replies to the sender, and the exchange repeats `max_loops` times. Each agent reads the conversation as typed turns, so it can tell its own earlier messages from the other agent's.
+
+- [one_to_one_class_example.py](one_to_one_class_example.py) - `OneToOne`, a reusable pair that can run many tasks (OpenAI `gpt-5.4`)
+- [one_to_one_function_example.py](one_to_one_function_example.py) - `one_to_one()`, the functional form for a single exchange (Anthropic `claude-sonnet-4-6`)
+
+```python
+from swarms import Agent, OneToOne, one_to_one
+
+pair = OneToOne(sender=writer, receiver=editor, output_type="dict")
+history = pair.run("Write a tagline.", max_loops=2)
+
+# or, for one exchange
+history = one_to_one(writer, editor, "Write a tagline.")
+```
+
+Both return the conversation history in the format named by `output_type`. See `swarms/structs/one_to_one.py`.
+
+Each example names its model with a plain LiteLLM string; swap it for any provider you have a key for. OpenRouter models need `OPENROUTER_API_KEY`.

--- a/examples/multi_agent/one_to_one_examples/one_to_one_class_example.py
+++ b/examples/multi_agent/one_to_one_examples/one_to_one_class_example.py
@@ -1,0 +1,32 @@
+from swarms import Agent, OneToOne
+
+writer = Agent(
+    agent_name="Writer",
+    system_prompt="You write short product taglines. Reply with one tagline.",
+    model_name="gpt-5.4",
+    max_loops=1,
+    print_on=False,
+)
+
+editor = Agent(
+    agent_name="Editor",
+    system_prompt="You are a strict editor. Rewrite the tagline to be shorter and punchier.",
+    model_name="gpt-5.4",
+    max_loops=1,
+    print_on=False,
+)
+
+pair = OneToOne(
+    sender=writer,
+    receiver=editor,
+    name="Tagline-Pair",
+    description="A writer drafts, an editor tightens.",
+    output_type="dict",
+)
+
+history = pair.run(
+    "Write a tagline for a password manager.", max_loops=2
+)
+
+for message in history:
+    print(f"[{message['role']}] {message['content']}\n")

--- a/examples/multi_agent/one_to_one_examples/one_to_one_function_example.py
+++ b/examples/multi_agent/one_to_one_examples/one_to_one_function_example.py
@@ -1,0 +1,27 @@
+from swarms import Agent, one_to_one
+
+analyst = Agent(
+    agent_name="Analyst",
+    system_prompt="You summarise a company's position in two sentences.",
+    model_name="claude-sonnet-4-6",
+    max_loops=1,
+    print_on=False,
+)
+
+skeptic = Agent(
+    agent_name="Skeptic",
+    system_prompt="You point out the single biggest risk in the analyst's summary.",
+    model_name="claude-sonnet-4-6",
+    max_loops=1,
+    print_on=False,
+)
+
+result = one_to_one(
+    sender=analyst,
+    receiver=skeptic,
+    task="Assess a mid-size airline expanding into long-haul routes.",
+    max_loops=1,
+    output_type="str",
+)
+
+print(result)

--- a/examples/multi_agent/one_to_three_examples/README.md
+++ b/examples/multi_agent/one_to_three_examples/README.md
@@ -1,0 +1,20 @@
+# One-to-Three Examples
+
+A fixed-shape broadcast: one sender, exactly three receivers. The sender answers the task, then each receiver reads the shared conversation and replies in turn. Any receiver count other than three raises `ValueError`, at construction for the class and at call time for the function.
+
+- [one_to_three_class_example.py](one_to_three_class_example.py) - `OneToThree`, a reusable sender-plus-trio (Qwen 3.8 Flash via OpenRouter)
+- [one_to_three_function_example.py](one_to_three_function_example.py) - `one_to_three()`, the functional form (DeepSeek V4 Flash via OpenRouter)
+
+```python
+from swarms import Agent, OneToThree, one_to_three
+
+panel = OneToThree(sender=founder, receivers=[a, b, c], output_type="dict")
+history = panel.run("Pitch the idea.")
+
+# or, for one run
+history = one_to_three(founder, [a, b, c], "Pitch the idea.")
+```
+
+Both return the conversation history in the format named by `output_type`. See `swarms/structs/one_to_three.py`.
+
+Each example names its model with a plain LiteLLM string; swap it for any provider you have a key for. OpenRouter models need `OPENROUTER_API_KEY`.

--- a/examples/multi_agent/one_to_three_examples/one_to_three_class_example.py
+++ b/examples/multi_agent/one_to_three_examples/one_to_three_class_example.py
@@ -1,0 +1,41 @@
+from swarms import Agent, OneToThree
+
+MODEL = "openrouter/qwen/qwen3.8-flash"
+
+founder = Agent(
+    agent_name="Founder",
+    system_prompt="You pitch a startup idea in three sentences.",
+    model_name=MODEL,
+    max_loops=1,
+    print_on=False,
+)
+
+investors = [
+    Agent(
+        agent_name=name,
+        system_prompt=f"You are a {style} investor. In two sentences, react to the pitch.",
+        model_name=MODEL,
+        max_loops=1,
+        print_on=False,
+    )
+    for name, style in [
+        ("Growth-VC", "growth-focused"),
+        ("Value-Investor", "cautious, numbers-first"),
+        ("Angel", "founder-friendly"),
+    ]
+]
+
+panel = OneToThree(
+    sender=founder,
+    receivers=investors,
+    name="Pitch-Panel",
+    description="One pitch, three investor reactions.",
+    output_type="dict",
+)
+
+history = panel.run(
+    "Pitch a marketplace for renting professional camera gear."
+)
+
+for message in history:
+    print(f"[{message['role']}] {message['content']}\n")

--- a/examples/multi_agent/one_to_three_examples/one_to_three_function_example.py
+++ b/examples/multi_agent/one_to_three_examples/one_to_three_function_example.py
@@ -1,0 +1,33 @@
+from swarms import Agent, one_to_three
+
+MODEL = "openrouter/deepseek/deepseek-v4-flash"
+
+author = Agent(
+    agent_name="Author",
+    system_prompt="You write the opening paragraph of a short story.",
+    model_name=MODEL,
+    max_loops=1,
+    max_tokens=2000,
+    print_on=False,
+)
+
+readers = [
+    Agent(
+        agent_name=name,
+        system_prompt=f"You are a {name}. In one sentence, say what you would change about the paragraph.",
+        model_name=MODEL,
+        max_loops=1,
+        max_tokens=2000,
+        print_on=False,
+    )
+    for name in ["Line-Editor", "Genre-Reader", "Teenager"]
+]
+
+result = one_to_three(
+    sender=author,
+    receivers=readers,
+    task="Open a story about a lighthouse keeper who receives a letter.",
+    output_type="str",
+)
+
+print(result)

--- a/examples/multi_agent/utils/one_to_one_broadcast_one_to_three.py
+++ b/examples/multi_agent/utils/one_to_one_broadcast_one_to_three.py
@@ -1,13 +1,3 @@
-"""
-The three point-to-point communication patterns, as classes and as functions.
-
-- OneToOne / one_to_one: a sender and a receiver exchange messages.
-- Broadcast / broadcast: one sender, many receivers.
-- OneToThree / one_to_three: one sender, exactly three receivers.
-
-Requires an ANTHROPIC_API_KEY (or swap MODEL for any LiteLLM model).
-"""
-
 import asyncio
 
 from dotenv import load_dotenv

--- a/swarms/structs/__init__.py
+++ b/swarms/structs/__init__.py
@@ -13,6 +13,7 @@ from swarms.structs.auto_agent_builder import (
 from swarms.structs.auto_swarm_builder import AutoSwarmBuilder
 from swarms.structs.batch_agent_execution import batch_agent_execution
 from swarms.structs.batched_grid_workflow import BatchedGridWorkflow
+from swarms.structs.broadcast import Broadcast, broadcast
 from swarms.structs.concurrent_workflow import ConcurrentWorkflow
 from swarms.structs.conversation import Conversation
 from swarms.structs.council_as_judge import CouncilAsAJudge
@@ -53,6 +54,8 @@ from swarms.structs.multi_agent_exec import (
     run_single_agent,
 )
 from swarms.structs.multi_agent_router import MultiAgentRouter
+from swarms.structs.one_to_one import OneToOne, one_to_one
+from swarms.structs.one_to_three import OneToThree, one_to_three
 from swarms.structs.planner_generator_evaluator import (
     EvaluationReport,
     HarnessResult,
@@ -69,9 +72,6 @@ from swarms.structs.swarm_router import (
     SwarmRouter,
     SwarmType,
 )
-from swarms.structs.broadcast import Broadcast, broadcast
-from swarms.structs.one_to_one import OneToOne, one_to_one
-from swarms.structs.one_to_three import OneToThree, one_to_three
 from swarms.structs.swarming_architectures import (
     circular_swarm,
     grid_swarm,
@@ -79,6 +79,13 @@ from swarms.structs.swarming_architectures import (
     pyramid_swarm,
     star_swarm,
 )
+
+from swarms.structs.check_models import (
+    model_count,
+    get_available_models,
+    is_model_available,
+)
+
 
 __all__ = [
     "AdvisorSwarm",
@@ -148,4 +155,7 @@ __all__ = [
     "SubagentTask",
     "TaskStatus",
     "RESPOND_TOOL",
+    "model_count",
+    "get_available_models",
+    "is_model_available",
 ]

--- a/swarms/structs/check_models.py
+++ b/swarms/structs/check_models.py
@@ -1,0 +1,209 @@
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+import httpx
+from litellm import model_list
+from loguru import logger
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+OPENROUTER_CACHE_TTL_SECONDS = 300
+OPENROUTER_TIMEOUT_SECONDS = 10
+_BASE_MODELS = list(dict.fromkeys(model_list))
+_BASE_MODEL_SET = frozenset(_BASE_MODELS)
+
+_openrouter_models_cache = []
+_openrouter_cache_expires_at = 0.0
+
+
+def _parse_openrouter_models(payload: Dict[str, Any]) -> List[str]:
+    """Turn an OpenRouter ``/models`` response into ``openrouter/<id>`` names."""
+    return [
+        f"openrouter/{model['id']}"
+        for model in payload.get("data", [])
+        if model.get("id")
+    ]
+
+
+def _store_openrouter_models(models: List[str]) -> None:
+    global _openrouter_models_cache, _openrouter_cache_expires_at
+
+    _openrouter_models_cache = models
+    # Set expiry even on failure so a dead endpoint retries once a TTL.
+    _openrouter_cache_expires_at = (
+        time.monotonic() + OPENROUTER_CACHE_TTL_SECONDS
+    )
+
+
+def _openrouter_cache_is_fresh() -> bool:
+    return time.monotonic() < _openrouter_cache_expires_at
+
+
+def clear_openrouter_cache() -> None:
+    """Forget the cached OpenRouter list so the next call fetches again."""
+    global _openrouter_models_cache, _openrouter_cache_expires_at
+
+    _openrouter_models_cache = []
+    _openrouter_cache_expires_at = 0.0
+
+
+def fetch_openrouter_models() -> List[str]:
+    """
+    Fetch the list of models from the OpenRouter API.
+
+    Each model id is prefixed with ``openrouter/`` (e.g.
+    ``openrouter/moonshotai/kimi-k3``). Results are cached for
+    ``OPENROUTER_CACHE_TTL_SECONDS``.
+
+    Returns:
+        List[str]: The OpenRouter model names. Empty if the request fails.
+    """
+    if _openrouter_cache_is_fresh():
+        return _openrouter_models_cache
+
+    models = []
+    try:
+        with httpx.Client(
+            timeout=OPENROUTER_TIMEOUT_SECONDS
+        ) as client:
+            response = client.get(OPENROUTER_MODELS_URL)
+        response.raise_for_status()
+        models = _parse_openrouter_models(response.json())
+    except Exception as e:
+        logger.warning(f"Could not fetch OpenRouter models: {str(e)}")
+
+    _store_openrouter_models(models)
+    return models
+
+
+async def afetch_openrouter_models() -> List[str]:
+    """Async form of :func:`fetch_openrouter_models`, sharing its cache."""
+    if _openrouter_cache_is_fresh():
+        return _openrouter_models_cache
+
+    models: List[str] = []
+    try:
+        async with httpx.AsyncClient(
+            timeout=OPENROUTER_TIMEOUT_SECONDS
+        ) as client:
+            response = await client.get(OPENROUTER_MODELS_URL)
+        response.raise_for_status()
+        models = _parse_openrouter_models(response.json())
+    except Exception as e:
+        logger.warning(f"Could not fetch OpenRouter models: {str(e)}")
+
+    _store_openrouter_models(models)
+    return models
+
+
+def _merge_models(
+    openrouter_models: Iterable[str],
+    exclude_keywords: Iterable[str],
+) -> List[str]:
+    """
+    Merge OpenRouter models into the static litellm list.
+
+    A model already present via litellm, with or without the ``openrouter/``
+    prefix, is skipped so each model appears once. ``exclude_keywords`` drops
+    any model whose name contains one of them, case-insensitively.
+    """
+    keywords = [keyword.lower() for keyword in exclude_keywords]
+
+    merged = _BASE_MODELS + [
+        model
+        for model in dict.fromkeys(openrouter_models)
+        if model not in _BASE_MODEL_SET
+        and model.removeprefix("openrouter/") not in _BASE_MODEL_SET
+    ]
+
+    if not keywords:
+        return merged
+
+    return [
+        model
+        for model in merged
+        if not any(keyword in model.lower() for keyword in keywords)
+    ]
+
+
+def _report(models: List[str]) -> Dict[str, Any]:
+    return {
+        "status": "success",
+        "count": len(models),
+        "models": models,
+    }
+
+
+def get_available_models(
+    include_openrouter: bool = True,
+    exclude_keywords: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """
+    List every model name litellm knows, plus OpenRouter's live catalogue.
+
+    Args:
+        include_openrouter (bool): Fetch OpenRouter's model list (cached for
+            5 minutes) and include it with an ``openrouter/`` prefix.
+            Defaults to True.
+        exclude_keywords (Iterable[str], optional): Drop any model whose name
+            contains one of these, case-insensitively. Defaults to none.
+
+    Returns:
+        Dict[str, Any]: ``status`` ("success"), ``count`` and ``models``.
+    """
+    openrouter_models = (
+        fetch_openrouter_models() if include_openrouter else []
+    )
+    return _report(
+        _merge_models(openrouter_models, exclude_keywords or ())
+    )
+
+
+async def aget_available_models(
+    include_openrouter: bool = True,
+    exclude_keywords: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """Async form of :func:`get_available_models`."""
+    openrouter_models = (
+        await afetch_openrouter_models() if include_openrouter else []
+    )
+    return _report(
+        _merge_models(openrouter_models, exclude_keywords or ())
+    )
+
+
+def is_model_available(
+    model: str, include_openrouter: bool = True
+) -> bool:
+    """
+    Whether ``model`` is a name litellm or OpenRouter can serve.
+
+    Args:
+        model (str): A model name as passed to ``Agent(model_name=...)``.
+        include_openrouter (bool): Also check OpenRouter's catalogue.
+            Defaults to True.
+
+    Returns:
+        bool: True if the name is listed.
+    """
+    return model in get_available_models(include_openrouter)["models"]
+
+
+def model_count(
+    include_openrouter: bool = True,
+    exclude_keywords: Optional[Iterable[str]] = None,
+) -> int:
+    """
+    How many model names :func:`get_available_models` would return.
+
+    Args:
+        include_openrouter (bool): Count OpenRouter's catalogue too.
+            Defaults to True.
+        exclude_keywords (Iterable[str], optional): Drop any model whose name
+            contains one of these, case-insensitively. Defaults to none.
+
+    Returns:
+        int: The number of available model names.
+    """
+    return get_available_models(include_openrouter, exclude_keywords)[
+        "count"
+    ]

--- a/tests/structs/test_check_models.py
+++ b/tests/structs/test_check_models.py
@@ -1,0 +1,167 @@
+import asyncio
+
+import pytest
+
+from swarms.structs import check_models
+from swarms.structs.check_models import (
+    afetch_openrouter_models,
+    aget_available_models,
+    clear_openrouter_cache,
+    fetch_openrouter_models,
+    get_available_models,
+    is_model_available,
+    model_count,
+)
+
+
+class _Response:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {"data": self._data}
+
+
+class _Client:
+    """Stand-in for httpx.Client / httpx.AsyncClient."""
+
+    calls = 0
+    data = [{"id": "fake-lab/alpha"}, {"id": "fake-lab/beta"}, {}]
+
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def get(self, url):
+        _Client.calls += 1
+        return _Response(_Client.data)
+
+
+class _AsyncClient(_Client):
+    async def get(self, url):
+        _Client.calls += 1
+        return _Response(_Client.data)
+
+
+@pytest.fixture(autouse=True)
+def fake_openrouter(monkeypatch):
+    _Client.calls = 0
+    monkeypatch.setattr(check_models.httpx, "Client", _Client)
+    monkeypatch.setattr(
+        check_models.httpx, "AsyncClient", _AsyncClient
+    )
+    clear_openrouter_cache()
+    yield
+    clear_openrouter_cache()
+
+
+def test_fetch_prefixes_ids_and_skips_blank_entries():
+    models = fetch_openrouter_models()
+
+    assert models == [
+        "openrouter/fake-lab/alpha",
+        "openrouter/fake-lab/beta",
+    ]
+
+
+def test_fetch_is_cached_for_the_ttl():
+    fetch_openrouter_models()
+    fetch_openrouter_models()
+
+    assert _Client.calls == 1
+
+
+def test_async_fetch_shares_the_cache():
+    fetch_openrouter_models()
+    models = asyncio.run(afetch_openrouter_models())
+
+    assert models[0] == "openrouter/fake-lab/alpha"
+    assert _Client.calls == 1
+
+
+def test_fetch_failure_returns_empty_and_does_not_raise(monkeypatch):
+    def boom(self, url):
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(_Client, "get", boom)
+
+    assert fetch_openrouter_models() == []
+
+
+def test_available_models_include_litellm_and_openrouter():
+    report = get_available_models()
+
+    assert report["status"] == "success"
+    assert report["count"] == len(report["models"])
+    assert "gpt-4o" in report["models"]
+    assert "openrouter/fake-lab/alpha" in report["models"]
+
+
+def test_available_models_without_openrouter_skips_the_fetch():
+    report = get_available_models(include_openrouter=False)
+
+    assert _Client.calls == 0
+    # litellm's own list already carries some openrouter/ names; only the
+    # live-fetched ones must be absent.
+    assert "openrouter/fake-lab/alpha" not in report["models"]
+    assert report["count"] == len(check_models._BASE_MODELS)
+
+
+def test_openrouter_duplicates_of_litellm_models_are_dropped(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        _Client, "data", [{"id": "openai/gpt-4o"}, {"id": "gpt-4o"}]
+    )
+    report = get_available_models()
+
+    models = report["models"]
+    assert models.count("gpt-4o") == 1
+    assert "openrouter/gpt-4o" not in models
+
+
+def test_exclude_keywords_are_case_insensitive():
+    report = get_available_models(exclude_keywords=["ALPHA", "gpt"])
+
+    assert not any("alpha" in m.lower() for m in report["models"])
+    assert not any("gpt" in m.lower() for m in report["models"])
+    assert "openrouter/fake-lab/beta" in report["models"]
+
+
+def test_async_report_matches_sync():
+    sync = get_available_models()
+    async_ = asyncio.run(aget_available_models())
+
+    assert async_ == sync
+
+
+def test_is_model_available():
+    assert is_model_available("gpt-4o")
+    assert is_model_available("openrouter/fake-lab/beta")
+    assert not is_model_available("no-such-model")
+
+
+def test_model_count_matches_report():
+    assert model_count() == get_available_models()["count"]
+    assert model_count(include_openrouter=False) == len(
+        check_models._BASE_MODELS
+    )
+    assert model_count(exclude_keywords=["gpt"]) < model_count()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## check_models

`swarms/structs/check_models.py` lists every model name litellm knows, plus OpenRouter's live catalogue with an `openrouter/` prefix, deduplicated so a model already known to litellm appears once.

- `get_available_models(include_openrouter=True, exclude_keywords=None)` returns `{"status", "count", "models"}`; `aget_available_models` is the async form.
- `fetch_openrouter_models()` / `afetch_openrouter_models()` share one 5-minute cache. A failed fetch logs a warning, returns `[]`, and still sets the expiry so a dead endpoint is retried once per TTL.
- `is_model_available(model)` and `model_count(...)` on top.
- `exclude_keywords` drops models by case-insensitive substring, for callers that want to hide a provider.

Exported from `swarms.structs`: `get_available_models`, `is_model_available`, `model_count`.

Live check against the real endpoint: 2392 models, 441 from OpenRouter, fetched in 0.17 s, second call served from cache. 11 offline tests with the HTTP client stubbed.

## Example folders

Follow-up to #2216. Each pattern gets its own folder with a class example, a function example and a README, plus entries in `examples/multi_agent/README.md`:

| Folder | Class example | Function example |
|---|---|---|
| `one_to_one_examples/` | `OneToOne`, OpenAI `gpt-5.4` | `one_to_one()`, Anthropic `claude-sonnet-4-6` |
| `broadcast_examples/` | `Broadcast`, Kimi K3 via OpenRouter | `broadcast()`, GLM 5.3 via OpenRouter |
| `one_to_three_examples/` | `OneToThree`, Qwen 3.8 Flash via OpenRouter | `one_to_three()`, DeepSeek V4 Flash via OpenRouter |

All six were run live. Five produced the expected `User`, sender, receiver transcript. The `gpt-5.4` example could not be verified because the OpenAI account used has no credits; the same code path was verified with Claude.

`examples/multi_agent/utils/one_to_one_broadcast_one_to_three.py` loses its module docstring to match the new files.

## Checks

black at line length 70 and ruff are clean on every changed file. New tests: `tests/structs/test_check_models.py`.
