### PR TITLE
[FIX][Agent._generate_final_summary][Shape the complete_task path by output_type like the other two]

### DIFF
--- a/swarms/structs/agent.py
+++ b/swarms/structs/agent.py
@@ -2161,7 +2161,7 @@ class Agent:
         self,
         streaming_callback: Optional[Callable[[str], None]] = None,
         messages: Optional[List[dict]] = None,
-    ) -> str:
+    ) -> Any:
         """
         Generate a comprehensive final summary of the autonomous task execution.
 
@@ -2173,7 +2173,7 @@ class Agent:
                 flattened string rendering of it.
 
         Returns:
-            str: Comprehensive summary
+            Any: The conversation shaped by ``output_type``, on every path.
         """
         summary_prompt = get_summary_prompt()
         self.short_memory.add(
@@ -2237,7 +2237,9 @@ class Agent:
                                 title="Task Completion Summary",
                             )
 
-                        return result
+                        return history_output_formatter(
+                            self.short_memory, type=self.output_type
+                        )
 
             # If complete_task wasn't called, generate summary manually
             comprehensive_summary = f"""Task Execution Summary

--- a/tests/agents/test_autonomous_loop.py
+++ b/tests/agents/test_autonomous_loop.py
@@ -1244,3 +1244,39 @@ class TestGlobTool:
             "pattern",
             "path",
         }
+
+
+class TestFinalSummaryShape:
+    """The complete_task path returns the same shape as the other paths."""
+
+    def test_complete_task_result_follows_output_type(
+        self, monkeypatch
+    ):
+        agent = build_agent(output_type="list")
+        script_llm(
+            agent,
+            monkeypatch,
+            [
+                plan(("step1", [])),
+                [
+                    tool_call(
+                        "subtask_done",
+                        task_id="step1",
+                        summary="done",
+                        success=True,
+                    )
+                ],
+                [
+                    tool_call(
+                        "complete_task",
+                        task_id="main",
+                        summary="all done",
+                        success=True,
+                    )
+                ],
+            ],
+        )
+
+        result = agent.run("test task")
+
+        assert isinstance(result, list)


### PR DESCRIPTION
Closes #1972

`_generate_final_summary` has three exits. The manual summary path and the exception path both return `history_output_formatter(self.short_memory, type=self.output_type)`. The `complete_task` path, which is the one that fires on a normal successful run, returned the raw string from `_complete_task_tool`. So `agent.run()` in `max_loops="auto"` mode came back as a `str` or as whatever `output_type` asked for depending on whether the model happened to call the tool.

The tool result is already appended to `short_memory` on that path, so returning the formatted history hands the caller the same information in the shape they configured, and all three exits now agree. The return annotation moves from `str` to `Any` to match what the other two exits were already returning.

One test in the existing autonomous loop test file: an agent with `output_type="list"` whose scripted model calls `complete_task` gets a list back. Fails on master.


#2103 opened a draft for this on 2026-08-30. It has been conflicting with master and untouched since, so this is a fresh, mergeable take on the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)