### PR TITLE
feat(structs): MCPDeployer serves agents and swarms as an authenticated MCP server

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -142,6 +142,7 @@ This directory contains comprehensive examples demonstrating various capabilitie
 | [crypto_price_server.py](mcp/servers/crypto_price_server.py) | FastMCP server exposing crypto prices |
 | [okx_crypto_server.py](mcp/servers/okx_crypto_server.py) | OKX price server (port 8001) |
 | [agent_as_tool_server.py](mcp/servers/agent_as_tool_server.py) | Expose a whole swarms Agent as one MCP tool |
+| [mcp_deployer/](mcp/mcp_deployer/) | `MCPDeployer`: serve any Agent or swarm as an MCP tool behind API-key, custom or token auth, over HTTP, SSE or stdio |
 | [streamable_http_server.py](mcp/servers/streamable_http_server.py) | Stateful vs stateless streamable-HTTP config |
 | [client/](mcp/client/) | **Call MCP directly with `MCPManager`, no Agent** |
 | [01_list_tools.py](mcp/client/01_list_tools.py) | Discover a server's tools; OpenAI vs MCP schema format |

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -11,6 +11,7 @@ These examples are split by what you're trying to do:
 | **[`agents/`](agents/)** | Give an agent tools from an MCP server | [`01_deepwiki_repo_qa.py`](agents/01_deepwiki_repo_qa.py) |
 | **[`servers/`](servers/)** | Build an MCP server that agents connect to | [`crypto_price_server.py`](servers/crypto_price_server.py) |
 | **[`client/`](client/)** | Call MCP directly with `MCPManager`, without an Agent | [`01_list_tools.py`](client/01_list_tools.py) |
+| **[`mcp_deployer/`](mcp_deployer/)** | Serve an Agent or swarm *as* an MCP server, with auth | [`single_agent_api_key.py`](mcp_deployer/single_agent_api_key.py) |
 
 ## 30-second version
 

--- a/examples/mcp/mcp_deployer/README.md
+++ b/examples/mcp/mcp_deployer/README.md
@@ -1,0 +1,41 @@
+# MCPDeployer Examples
+
+`MCPDeployer` turns one `Agent`, any swarm with a `run()` method, or a plain callable into an MCP server with an auth layer in front of it. Each target becomes one tool, named after it, taking `task` and an optional `img`. Pass a list, or a dict of tool name to target, to serve several agents and swarms from one server; `add_tool()` registers more before start.
+
+```python
+from swarms import Agent, MCPDeployer
+
+agent = Agent(agent_name="Researcher", model_name="gpt-5.4", max_loops=1)
+MCPDeployer(agent, api_keys=["sk-local-dev"], port=8000).run()
+```
+
+Another agent then connects with `Agent(mcp_url=MCPConnection(url="http://127.0.0.1:8000/mcp", api_key="sk-local-dev"))`.
+
+| Example | Target | Auth | Transport | Runs on its own? |
+|---|---|---|---|---|
+| [single_agent_api_key.py](single_agent_api_key.py) | One `Agent` | static `api_keys` | streamable HTTP | serves until stopped |
+| [sequential_workflow_as_tool.py](sequential_workflow_as_tool.py) | `SequentialWorkflow` | static `api_keys` | streamable HTTP | serves until stopped |
+| [multiple_agents_one_server.py](multiple_agents_one_server.py) | two Agents, a `SequentialWorkflow` and two functions, each its own tool | static `api_keys` | streamable HTTP | serves until stopped |
+| [custom_auth_per_tenant.py](custom_auth_per_tenant.py) | One `Agent` | async `auth` callable reading `x-tenant` | streamable HTTP | serves until stopped |
+| [owner_key_or_tenant_auth.py](owner_key_or_tenant_auth.py) | One `Agent` | sync `auth` callable: an owner key from the environment, or an allow-listed `x-tenant` | streamable HTTP | serves until stopped |
+| [token_verifier_with_scopes.py](token_verifier_with_scopes.py) | One `Agent` | `TokenVerifier` with `required_scopes` | streamable HTTP | serves until stopped |
+| [env_keys_and_extra_tools.py](env_keys_and_extra_tools.py) | One `Agent` plus two plain functions | `api_key_env` | streamable HTTP | serves until stopped |
+| [background_server_and_client_agent.py](background_server_and_client_agent.py) | One `Agent` | static `api_keys` | streamable HTTP | yes: serves, calls, stops |
+| [plain_function_json_response.py](plain_function_json_response.py) | A plain function, no LLM | static `api_keys` | streamable HTTP, JSON replies | yes, no LLM key needed |
+| [sse_transport.py](sse_transport.py) | One `Agent` | static `api_keys` | SSE | serves until stopped |
+| [stdio_transport.py](stdio_transport.py) | One `Agent` | none (host is the boundary) | stdio | launched by an MCP host |
+
+## Auth, in order of precedence
+
+1. `auth=callable(credential, headers)`: your own check, sync or async. Truthy admits, a dict is kept as the request's claims, falsy or an exception refuses.
+2. `token_verifier=`: the `mcp` package's `TokenVerifier` protocol. `required_scopes` and expiry are enforced.
+3. `api_keys=[...]` and `api_key_env="VAR"`: static keys compared in constant time.
+4. `allow_anonymous=True`: opt in explicitly. With nothing configured the constructor refuses to build.
+
+Clients may send the key as `x-api-key` (rename with `api_key_header`) or as `Authorization: Bearer`, which is what `MCPManager` sends by default. Refused requests get a 401 with `WWW-Authenticate: Bearer`. `/health` is always public.
+
+## Lifecycle
+
+`run()` blocks. `start()` and `stop()`, or `with MCPDeployer(...) as d:`, run the server on a background thread, which is what the background_server_and_client_agent and plain_function_json_response examples do. `timeout` bounds one tool call; `extra_tools` exposes more plain functions beside the main tool.
+
+Each example names its model with a plain LiteLLM string; swap it for any provider you have a key for.

--- a/examples/mcp/mcp_deployer/background_server_and_client_agent.py
+++ b/examples/mcp/mcp_deployer/background_server_and_client_agent.py
@@ -1,0 +1,41 @@
+import socket
+
+from swarms import Agent, MCPDeployer
+from swarms.schemas.mcp_schemas import MCPConnection
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+poet = Agent(
+    agent_name="Poet",
+    agent_description="Writes a two-line poem about the topic it is given.",
+    system_prompt="Write exactly two short lines of poetry about the topic. Nothing else.",
+    model_name="claude-haiku-4-5-20251001",
+    max_loops=1,
+    print_on=False,
+)
+
+if __name__ == "__main__":
+    with MCPDeployer(
+        poet, api_keys=["demo-key"], port=free_port()
+    ) as server:
+        print(f"serving {server.tool_name} at {server.url}")
+
+        client = Agent(
+            agent_name="Client",
+            system_prompt="Use the poet tool to get a poem, then return it verbatim.",
+            model_name="claude-haiku-4-5-20251001",
+            mcp_url=MCPConnection(url=server.url, api_key="demo-key"),
+            max_loops=2,
+            print_on=False,
+            output_type="final",
+        )
+        client.run("Get a poem about lighthouses.")
+
+        print("\nwhat the served agent produced:")
+        print(poet.short_memory.get_final_message_content())
+    # Leaving the `with` block stops the server.

