### PR TITLE
[FEAT][AutoSwarmBuilder][Trace the build phase so it shares one trace with the delegated run]

### DIFF
--- a/swarms/structs/auto_swarm_builder.py
+++ b/swarms/structs/auto_swarm_builder.py
@@ -12,6 +12,7 @@ from swarms.structs.agent import Agent
 from swarms.structs.conversation import Conversation
 from swarms.structs.swarm_router import SwarmRouter, SwarmType
 from swarms.utils.litellm_wrapper import LiteLLM
+from swarms.telemetry.otel import capture_init, trace_run
 
 load_dotenv()
 
@@ -307,6 +308,8 @@ class AutoSwarmBuilder:
         self.agents_pool = []
 
         self.reliability_check()
+
+        capture_init(self)
 
     def reliability_check(self):
         """Validate the AutoSwarmBuilder configuration.
@@ -796,6 +799,7 @@ class AutoSwarmBuilder:
         """
         return swarm_types
 
+    @trace_run("AutoSwarmBuilder.run")
     def run(
         self,
         task: str,

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -674,6 +674,7 @@ def _load_arch_classes():
     from swarms import (
         Agent,
         AgentRearrange,
+        AutoSwarmBuilder,
         ConcurrentWorkflow,
         CouncilAsAJudge,
         GraphWorkflow,
@@ -717,6 +718,7 @@ def _load_arch_classes():
         "BatchedGridWorkflow": BatchedGridWorkflow,
         "LLMCouncil": LLMCouncil,
         "SelfMoASeq": SelfMoASeq,
+        "AutoSwarmBuilder": AutoSwarmBuilder,
     }
 
 


### PR DESCRIPTION
Closes #1777

`AutoSwarmBuilder` is public API and imported nothing from `swarms.telemetry.otel`.

The specific gap is a split trace, not simply a missing span. Execution is delegated to `SwarmRouter`, which is instrumented, so the delegated run already produced spans. The parent was missing: the LiteLLM calls that generate the agent specifications, the build phase, were untraced, and the `SwarmRouter` spans had no builder span to attach to. One logical operation showed up as an untraced build followed by a separately rooted swarm run, which makes the question users actually ask about this class hard to answer, namely how much wall-clock went to deciding the swarm versus running it.

Changes, following the pattern in `swarm_router.py`:

- `capture_init(self)` as the last line of `__init__`.
- `@trace_run("AutoSwarmBuilder.run")` on `run()`.

`batch_run()` dispatches through `batched_run(self.run, ...)`, so each task gets its own span from the same decorator. No `ThreadPoolExecutor` in this file, so there is no executor swap.

`AutoSwarmBuilder` joins the `ARCH` registry in `tests/telemetry/test_telemetry.py`, so the two existing coverage checks now cover it. Both fail on master. The telemetry file has 7 failures on master unrelated to this change; the count and the set are identical on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
