### PR TITLE
[DOCS][CONTRIBUTING][Require the WARP git message format for commits, PRs and issues]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1067,6 +1067,28 @@ results = wf.run(task="Process this dataset from two angles and merge the findin
 
 ---
 
+## Contributing: WARP Git Messages (required)
+
+Every commit message, PR title and issue title you write for this repository must use the WARP (Warp Speed Protocol) shorthand. This is required of AI agents exactly as it is of people; a PR or issue without it is triaged later, so expect a delay if it is skipped.
+
+```
+[TYPE][Function/FileName][Short Description]
+```
+
+- `TYPE` in capitals: for example `FEAT`, `FIX`, `DOCS`, `REFACTOR`, `TEST`, `CHORE`.
+- `Function/FileName`: the function, class, module or file the change is about.
+- `Short Description`: one imperative line.
+
+```
+[FIX][Agent._run][Raise AgentLLMError after retry exhaustion]
+[FEAT][MCPDeployer][Serve several agents as separate tools]
+[DOCS][README][Add the MCPDeployer section]
+```
+
+Full specification: the [WARP Git Message Skill](https://swarms.world/prompt/32d1e7b4-34da-4035-bc05-d18f8e71a2f1) on the Swarms marketplace. Load it before writing a commit message, PR or issue for this repo.
+
+---
+
 ## What to Avoid
 
 **Don't import from submodules directly** — always import from `swarms`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,17 +54,41 @@ Search existing issues first. If it's new, open a [Bug Report](https://github.co
 
 ---
 
+## WARP Git Messages
+
+Every commit message, PR title and issue title in this repository must use the WARP (Warp Speed Protocol) shorthand. This applies to people and to AI agents alike.
+
+```
+[TYPE][Function/FileName][Short Description]
+```
+
+- `TYPE`: what kind of change it is, in capitals, for example `FEAT`, `FIX`, `DOCS`, `REFACTOR`, `TEST`, `CHORE`.
+- `Function/FileName`: the function, class, module or file the change is about.
+- `Short Description`: one line, imperative, saying what changed.
+
+```
+[FIX][Agent._run][Raise AgentLLMError after retry exhaustion]
+[FEAT][MCPDeployer][Serve several agents as separate tools]
+[DOCS][README][Add the MCPDeployer section]
+```
+
+The full specification, with the type list, validation rules and examples, is the [WARP Git Message Skill](https://swarms.world/prompt/32d1e7b4-34da-4035-bc05-d18f8e71a2f1) on the Swarms marketplace. Agents can load it directly; humans can read it.
+
+Issues and PRs that do not follow WARP are triaged after the ones that do, so expect a delay on review and merge if it is not used.
+
+---
+
 ## Pull Requests
 
 ```bash
 git checkout -b fix/short-description
 # make the change, add a test
 pytest tests/
-git commit -am "Fix X in Y"
+git commit -am "[FIX][Y][Fix X]"
 git push origin fix/short-description
 ```
 
-Then open the PR against `master`, describe the problem it solves, and link the issue (`Fixes #1234`).
+Then open the PR against `master` with a WARP title, describe the problem it solves, and link the issue (`Fixes #1234`).
 
 ### Keep PRs short and simple
 

--- a/README.md
+++ b/README.md
@@ -851,6 +851,8 @@ We've made it easy to start contributing. Here's how you can help:
 
 4. **Join the Discussion:** To participate in roadmap discussions and connect with other developers, join our community on [**Discord**](https://discord.gg/EamjgSaEQf).
 
+5. **Use WARP for Every Commit, PR and Issue:** All contributors, people and AI agents alike, must write commit messages, PR titles and issue titles in the WARP (Warp Speed Protocol) shorthand: `[TYPE][Function/FileName][Short Description]`, for example `[FIX][Agent._run][Raise AgentLLMError after retry exhaustion]`. The full spec is the [**WARP Git Message Skill**](https://swarms.world/prompt/32d1e7b4-34da-4035-bc05-d18f8e71a2f1). Issues and PRs that skip WARP are triaged after the ones that use it, so expect a delay without it.
+
 ### Thank You to Our Contributors
 
 Thank you for contributing to swarms. Your work is extremely appreciated and recognized.

--- a/README_zh.md
+++ b/README_zh.md
@@ -789,6 +789,8 @@ Swarms 是一个开源、社区驱动的框架，旨在通过为部署和编排�
 
 4. **加入讨论：** 想参与路线图讨论并与其他开发者交流，请加入我们的 [**Discord**](https://discord.gg/EamjgSaEQf) 社区。
 
+5. **所有提交、PR 和 Issue 都必须使用 WARP：** 无论是人还是 AI 智能体，所有贡献者的提交信息、PR 标题和 Issue 标题都必须采用 WARP（Warp Speed Protocol）速记格式：`[TYPE][Function/FileName][Short Description]`，例如 `[FIX][Agent._run][Raise AgentLLMError after retry exhaustion]`。完整规范见 [**WARP Git Message Skill**](https://swarms.world/prompt/32d1e7b4-34da-4035-bc05-d18f8e71a2f1)。未使用 WARP 的 Issue 和 PR 会排在使用了 WARP 的之后处理，因此不使用会有延迟。
+
 ### 感谢我们的贡献者
 
 感谢你为 swarms 做出的贡献。你的工作备受重视和认可。


### PR DESCRIPTION
Adds the WARP (Warp Speed Protocol) requirement to the four places contributors and agents read before opening work:

- `CONTRIBUTING.md`: a new "WARP Git Messages" section before "Pull Requests", with the format, three examples, a link to the full spec, and the note that non-WARP issues and PRs are triaged later. The commit example in the PR walkthrough is rewritten in the format.
- `CLAUDE.md`: a "Contributing: WARP Git Messages (required)" section before "What to Avoid", so AI coding assistants pick it up when they load the file.
- `README.md` and `README_zh.md`: a fifth step under "How to Contribute" / "如何贡献".

The format is `[TYPE][Function/FileName][Short Description]`. All four files link the [WARP Git Message Skill](https://swarms.world/prompt/32d1e7b4-34da-4035-bc05-d18f8e71a2f1) for the full specification rather than restating the type list, so the marketplace prompt stays the single source of truth.

Not touched: `.github/PULL_REQUEST_TEMPLATE.md` and the two issue templates. They could carry a one-line reminder of the format if you want it enforced at the point of writing.