--- a/examples/mcp/mcp_deployer/custom_auth_per_tenant.py
+++ b/examples/mcp/mcp_deployer/custom_auth_per_tenant.py
@@ -1,0 +1,38 @@
+import os
+
+from swarms import Agent, MCPDeployer
+
+TENANT_KEYS = {
+    "acme": os.getenv("ACME_MCP_KEY", "acme-secret"),
+    "globex": os.getenv("GLOBEX_MCP_KEY", "globex-secret"),
+}
+
+
+async def tenant_auth(credential, headers):
+    """Admit a tenant only when its key matches; attach the tenant as claims."""
+    tenant = headers.get("x-tenant")
+    if tenant not in TENANT_KEYS:
+        return False
+    if credential != TENANT_KEYS[tenant]:
+        return False
+    return {"subject": tenant, "scopes": ["run"], "tenant": tenant}
+
+
+analyst = Agent(
+    agent_name="Support-Analyst",
+    agent_description="Classifies a support ticket and drafts a first reply.",
+    system_prompt="Classify the ticket (billing, bug, how-to) and draft a two-sentence reply.",
+    model_name="openrouter/moonshotai/kimi-k3",
+    max_loops=1,
+    print_on=False,
+)
+
+deployer = MCPDeployer(
+    analyst,
+    auth=tenant_auth,
+    port=8002,
+    verbose=True,
+)
+
+if __name__ == "__main__":
+    deployer.run()

--- a/examples/mcp/mcp_deployer/env_keys_and_extra_tools.py
+++ b/examples/mcp/mcp_deployer/env_keys_and_extra_tools.py
@@ -1,0 +1,34 @@
+import datetime
+
+from swarms import Agent, MCPDeployer
+
+
+def utc_now() -> str:
+    """The current UTC time as an ISO 8601 string."""
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def word_count(text: str) -> int:
+    """Count the words in a piece of text."""
+    return len(text.split())
+
+
+editor = Agent(
+    agent_name="Editor",
+    agent_description="Tightens prose without changing its meaning.",
+    system_prompt="Rewrite the text to be shorter and clearer. Keep the meaning.",
+    model_name="claude-haiku-4-5-20251001",
+    max_loops=1,
+    print_on=False,
+)
+
+deployer = MCPDeployer(
+    editor,
+    api_key_env="MCP_DEPLOYER_KEYS",  # e.g. MCP_DEPLOYER_KEYS="key-a,key-b"
+    extra_tools=[utc_now, word_count],
+    port=8004,
+)
+
+if __name__ == "__main__":
+    # Clients see three tools: editor, utc_now and word_count.
+    deployer.run()

--- a/examples/mcp/mcp_deployer/multiple_agents_one_server.py
+++ b/examples/mcp/mcp_deployer/multiple_agents_one_server.py
@@ -1,0 +1,58 @@
+from swarms import Agent, MCPDeployer, SequentialWorkflow
+
+researcher = Agent(
+    agent_name="Researcher",
+    agent_description="Finds the key facts on a topic.",
+    system_prompt="List the five most important facts about the topic.",
+    model_name="claude-sonnet-4-6",
+    max_loops=1,
+    print_on=False,
+)
+
+critic = Agent(
+    agent_name="Critic",
+    agent_description="Finds the weakest point in an argument.",
+    system_prompt="Name the single weakest point in the text and why.",
+    model_name="openrouter/moonshotai/kimi-k3",
+    max_loops=1,
+    print_on=False,
+)
+
+writer = Agent(
+    agent_name="Writer",
+    system_prompt="Turn the facts into a tight three-paragraph briefing.",
+    model_name="gpt-5.4",
+    max_loops=1,
+    print_on=False,
+)
+
+briefing = SequentialWorkflow(
+    name="Briefing-Pipeline",
+    description="Researches a topic, then writes a briefing from the facts.",
+    agents=[researcher, writer],
+    max_loops=1,
+)
+
+
+def word_count(task: str) -> int:
+    """Count the words in the text."""
+    return len(task.split())
+
+
+deployer = MCPDeployer(
+    {
+        "research": researcher,
+        "critique": critic,
+        "write_briefing": briefing,
+        "word_count": word_count,
+    },
+    name="Editorial-Team",
+    api_keys=["sk-local-dev"],
+    port=8006,
+    timeout=300,
+)
+
+deployer.add_tool(lambda task: task[::-1], name="reverse")
+
+if __name__ == "__main__":
+    deployer.run()

--- a/examples/mcp/mcp_deployer/owner_key_or_tenant_auth.py
+++ b/examples/mcp/mcp_deployer/owner_key_or_tenant_auth.py
@@ -1,0 +1,34 @@
+import os
+
+from swarms import Agent, MCPDeployer
+
+researcher = Agent(
+    agent_name="Researcher",
+    agent_description="Answers research questions with a short, sourced summary.",
+    system_prompt="You are a careful researcher. Answer in a short paragraph.",
+    model_name="gpt-5.4",
+    max_loops=1,
+    print_on=False,
+)
+
+
+def is_allowed(credential, headers):
+    """Custom auth: accept the key from MCP_DEPLOYER_KEY, or any tenant on the allow list."""
+    if credential and credential == os.getenv("MCP_DEPLOYER_KEY"):
+        return {"subject": "owner", "scopes": ["run"]}
+    tenant = headers.get("x-tenant")
+    if tenant in {"acme", "globex"}:
+        return {"subject": tenant, "scopes": ["run"]}
+    return False
+
+
+deployer = MCPDeployer(
+    researcher,
+    port=8000,
+    auth=is_allowed,
+    timeout=120,
+    verbose=True,
+)
+
+if __name__ == "__main__":
+    deployer.run()

--- a/examples/mcp/mcp_deployer/plain_function_json_response.py
+++ b/examples/mcp/mcp_deployer/plain_function_json_response.py
@@ -1,0 +1,38 @@
+import socket
+
+from swarms import MCPDeployer
+from swarms.tools.mcp_manager import MCPManager
+
+
+def analyse(task: str) -> dict:
+    """Trivial text statistics for the task string."""
+    words = task.split()
+    return {
+        "characters": len(task),
+        "words": len(words),
+        "longest_word": max(words, key=len) if words else "",
+    }
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+if __name__ == "__main__":
+    deployer = MCPDeployer(
+        analyse,
+        api_keys=["stats-key"],
+        port=free_port(),
+        json_response=True,  # plain JSON replies instead of an event stream
+        timeout=5,
+    )
+    with deployer:
+        client = MCPManager(mcp_url=deployer.url, api_key="stats-key")
+        print("tools:", client.list_tool_names())
+        result = client.call_tool(
+            "analyse",
+            {"task": "the quick brown fox jumps over the lazy dog"},
+        )
+        print(result["result"])

--- a/examples/mcp/mcp_deployer/sequential_workflow_as_tool.py
+++ b/examples/mcp/mcp_deployer/sequential_workflow_as_tool.py
@@ -1,0 +1,34 @@
+from swarms import Agent, MCPDeployer, SequentialWorkflow
+
+researcher = Agent(
+    agent_name="Researcher",
+    system_prompt="Research the topic and list the five most important facts.",
+    model_name="claude-sonnet-4-6",
+    max_loops=1,
+    print_on=False,
+)
+writer = Agent(
+    agent_name="Writer",
+    system_prompt="Turn the facts into a tight three-paragraph briefing.",
+    model_name="claude-sonnet-4-6",
+    max_loops=1,
+    print_on=False,
+)
+
+pipeline = SequentialWorkflow(
+    name="Briefing-Pipeline",
+    description="Researches a topic and writes a three-paragraph briefing.",
+    agents=[researcher, writer],
+    max_loops=1,
+)
+
+deployer = MCPDeployer(
+    pipeline,
+    tool_name="write_briefing",
+    api_keys=["sk-local-dev"],
+    port=8001,
+    timeout=300,  # two model calls in series; give it room
+)
+
+if __name__ == "__main__":
+    deployer.run()

