### PR TITLE
[FEAT][SpreadSheetSwarm][Add OpenTelemetry init and run spans]

### DIFF
--- a/swarms/structs/spreadsheet_swarm.py
+++ b/swarms/structs/spreadsheet_swarm.py
@@ -10,6 +10,7 @@ from swarms.structs.multi_agent_exec import (
 )
 from swarms.structs.omni_agent_types import AgentType
 from swarms.utils.workspace_manager import WorkspaceManager
+from swarms.telemetry.otel import capture_init, trace_run
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.workspace_utils import get_workspace_dir
 
@@ -95,6 +96,8 @@ class SpreadSheetSwarm:
         self.agent_tasks = {}  # Simple dict to store agent tasks
 
         self.reliability_check()
+
+        capture_init(self)
 
     def reliability_check(self):
         """
@@ -188,6 +191,7 @@ class SpreadSheetSwarm:
     def load_from_csv(self):
         self._load_from_csv()
 
+    @trace_run("SpreadSheetSwarm.run_from_config", input_params=())
     def run_from_config(self):
         """
         Run all agents with their configured tasks concurrently
@@ -279,6 +283,7 @@ class SpreadSheetSwarm:
                 "outputs": self.outputs,
             }
 
+    @trace_run("SpreadSheetSwarm.run")
     def run(self, task: str = None, *args, **kwargs):
         """
         Run the swarm with the specified task.

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -687,6 +687,7 @@ def _load_arch_classes():
         RoundRobinSwarm,
         SelfMoASeq,
         SequentialWorkflow,
+        SpreadSheetSwarm,
         SwarmRouter,
     )
     from swarms.structs.batched_grid_workflow import (
@@ -717,6 +718,7 @@ def _load_arch_classes():
         "BatchedGridWorkflow": BatchedGridWorkflow,
         "LLMCouncil": LLMCouncil,
         "SelfMoASeq": SelfMoASeq,
+        "SpreadSheetSwarm": SpreadSheetSwarm,
     }
 
 


### PR DESCRIPTION
Closes #1775

`SpreadSheetSwarm` is public API and imported nothing from `swarms.telemetry.otel`, so a run produced no swarm-level span.

Worth stating so the scope is clear: agent execution is delegated to `run_agents_with_different_tasks`, which already uses `ContextThreadPoolExecutor`, so context propagation across threads was never broken here. The agent spans existed. What was missing is the parent, so a run appeared as a flat set of agent spans with nothing describing the run they belong to.

Changes, following the pattern in `swarm_router.py` and the two that merged yesterday for `ModelRouter` and `SelfMoASeq`:

- `capture_init(self)` as the last line of `__init__`.
- `@trace_run("SpreadSheetSwarm.run")` on `run()`.
- `@trace_run("SpreadSheetSwarm.run_from_config", input_params=())` on `run_from_config()`, the second public entry point the issue asks to consider. It takes no task, hence the empty `input_params`. When the swarm was built from a config, `run()` reaches it through `_run`, so that call nests inside the run span; a direct call now gets its own span instead of none.

No executor change.

`SpreadSheetSwarm` joins the `ARCH` registry in `tests/telemetry/test_telemetry.py`, so the two existing coverage checks (run is traced, init calls `capture_init`) now cover it. Both fail on master. The telemetry file has 7 failures on master unrelated to this change; the count and the set are identical on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
