### PR TITLE
[FIX][autonomous_agent_prompt][Recompute AUTONOMOUS_AGENT_SYSTEM_PROMPT on access instead of freezing it at import]

### DIFF
--- a/swarms/prompts/__init__.py
+++ b/swarms/prompts/__init__.py
@@ -1,5 +1,5 @@
+from swarms.prompts import autonomous_agent_prompt as _autonomous_agent_prompt
 from swarms.prompts.autonomous_agent_prompt import (
-    AUTONOMOUS_AGENT_SYSTEM_PROMPT,
     get_autonomous_agent_prompt,
     get_autonomous_agent_prompt_with_context,
 )
@@ -31,3 +31,11 @@ __all__ = [
     "get_autonomous_agent_prompt",
     "get_autonomous_agent_prompt_with_context",
 ]
+
+
+def __getattr__(name: str):
+    if name == "AUTONOMOUS_AGENT_SYSTEM_PROMPT":
+        return _autonomous_agent_prompt.AUTONOMOUS_AGENT_SYSTEM_PROMPT
+    raise AttributeError(
+        f"module {__name__!r} has no attribute {name!r}"
+    )

--- a/swarms/prompts/autonomous_agent_prompt.py
+++ b/swarms/prompts/autonomous_agent_prompt.py
@@ -12,7 +12,15 @@ def get_time() -> str:
     return f"Current date and time: {now.strftime('%A, %B %d, %Y %H:%M %Z')}\n"
 
 
-AUTONOMOUS_AGENT_SYSTEM_PROMPT = f"""
+def _build_autonomous_agent_system_prompt() -> str:
+    """
+    Build the autonomous agent system prompt, embedding the current time.
+
+    Called fresh each time instead of once at import, so the "Current
+    date and time" line reflects when the prompt is requested rather
+    than when this module first loaded.
+    """
+    return f"""
 You are an elite autonomous agent operating in a structured autonomous loop by The Swarms Corporation.
 Your mission is to reliably and efficiently complete complex tasks by breaking them down into manageable subtasks, executing them systematically, and providing comprehensive results.
 
@@ -280,10 +288,13 @@ def get_autonomous_agent_prompt(
         str: The autonomous agent system prompt.
     """
     if include_think_tool:
-        return AUTONOMOUS_AGENT_SYSTEM_PROMPT
+        return _build_autonomous_agent_system_prompt()
 
     # Overridden at the end rather than excised; the think guidance is woven through in a dozen places.
-    return AUTONOMOUS_AGENT_SYSTEM_PROMPT + NO_THINK_TOOL_OVERRIDE
+    return (
+        _build_autonomous_agent_system_prompt()
+        + NO_THINK_TOOL_OVERRIDE
+    )
 
 
 def get_autonomous_agent_prompt_with_context(
@@ -302,7 +313,7 @@ def get_autonomous_agent_prompt_with_context(
     Returns:
         str: Contextualized autonomous agent prompt
     """
-    prompt = AUTONOMOUS_AGENT_SYSTEM_PROMPT
+    prompt = _build_autonomous_agent_system_prompt()
 
     if agent_name:
         prompt = prompt.replace(
@@ -327,3 +338,15 @@ def get_autonomous_agent_prompt_with_context(
         )
 
     return prompt
+
+
+def __getattr__(name: str) -> str:
+    """
+    Recompute ``AUTONOMOUS_AGENT_SYSTEM_PROMPT`` on every attribute
+    access (PEP 562) instead of returning a value frozen at import time.
+    """
+    if name == "AUTONOMOUS_AGENT_SYSTEM_PROMPT":
+        return _build_autonomous_agent_system_prompt()
+    raise AttributeError(
+        f"module {__name__!r} has no attribute {name!r}"
+    )


### PR DESCRIPTION
Type: Fix

Closes #1975

`AUTONOMOUS_AGENT_SYSTEM_PROMPT` was a module-level f-string, so `get_time()` ran exactly once, at import. Every long-running process (server, notebook, agent pool) got a "Current date and time" line frozen at process start:

```python
>>> from swarms.prompts import autonomous_agent_prompt as m
>>> "Current date and time" in m.AUTONOMOUS_AGENT_SYSTEM_PROMPT
True   # frozen at import
```

`get_autonomous_agent_prompt()` and `get_autonomous_agent_prompt_with_context()` (the paths `Agent` actually uses) just returned that same frozen constant, so an autonomous agent running for hours or days kept telling the model whatever time the process happened to start.

Fix: the template is now built by `_build_autonomous_agent_system_prompt()`, which calls `get_time()` fresh on every invocation. Both consumer functions call it directly. For the module-level name itself, `swarms/prompts/autonomous_agent_prompt.py` and `swarms/prompts/__init__.py` each add a PEP 562 `__getattr__` so `AUTONOMOUS_AGENT_SYSTEM_PROMPT` is recomputed on every attribute access instead of being a value baked in once — this preserves the existing import shape (`from swarms.prompts import AUTONOMOUS_AGENT_SYSTEM_PROMPT` still works) while fixing the exact repro above.

Verified with a throwaway script against the built venv: mocking `datetime.now()` to return a time two days in the future and re-reading `autonomous_agent_prompt.AUTONOMOUS_AGENT_SYSTEM_PROMPT` (module attribute access, both directly and via the `swarms.prompts` package) returns the new time rather than the value observed a moment earlier; `get_autonomous_agent_prompt()` and `get_autonomous_agent_prompt_with_context()` both stay on the same fresh-per-call path. `ruff check` on both touched files passes, and `import swarms` plus `Agent` construction succeed unchanged.

No new test file: the change is a private helper plus a stdlib `__getattr__` hook behind two already-tested public functions, not a new entry point.
