### PR TITLE
[FEAT][update_file_tool][Refuse a whole-file replace of a file this run has not read]

### DIFF
--- a/swarms/agents/autonomous_loop.py
+++ b/swarms/agents/autonomous_loop.py
@@ -260,6 +260,7 @@ class AutonomousAgentLoop:
             self.agent.subtask_status = {}
             self.agent.plan_created = False
             self.agent.think_call_count = 0
+            self.agent._read_paths = {}
 
             self._say_user(task)
 

--- a/swarms/structs/autonomous_loop_utils.py
+++ b/swarms/structs/autonomous_loop_utils.py
@@ -371,7 +371,7 @@ def get_autonomous_planning_tools() -> List[Dict[str, Any]]:
             "type": "function",
             "function": {
                 "name": "update_file",
-                "description": "Update an existing file with new content. You can replace the entire file or append to it.",
+                "description": "Update an existing file with new content. You can replace the entire file or append to it. A 'replace' is refused unless you have already read the file in this run, so call read_file first.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -695,6 +695,66 @@ def respond_to_user_tool(
     return f"Message sent to user: {message}"
 
 
+def _record_read(agent: Any, full_path: str) -> None:
+    """
+    Record that the agent has seen the current contents of a path.
+
+    Args:
+        agent: The agent instance
+        full_path: Absolute path whose contents the agent now holds
+
+    Returns:
+        None
+    """
+    reads = getattr(agent, "_read_paths", None)
+    if not isinstance(reads, dict):
+        reads = {}
+        agent._read_paths = reads
+
+    try:
+        reads[os.path.realpath(full_path)] = os.path.getmtime(
+            full_path
+        )
+    except OSError:
+        pass
+
+
+def _read_before_write_error(agent: Any, full_path: str) -> Any:
+    """
+    Check the read-before-write invariant for a whole-file replace.
+
+    Args:
+        agent: The agent instance
+        full_path: Absolute path about to be replaced
+
+    Returns:
+        An actionable error message, or None when the replace may proceed.
+    """
+    key = os.path.realpath(full_path)
+    reads = getattr(agent, "_read_paths", None)
+    if not isinstance(reads, dict) or key not in reads:
+        return (
+            f"Error: {full_path} has not been read in this run, so "
+            "replacing it would overwrite contents you have not seen. "
+            "Call read_file on it first, or use mode='append' to add to "
+            "it without replacing what is there."
+        )
+
+    try:
+        current_mtime = os.path.getmtime(full_path)
+    except OSError:
+        return None
+
+    if current_mtime != reads[key]:
+        return (
+            f"Error: {full_path} changed on disk after you read it, so "
+            "replacing it would discard that change. Call read_file on "
+            "it again before replacing it."
+        )
+
+    return None
+
+
 def create_file_tool(
     agent: Any, file_path: str, content: str, **kwargs
 ) -> str:
@@ -735,6 +795,8 @@ def create_file_tool(
             content=f"Created file: {full_path}",
         )
 
+        _record_read(agent, full_path)
+
         if agent.verbose:
             logger.info(f"Created file: {full_path}")
 
@@ -768,6 +830,12 @@ def update_file_tool(
 
     Returns:
         str: Success message or error message
+
+    Notes:
+        A 'replace' is refused unless the agent read the file earlier in this
+        run and the file has not changed since, because replacing a file the
+        model has not seen destroys whatever it was guessing at. 'append' and
+        create_file are exempt.
     """
     try:
         # Resolve path - if relative, use agent workspace
@@ -780,6 +848,15 @@ def update_file_tool(
         # Check if file exists
         if not os.path.exists(full_path):
             return f"Error: File does not exist at {full_path}. Use create_file to create new files."
+
+        if mode != "append":
+            refusal = _read_before_write_error(agent, full_path)
+            if refusal is not None:
+                agent.short_memory.add(
+                    role="File Operations",
+                    content=refusal,
+                )
+                return refusal
 
         # Update file based on mode
         if mode == "append":
@@ -796,6 +873,8 @@ def update_file_tool(
             role="File Operations",
             content=f"{action.capitalize()} file: {full_path}",
         )
+
+        _record_read(agent, full_path)
 
         if agent.verbose:
             logger.info(f"{action.capitalize()} file: {full_path}")
@@ -822,6 +901,10 @@ def read_file_tool(agent: Any, file_path: str, **kwargs) -> str:
 
     Returns:
         str: File contents or error message
+
+    Notes:
+        A successful read satisfies the read-before-write invariant that
+        update_file's 'replace' mode enforces.
     """
     try:
         # Resolve path - if relative, use agent workspace
@@ -849,6 +932,8 @@ def read_file_tool(agent: Any, file_path: str, **kwargs) -> str:
             role="File Operations",
             content=f"Read file: {full_path} ({len(raw)} characters)",
         )
+
+        _record_read(agent, full_path)
 
         if agent.verbose:
             logger.info(f"Read file: {full_path}")

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -21,6 +21,8 @@ Covers four fixed defects:
 * #1962 — ``ContextCompressor.maybe_compress`` was never called on the
   ``max_loops="auto"`` path, so history grew unbounded in exactly the mode
   that needs compression most.
+* #1982 — ``update_file(mode="replace")`` overwrote files the model had never
+  read, so a guess at the contents silently replaced the real ones.
 
 Run:
     cd /Users/swarms_wd/Desktop/research/swarms
@@ -36,10 +38,12 @@ from swarms import Agent
 from swarms.agents.autonomous_loop import AutonomousAgentLoop
 from swarms.structs.autonomous_loop_utils import (
     MAX_SUBTASK_LOOPS,
+    create_file_tool,
     get_autonomous_planning_tools,
     glob_tool,
     TOOL_OUTPUT_CONTEXT_SHARE,
     read_file_tool,
+    update_file_tool,
 )
 from swarms.utils.litellm_tokenizer import count_tokens
 
@@ -1244,3 +1248,187 @@ class TestGlobTool:
             "pattern",
             "path",
         }
