### PR TITLE
[FEAT][SocialAlgorithms][Add OpenTelemetry init and run spans]

### DIFF
--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -9,6 +9,7 @@ from swarms.structs.conversation import Conversation
 from swarms.structs.omni_agent_types import AgentType
 from swarms.utils.loguru_logger import initialize_logger
 from swarms.utils.output_types import OutputType
+from swarms.telemetry.otel import capture_init, trace_run
 
 
 logger = initialize_logger(log_folder="social_algorithms")
@@ -120,6 +121,8 @@ class SocialAlgorithms:
             logger.info(
                 f"Initialized {self.name} with {len(self.agents)} agents"
             )
+
+        capture_init(self)
 
     def _validate_inputs(self) -> None:
         """
@@ -364,6 +367,7 @@ class SocialAlgorithms:
 
         return result
 
+    @trace_run("SocialAlgorithms.run")
     def run(
         self,
         task: str,

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -687,6 +687,7 @@ def _load_arch_classes():
         RoundRobinSwarm,
         SelfMoASeq,
         SequentialWorkflow,
+        SocialAlgorithms,
         SwarmRouter,
     )
     from swarms.structs.batched_grid_workflow import (
@@ -717,6 +718,7 @@ def _load_arch_classes():
         "BatchedGridWorkflow": BatchedGridWorkflow,
         "LLMCouncil": LLMCouncil,
         "SelfMoASeq": SelfMoASeq,
+        "SocialAlgorithms": SocialAlgorithms,
     }
 
 


### PR DESCRIPTION
Closes #1778

`SocialAlgorithms` is public API and imported nothing from `swarms.telemetry.otel`, so neither construction nor a run was traced. The class already tracks its own communication steps and returns a `SocialAlgorithmResult`, but none of that work was attributable to a run.

Changes, following the pattern in `swarm_router.py`:

- `capture_init(self)` as the last line of `__init__`.
- `@trace_run("SocialAlgorithms.run")` on `run()`.

No `ThreadPoolExecutor` in this file, so there is no executor swap.

One note on scope. The issue asks for both the sync and async paths, but `run_async` no longer exists on master, so `run()` is the only public entry point left to instrument. The issue also flags a pre-existing `SIGALRM` problem in the timeout path; that is untouched here and is being handled separately in #2109.

`SocialAlgorithms` joins the `ARCH` registry in `tests/telemetry/test_telemetry.py`, so the two existing coverage checks now cover it. Both fail on master. The telemetry file has 7 failures on master unrelated to this change; the count and the set are identical on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
