### PR TITLE
Add opt-in Codex CLI backend for Agent and YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ GROQ_API_KEY=""
 
 ### Your First Agent
 
+To use an existing local Codex login, see the optional
+[Codex CLI backend](examples/models/codex/README.md) and its Python/YAML examples.
+
+
 An **Agent** is the fundamental building block of a swarm—an autonomous entity powered by an LLM + Tools + Memory. [Learn more Here](https://docs.swarms.world/api/agent)
 
 ```python

--- a/examples/models/codex/README.md
+++ b/examples/models/codex/README.md
@@ -1,0 +1,84 @@
+# Codex CLI backend
+
+Use an existing local Codex login from Swarms without writing a custom LLM adapter.
+The optional backend uses the official `codex exec` command. Swarms runs locally;
+model requests still go to Codex and use that account's access and usage limits.
+
+## Setup
+
+Install Swarms and [Codex CLI](https://learn.chatgpt.com/docs/cli), then log in:
+
+```sh
+npm install -g @openai/codex
+codex login
+codex login status
+```
+
+Codex CLI 0.147.0 or newer is required for the flags used here. Authentication is
+managed by Codex; Swarms does not read or copy login tokens. Keep authentication
+on your own machine. The automated tests use a fake CLI and require no credentials.
+
+## Python
+
+```python
+from swarms import Agent
+
+agent = Agent(
+    agent_name="LocalAssistant",
+    system_prompt="Answer clearly and concisely.",
+    llm_backend="codex",
+    model_name=None,  # Use the Codex CLI default model.
+    codex_config={"timeout": 180},
+    max_loops=1,
+    retry_attempts=1,
+    output_type="final",
+)
+print(agent.run("Explain how to combine CSV files with pandas."))
+```
+
+Set `model_name` to a model supported by your Codex account to select it explicitly.
+Omitting `model_name` in Python retains Agent's usual model default; pass `None`
+to use the CLI default. `codex_config` currently accepts only `timeout`, a positive,
+finite number of seconds per CLI invocation. Unknown keys fail rather than being
+silently ignored. Existing LiteLLM agents and custom `llm` objects work as before.
+
+## YAML
+
+The existing YAML loader forwards these options to Agent:
+
+```yaml
+agents:
+  - agent_name: LocalAssistant
+    system_prompt: Answer clearly and concisely.
+    llm_backend: codex
+    model_name: null
+    max_loops: 1
+    retry_attempts: 1
+    codex_config:
+      timeout: 180
+```
+
+Load it with `create_agents_from_yaml(yaml_file="agents.yaml", return_type="agents")`.
+See [the example notebook](codex_backend.ipynb) for a two-agent SequentialWorkflow.
+
+## Execution behavior and limits
+
+- Each invocation starts an ephemeral Codex session in its own temporary directory.
+  Swarms forwards the current system prompt and text message history. Memory
+  compression also uses this backend instead of making a separate LiteLLM request.
+- The CLI runs with a read-only sandbox. Shell tools, web search, Codex multi-agent
+  delegation, apps, plugins, and project instructions are disabled for these text
+  requests. This is not a repository-editing backend.
+- `--ignore-user-config` prevents loading the user's Codex `config.toml` for this
+  invocation. Saved authentication is still used. No global settings are changed.
+- The final-message file supplies the response; progress logs are not treated as
+  model output. Timeouts and keyboard cancellation terminate the CLI and its child
+  processes, and temporary files are cleaned up.
+- The first version rejects Swarms tools/MCP, image inputs, streaming, and
+  `max_loops="auto"`. Use bounded text agents and workflows. Provider sampling knobs
+  such as `temperature` and `max_tokens` are not forwarded to Codex, and Codex token
+  usage is not yet included in `agent.usage`.
+- For authentication or model errors, check `codex login status` and the installed
+  CLI version. Retry behavior still follows the Agent's `retry_attempts` setting.
+
+Reference: [Codex non-interactive mode](https://learn.chatgpt.com/docs/non-interactive-mode).

--- a/examples/models/codex/codex_backend.ipynb
+++ b/examples/models/codex/codex_backend.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Swarms with a local Codex login\n",
+    "\n",
+    "Install Codex CLI 0.147.0+ and run `codex login` in your terminal first. These cells send real requests using your own account allowance. See [setup and limitations](README.md)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from swarms import Agent, SequentialWorkflow\n",
+    "from swarms.agents.create_agents_from_yaml import (\n",
+    "    create_agents_from_yaml,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure one text agent\n",
+    "\n",
+    "Set `model_name=None` to use the CLI default, or supply a model supported by your account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent = Agent(\n",
+    "    agent_name=\"Writer\",\n",
+    "    system_prompt=\"Explain Python clearly and concisely.\",\n",
+    "    llm_backend=\"codex\",\n",
+    "    model_name=None,\n",
+    "    codex_config={\"timeout\": 180},\n",
+    "    max_loops=1,\n",
+    "    retry_attempts=1,\n",
+    "    output_type=\"final\",\n",
+    ")\n",
+    "print(agent.run(\"Show how to combine CSV files with pandas.\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add a reviewer from YAML\n",
+    "\n",
+    "The workflow makes one model invocation per agent. The writer produces a draft and the reviewer returns the final answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reviewer = create_agents_from_yaml(\n",
+    "    yaml_string=\"\"\"\n",
+    "agents:\n",
+    "  - agent_name: Reviewer\n",
+    "    system_prompt: Review the supplied draft and return a concise corrected answer.\n",
+    "    llm_backend: codex\n",
+    "    model_name: null\n",
+    "    max_loops: 1\n",
+    "    retry_attempts: 1\n",
+    "    autosave: false\n",
+    "    output_type: final\n",
+    "    codex_config:\n",
+    "      timeout: 180\n",
+    "\"\"\",\n",
+    "    return_type=\"agents\",\n",
+    ")\n",
+    "workflow = SequentialWorkflow(\n",
+    "    agents=[agent, reviewer], output_type=\"final\", autosave=False\n",
+    ")\n",
+    "print(\n",
+    "    workflow.run(\"Explain pd.read_csv and give a one-line example.\")\n",
+    ")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/swarms/agents/context_compressor.py
+++ b/swarms/agents/context_compressor.py
@@ -91,6 +91,13 @@ class ContextCompressor:
         return self.usage_ratio(agent) >= self.threshold
 
     def _summarize(self, agent: Any, history: str) -> str:
+        if getattr(agent, "llm_backend", None) == "codex":
+            return agent.llm.run(
+                task=COMPRESSION_USER_TEMPLATE.format(
+                    history=history
+                ),
+                system_prompt=COMPRESSION_SYSTEM_PROMPT,
+            )
         model = self.summarizer_model or getattr(
             agent, "model_name", None
         )

--- a/swarms/agents/llm_manager.py
+++ b/swarms/agents/llm_manager.py
@@ -47,6 +47,7 @@ from swarms.schemas.agent_errors import AgentLLMInitializationError
 from swarms.utils.formatter import formatter
 from swarms.utils.index import exists
 from swarms.utils.litellm_wrapper import LiteLLM
+from swarms.utils.codex_cli import CodexCLI, validate_codex_agent
 
 DEFAULT_MODEL_NAME = "gpt-5.4"
 
@@ -173,9 +174,11 @@ class LLMManager:
 
     # Construction and configuration.
 
-    def build(self, *args, **kwargs) -> Optional[LiteLLM]:
+    def build(
+        self, *args, **kwargs
+    ) -> Optional[Union[LiteLLM, CodexCLI]]:
         """
-        Build the LiteLLM instance from every configuration source.
+        Build the selected LLM backend from the agent configuration.
 
         Combines the agent's core settings, ``llm_args``,
         ``tools_list_dictionary``, MCP tool schemas, and any arguments passed
@@ -187,9 +190,25 @@ class LLMManager:
             **kwargs: Merged into the LiteLLM configuration, taking precedence.
 
         Returns:
-            LiteLLM: The initialized instance, or None if initialization failed.
+            The initialized backend, or None if LiteLLM initialization failed.
         """
         agent = self.agent
+
+        if getattr(agent, "llm_backend", "litellm") == "codex":
+            validate_codex_agent(agent)
+            if args or kwargs:
+                raise ValueError(
+                    "Use codex_config for Codex backend options"
+                )
+            return CodexCLI(
+                model_name=(
+                    self.get_current_model()
+                    if agent.fallback_models
+                    else agent.model_name
+                ),
+                system_prompt=agent.system_prompt,
+                **agent.codex_config,
+            )
 
         if agent.model_name is None:
             agent.model_name = DEFAULT_MODEL_NAME
@@ -318,12 +337,20 @@ class LLMManager:
 
         Checks vision support when an image is supplied, function calling when
         a tool schema is set, and parallel function calling when more than two
-        tools are registered. Logging only — never raises.
+        tools are registered. Codex rejects unsupported inputs explicitly.
 
         Args:
             img (str, optional): Image input to check vision support for.
         """
         agent = self.agent
+
+        if getattr(agent, "llm_backend", "litellm") == "codex":
+            validate_codex_agent(agent)
+            if img is not None:
+                raise ValueError(
+                    "Codex supports text only, not images"
+                )
+            return
 
         # Only check vision support if an image is provided
         if img is not None:
@@ -522,6 +549,14 @@ class LLMManager:
         # Filter out is_last from kwargs if present
         if "is_last" in kwargs:
             del kwargs["is_last"]
+
+        if getattr(agent, "llm_backend", "litellm") == "codex":
+            validate_codex_agent(agent)
+            if streaming_callback is not None:
+                raise ValueError(
+                    "Codex does not support streaming callbacks"
+                )
+            agent.llm.system_prompt = agent.system_prompt
 
         try:
             if agent.stream and hasattr(agent.llm, "stream"):

--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -113,6 +113,7 @@ from swarms.utils.index import (
 )
 from swarms.utils.litellm_tokenizer import count_tokens
 from swarms.utils.litellm_wrapper import LiteLLM, empty_usage
+from swarms.utils.codex_cli import validate_codex_agent
 from swarms.utils.output_types import OutputType
 from swarms.utils.workspace_manager import WorkspaceManager
 from swarms.utils.workspace_utils import get_workspace_dir
@@ -146,6 +147,8 @@ class Agent:
 
     Args:
         llm (Any): The language model to use
+        llm_backend (str): "litellm" (default) or the opt-in "codex" CLI backend.
+        codex_config (dict): Codex options: positive timeout in seconds (default 180).
         max_loops (int): The maximum number of loops to run
         stopping_condition (Callable): The stopping condition to use
         loop_interval (int): The loop interval
@@ -408,9 +411,32 @@ class Agent:
         selected_tools: Optional[Union[str, List[str]]] = "all",
         context_compression: bool = True,
         persistent_memory: bool = False,
+        llm_backend: Literal["litellm", "codex"] = "litellm",
+        codex_config: Optional[Dict[str, Any]] = None,
         *args,
         **kwargs,
     ):
+        if llm_backend not in ("litellm", "codex"):
+            raise ValueError(
+                "llm_backend must be 'litellm' or 'codex'"
+            )
+        if codex_config is not None and (
+            llm_backend != "codex"
+            or not isinstance(codex_config, dict)
+        ):
+            raise ValueError(
+                "codex_config requires the Codex backend and a dict"
+            )
+        if llm_backend == "codex" and llm is not None:
+            raise ValueError(
+                "Use either llm_backend='codex' or a custom llm"
+            )
+        self.llm_backend = llm_backend
+        self.codex_config = (
+            dict(codex_config or {})
+            if llm_backend == "codex"
+            else None
+        )
         # super().__init__(*args, **kwargs)
         self.id = id or generate_id("agent")
         self.skills = SkillsManager(skills_dir=skills_dir)
@@ -519,6 +545,9 @@ class Agent:
         self.mode = mode
         self.publish_to_marketplace = publish_to_marketplace
         self.marketplace_prompt_id = marketplace_prompt_id
+
+        if self.llm_backend == "codex":
+            validate_codex_agent(self)
 
         self.mcp_manager = MCPManager(
             mcp_url=self.mcp_url,
@@ -2566,7 +2595,10 @@ Subtask Breakdown:
         except Exception:
             pass
 
-        if self.model_name not in model_list:
+        if (
+            self.llm_backend != "codex"
+            and self.model_name not in model_list
+        ):
             logger.warning(
                 f"The model '{self.model_name}' may not be supported. Please use a supported model, or override the model name with the 'llm' parameter, which should be a class with a 'run(task: str)' method or a '__call__' method."
             )

--- a/swarms/utils/codex_cli.py
+++ b/swarms/utils/codex_cli.py
@@ -1,0 +1,253 @@
+"""Optional, text-only backend using an authenticated Codex CLI."""
+
+import json
+import math
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import psutil
+
+
+def validate_codex_agent(agent: Any) -> None:
+    """Reject agent options that require an unsupported Codex capability.
+
+    Args:
+        agent: Agent configuration to validate before setup or invocation.
+
+    Raises:
+        ValueError: An option requires tools, streaming, or API configuration.
+    """
+    unsupported = [
+        name
+        for name in (
+            "tools",
+            "tools_list_dictionary",
+            "tool_schema",
+            "list_base_models",
+            "mcp_url",
+            "mcp_urls",
+            "mcp_config",
+            "mcp_configs",
+            "handoffs",
+            "think_tool",
+            "stream",
+            "streaming_on",
+            "streaming_callback",
+            "multi_modal",
+            "llm_args",
+            "llm_base_url",
+            "llm_api_key",
+            "prompt_caching",
+            "random_models_on",
+            "react_on",
+        )
+        if getattr(agent, name, None)
+    ]
+    if agent.max_loops == "auto":
+        unsupported.append('max_loops="auto"')
+    if unsupported:
+        raise ValueError(
+            "The Codex backend supports bounded text-only runs; "
+            "unsupported options: " + ", ".join(unsupported)
+        )
+
+
+class CodexCLI:
+    """Generate text through the official CLI without handling login tokens.
+
+    Args:
+        model_name: Codex model identifier, or None for the CLI default.
+        system_prompt: Instructions accompanying each conversation.
+        timeout: Positive, finite maximum subprocess duration in seconds.
+
+    Raises:
+        ValueError: The model or timeout is invalid.
+        FileNotFoundError: Codex is not installed on PATH.
+    """
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        system_prompt: str = "",
+        timeout: float = 180,
+    ) -> None:
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(timeout)
+            or timeout <= 0
+        ):
+            raise ValueError(
+                "codex_config.timeout must be positive and finite"
+            )
+        if model_name is not None and (
+            not isinstance(model_name, str) or not model_name.strip()
+        ):
+            raise ValueError(
+                "model_name must be a non-empty string or None"
+            )
+        self.executable = shutil.which("codex")
+        if self.executable is None:
+            raise FileNotFoundError(
+                "Codex CLI was not found on PATH. Install @openai/codex "
+                "and run `codex login` before using llm_backend='codex'."
+            )
+        self.model_name = model_name
+        self.system_prompt = system_prompt
+        self.timeout = timeout
+
+    def run(
+        self,
+        task: Optional[str] = None,
+        messages: Optional[List[Dict[str, Any]]] = None,
+        system_prompt: Optional[str] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Return the final response to text or a role-preserving transcript.
+
+        Args:
+            task: Text appended as a user turn when provided.
+            messages: System, developer, user, or assistant text messages.
+            system_prompt: Per-call override, used for memory compression.
+            **kwargs: Non-empty unsupported options are rejected.
+
+        Returns:
+            The final non-empty Codex response.
+
+        Raises:
+            ValueError: Input is empty, malformed, or requires unsupported tools.
+            TimeoutError: The CLI exceeds the configured deadline.
+            RuntimeError: The CLI fails or produces no final message.
+        """
+        if any(kwargs.values()):
+            raise ValueError(
+                "Codex supports text only; unsupported run options"
+            )
+        transcript = list(messages or [])
+        if task is not None:
+            transcript.append({"role": "user", "content": task})
+        if not transcript:
+            raise ValueError(
+                "Codex requires a non-empty task or messages"
+            )
+        for message in transcript:
+            if (
+                not isinstance(message, dict)
+                or message.get("role")
+                not in {"system", "developer", "user", "assistant"}
+                or not isinstance(message.get("content"), str)
+                or message.get("tool_calls")
+                or message.get("function_call")
+            ):
+                raise ValueError(
+                    "Codex accepts text messages without tool calls"
+                )
+        if not any(
+            message["content"].strip() for message in transcript
+        ):
+            raise ValueError(
+                "Codex requires non-empty message content"
+            )
+        prompt = json.dumps(
+            {
+                "system_prompt": (
+                    self.system_prompt
+                    if system_prompt is None
+                    else system_prompt
+                ),
+                "messages": transcript,
+            },
+            ensure_ascii=False,
+        )
+        with tempfile.TemporaryDirectory(
+            prefix="swarms-codex-"
+        ) as directory:
+            output = Path(directory) / "response.txt"
+            command = [
+                self.executable,
+                "exec",
+                "--ignore-user-config",
+                "--ephemeral",
+                "--skip-git-repo-check",
+                "--sandbox",
+                "read-only",
+                "--color",
+                "never",
+                "--cd",
+                directory,
+                "--output-last-message",
+                str(output),
+                "-c",
+                'web_search="disabled"',
+                "-c",
+                "features.shell_tool=false",
+                "-c",
+                "features.multi_agent=false",
+                "-c",
+                "features.apps=false",
+                "-c",
+                "features.plugins=false",
+                "-c",
+                "project_doc_max_bytes=0",
+            ]
+            if self.model_name is not None:
+                command.extend(["--model", self.model_name])
+            command.append("-")
+            with subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                cwd=directory,
+            ) as process:
+                try:
+                    _, stderr = process.communicate(
+                        "Continue this conversation, following system_prompt "
+                        "and the message roles. Return only the final answer.\n"
+                        + prompt,
+                        timeout=self.timeout,
+                    )
+                except (
+                    subprocess.TimeoutExpired,
+                    KeyboardInterrupt,
+                ) as error:
+                    # The npm launcher may have a native Codex child process.
+                    try:
+                        children = psutil.Process(
+                            process.pid
+                        ).children(recursive=True)
+                        for child in children:
+                            try:
+                                child.kill()
+                            except psutil.NoSuchProcess:
+                                pass
+                    except psutil.NoSuchProcess:
+                        pass
+                    process.kill()
+                    process.communicate()
+                    if isinstance(error, KeyboardInterrupt):
+                        raise
+                    raise TimeoutError(
+                        f"Codex exceeded codex_config.timeout={self.timeout}s"
+                    ) from error
+                if process.returncode:
+                    raise RuntimeError(
+                        f"Codex exited with status {process.returncode}. "
+                        "Check `codex login status`, model access, and CLI version.\n"
+                        + stderr.strip()[-2000:]
+                    )
+            response = (
+                output.read_text(encoding="utf-8").strip()
+                if output.is_file()
+                else ""
+            )
+            if not response:
+                raise RuntimeError(
+                    "Codex completed without a final text response"
+                )
+            return response

--- a/tests/utils/test_codex_cli.py
+++ b/tests/utils/test_codex_cli.py
@@ -1,0 +1,359 @@
+"""Offline Codex transport, Agent, YAML, and workflow integration tests."""
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import yaml
+
+from swarms import Agent, SequentialWorkflow
+from swarms.agents.context_compressor import ContextCompressor
+from swarms.agents.create_agents_from_yaml import (
+    create_agents_from_yaml,
+)
+from swarms.utils import codex_cli
+from swarms.utils.codex_cli import CodexCLI
+from swarms.utils.litellm_wrapper import LiteLLM
+
+
+@pytest.fixture
+def transport(monkeypatch):
+    state = SimpleNamespace(
+        answer="سلام",
+        returncode=0,
+        error=None,
+        missing=False,
+        calls=[],
+    )
+    monkeypatch.setattr(
+        codex_cli.shutil, "which", lambda name: "/test/codex"
+    )
+
+    def popen(command, **options):
+        process = Mock(pid=12345, returncode=state.returncode)
+
+        def communicate(prompt=None, timeout=None):
+            if prompt is None:
+                return "", ""
+            state.calls.append((command, options, prompt, timeout))
+            if state.error:
+                raise state.error
+            if not state.missing:
+                output = Path(
+                    command[
+                        command.index("--output-last-message") + 1
+                    ]
+                )
+                output.write_text(state.answer, encoding="utf-8")
+            return (
+                "progress is not the final answer",
+                "authentication required",
+            )
+
+        process.communicate.side_effect = communicate
+        context = Mock()
+        context.__enter__ = Mock(return_value=process)
+        context.__exit__ = Mock(return_value=False)
+        state.process = process
+        return context
+
+    monkeypatch.setattr(codex_cli.subprocess, "Popen", popen)
+    return state
+
+
+def agent(**kwargs):
+    return Agent(
+        llm_backend="codex",
+        model_name=None,
+        print_on=False,
+        output_type="final",
+        retry_attempts=1,
+        **kwargs,
+    )
+
+
+def payload(call):
+    return json.loads(call[2].split("\n", 1)[1])
+
+
+def test_text_transport_and_isolated_defaults(transport):
+    llm = CodexCLI(system_prompt="Answer in Persian.", timeout=12)
+    assert llm.run("سلام؛ $HOME `echo never` 🐍") == "سلام"
+    command, options, prompt, timeout = transport.calls[0]
+    assert "--model" not in command
+    assert command[-1] == "-"
+    assert "--ignore-user-config" in command
+    assert "--ephemeral" in command
+    assert command[command.index("--sandbox") + 1] == "read-only"
+    assert "features.shell_tool=false" in command
+    assert options["encoding"] == "utf-8"
+    assert not options.get("shell")
+    assert not Path(options["cwd"]).exists()
+    assert timeout == 12
+    assert "سلام" in prompt
+    assert "$HOME" not in " ".join(command)
+    assert (
+        payload(transport.calls[0])["system_prompt"]
+        == "Answer in Persian."
+    )
+
+
+def test_structured_history_and_model_selection(transport):
+    messages = [
+        {"role": "user", "content": "My name is Ada."},
+        {"role": "assistant", "content": "Hello Ada."},
+    ]
+    CodexCLI(model_name="codex-model").run(
+        task="What is my name?", messages=messages
+    )
+    command = transport.calls[0][0]
+    assert command[command.index("--model") + 1] == "codex-model"
+    sent = payload(transport.calls[0])["messages"]
+    assert sent[:2] == messages
+    assert sent[-1]["content"] == "What is my name?"
+    assert len(messages) == 2
+
+
+def test_agent_forwards_history_and_updated_instructions(transport):
+    assistant = agent(system_prompt="Initial instructions")
+    assistant.run("First question")
+    assistant.update_system_prompt("New instructions")
+    assistant.run("Second question")
+    sent = payload(transport.calls[-1])
+    assert sent["system_prompt"] == "New instructions"
+    assert [m["content"] for m in sent["messages"]] == [
+        "First question",
+        "سلام",
+        "Second question",
+    ]
+
+
+def test_yaml_and_two_agent_workflow(transport):
+    config = {
+        "agents": [
+            {
+                "agent_name": name,
+                "system_prompt": prompt,
+                "llm_backend": "codex",
+                "model_name": None,
+                "max_loops": 1,
+                "autosave": False,
+                "print_on": False,
+                "output_type": "final",
+                "codex_config": {"timeout": 15},
+            }
+            for name, prompt in [
+                ("Writer", "Write a draft"),
+                ("Reviewer", "Review it"),
+            ]
+        ]
+    }
+    agents = create_agents_from_yaml(
+        yaml_string=yaml.safe_dump(config), return_type="agents"
+    )
+    result = SequentialWorkflow(
+        agents=agents, output_type="final", autosave=False
+    ).run("Explain CSV files")
+    assert result == "سلام"
+    assert len(transport.calls) == 2
+    assert transport.calls[1][3] == 15
+    assert "سلام" in transport.calls[1][2]
+
+
+def test_compression_stays_on_codex(transport, monkeypatch):
+    completion = Mock(
+        side_effect=AssertionError("Must not call an API provider")
+    )
+    monkeypatch.setattr(
+        "swarms.agents.context_compressor.completion", completion
+    )
+    assistant = agent(system_prompt="Original instructions")
+    assert (
+        ContextCompressor()._summarize(assistant, "Remember Ada")
+        == "سلام"
+    )
+    assert "Remember Ada" in transport.calls[0][2]
+    assert (
+        "compression expert"
+        in payload(transport.calls[0])["system_prompt"]
+    )
+    assert assistant.llm.system_prompt == "Original instructions"
+    completion.assert_not_called()
+
+
+def test_existing_backend_and_custom_llm_unchanged():
+    original = Agent(print_on=False)
+    restored = Agent(
+        llm_backend=original.llm_backend,
+        codex_config=original.codex_config,
+        print_on=False,
+    )
+    assert isinstance(restored.llm, LiteLLM)
+    fake = Mock()
+    assert Agent(llm=fake, print_on=False).llm is fake
+
+
+@pytest.mark.parametrize(
+    "timeout", [0, -1, float("inf"), float("nan"), True, "10"]
+)
+def test_invalid_timeout(timeout, transport):
+    with pytest.raises(ValueError, match="timeout"):
+        agent(codex_config={"timeout": timeout})
+    assert not transport.calls
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"llm_backend": "unknown"},
+        {"codex_config": {}},
+        {"llm_backend": "codex", "codex_config": []},
+        {"llm_backend": "codex", "llm": Mock()},
+    ],
+)
+def test_invalid_backend_configuration(config, transport):
+    with pytest.raises(ValueError):
+        Agent(**config)
+
+
+def test_unknown_codex_option(transport):
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        agent(codex_config={"timeuot": 10})
+
+
+@pytest.mark.parametrize(
+    "option,value",
+    [
+        ("tools", [lambda: None]),
+        ("tools_list_dictionary", [{"type": "function"}]),
+        ("mcp_url", "https://example.invalid/mcp"),
+        ("stream", True),
+        ("streaming_on", True),
+        ("multi_modal", True),
+        ("max_loops", "auto"),
+        ("handoffs", ["other-agent"]),
+        ("think_tool", True),
+        ("llm_args", {"tools": []}),
+        ("llm_base_url", "https://example.invalid"),
+    ],
+)
+def test_unsupported_agent_options(option, value, transport):
+    with pytest.raises(ValueError, match="unsupported options"):
+        agent(**{option: value})
+    assert not transport.calls
+
+
+def test_runtime_streaming_toggle_rejected(transport):
+    assistant = agent()
+    assistant.stream = True
+    with pytest.raises(ValueError, match="unsupported options"):
+        assistant.call_llm("hello")
+    assert not transport.calls
+
+
+def test_codex_capabilities_do_not_use_litellm_catalog(
+    transport, monkeypatch
+):
+    capability_lookup = Mock(
+        side_effect=AssertionError("Not a LiteLLM model")
+    )
+    monkeypatch.setattr(
+        "swarms.agents.llm_manager.supports_function_calling",
+        capability_lookup,
+    )
+    assistant = agent()
+    assert assistant.run("Hello") == "سلام"
+    capability_lookup.assert_not_called()
+    with pytest.raises(ValueError, match="images"):
+        assistant.check_model_supports_utilities(img="picture.png")
+    with pytest.raises(ValueError, match="streaming callbacks"):
+        assistant.call_llm(
+            "Hello", streaming_callback=lambda text: None
+        )
+
+
+def test_codex_model_rotation_stays_on_backend(transport):
+    assistant = agent(fallback_models=["codex-a", "codex-b"])
+    assert assistant.llm.model_name == "codex-a"
+    assert assistant.switch_to_next_model()
+    assert isinstance(assistant.llm, CodexCLI)
+    assert assistant.llm.model_name == "codex-b"
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        {},
+        {"task": " "},
+        {"task": "hi", "img": "picture.png"},
+        {"task": "hi", "stream": True},
+        {"messages": [{"role": "tool", "content": "result"}]},
+        {
+            "messages": [
+                {"role": "user", "content": [{"type": "image_url"}]}
+            ]
+        },
+        {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{}],
+                }
+            ]
+        },
+    ],
+)
+def test_unsupported_input(inputs, transport):
+    with pytest.raises(ValueError):
+        CodexCLI().run(**inputs)
+    assert not transport.calls
+
+
+def test_missing_cli(monkeypatch):
+    monkeypatch.setattr(codex_cli.shutil, "which", lambda name: None)
+    with pytest.raises(FileNotFoundError, match="codex login"):
+        agent()
+
+
+@pytest.mark.parametrize(
+    "missing,answer", [(True, "unused"), (False, "  ")]
+)
+def test_empty_response(missing, answer, transport):
+    transport.missing, transport.answer = missing, answer
+    with pytest.raises(RuntimeError, match="without a final"):
+        CodexCLI().run("Hello")
+    assert not Path(transport.calls[0][1]["cwd"]).exists()
+
+
+def test_cli_auth_failure(transport):
+    transport.returncode = 1
+    with pytest.raises(RuntimeError, match="codex login status"):
+        CodexCLI().run("Hello")
+    assert not Path(transport.calls[0][1]["cwd"]).exists()
+
+
+@pytest.mark.parametrize("interrupted", [False, True])
+def test_timeout_and_cancellation_cleanup(
+    transport, monkeypatch, interrupted
+):
+    transport.error = (
+        KeyboardInterrupt()
+        if interrupted
+        else subprocess.TimeoutExpired("codex", 1)
+    )
+    child = Mock()
+    parent = Mock()
+    parent.children.return_value = [child]
+    monkeypatch.setattr(
+        codex_cli.psutil, "Process", lambda pid: parent
+    )
+    expected = KeyboardInterrupt if interrupted else TimeoutError
+    with pytest.raises(expected):
+        CodexCLI(timeout=1).run("Hello")
+    child.kill.assert_called_once()
+    transport.process.kill.assert_called_once()
+    assert not Path(transport.calls[0][1]["cwd"]).exists()


### PR DESCRIPTION
Swarms users with an existing local Codex login currently need to write their own LLM adapter. This adds `llm_backend="codex"` to `Agent` and the existing YAML configuration path so bounded text agents and workflows can use the official Codex CLI.

Closes #2222.

```python
agent = Agent(
    llm_backend="codex",
    model_name=None,  # Codex CLI default; an explicit model also works.
    codex_config={"timeout": 180},
    max_loops=1,
)
```

The backend forwards system instructions and message history, reads the final-message output, and handles missing CLI/authentication, empty responses, timeouts, and cancellation. Each invocation uses a temporary working directory and an ephemeral, read-only Codex session with user configuration, shell tools, web search, apps, plugins, and Codex delegation disabled. Login credentials remain managed by Codex. Memory compression stays on the selected backend instead of calling LiteLLM separately.

This first version rejects Swarms tools/MCP, images, streaming, and autonomous loops. Provider sampling parameters and Codex usage reporting are not mapped yet; the setup guide documents these limits. Includes Python/YAML documentation and an example notebook.

**Dependencies:** none added. Subprocess cleanup uses the existing `psutil` dependency. Codex CLI 0.147.0+ must be installed separately; offline tests do not require it or any credentials.

**Validation**

- All 44 new offline tests pass on Python 3.10.20 and 3.13.15.
- A real Writer → Reviewer `SequentialWorkflow` completed on macOS through Codex CLI 0.147.0 using an existing local login.
- Every notebook code cell executed with an offline backend; notebook cells were formatted and syntax-checked.
- `ruff check .`, `black . --check`, and `git diff --check` pass. Black skips notebooks without its optional Jupyter dependency; their code cells were formatted separately with Black.

**Existing test failures reproduced before this change**

- `pytest tests/ --maxfail=1 -q`: 74 passed, then `TestAgentErrorHierarchy::test_importable_from_schemas_and_structs_agent_same_object[AgentError]` fails because `swarms.structs.agent` does not export `AgentError`. The same failure occurs on the unmodified base (`90897d9`).
- The new Codex tests plus the LLM manager/context-compressor suites produce 138 passed and one existing failure: `TestAgentWrapperDelegation::test_call_llm_delegates` expects a call without `imgs=None`, while the existing wrapper passes that argument. Reproduced on the unchanged implementation as well.

These unrelated failures are left unchanged. The full repository suite is therefore not claimed to be green.

@kyegomez, this implements the CLI-based option proposed in #2222. Feedback on the configuration surface is welcome.