+
+
+class TestReadBeforeWrite:
+    """
+    Whole-file replace is the only edit mode, so an unread replace turns a
+    model's guess at the contents into the contents.
+    """
+
+    def _file(self, tmp_path, text="original\n"):
+        target = tmp_path / "notes.txt"
+        target.write_text(text)
+        return target
+
+    def test_replacing_an_unread_file_is_refused(self, tmp_path):
+        agent = build_agent()
+        target = self._file(tmp_path)
+
+        output = update_file_tool(agent, str(target), "guessed")
+
+        assert "has not been read" in output
+        assert target.read_text() == "original\n"
+
+    def test_reading_first_allows_the_replace(self, tmp_path):
+        agent = build_agent()
+        target = self._file(tmp_path)
+
+        read_file_tool(agent, str(target))
+        output = update_file_tool(agent, str(target), "rewritten")
+
+        assert "Successfully updated" in output
+        assert target.read_text() == "rewritten"
+
+    def test_a_change_on_disk_after_the_read_is_refused(
+        self, tmp_path
+    ):
+        agent = build_agent()
+        target = self._file(tmp_path)
+
+        read_file_tool(agent, str(target))
+        target.write_text("someone else got here first\n")
+        os.utime(target, (9_000, 9_000))
+        output = update_file_tool(agent, str(target), "rewritten")
+
+        assert "changed on disk" in output
+        assert target.read_text() == "someone else got here first\n"
+
+    def test_append_does_not_need_a_read(self, tmp_path):
+        agent = build_agent()
+        target = self._file(tmp_path)
+
+        output = update_file_tool(
+            agent, str(target), "more\n", mode="append"
+        )
+
+        assert "Successfully appended" in output
+        assert target.read_text() == "original\nmore\n"
+
+    def test_a_file_this_run_created_may_be_replaced(self, tmp_path):
+        agent = build_agent()
+        target = tmp_path / "fresh.txt"
+
+        create_file_tool(agent, str(target), "first")
+        output = update_file_tool(agent, str(target), "second")
+
+        assert "Successfully updated" in output
+        assert target.read_text() == "second"
+
+    def test_two_replaces_in_a_row_are_allowed(self, tmp_path):
+        agent = build_agent()
+        target = self._file(tmp_path)
+
+        read_file_tool(agent, str(target))
+        update_file_tool(agent, str(target), "first")
+        output = update_file_tool(agent, str(target), "second")
+
+        assert "Successfully updated" in output
+        assert target.read_text() == "second"
+
+    def test_the_refusal_reaches_the_model(self, tmp_path):
+        agent = build_agent()
+        target = self._file(tmp_path)
+
+        update_file_tool(agent, str(target), "guessed")
+
+        assert "has not been read" in history(agent)
+
+    def test_one_agent_read_does_not_license_another(self, tmp_path):
+        reader = build_agent()
+        writer = build_agent()
+        target = self._file(tmp_path)
+
+        read_file_tool(reader, str(target))
+        output = update_file_tool(writer, str(target), "guessed")
+
+        assert "has not been read" in output
+
+    def _run_that(self, agent, monkeypatch, *calls):
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                plan(("step1", [])),
+                list(calls)
+                + [
+                    tool_call(
+                        "complete_task",
+                        task_id="main",
+                        summary="done",
+                        success=True,
+                    )
+                ],
+            ],
+        )
+        agent.run("test task")
+
+    def test_a_blind_replace_inside_a_run_leaves_the_file_alone(
+        self, monkeypatch, tmp_path
+    ):
+        agent = build_agent()
+        target = self._file(tmp_path)
+
+        self._run_that(
+            agent,
+            monkeypatch,
+            tool_call(
+                "update_file",
+                file_path=str(target),
+                content="guessed",
+            ),
+        )
+
+        assert target.read_text() == "original\n"
+        assert "has not been read" in history(agent)
+
+    def test_a_read_then_replace_inside_one_run_writes(
+        self, monkeypatch, tmp_path
+    ):
+        agent = build_agent()
+        target = self._file(tmp_path)
+
+        self._run_that(
+            agent,
+            monkeypatch,
+            tool_call("read_file", file_path=str(target)),
+            tool_call(
+                "update_file",
+                file_path=str(target),
+                content="rewritten",
+            ),
+        )
+
+        assert target.read_text() == "rewritten"
+
+    def test_a_new_run_forgets_the_previous_run_reads(
+        self, monkeypatch, tmp_path
+    ):
+        agent = build_agent()
+        target = self._file(tmp_path)
+
+        self._run_that(
+            agent,
+            monkeypatch,
+            tool_call("read_file", file_path=str(target)),
+        )
+        self._run_that(
+            agent,
+            monkeypatch,
+            tool_call(
+                "update_file",
+                file_path=str(target),
+                content="guessed",
+            ),
+        )
+
+        assert target.read_text() == "original\n"
+
+    def test_the_schema_tells_the_model_to_read_first(self):
+        update_schema = next(
+            tool["function"]
+            for tool in get_autonomous_planning_tools()
+            if tool["function"]["name"] == "update_file"
+        )
+
+        assert "read_file" in update_schema["description"]