--- a/examples/mcp/mcp_deployer/single_agent_api_key.py
+++ b/examples/mcp/mcp_deployer/single_agent_api_key.py
@@ -1,0 +1,20 @@
+from swarms import Agent, MCPDeployer
+
+# The simplest deployment: one agent, one static key.
+researcher = Agent(
+    agent_name="Researcher",
+    agent_description="Answers research questions with a short, sourced summary.",
+    system_prompt="You are a careful researcher. Answer in one short paragraph.",
+    model_name="gpt-5.4",
+    max_loops=1,
+    print_on=False,
+)
+
+deployer = MCPDeployer(
+    researcher,
+    api_keys=["sk-local-dev"],
+    port=8000,
+)
+
+if __name__ == "__main__":
+    deployer.run()

--- a/examples/mcp/mcp_deployer/sse_transport.py
+++ b/examples/mcp/mcp_deployer/sse_transport.py
@@ -1,0 +1,20 @@
+from swarms import Agent, MCPDeployer
+
+translator = Agent(
+    agent_name="Translator",
+    agent_description="Translates text into French.",
+    system_prompt="Translate the text into French. Return only the translation.",
+    model_name="openrouter/z-ai/glm-5.3",
+    max_loops=1,
+    print_on=False,
+)
+
+deployer = MCPDeployer(
+    translator,
+    transport="sse",
+    api_keys=["sk-local-dev"],
+    port=8005,
+)
+
+if __name__ == "__main__":
+    deployer.run()

--- a/examples/mcp/mcp_deployer/stdio_transport.py
+++ b/examples/mcp/mcp_deployer/stdio_transport.py
@@ -1,0 +1,18 @@
+from swarms import Agent, MCPDeployer
+
+assistant = Agent(
+    agent_name="Desktop-Assistant",
+    agent_description="A general assistant exposed to a desktop MCP host.",
+    model_name="gpt-5.4",
+    max_loops=1,
+    print_on=False,
+)
+
+deployer = MCPDeployer(
+    assistant,
+    transport="stdio",
+    allow_anonymous=True,
+)
+
+if __name__ == "__main__":
+    deployer.run()

--- a/examples/mcp/mcp_deployer/token_verifier_with_scopes.py
+++ b/examples/mcp/mcp_deployer/token_verifier_with_scopes.py
@@ -1,0 +1,45 @@
+import time
+
+from mcp.server.auth.provider import AccessToken
+
+from swarms import Agent, MCPDeployer
+
+ISSUED_TOKENS = {
+    "tok-admin": AccessToken(
+        token="tok-admin",
+        client_id="ops-team",
+        scopes=["agent:run", "agent:admin"],
+        expires_at=int(time.time()) + 3600,
+    ),
+    "tok-reader": AccessToken(
+        token="tok-reader",
+        client_id="dashboard",
+        scopes=["agent:read"],  # missing agent:run, so it is refused
+    ),
+}
+
+
+class StaticTokenVerifier:
+    async def verify_token(self, token: str):
+        return ISSUED_TOKENS.get(token)
+
+
+summariser = Agent(
+    agent_name="Summariser",
+    agent_description="Summarises any text into three bullet points.",
+    system_prompt="Summarise the input into exactly three bullet points.",
+    model_name="gpt-5.4",
+    max_loops=1,
+    print_on=False,
+)
+
+deployer = MCPDeployer(
+    summariser,
+    token_verifier=StaticTokenVerifier(),
+    required_scopes=["agent:run"],
+    port=8003,
+)
+
+if __name__ == "__main__":
+    # `Authorization: Bearer tok-admin` is admitted; tok-reader gets a 401.
+    deployer.run()

--- a/examples/mcp/servers/README.md
+++ b/examples/mcp/servers/README.md
@@ -40,3 +40,5 @@ Most examples under [`../agents/`](../agents/) and [`../client/`](../client/) th
 [`agent_as_tool_server.py`](agent_as_tool_server.py) is the interesting one: it turns a
 swarms `Agent` into an MCP tool, so *another* agent — or any MCP client — can spawn and
 run it remotely. That's how you compose swarms across process or machine boundaries.
+
+To serve an Agent or a whole swarm as an MCP tool with an auth layer, see [`../mcp_deployer/`](../mcp_deployer/).

--- a/swarms/structs/__init__.py
+++ b/swarms/structs/__init__.py
@@ -53,6 +53,7 @@ from swarms.structs.multi_agent_exec import (
     run_agents_with_different_tasks,
     run_single_agent,
 )
+from swarms.structs.mcp_deployer import MCPDeployer, deploy_as_mcp
 from swarms.structs.multi_agent_router import MultiAgentRouter
 from swarms.structs.one_to_one import OneToOne, one_to_one
 from swarms.structs.one_to_three import OneToThree, one_to_three
@@ -156,6 +157,8 @@ __all__ = [
     "TaskStatus",
     "RESPOND_TOOL",
     "model_count",
+    "MCPDeployer",
+    "deploy_as_mcp",
     "get_available_models",
     "is_model_available",
 ]

