### PR TITLE
[FIX][SocialAlgorithms._execute_with_timeout][Time out with a joined thread, not SIGALRM]

### DIFF
--- a/swarms/structs/social_algorithms.py
+++ b/swarms/structs/social_algorithms.py
@@ -1,5 +1,7 @@
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
@@ -309,6 +311,15 @@ class SocialAlgorithms:
         """
         Execute a function with a timeout.
 
+        Runs ``func`` on a worker thread and joins it with a deadline,
+        rather than installing a ``signal.SIGALRM`` handler. A signal
+        handler can only be installed from the interpreter's main
+        thread, so it raises ``ValueError`` whenever ``run()`` is
+        itself called off the main thread (e.g. from another thread
+        pool). This approach works from any thread, keeps a fractional
+        ``max_execution_time`` instead of truncating it to whole
+        seconds, and is portable to platforms without ``SIGALRM``.
+
         Args:
             func (Callable): The function to execute.
             *args: Positional arguments for the function.
@@ -320,24 +331,21 @@ class SocialAlgorithms:
         Raises:
             TimeoutError: If the function execution exceeds max_execution_time.
         """
-        import signal
-
-        def timeout_handler(signum, frame):
+        pool = ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(func, *args, **kwargs)
+        try:
+            result = future.result(timeout=self.max_execution_time)
+        except FuturesTimeoutError:
+            # Don't block here waiting for the runaway call to finish;
+            # report the timeout the moment the deadline passes. The
+            # thread itself keeps running in the background and is
+            # reclaimed once it returns.
+            pool.shutdown(wait=False)
             raise TimeoutError(
                 f"Algorithm execution exceeded {self.max_execution_time} seconds"
             )
-
-        # Set up timeout
-        old_handler = signal.signal(signal.SIGALRM, timeout_handler)
-        signal.alarm(int(self.max_execution_time))
-
-        try:
-            result = func(*args, **kwargs)
-            return result
-        finally:
-            # Restore original handler
-            signal.alarm(0)
-            signal.signal(signal.SIGALRM, old_handler)
+        pool.shutdown(wait=False)
+        return result
 
     def _format_output(self, result: Any) -> Any:
         """


### PR DESCRIPTION
Type: Fix

Closes #2070

`SocialAlgorithms._execute_with_timeout` installs a `signal.SIGALRM` handler, and `signal.signal` raises `ValueError: signal only works in main thread of the main interpreter` whenever it's called from anything but the interpreter's main thread. `run()` takes this path by default (`max_execution_time` defaults to `300.0`), so any caller that invokes `run()` from a worker thread — a `ThreadPoolExecutor`, `asyncio.to_thread`, another swarm's executor — hits this immediately, before the algorithm itself runs.

The issue was filed against `run_async()`, which called `self.run` via `asyncio.to_thread` and hit exactly this. That method has since been removed from `SocialAlgorithms`, but the defect it exposed is unchanged: `_execute_with_timeout` still can't be called off the main thread, so anyone driving `run()` from a worker thread hits the same `ValueError`. Confirmed on `upstream/master` with a minimal repro — `run()` called from a plain `threading.Thread` raises immediately with the default `max_execution_time`.

Two smaller defects ride the same code path: `signal.alarm(int(self.max_execution_time))` truncates to whole seconds, so any budget under `1.0` schedules `signal.alarm(0)` — which cancels rather than shortens the timeout — and `SIGALRM`/`signal.alarm` don't exist on Windows at all.

Fix: run the algorithm on a one-shot worker thread and bound it with `future.result(timeout=...)` instead of interrupting the calling thread. This works from any thread, keeps the fractional budget instead of flooring it, and needs no platform-specific signal. The pool is shut down with `wait=False` on both the success and timeout paths so a timeout is reported the moment the deadline passes rather than blocking until the runaway call itself returns (the runaway thread is reclaimed once it finishes in the background; it can't be safely killed from the outside either way).

Verified with a throwaway script: `run()` invoked from a plain `threading.Thread` now completes instead of raising; a sub-second `max_execution_time=0.5` against a 2-second algorithm times out at ~0.5s (not 0, not 2s); and ordinary main-thread `run()` is unaffected. `ruff check` and `python -m py_compile` are clean on the changed file. No test file added — this is a small internal helper, not an entry point, with no existing test module to extend.
