### PR TITLE
[FIX][autonomous_agent_system_prompt][Build the autonomous prompt at call time so its Time line is current]

### DIFF
--- a/swarms/prompts/__init__.py
+++ b/swarms/prompts/__init__.py
@@ -1,5 +1,5 @@
 from swarms.prompts.autonomous_agent_prompt import (
-    AUTONOMOUS_AGENT_SYSTEM_PROMPT,
+    autonomous_agent_system_prompt,
     get_autonomous_agent_prompt,
     get_autonomous_agent_prompt_with_context,
 )
@@ -27,7 +27,7 @@ __all__ = [
     "PRODUCT_AGENT_PROMPT",
     "DOCUMENTATION_WRITER_SOP",
     "Prompt",
-    "AUTONOMOUS_AGENT_SYSTEM_PROMPT",
+    "autonomous_agent_system_prompt",
     "get_autonomous_agent_prompt",
     "get_autonomous_agent_prompt_with_context",
 ]

--- a/swarms/prompts/autonomous_agent_prompt.py
+++ b/swarms/prompts/autonomous_agent_prompt.py
@@ -2,17 +2,14 @@ from datetime import datetime
 
 
 def get_time() -> str:
-    """
-    Build the autonomous agent system prompt with current date/time injected.
-
-    Returns:
-        str: Full system prompt with date/time line prepended.
-    """
+    """The current local date and time as one prompt line."""
     now = datetime.now().astimezone()
     return f"Current date and time: {now.strftime('%A, %B %d, %Y %H:%M %Z')}\n"
 
 
-AUTONOMOUS_AGENT_SYSTEM_PROMPT = f"""
+def autonomous_agent_system_prompt() -> str:
+    """The autonomous agent system prompt, with the time as of this call."""
+    return f"""
 You are an elite autonomous agent operating in a structured autonomous loop by The Swarms Corporation.
 Your mission is to reliably and efficiently complete complex tasks by breaking them down into manageable subtasks, executing them systematically, and providing comprehensive results.
 
@@ -279,11 +276,12 @@ def get_autonomous_agent_prompt(
     Returns:
         str: The autonomous agent system prompt.
     """
+    prompt = autonomous_agent_system_prompt()
     if include_think_tool:
-        return AUTONOMOUS_AGENT_SYSTEM_PROMPT
+        return prompt
 
     # Overridden at the end rather than excised; the think guidance is woven through in a dozen places.
-    return AUTONOMOUS_AGENT_SYSTEM_PROMPT + NO_THINK_TOOL_OVERRIDE
+    return prompt + NO_THINK_TOOL_OVERRIDE
 
 
 def get_autonomous_agent_prompt_with_context(
@@ -302,7 +300,7 @@ def get_autonomous_agent_prompt_with_context(
     Returns:
         str: Contextualized autonomous agent prompt
     """
-    prompt = AUTONOMOUS_AGENT_SYSTEM_PROMPT
+    prompt = autonomous_agent_system_prompt()
 
     if agent_name:
         prompt = prompt.replace(

--- a/tests/prompts/test_autonomous_agent_prompt.py
+++ b/tests/prompts/test_autonomous_agent_prompt.py
@@ -1,0 +1,29 @@
+import swarms.prompts.autonomous_agent_prompt as prompt_module
+
+
+def _freeze(monkeypatch, value):
+    monkeypatch.setattr(
+        prompt_module,
+        "get_time",
+        lambda: f"Current date and time: {value}\n",
+    )
+
+
+def test_prompt_reflects_the_clock_at_call_time(monkeypatch):
+    _freeze(monkeypatch, "FIRST")
+    first = prompt_module.get_autonomous_agent_prompt()
+    _freeze(monkeypatch, "SECOND")
+    second = prompt_module.get_autonomous_agent_prompt()
+
+    assert "Time: Current date and time: FIRST" in first
+    assert "Time: Current date and time: SECOND" in second
+
+
+def test_contextual_prompt_uses_the_same_clock(monkeypatch):
+    _freeze(monkeypatch, "NOW")
+    built = prompt_module.get_autonomous_agent_prompt_with_context(
+        agent_name="Scout"
+    )
+
+    assert "Time: Current date and time: NOW" in built
+    assert "You are Scout, an elite autonomous agent" in built


### PR DESCRIPTION
Closes #1975.

`AUTONOMOUS_AGENT_SYSTEM_PROMPT` was a module-level f-string, so `get_time()` ran once at import and every agent in a long-lived process was told the process start time.

## Fix

The constant becomes a function, `autonomous_agent_system_prompt()`, that returns the same f-string when called. `get_autonomous_agent_prompt` and `get_autonomous_agent_prompt_with_context`, which `Agent.__init__` uses on the `max_loops="auto"` path, call it, so the Time line reflects the clock when the agent is built. `swarms.prompts` exports the function in place of the constant.

10 lines added, 12 removed, across the prompt module and the package export. The prompt text is untouched.

## Verification

- New `tests/prompts/test_autonomous_agent_prompt.py`, two tests, following the pattern of the existing `test_agent_system_prompts.py`. Both fail on master and pass here.
- `tests/prompts` and `tests/agents/test_autonomous_loop.py`: 55 passed.
- black at 70 and ruff clean.

Supersedes #2130, which fixes the same issue with a larger diff.