--- a/swarms/structs/mcp_deployer.py
+++ b/swarms/structs/mcp_deployer.py
@@ -1,0 +1,809 @@
+"""
+Serve one agent, or any swarm, as an MCP server.
+
+``MCPDeployer`` wraps one or more targets, each an ``Agent`` or any callable
+structure (a ``SequentialWorkflow``, a ``SwarmRouter``, a plain function), and
+exposes each as its own MCP tool over streamable HTTP, SSE or stdio. Every HTTP request passes
+through an auth layer before it reaches the MCP transport, so the deployed
+server can require an API key, a bearer token checked by your own code, or an
+OAuth-style ``TokenVerifier`` from the ``mcp`` package.
+
+Example:
+    >>> from swarms import Agent, MCPDeployer
+    >>> agent = Agent(agent_name="Researcher", model_name="gpt-5.4", max_loops=1)
+    >>> MCPDeployer(agent, api_keys=["sk-local-dev"], port=8000).run()
+
+    Several agents and swarms become several tools on one server:
+
+    >>> MCPDeployer(
+    ...     {"research": researcher, "write": writer, "review": pipeline},
+    ...     api_keys=["sk-local-dev"],
+    ... ).run()
+
+    Another agent can then use it with
+    ``Agent(mcp_url="http://127.0.0.1:8000/mcp", ...)`` and the key in
+    ``MCPConnection(api_key="sk-local-dev")``.
+"""
+
+import hmac
+import inspect
+import json
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass, field
+from functools import partial
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Union,
+)
+
+import anyio
+from loguru import logger
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.rule import Rule
+from rich.table import Table
+from rich.text import Text
+from starlette.datastructures import Headers
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+AuthCallable = Callable[
+    [Optional[str], Headers],
+    Union[bool, Dict[str, Any], None, Awaitable[Any]],
+]
+
+# Paths any client may hit without credentials.
+DEFAULT_PUBLIC_PATHS = ("/health",)
+
+# Banner palette: the CLI's alien in three shades of purple instead of red.
+BANNER_DEEP = "#7B2CFF"
+BANNER_PURPLE = "#9B5CFF"
+BANNER_VIOLET = "#C77DFF"
+
+
+@dataclass
+class AuthResult:
+    """What the auth layer learned about a request it let through."""
+
+    method: str
+    subject: Optional[str] = None
+    scopes: List[str] = field(default_factory=list)
+    claims: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ServedTool:
+    """One target exposed as one MCP tool."""
+
+    name: str
+    target: Any
+    description: str
+
+    @property
+    def target_type(self) -> str:
+        return type(self.target).__name__
+
+
+def _is_servable(target: Any) -> bool:
+    return callable(target) or callable(getattr(target, "run", None))
+
+
+def _default_tool_name(target: Any) -> str:
+    """A snake_case MCP tool name derived from the target."""
+    raw = (
+        getattr(target, "agent_name", None)
+        or getattr(target, "name", None)
+        or getattr(target, "__name__", None)
+        or type(target).__name__
+    )
+    name = re.sub(r"[^0-9a-zA-Z]+", "_", str(raw)).strip("_").lower()
+    return name or "run"
+
+
+def _default_description(target: Any) -> str:
+    for attr in ("agent_description", "description"):
+        value = getattr(target, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    doc = inspect.getdoc(target)
+    if doc:
+        return doc.strip().splitlines()[0]
+    return f"Run {_default_tool_name(target)} on a task."
+
+
+def _to_text(result: Any) -> str:
+    """Render whatever the target returned as the tool's text result."""
+    if result is None:
+        return ""
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, indent=2, default=str)
+    except Exception:
+        return str(result)
+
+
+def credential_from_headers(
+    headers: Headers, api_key_header: str = "x-api-key"
+) -> Optional[str]:
+    """
+    Pull the credential a client sent, from either supported header.
+
+    ``api_key_header`` is read first, with an optional ``Bearer`` prefix
+    stripped. ``Authorization: Bearer <token>`` is the fallback, which is
+    what ``MCPManager`` sends by default.
+
+    Args:
+        headers: The request headers.
+        api_key_header: The dedicated key header to look at first.
+
+    Returns:
+        The credential, or None when neither header carries one.
+    """
+    raw = headers.get(api_key_header)
+    if raw and raw.strip():
+        value = raw.strip()
+        if value.lower().startswith("bearer "):
+            value = value[7:].strip()
+        return value or None
+
+    authorization = headers.get("authorization", "")
+    if authorization.lower().startswith("bearer "):
+        token = authorization[7:].strip()
+        return token or None
+    return None
+
+
+class _AuthMiddleware:
+    """ASGI middleware that asks the deployer to admit each HTTP request."""
+
+    def __init__(self, app: Any, deployer: "MCPDeployer"):
+        self.app = app
+        self.deployer = deployer
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if path in self.deployer.public_paths:
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        try:
+            result = await self.deployer.authenticate(headers)
+        except Exception as e:
+            logger.warning(
+                f"MCPDeployer auth check raised on {path}: {e}"
+            )
+            result = None
+
+        if result is None:
+            logger.warning(f"MCPDeployer rejected request to {path}")
+            response = JSONResponse(
+                {"error": "unauthorized"},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+            await response(scope, receive, send)
+            return
+
+        scope.setdefault("state", {})["mcp_auth"] = result
+        await self.app(scope, receive, send)
+
+
+class MCPDeployer:
+    """
+    Expose an agent or swarm as an authenticated MCP server.
+
+    Args:
+        targets: What to serve. One target, a list of targets, or a dict
+            of tool name to target. A target is an ``Agent``, any structure
+            with a ``run(task, ...)`` method, or a plain callable taking the
+            task string. Each target becomes one MCP tool with a
+            ``(task, img)`` schema. More can be added with :meth:`add_tool`.
+        name: Server name advertised to MCP clients. Defaults to the first
+            tool's name.
+        description: Tool description for a single target. Defaults to the
+            target's ``agent_description`` / ``description`` / docstring.
+            With several targets use a dict or :meth:`add_tool` instead.
+        tool_name: Tool name for a single target. Defaults to a snake_case
+            form of the target's name. With several targets use a dict.
+        host: Bind address. Defaults to ``127.0.0.1``.
+        port: Bind port. Defaults to ``8000``.
+        transport: ``"streamable-http"`` (default), ``"sse"`` or
+            ``"stdio"``. Auth applies to the two HTTP transports only.
+        path: URL path for the MCP endpoint. Defaults to ``/mcp`` (or
+            ``/sse`` for SSE).
+        api_keys: Static keys accepted in ``api_key_header`` or as a
+            bearer token. Compared in constant time.
+        api_key_env: Name of an environment variable holding more keys,
+            comma-separated. Read at construction.
+        api_key_header: Header clients may use for a raw key. Defaults to
+            ``x-api-key``. ``Authorization: Bearer`` always works too.
+        auth: Your own check, ``(credential, headers) -> bool | dict |
+            None``, sync or async. A truthy return admits the request; a
+            dict is stored as the request's claims. Takes precedence over
+            ``api_keys`` and ``token_verifier``.
+        token_verifier: An ``mcp.server.auth.provider.TokenVerifier``.
+            Used when ``auth`` is not given; the token must carry every
+            scope in ``required_scopes``.
+        required_scopes: Scopes a verified token must include.
+        allow_anonymous: Serve without any auth. Off by default, so a
+            server with no credentials configured refuses to start.
+        public_paths: Paths exempt from auth. Defaults to ``/health``.
+        extra_tools: Additional plain functions to expose as MCP tools.
+            Each needs a docstring; the signature becomes the schema.
+        timeout: Seconds a single tool call may run before it fails.
+        json_response: Streamable HTTP only. Return plain JSON instead of
+            an event stream.
+        stateless_http: Streamable HTTP only. Do not keep per-session
+            state; the right choice behind a load balancer.
+        verbose: Log every admitted call.
+        show_banner: Print the startup banner from ``run`` and ``start``.
+    """
+
+    def __init__(
+        self,
+        targets: Any,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        tool_name: Optional[str] = None,
+        host: str = "127.0.0.1",
+        port: int = 8000,
+        transport: str = "streamable-http",
+        path: Optional[str] = None,
+        api_keys: Optional[Iterable[str]] = None,
+        api_key_env: Optional[str] = None,
+        api_key_header: str = "x-api-key",
+        auth: Optional[AuthCallable] = None,
+        token_verifier: Optional[Any] = None,
+        required_scopes: Optional[Iterable[str]] = None,
+        allow_anonymous: bool = False,
+        public_paths: Optional[Iterable[str]] = None,
+        extra_tools: Optional[Iterable[Callable]] = None,
+        timeout: Optional[float] = None,
+        json_response: bool = False,
+        stateless_http: bool = True,
+        verbose: bool = False,
+        show_banner: bool = True,
+    ):
+        if targets is None:
+            raise ValueError("MCPDeployer needs a target to serve.")
+        if transport not in ("streamable-http", "sse", "stdio"):
+            raise ValueError(
+                "transport must be 'streamable-http', 'sse' or 'stdio', "
+                f"got {transport!r}."
+            )
+
+        self.tools: Dict[str, ServedTool] = {}
+        self._register_targets(targets, tool_name, description)
+        self.name = name or self.tool_name
+        self.host = host
+        self.port = int(port)
+        self.transport = transport
+        self.path = path or ("/sse" if transport == "sse" else "/mcp")
+        self.api_key_header = api_key_header.lower()
+        self.auth = auth
+        self.token_verifier = token_verifier
+        self.required_scopes = list(required_scopes or [])
+        self.allow_anonymous = allow_anonymous
+        self.public_paths = tuple(
+            public_paths or DEFAULT_PUBLIC_PATHS
+        )
+        self.extra_tools = list(extra_tools or [])
+        self.timeout = timeout
+        self.json_response = json_response
+        self.stateless_http = stateless_http
+        self.verbose = verbose
+        self.show_banner = show_banner
+
+        self.api_keys = self._collect_api_keys(api_keys, api_key_env)
+
+        if (
+            not self.allow_anonymous
+            and self.auth is None
+            and self.token_verifier is None
+            and not self.api_keys
+        ):
+            raise ValueError(
+                "No auth configured. Pass api_keys, api_key_env, auth or "
+                "token_verifier, or set allow_anonymous=True."
+            )
+
+        self.server = self._build_server()
+        for tool in self.tools.values():
+            self._register_on_server(tool)
+        self._app = None
+        self._uvicorn = None
+        self._thread: Optional[threading.Thread] = None
+
+    # ------------------------------------------------------------------
+    # Targets
+    # ------------------------------------------------------------------
+
+    def _register_targets(
+        self,
+        targets: Any,
+        tool_name: Optional[str],
+        description: Optional[str],
+    ) -> None:
+        if isinstance(targets, dict):
+            if tool_name or description:
+                raise ValueError(
+                    "tool_name and description apply to a single target; "
+                    "with a dict the keys are the tool names."
+                )
+            for key, target in targets.items():
+                self._add(target, key, None)
+            return
+
+        if isinstance(targets, (list, tuple)):
+            if tool_name or description:
+                raise ValueError(
+                    "tool_name and description apply to a single target; "
+                    "pass a dict to name several."
+                )
+            for target in targets:
+                self._add(target, None, None)
+            return
+
+        self._add(targets, tool_name, description)
+
+        if not self.tools:
+            raise ValueError("MCPDeployer needs at least one target.")
+
+    def _add(
+        self,
+        target: Any,
+        name: Optional[str],
+        description: Optional[str],
+    ) -> ServedTool:
+        if not _is_servable(target):
+            raise ValueError(
+                f"{target!r} must be callable or expose a run() method."
+            )
+        tool = ServedTool(
+            name=name or _default_tool_name(target),
+            target=target,
+            description=description or _default_description(target),
+        )
+        if tool.name in self.tools:
+            raise ValueError(
+                f"A tool named {tool.name!r} is already registered; "
+                "pass a dict to give each target its own name."
+            )
+        self.tools[tool.name] = tool
+        return tool
+
+    def add_tool(
+        self,
+        target: Any,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> ServedTool:
+        """
+        Register one more agent, swarm or callable as a tool.
+
+        Call before :meth:`run` or :meth:`start`.
+
+        Args:
+            target: The agent, swarm or callable to serve.
+            name: Tool name. Defaults to a snake_case form of the target's
+                name.
+            description: Tool description. Defaults to the target's own.
+
+        Returns:
+            The registered ``ServedTool``.
+        """
+        if self._thread is not None:
+            raise RuntimeError(
+                "add_tool must be called before start()."
+            )
+        tool = self._add(target, name, description)
+        self._register_on_server(tool)
+        return tool
+
+    @property
+    def tool_names(self) -> List[str]:
+        return list(self.tools)
+
+    @property
+    def tool_name(self) -> str:
+        """The first registered tool's name."""
+        return next(iter(self.tools))
+
+    @property
+    def target(self) -> Any:
+        """The first registered target."""
+        return self.tools[self.tool_name].target
+
+    @property
+    def description(self) -> str:
+        """The first registered tool's description."""
+        return self.tools[self.tool_name].description
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _collect_api_keys(
+        api_keys: Optional[Iterable[str]], api_key_env: Optional[str]
+    ) -> List[str]:
+        keys = [
+            k.strip() for k in (api_keys or []) if k and k.strip()
+        ]
+        if api_key_env:
+            raw = os.getenv(api_key_env, "")
+            keys += [k.strip() for k in raw.split(",") if k.strip()]
+        return list(dict.fromkeys(keys))
+
+    def _key_matches(self, credential: str) -> bool:
+        return any(
+            hmac.compare_digest(credential, key)
+            for key in self.api_keys
+        )
+
+    async def authenticate(
+        self, headers: Headers
+    ) -> Optional[AuthResult]:
+        """
+        Decide whether a request may proceed.
+
+        Checks, in order: ``allow_anonymous``, the custom ``auth``
+        callable, ``token_verifier``, then the static key set.
+
+        Args:
+            headers: The request headers.
+
+        Returns:
+            An ``AuthResult`` when admitted, None when refused.
+        """
+        if self.allow_anonymous:
+            return AuthResult(method="anonymous")
+
+        credential = credential_from_headers(
+            headers, self.api_key_header
+        )
+
+        if self.auth is not None:
+            verdict = self.auth(credential, headers)
+            if inspect.isawaitable(verdict):
+                verdict = await verdict
+            if not verdict:
+                return None
+            claims = verdict if isinstance(verdict, dict) else {}
+            return AuthResult(
+                method="custom",
+                subject=claims.get("subject") or claims.get("sub"),
+                scopes=list(claims.get("scopes", [])),
+                claims=claims,
+            )
+
+        if credential is None:
+            return None
+
+        if self.token_verifier is not None:
+            token = await self.token_verifier.verify_token(credential)
+            if token is None:
+                return None
+            if token.expires_at and token.expires_at < int(
+                time.time()
+            ):
+                return None
+            scopes = list(token.scopes or [])
+            if any(s not in scopes for s in self.required_scopes):
+                return None
+            return AuthResult(
+                method="token",
+                subject=getattr(token, "subject", None)
+                or token.client_id,
+                scopes=scopes,
+                claims=dict(getattr(token, "claims", None) or {}),
+            )
+
+        if self._key_matches(credential):
+            return AuthResult(method="api_key")
+        return None
+
+    # ------------------------------------------------------------------
+    # Tool
+    # ------------------------------------------------------------------
+
+    def _invoke(
+        self, name: str, task: str, img: Optional[str] = None
+    ) -> str:
+        """Run one tool's target synchronously and render its output."""
+        target = self.tools[name].target
+        run = getattr(target, "run", None)
+        if callable(run):
+            if img:
+                try:
+                    return _to_text(run(task, img=img))
+                except TypeError:
+                    pass
+            return _to_text(run(task))
+        return _to_text(target(task))
+
+    async def _call(
+        self, name: str, task: str, img: Optional[str] = None
+    ) -> str:
+        if self.verbose:
+            logger.info(
+                f"MCPDeployer[{self.name}] {name}: {task[:80]!r}"
+            )
+        fn = partial(self._invoke, name, task, img)
+        if self.timeout:
+            with anyio.fail_after(self.timeout):
+                return await anyio.to_thread.run_sync(fn)
+        return await anyio.to_thread.run_sync(fn)
+
+    def _build_server(self):
+        from mcp.server.mcpserver import MCPServer
+
+        instructions = "\n".join(
+            f"{t.name}: {t.description}" for t in self.tools.values()
+        )
+        server = MCPServer(name=self.name, instructions=instructions)
+
+        for fn in self.extra_tools:
+            server.tool()(fn)
+
+        deployer = self
+
+        @server.custom_route("/health", methods=["GET"])
+        async def health(request: Request) -> JSONResponse:
+            return JSONResponse(
+                {
+                    "status": "ok",
+                    "name": deployer.name,
+                    "tool": deployer.tool_name,
+                    "tools": deployer.tool_names,
+                    "transport": deployer.transport,
+                }
+            )
+
+        return server
+
+    def _register_on_server(self, tool: ServedTool) -> None:
+        name = tool.name
+
+        # The closure carries no `self` in its signature so the schema is
+        # just (task, img).
+        async def run(task: str, img: Optional[str] = None) -> str:
+            return await self._call(name, task, img)
+
+        run.__name__ = name
+        run.__doc__ = tool.description
+        self.server.tool(name=name, description=tool.description)(run)
+
+    # ------------------------------------------------------------------
+    # App and lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}{self.path}"
+
+    def _transport_security(self):
+        from mcp.server.transport_security import (
+            TransportSecuritySettings,
+        )
+
+        if self.host in ("127.0.0.1", "localhost"):
+            return None
+        # The default rebinding guard only admits localhost Host headers,
+        # which would reject every request to a server bound elsewhere.
+        return TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        )
+
+    def build_app(self):
+        """The ASGI app: the MCP transport wrapped in the auth layer."""
+        if self.transport == "stdio":
+            raise ValueError("stdio transport has no ASGI app.")
+
+        if self.transport == "sse":
+            inner = self.server.sse_app(
+                sse_path=self.path,
+                transport_security=self._transport_security(),
+                host=self.host,
+            )
+        else:
+            inner = self.server.streamable_http_app(
+                streamable_http_path=self.path,
+                json_response=self.json_response,
+                stateless_http=self.stateless_http,
+                transport_security=self._transport_security(),
+                host=self.host,
+            )
+        return _AuthMiddleware(inner, self)
+
+    @property
+    def app(self):
+        if self._app is None:
+            self._app = self.build_app()
+        return self._app
+
+    def _auth_label(self) -> str:
+        if self.allow_anonymous:
+            return "anonymous (open)"
+        if self.auth is not None:
+            return "custom auth callable"
+        if self.token_verifier is not None:
+            scopes = ", ".join(self.required_scopes) or "any"
+            return f"token verifier · scopes: {scopes}"
+        n = len(self.api_keys)
+        return f"{n} api key{'s' if n != 1 else ''} · {self.api_key_header} or Bearer"
+
+    def print_banner(self, console: Optional[Console] = None) -> None:
+        """Print the startup banner: the swarms alien in purple."""
+        console = console or Console()
+
+        icon = Text()
+        icon.append("▄     ▄\n", style=f"bold {BANNER_DEEP}")
+        icon.append("▀█████▀\n", style=f"bold {BANNER_DEEP}")
+        icon.append("█▀███▀█\n", style=f"bold {BANNER_PURPLE}")
+        icon.append("███████\n", style=f"bold {BANNER_PURPLE}")
+        icon.append("▀█   █▀", style=f"bold {BANNER_VIOLET}")
+
+        endpoint = "stdio" if self.transport == "stdio" else self.url
+        info = Text()
+        info.append("MCPDeployer", style="bold white")
+        info.append(f"  {self.name}\n", style=f"bold {BANNER_VIOLET}")
+        tools = list(self.tools.values())
+        shown, hidden = tools[:4], tools[4:]
+        label = "tool      " if len(tools) == 1 else "tools     "
+        for i, tool in enumerate(shown):
+            info.append(
+                label if i == 0 else "          ", style="dim white"
+            )
+            info.append(tool.name, style=f"{BANNER_DEEP}")
+            info.append(
+                f"  ({tool.target_type})\n", style="dim white"
+            )
+        if hidden:
+            info.append("          ", style="dim white")
+            info.append(f"+{len(hidden)} more\n", style="dim white")
+        info.append("endpoint  ", style="dim white")
+        info.append(f"{endpoint}\n", style=f"{BANNER_DEEP}")
+        info.append("transport ", style="dim white")
+        info.append(f"{self.transport}\n", style="white")
+        info.append("auth      ", style="dim white")
+        info.append(self._auth_label(), style="white")
+
+        header = Table.grid(padding=(0, 1))
+        header.add_column(width=9, vertical="top")
+        header.add_column(vertical="top")
+        header.add_row(icon, info)
+
+        hint = Text()
+        if self.transport == "stdio":
+            hint.append(
+                "Launched by an MCP host over stdin/stdout.",
+                style="dim white",
+            )
+        else:
+            hint.append("Connect with  ", style="dim white")
+            hint.append(
+                f'Agent(mcp_url=MCPConnection(url="{self.url}", api_key=...))',
+                style=BANNER_PURPLE,
+            )
+            hint.append(
+                f"\nHealth check  GET http://{self.host}:{self.port}/health",
+                style="dim white",
+            )
+
+        console.print(
+            Panel(
+                Group(
+                    header,
+                    Text(""),
+                    Rule(style=f"dim {BANNER_PURPLE}"),
+                    hint,
+                ),
+                border_style=BANNER_DEEP,
+                title=f"[bold {BANNER_VIOLET}] 👾 Swarms MCP [/bold {BANNER_VIOLET}]",
+                title_align="left",
+                subtitle="[dim white] ctrl+c to stop [/dim white]",
+                subtitle_align="right",
+                padding=(0, 2),
+            )
+        )
+
+    def run(self, log_level: str = "info") -> None:
+        """Serve until interrupted. Blocks."""
+        if self.show_banner:
+            self.print_banner()
+        if self.transport == "stdio":
+            if not self.allow_anonymous:
+                logger.warning(
+                    "stdio transport carries no headers; auth settings "
+                    "are ignored."
+                )
+            self.server.run("stdio")
+            return
+
+        import uvicorn
+
+        uvicorn.run(
+            self.app,
+            host=self.host,
+            port=self.port,
+            log_level=log_level,
+        )
+
+    def start(self, wait: float = 10.0) -> "MCPDeployer":
+        """
+        Serve in a background thread and return once the socket is open.
+
+        Args:
+            wait: Seconds to wait for startup before raising.
+        """
+        if self.transport == "stdio":
+            raise ValueError("start() needs an HTTP transport.")
+        if self._thread is not None:
+            return self
+        if self.show_banner:
+            self.print_banner()
+
+        import uvicorn
+
+        config = uvicorn.Config(
+            self.app,
+            host=self.host,
+            port=self.port,
+            log_level="warning",
+        )
+        self._uvicorn = uvicorn.Server(config)
+        self._thread = threading.Thread(
+            target=self._uvicorn.run, daemon=True
+        )
+        self._thread.start()
+
+        deadline = time.monotonic() + wait
+        while not self._uvicorn.started:
+            if (
+                time.monotonic() > deadline
+                or not self._thread.is_alive()
+            ):
+                self.stop()
+                raise RuntimeError(
+                    f"MCPDeployer did not start on {self.host}:{self.port}"
+                )
+            time.sleep(0.05)
+        return self
+
+    def stop(self, wait: float = 10.0) -> None:
+        """Stop a server started with :meth:`start`."""
+        if self._uvicorn is not None:
+            self._uvicorn.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=wait)
+        self._uvicorn = None
+        self._thread = None
+
+    def __enter__(self) -> "MCPDeployer":
+        return self.start()
+
+    def __exit__(self, *exc) -> None:
+        self.stop()
+
+
+def deploy_as_mcp(target: Any, **kwargs) -> MCPDeployer:
+    """Build an :class:`MCPDeployer` and serve it. Blocks."""
+    deployer = MCPDeployer(target, **kwargs)
+    deployer.run()
+    return deployer

