### PR TITLE
[FEAT][SelfMoASeq][Add OpenTelemetry init and run spans]

### DIFF
--- a/swarms/structs/self_moa_seq.py
+++ b/swarms/structs/self_moa_seq.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 from swarms.structs.serialization import SerializableMixin
 from swarms.structs.agent import Agent
+from swarms.telemetry.otel import capture_init, trace_run
 
 
 class SelfMoASeq(SerializableMixin):
@@ -113,6 +114,7 @@ class SelfMoASeq(SerializableMixin):
         }
 
         self._log("info", "Self-MoA-Seq initialization complete")
+        capture_init(self)
 
     def setup(self) -> None:
         """
@@ -263,6 +265,7 @@ class SelfMoASeq(SerializableMixin):
             )
             raise
 
+    @trace_run("SelfMoASeq.run")
     def run(
         self,
         task: str,

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -684,6 +684,7 @@ def _load_arch_classes():
         MixtureOfAgents,
         MultiAgentRouter,
         RoundRobinSwarm,
+        SelfMoASeq,
         SequentialWorkflow,
         SwarmRouter,
     )
@@ -713,6 +714,7 @@ def _load_arch_classes():
         "PlannerWorkerSwarm": PlannerWorkerSwarm,
         "BatchedGridWorkflow": BatchedGridWorkflow,
         "LLMCouncil": LLMCouncil,
+        "SelfMoASeq": SelfMoASeq,
     }
 
 


### PR DESCRIPTION
Closes #1776

`SelfMoASeq` is public API and extends `SerializableMixin`, not a swarm base class, so it inherited no instrumentation and imported nothing from `swarms.telemetry.otel`. One `run()` fans out into `num_samples` proposer calls plus an aggregation pass per window, and nothing tied those calls together or attributed their latency to the run.

Changes, following the pattern in `swarm_router.py`:

- `capture_init(self)` as the last line of `__init__`.
- `@trace_run("SelfMoASeq.run")` on `run()`.

No executor in this file, so there is no context-propagation change.

`SelfMoASeq` is added to the `ARCH` registry in `tests/telemetry/test_telemetry.py`, so the two existing coverage checks (run is traced, init calls `capture_init`) now cover it. Both fail on master. `tests/structs/test_self_moa_seq.py` has 8 failures on master unrelated to this change; the count is the same on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
