### PR TITLE
[FIX][SequentialWorkflow.run_concurrent][Run each task on its own clone instead of the shared AgentRearrange]

### DIFF
--- a/swarms/structs/sequential_workflow.py
+++ b/swarms/structs/sequential_workflow.py
@@ -540,7 +540,10 @@ class SequentialWorkflow:
                 max_workers=os.cpu_count()
             ) as executor:
                 results = [
-                    executor.submit(self.agent_rearrange.run, task)
+                    executor.submit(
+                        self.agent_rearrange._clone_for_task().run,
+                        task,
+                    )
                     for task in tasks
                 ]
                 return [


### PR DESCRIPTION
Refs #2041, the `SequentialWorkflow.run_concurrent` row of its table.

## What is wrong

`run_concurrent` submits `self.agent_rearrange.run` once per task. `AgentRearrange._run` begins by resetting `self.conversation` and then appends every agent's turn to it, so N threads on one instance reassign and write into one transcript: a later task's reset drops an earlier task's turns mid-run, and each result is `history_output_formatter` over whatever mixture is in the shared object when that thread finishes. Agents also read their context from that same conversation, so they are served other tasks' turns.

## Fix

Submit `self.agent_rearrange._clone_for_task().run` instead. `run_batched`, two methods above in the same class, already does exactly this for the same reason; the concurrent path was the one caller left on the shared instance. One file, one call site.

## Verify

`black -l 70 --check` clean. No new test: the existing `test_sequential_workflow_concurrent_execution` covers the call path, and a test that proves absence of interleaving would need real agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)