--- a/tests/structs/test_mcp_deployer.py
+++ b/tests/structs/test_mcp_deployer.py
@@ -1,0 +1,395 @@
+import asyncio
+import socket
+
+import httpx
+import pytest
+from starlette.datastructures import Headers
+
+from swarms.structs.mcp_deployer import (
+    AuthResult,
+    MCPDeployer,
+    credential_from_headers,
+)
+
+
+class EchoAgent:
+    agent_name = "Echo-Agent"
+    agent_description = "Echoes the task back."
+
+    def __init__(self):
+        self.calls = []
+
+    def run(self, task, img=None, **kwargs):
+        self.calls.append((task, img))
+        return f"echo: {task}"
+
+
+def headers(**kwargs) -> Headers:
+    return Headers(
+        {k.replace("_", "-"): v for k, v in kwargs.items()}
+    )
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ----------------------------------------------------------------------
+# Construction
+# ----------------------------------------------------------------------
+
+
+def test_refuses_to_build_without_any_auth():
+    with pytest.raises(ValueError, match="No auth configured"):
+        MCPDeployer(EchoAgent())
+
+
+def test_allow_anonymous_builds_without_keys():
+    deployer = MCPDeployer(EchoAgent(), allow_anonymous=True)
+    assert deployer.tool_name == "echo_agent"
+    assert deployer.description == "Echoes the task back."
+
+
+def test_plain_function_target_uses_its_name_and_docstring():
+    def summarise(task: str) -> str:
+        """Summarise the task."""
+        return task.upper()
+
+    deployer = MCPDeployer(summarise, api_keys=["k"])
+    assert deployer.tool_name == "summarise"
+    assert deployer.description == "Summarise the task."
+    assert deployer._invoke("summarise", "hi") == "HI"
+
+
+def test_rejects_non_callable_target():
+    with pytest.raises(ValueError, match="callable"):
+        MCPDeployer(object(), api_keys=["k"])
+
+
+def test_api_key_env_is_read_and_deduplicated(monkeypatch):
+    monkeypatch.setenv("MCP_KEYS_TEST", "a, b ,a,")
+    deployer = MCPDeployer(
+        EchoAgent(), api_keys=["b"], api_key_env="MCP_KEYS_TEST"
+    )
+    assert deployer.api_keys == ["b", "a"]
+
+
+def test_list_of_targets_becomes_one_tool_each():
+    def summarise(task: str) -> str:
+        """Summarise."""
+        return task
+
+    deployer = MCPDeployer(
+        [EchoAgent(), summarise], api_keys=["k"], show_banner=False
+    )
+    assert deployer.tool_names == ["echo_agent", "summarise"]
+    assert deployer.name == "echo_agent"
+    assert deployer.tools["summarise"].description == "Summarise."
+
+
+def test_dict_of_targets_uses_keys_as_tool_names():
+    deployer = MCPDeployer(
+        {"research": EchoAgent(), "shout": lambda t: t.upper()},
+        api_keys=["k"],
+        name="Team",
+    )
+    assert deployer.tool_names == ["research", "shout"]
+    assert deployer.name == "Team"
+    assert deployer._invoke("shout", "hi") == "HI"
+    assert deployer._invoke("research", "hi") == "echo: hi"
+
+
+def test_add_tool_registers_before_start_only():
+    deployer = MCPDeployer(
+        EchoAgent(), api_keys=["k"], show_banner=False
+    )
+    served = deployer.add_tool(lambda t: t[::-1], name="reverse")
+    assert served.name == "reverse"
+    assert deployer.tool_names == ["echo_agent", "reverse"]
+    assert deployer._invoke("reverse", "abc") == "cba"
+
+
+def test_duplicate_tool_names_are_rejected():
+    with pytest.raises(ValueError, match="already registered"):
+        MCPDeployer([EchoAgent(), EchoAgent()], api_keys=["k"])
+
+
+def test_tool_name_and_description_need_a_single_target():
+    with pytest.raises(ValueError, match="single target"):
+        MCPDeployer([EchoAgent()], api_keys=["k"], tool_name="x")
+    with pytest.raises(ValueError, match="single target"):
+        MCPDeployer(
+            {"a": EchoAgent()}, api_keys=["k"], description="d"
+        )
+
+
+def test_unservable_entry_in_list_is_rejected():
+    with pytest.raises(ValueError, match="callable"):
+        MCPDeployer([EchoAgent(), object()], api_keys=["k"])
+
+
+# ----------------------------------------------------------------------
+# Credential extraction and authenticate()
+# ----------------------------------------------------------------------
+
+
+def test_credential_prefers_api_key_header_then_bearer():
+    assert credential_from_headers(headers(x_api_key="k1")) == "k1"
+    assert (
+        credential_from_headers(headers(x_api_key="Bearer k2"))
+        == "k2"
+    )
+    assert (
+        credential_from_headers(headers(authorization="Bearer k3"))
+        == "k3"
+    )
+    assert (
+        credential_from_headers(headers(authorization="Basic x"))
+        is None
+    )
+    assert credential_from_headers(headers()) is None
+
+
+def test_api_key_auth_admits_only_configured_keys():
+    deployer = MCPDeployer(EchoAgent(), api_keys=["good"])
+
+    ok = asyncio.run(deployer.authenticate(headers(x_api_key="good")))
+    assert ok.method == "api_key"
+    assert (
+        asyncio.run(deployer.authenticate(headers(x_api_key="bad")))
+        is None
+    )
+    assert asyncio.run(deployer.authenticate(headers())) is None
+
+
+def test_custom_auth_callable_sync_and_async():
+    def sync_auth(credential, hdrs):
+        return credential == "s" and {
+            "subject": "alice",
+            "scopes": ["r"],
+        }
+
+    deployer = MCPDeployer(EchoAgent(), auth=sync_auth)
+    result = asyncio.run(
+        deployer.authenticate(headers(x_api_key="s"))
+    )
+    assert result.method == "custom"
+    assert result.subject == "alice"
+    assert result.scopes == ["r"]
+    assert (
+        asyncio.run(deployer.authenticate(headers(x_api_key="x")))
+        is None
+    )
+
+    async def async_auth(credential, hdrs):
+        return hdrs.get("x-tenant") == "acme"
+
+    deployer = MCPDeployer(EchoAgent(), auth=async_auth)
+    assert asyncio.run(
+        deployer.authenticate(headers(x_tenant="acme"))
+    )
+    assert asyncio.run(deployer.authenticate(headers())) is None
+
+
+def test_custom_auth_wins_over_api_keys():
+    deployer = MCPDeployer(
+        EchoAgent(), api_keys=["good"], auth=lambda c, h: False
+    )
+    assert (
+        asyncio.run(deployer.authenticate(headers(x_api_key="good")))
+        is None
+    )
+
+
+def test_token_verifier_checks_scopes_and_expiry():
+    from mcp.server.auth.provider import AccessToken
+
+    class Verifier:
+        async def verify_token(self, token):
+            if token == "admin":
+                return AccessToken(
+                    token=token,
+                    client_id="c1",
+                    scopes=["read", "write"],
+                )
+            if token == "reader":
+                return AccessToken(
+                    token=token, client_id="c2", scopes=["read"]
+                )
+            if token == "stale":
+                return AccessToken(
+                    token=token,
+                    client_id="c3",
+                    scopes=["write"],
+                    expires_at=1,
+                )
+            return None
+
+    deployer = MCPDeployer(
+        EchoAgent(),
+        token_verifier=Verifier(),
+        required_scopes=["write"],
+    )
+    admitted = asyncio.run(
+        deployer.authenticate(headers(authorization="Bearer admin"))
+    )
+    assert admitted.method == "token"
+    assert admitted.subject == "c1"
+    for token in ("reader", "stale", "unknown"):
+        assert (
+            asyncio.run(
+                deployer.authenticate(
+                    headers(authorization=f"Bearer {token}")
+                )
+            )
+            is None
+        )
+
+
+def test_invoke_forwards_img_and_renders_non_string_output():
+    agent = EchoAgent()
+    deployer = MCPDeployer(agent, api_keys=["k"])
+    deployer._invoke("echo_agent", "look", img="chart.png")
+    assert agent.calls[-1] == ("look", "chart.png")
+
+    deployer = MCPDeployer(lambda task: {"a": 1}, api_keys=["k"])
+    assert deployer._invoke("lambda", "x") == '{\n  "a": 1\n}'
+
+
+# ----------------------------------------------------------------------
+# Live server over streamable HTTP
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def live():
+    agent = EchoAgent()
+
+    def shout(task: str) -> str:
+        """Upper-case the task."""
+        return task.upper()
+
+    deployer = MCPDeployer(
+        [agent, shout],
+        api_keys=["secret-key"],
+        port=free_port(),
+        verbose=True,
+        show_banner=False,
+    )
+    with deployer:
+        yield deployer, agent
+
+
+def test_health_is_public(live):
+    deployer, _ = live
+    response = httpx.get(
+        f"http://{deployer.host}:{deployer.port}/health"
+    )
+    assert response.status_code == 200
+    assert response.json()["tool"] == "echo_agent"
+    assert response.json()["tools"] == ["echo_agent", "shout"]
+
+
+def test_mcp_endpoint_rejects_missing_and_wrong_keys(live):
+    deployer, _ = live
+    body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    hdrs = {
+        "accept": "application/json, text/event-stream",
+        "content-type": "application/json",
+    }
+    anonymous = httpx.post(deployer.url, json=body, headers=hdrs)
+    assert anonymous.status_code == 401
+    assert anonymous.headers["www-authenticate"] == "Bearer"
+
+    wrong = httpx.post(
+        deployer.url, json=body, headers={**hdrs, "x-api-key": "nope"}
+    )
+    assert wrong.status_code == 401
+
+
+def test_mcp_client_lists_and_calls_the_tool_with_bearer_key(live):
+    from swarms.tools.mcp_manager import MCPManager
+
+    deployer, agent = live
+    manager = MCPManager(mcp_url=deployer.url, api_key="secret-key")
+
+    tools = manager.get_tools()
+    assert sorted(t["function"]["name"] for t in tools) == [
+        "echo_agent",
+        "shout",
+    ]
+    for tool in tools:
+        params = tool["function"]["parameters"]["properties"]
+        assert set(params) == {"task", "img"}
+
+    result = manager.call_tool("echo_agent", {"task": "ping"})
+    assert "echo: ping" in str(result)
+    assert agent.calls[-1] == ("ping", None)
+
+    shouted = manager.call_tool("shout", {"task": "quiet"})
+    assert "QUIET" in str(shouted)
+
+
+def test_mcp_client_can_use_the_x_api_key_header(live):
+    from swarms.schemas.mcp_schemas import MCPConnection
+    from swarms.tools.mcp_manager import MCPManager
+
+    deployer, _ = live
+    manager = MCPManager(
+        mcp_url=MCPConnection(
+            url=deployer.url,
+            api_key="secret-key",
+            api_key_header="x-api-key",
+            api_key_prefix=None,
+        )
+    )
+    assert sorted(manager.list_tool_names()) == [
+        "echo_agent",
+        "shout",
+    ]
+
+
+def test_mcp_client_with_bad_key_fails(live):
+    from swarms.tools.mcp_manager import MCPManager
+
+    deployer, _ = live
+    manager = MCPManager(
+        mcp_url=deployer.url, api_key="wrong", retry_attempts=1
+    )
+    with pytest.raises(Exception):
+        manager.get_tools()
+
+
+def test_banner_renders_for_every_auth_mode():
+    from io import StringIO
+    from rich.console import Console
+
+    def render(deployer):
+        buf = StringIO()
+        deployer.print_banner(
+            Console(file=buf, width=100, force_terminal=False)
+        )
+        return buf.getvalue()
+
+    keyed = render(
+        MCPDeployer(EchoAgent(), api_keys=["a", "b"], port=1)
+    )
+    assert "MCPDeployer" in keyed and "echo_agent" in keyed
+    assert "2 api keys" in keyed and "http://127.0.0.1:1/mcp" in keyed
+    assert "Swarms MCP" in keyed
+
+    custom = render(MCPDeployer(EchoAgent(), auth=lambda c, h: True))
+    assert "custom auth callable" in custom
+
+    open_ = render(
+        MCPDeployer(
+            EchoAgent(), allow_anonymous=True, transport="stdio"
+        )
+    )
+    assert "anonymous (open)" in open_ and "stdin/stdout" in open_
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
`MCPDeployer` turns one or more agents or swarms into an MCP server with an auth layer in front of it.

