### PR TITLE
[FIX][batch_agent_execution][Track futures by index so results land in agent order]

### DIFF
--- a/swarms/structs/batch_agent_execution.py
+++ b/swarms/structs/batch_agent_execution.py
@@ -1,7 +1,7 @@
 import concurrent.futures
 import os
 import traceback
-from typing import Callable, List, Union
+from typing import Any, Callable, List, Union
 
 from loguru import logger
 
@@ -25,12 +25,14 @@ def batch_agent_execution(
     Args:
         agents (List[Agent]): List of agents to execute
         tasks (list[str]): List of tasks to execute
+        imgs (list[str]): Optional list of image paths, one per agent/task pair
 
     Returns:
-        List[str]: List of results from each agent execution
+        List[str]: List of results from each agent execution, in the same
+            order as ``agents``/``tasks`` regardless of completion order
 
     Raises:
-        ValueError: If number of agents doesn't match number of tasks
+        ValueError: If number of agents doesn't match number of tasks or imgs
     """
     try:
 
@@ -43,7 +45,14 @@ def batch_agent_execution(
                 "Number of agents must match number of tasks"
             )
 
-        results = []
+        if imgs is None:
+            imgs = [None] * len(agents)
+        elif len(imgs) != len(agents):
+            raise ValueError(
+                "Number of imgs must match number of agents"
+            )
+
+        results: List[Any] = [None] * len(agents)
 
         formatter.print_panel(
             f"Executing {len(agents)} agents on {len(tasks)} tasks using {max_workers} workers"
@@ -52,32 +61,26 @@ def batch_agent_execution(
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=max_workers
         ) as executor:
-            # Submit all tasks to the executor
-            future_to_task = {
-                executor.submit(agent.run, task, imgs): (
-                    agent,
-                    task,
-                    imgs,
+            # Submit all tasks to the executor, tracking each future's index
+            # so results land back in agents[i]/tasks[i] order regardless of
+            # completion order.
+            future_to_index = {
+                executor.submit(agent.run, task, img): index
+                for index, (agent, task, img) in enumerate(
+                    zip(agents, tasks, imgs)
                 )
-                for agent, task, imgs in zip(agents, tasks, imgs)
             }
 
-            # Collect results as they complete
             for future in concurrent.futures.as_completed(
-                future_to_task
+                future_to_index
             ):
-                agent, task = future_to_task[future]
+                index = future_to_index[future]
                 try:
-                    result = future.result()
-                    results.append(result)
+                    results[index] = future.result()
                 except Exception as e:
-                    print(
-                        f"Task failed for agent {agent.agent_name}: {str(e)}"
+                    logger.error(
+                        f"Task failed for agent {agents[index].agent_name}: {str(e)}"
                     )
-                    results.append(None)
-
-            # Wait for all futures to complete before returning
-            concurrent.futures.wait(future_to_task.keys())
 
         return results
     except Exception as e:

--- a/swarms/structs/batch_agent_execution.py
+++ b/swarms/structs/batch_agent_execution.py
@@ -1,7 +1,7 @@
 import concurrent.futures
 import os
 import traceback
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List, Optional, Union
 
 from loguru import logger
 
@@ -16,7 +16,7 @@ class BatchAgentExecutionError(Exception):
 def batch_agent_execution(
     agents: List[Union[Agent, Callable]],
     tasks: List[str] = None,
-    imgs: List[str] = None,
+    imgs: Optional[List[str]] = None,
     max_workers: int = max(1, int(os.cpu_count() * 0.9)),
 ):
     """


### PR DESCRIPTION
Type: Fix

Closes #2122

`batch_agent_execution` cannot succeed on any input today. The map built from futures used the loop's `imgs` name for the per-call image *and* rebound the outer `imgs` list, so `zip(agents, tasks, imgs)` iterates its own overwritten iterator:

- Called the documented way, `batch_agent_execution(agents, tasks)`, `imgs` is `None` and `zip(agents, tasks, None)` raises `TypeError: 'NoneType' object is not iterable` before any agent runs.
- Called with `imgs` supplied, the dict value stored per future is the 3-tuple `(agent, task, imgs)`, but `agent, task = future_to_task[future]` unpacks it into two names — `ValueError: too many values to unpack (expected 2)` on the first completed future.

Both are caught by the function's own `try` and re-raised as `BatchAgentExecutionError`, which is why it reads as a batch-execution failure rather than the two-line bug it is. Confirmed with the repro in the issue on `upstream/master` — both call shapes raise before any agent executes, and no fix currently exists on `master`.

A third defect survives fixing the crash: `results.append(result)` inside `as_completed` appends in completion order, not `agents[i]`/`tasks[i]` order, so a caller has no way to tell which result belongs to which agent once the crash is gone.

Fix: build the map from future to index instead of future to a tuple, and pre-size `results` so each slot is written by index.

- `imgs=None` defaults to `[None] * len(agents)`; a supplied `imgs` of the wrong length raises `ValueError` up front, matching the existing `tasks` length check.
- `results[index] = future.result()` puts each answer back in `agents[i]`/`tasks[i]` order regardless of which thread finishes first.
- An agent that raises leaves `None` in its own slot (unchanged behavior) and logs through `loguru`, replacing the bare `print` the module previously used everywhere else.

Verified with a throwaway script (three agents at staggered delays, one forced to raise): result ordering matches `agents`/`tasks` order regardless of completion order, a mismatched `imgs` length raises `ValueError`, and the failing agent's slot is `None` without disturbing its neighbours. `ruff check` and `python -m py_compile` are clean on the changed file. No test file added — `batch_agent_execution` is a small non-entry-point utility with no existing test coverage to extend.
