### PR TITLE
[FIX][MixtureOfAgents.run_concurrently][Run each task on its own clone instead of the shared instance]

### DIFF
--- a/swarms/structs/mixture_of_agents.py
+++ b/swarms/structs/mixture_of_agents.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any, Dict, List, Optional
 
 from swarms.prompts.ag_prompt import AGGREGATOR_SYSTEM_PROMPT_MAIN
@@ -320,8 +321,23 @@ class MixtureOfAgents:
         """
         return batched_run(self.run, tasks)
 
+    def _clone_for_task(self) -> "MixtureOfAgents":
+        """Build a copy of this mixture with its own ``Conversation``.
+
+        ``_run`` resets and appends to ``self.conversation``, so one
+        instance cannot serve several threads. The copy shares the agents,
+        as the instance already did, and only the transcript is isolated.
+        """
+        clone = copy.copy(self)
+        clone._reset_conversation()
+        return clone
+
     def run_concurrently(self, tasks: List[str]) -> List[str]:
-        """Run multiple tasks concurrently through this mixture.
+        """Run multiple tasks concurrently, each on its own clone.
+
+        ``_run`` resets and appends to ``self.conversation``, so running
+        the same instance from several threads interleaves the tasks into
+        one transcript. Each task therefore runs on ``_clone_for_task()``.
 
         Args:
             tasks: Tasks to submit to the mixture in parallel.
@@ -330,4 +346,6 @@ class MixtureOfAgents:
             A list of formatted responses, one per task, in the order the
             tasks were given.
         """
-        return run_concurrently(self.run, tasks)
+        return run_concurrently(
+            lambda task: self._clone_for_task().run(task), tasks
+        )


### PR DESCRIPTION
Refs #2041, the `MixtureOfAgents.run_concurrently` row of its table.

## What is wrong

`run_concurrently` fans `self.run` across a thread pool. `_run` starts with `self._reset_conversation()` and then adds the task, every layer's worker outputs and the aggregator's answer to `self.conversation`. With several threads on one instance, each reset replaces the conversation the other threads are still writing to, `messages_for(self.aggregator_agent...)` reads a transcript mixing several tasks, and each returned `history_output_formatter` carries other tasks' turns.

## Fix

`_clone_for_task()` returns a shallow copy of the mixture with its own fresh `Conversation`, and `run_concurrently` runs each task on one. The agents are shared by the copy exactly as the single instance already shared them across threads, so the diff isolates the transcript, which is the state `_run` writes to. A deep copy of the agents is not attempted: `copy.deepcopy(Agent)` raises `TypeError: cannot pickle '_thread.lock' object` today, so the try/except fallback `AgentRearrange._clone_for_task` carries would always take the fallback here.

## Verify

`black -l 70 --check` clean. Constructing a mixture and calling `_clone_for_task()` yields a copy whose `conversation` is a different object and whose agents are the same objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)