```python
from swarms import Agent, MCPDeployer

agent = Agent(agent_name="Researcher", model_name="gpt-5.4", max_loops=1)
MCPDeployer(agent, api_keys=["sk-local-dev"], port=8000).run()
```

Another agent connects with `Agent(mcp_url=MCPConnection(url="http://127.0.0.1:8000/mcp", api_key="sk-local-dev"))`.

## Targets

The first argument is one target, a list, or a dict of tool name to target. A target is an `Agent`, any structure with a `run()` method (`SequentialWorkflow`, `SwarmRouter`, ...), or a plain callable. Each becomes its own MCP tool with a `(task, img)` schema; a dict's keys are the tool names, a list derives them. `add_tool()` registers more before start. Duplicate names and unservable entries raise at construction.

## Auth, in order of precedence

1. `auth=callable(credential, headers)`: sync or async; truthy admits, a dict is kept as claims, falsy or an exception refuses.
2. `token_verifier=`: the `mcp` package's `TokenVerifier` protocol, with `required_scopes` and expiry enforced.
3. `api_keys=[...]` / `api_key_env="VAR"`: static keys compared in constant time.
4. `allow_anonymous=True`: opt in only. With nothing configured the constructor refuses to build.

Clients may send the key as `x-api-key` (rename with `api_key_header`) or `Authorization: Bearer`, which is what `MCPManager` sends by default. Refusals are a 401 with `WWW-Authenticate: Bearer`; the key is never logged. `/health` is public and lists the tools.