### PR DESCRIPTION
Closes #1982.

`update_file(mode="replace")` now refuses a path the agent has not read in the current run. **Whole-file replace is the only edit mode the autonomous loop has**, so before this the model's guess at a file's contents *became* the contents, with a success message on top.

## Problem

`swarms/structs/autonomous_loop_utils.py`, `update_file_tool` — the only precondition is existence:

```python
if not os.path.exists(full_path):
    return f"Error: File does not exist at {full_path}. Use create_file to create new files."
```

and then, for the default mode:

```python
with open(full_path, "w", encoding="utf-8") as f:
    f.write(content)
```

Reproducer on clean `master` @ `90897d9`. A model asked to change a timeout emits the file as it imagines it, and the line it never saw is gone:

```
before      : 'API_KEY = load_from_vault()\nTIMEOUT = 30\n'
tool result : Successfully updated file: /tmp/.../config.py
after       : 'TIMEOUT = 30\n'
```

Nothing in the loop, the tool, or the schema asks the model to look first.

## Fix

| Site | Change |
|---|---|
| `_record_read` | **new** — stores `os.path.realpath(path) -> mtime` on `agent._read_paths` |
| `_read_before_write_error` | **new** — returns the refusal a replace should fail with, or `None` |
| `read_file_tool` | records the read on success |
| `create_file_tool` | records the file it just wrote |
| `update_file_tool` | `mode="replace"` consults the invariant before opening the file; records on success so a second replace is allowed |
| `update_file` schema | description tells the model to call `read_file` first |
| `AutonomousAgentLoop.run` | clears `agent._read_paths` with the rest of the per-run state |

Same reproducer on this branch:

```
before      : 'API_KEY = load_from_vault()\nTIMEOUT = 30\n'
tool result : Error: /tmp/.../config.py has not been read in this run, so replacing it would overwrite contents you have not seen
after       : 'API_KEY = load_from_vault()\nTIMEOUT = 30\n'
```

## Design decisions

- **The refusal goes into `short_memory`, not just the return value.** A model that only sees a string may retry the identical blind write. Writing it to the conversation puts the reason in front of the next turn, the way #1963 put tool errors there. The error names the two ways forward — `read_file`, or `mode="append"` — rather than only saying no.
- **mtime as well as membership.** A read that happened before a concurrent process touched the file is not a read of what is on disk now. Recording the mtime at read time and comparing it at write time catches that for free. If `getmtime` raises at write time the check passes rather than inventing a failure — the write itself will produce the real error.
- **`realpath`, not the string.** `notes.txt` and `./notes.txt` resolve to one key, so reading a file by one spelling and replacing it by another is allowed; a symlink and its target are also one key, which is the conservative direction.
- **`create_file` registers the path.** It is exempt from the *check*, per the issue, but a file the agent authored seconds ago is a file it has seen, and create-then-replace is an ordinary sequence. Not registering it would refuse a write the invariant has no reason to refuse.
- **A successful replace re-records.** Otherwise the second of two consecutive replaces would fail on its own predecessor's mtime.
- **Per run, not per agent.** Cleared in `AutonomousAgentLoop.run` next to `autonomous_subtasks` and `plan_created`. A read in a previous run is not knowledge of the file now. There is a test that fails if that line is removed.
- **`getattr` with a default everywhere.** `update_file_tool` is a plain module function and is callable outside the loop; nothing requires `Agent.__init__` to grow a field.
- **`delete_file` is untouched.** Deleting a file you have not read is a different question and belongs in its own change.

## Behavior-change note

A `max_loops="auto"` agent that today replaces a file without reading it will now get an error instead of a write. That is the point, but it is a real behavior change for any prompt that relied on blind overwrites. The two escapes are in the error text itself: read the file, or append. `create_file` and `mode="append"` are unaffected, and nothing outside the autonomous loop's file tools changes.

Known limit, not addressed here: `read_file_tool` truncates its output to a share of the context window, so a read of a very large file satisfies the invariant while the model has only seen part of it. Narrowing that depends on the windowed reads in #1981, and is that issue's to fix.

## Verification

**Unit**: 12 new tests in the existing `tests/agents/test_autonomous_loop.py` — no new file — added as `TestReadBeforeWrite`. Direct-call cases: an unread replace is refused and the file is untouched; a read first allows it; a change on disk after the read is refused; append needs no read; a file this run created may be replaced; two replaces in a row are allowed; the refusal reaches the conversation; one agent's read does not license another's write; the schema mentions `read_file`. End-to-end cases drive `agent.run()` with a scripted LLM: a blind replace inside a run leaves the file alone, a read-then-replace inside one run writes, and a read in one run does not license a replace in the next.

```
tests/agents/test_autonomous_loop.py .............................................................
61 passed
```

The per-run reset is load-bearing, not decorative — deleting the one line in `AutonomousAgentLoop.run` fails `test_a_new_run_forgets_the_previous_run_reads`:

```
FAILED tests/agents/test_autonomous_loop.py::TestReadBeforeWrite::test_a_new_run_forgets_the_previous_run_reads
E         + guessed
```

**Wider suite**: `tests/agents tests/structs/test_agent.py` → **425 passed, 8 failed**. All 8 fail identically on clean `upstream/master` in a separate worktree (413 passed, same 8): the two `test_agent_marketplace_handler.py::TestAgentErrorHierarchy` parametrisations, `test_llm_manager.py::TestAgentWrapperDelegation::test_call_llm_delegates`, and the five `test_agent.py::TestAgentUsage` cases. None are touched by this change.

**Not verified here**: no live model run. Every test is offline — real `Agent`, real `AutonomousAgentLoop`, real tool dispatch, with `Agent.call_llm` scripted, which is the pattern the rest of this file already uses.

**Lint**: `ruff check` reports the same 97 pre-existing errors on the three touched files as it does on clean `master`; this adds none. `black --line-length 70` clean on both source files. The one blank-line difference black reports in `tests/agents/test_autonomous_loop.py` is pre-existing and was left alone rather than pulled into this diff.