## Transports and lifecycle

Streamable HTTP by default, or SSE or stdio (stdio has no headers, so no auth; the host is the boundary). `run()` blocks; `start()`/`stop()` or a `with` block serve on a background thread. Tool calls run the target in a worker thread with an optional `timeout`; `extra_tools` exposes plain functions beside the targets. A purple startup banner in the CLI's style shows the tools, endpoint, transport and auth mode; `show_banner=False` hides it.

Built on `mcp` 2.0's `mcp.server.mcpserver.MCPServer`. The auth layer is a plain ASGI middleware wrapped around the transport app, so it applies uniformly to both HTTP transports.

## Examples

`examples/mcp/mcp_deployer/`, eleven files: single agent, a `SequentialWorkflow` as one tool, several agents and swarms as separate tools, per-tenant custom auth (sync and async variants), a `TokenVerifier` with scopes, keys from an environment variable with extra tools, a self-contained two-agent round trip, a plain function with JSON replies and no LLM, SSE, and stdio. Listed from `examples/README.md`, `examples/mcp/README.md`, and pointed to from the servers README.

## Verification

- 23 offline tests in `tests/structs/test_mcp_deployer.py`: construction rules, both header styles, every auth mode including scopes and expiry, the multi-target registry, the banner, and a live streamable-HTTP server serving an agent and a function together, called through `MCPManager` with both header styles, plus 401 checks.
- SSE checked live through `MCPManager` as well.
- End to end with real models: a Claude Haiku agent served behind a key, and a second Claude agent given `mcp_url` plus the key discovered the tool and got the served agent's answer back. A third agent with a wrong key got a 401 and no remote tools.
- Every example imports cleanly; the two self-contained ones run end to end.
- black at line length 70 and ruff clean.
